### PR TITLE
Rename beta bar to announcement bar and hide it for now

### DIFF
--- a/app/assets/stylesheets/announcement-bar.css.scss
+++ b/app/assets/stylesheets/announcement-bar.css.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 @import 'mixins';
 
-.beta-bar {
+.announcement-bar {
     background:$error-red-color;
     padding:10px;
     text-align:center;

--- a/app/views/layouts/_announcement_bar.html.haml
+++ b/app/views/layouts/_announcement_bar.html.haml
@@ -1,3 +1,3 @@
-.beta-bar
+.announcement-bar
   %i.fa.fa-warning
   This is a beta version of Exercism. All data will be periodically deleted. Please visit #{link_to "our main website", "http://exercism.io"} for normal usage.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
 
   %body{class: body_class}
 
-    =render "layouts/beta_bar"
+    /=render "layouts/announcement_bar"
     =render_header
     = yield
     =render "layouts/footer"

--- a/app/views/layouts/teams.html.haml
+++ b/app/views/layouts/teams.html.haml
@@ -10,7 +10,7 @@
 
   %body{class: "#{body_class} namespace-teams"}
 
-    =render "layouts/beta_bar"
+    /=render "layouts/announcement_bar"
     =render_teams_header
     = yield
     =render "layouts/teams_footer"


### PR DESCRIPTION
I've left this in the codebase because we might want it periodically.