### PR TITLE
Use secrets.yml to handle the GitHub webhook secret

### DIFF
--- a/app/controllers/webhooks/contributors_controller.rb
+++ b/app/controllers/webhooks/contributors_controller.rb
@@ -31,7 +31,7 @@ class Webhooks::ContributorsController < WebhooksController
   end
 
   def secret
-    ENV['GITHUB_WEBHOOK_SECRET'] || 'hot fudge sundae' # default for test env
+    Rails.application.secrets.github_webhook_secret
   end
 
   def github_signature

--- a/app/controllers/webhooks/repo_updates_controller.rb
+++ b/app/controllers/webhooks/repo_updates_controller.rb
@@ -30,7 +30,7 @@ class Webhooks::RepoUpdatesController < WebhooksController
   end
 
   def secret
-    ENV['GITHUB_WEBHOOK_SECRET'] || 'hot fudge sundae' # default for test env
+    Rails.application.secrets.github_webhook_secret
   end
 
   def github_signature

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -8,3 +8,4 @@ development:
 
 test:
   secret_key_base: 60785574a657542ba208c881c80b06b30cf6b4d6ad57a2bb2deb4e0de315fa1256dc74bad3d4dd483a37f467c75412a143344e11ace332e8ab2eff254ef05f2c
+  github_webhook_secret: hot fudge sundae


### PR DESCRIPTION
## Description
Instead of using the `GITHUB_WEBHOOK_SECRET` env, use `secrets.yml` to handle the storage of the GitHub webook secret.