### PR TITLE
Fetch repo before syncing

### DIFF
--- a/app/jobs/sync_repo_update_job.rb
+++ b/app/jobs/sync_repo_update_job.rb
@@ -8,6 +8,17 @@ class SyncRepoUpdateJob < ApplicationJob
   def perform(repo_update_id)
     repo_update = RepoUpdate.find(repo_update_id)
 
+    fetch_repo!(repo_update)
+    sync_repo!(repo_update)
+  end
+
+  private
+
+  def fetch_repo!(repo_update)
+    Git::FetchesRepo.fetch(repo_update.repo)
+  end
+
+  def sync_repo!(repo_update)
     case repo_update.slug
     when "website-copy"
       Git::SyncsWebsiteCopy.()

--- a/test/jobs/sync_repo_update_job_test.rb
+++ b/test/jobs/sync_repo_update_job_test.rb
@@ -1,9 +1,20 @@
 require 'test_helper'
 
 class SyncRepoUpdateJobTest < ActiveJob::TestCase
+  test "fetches tracks" do
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    Git::SyncsTracks.stubs(:sync)
+
+    Git::FetchesRepo.expects(:fetch).with(repo_update.repo)
+
+    SyncRepoUpdateJob.perform_now(repo_update.id)
+  end
+
   test "syncs tracks" do
     track = create(:track, slug: "ruby")
     repo_update = create(:repo_update, slug: "ruby")
+    Git::FetchesRepo.stubs(:fetch)
 
     Git::SyncsTracks.expects(:sync).with([track])
 
@@ -12,6 +23,7 @@ class SyncRepoUpdateJobTest < ActiveJob::TestCase
 
   test "syncs website-copy repo" do
     repo_update = create(:repo_update, slug: "website-copy")
+    Git::FetchesRepo.stubs(:fetch)
 
     Git::SyncsWebsiteCopy.expects(:call)
 
@@ -20,6 +32,7 @@ class SyncRepoUpdateJobTest < ActiveJob::TestCase
 
   test "does not sync unregistered repos" do
     repo_update = create(:repo_update, slug: "problem-specifications")
+    Git::FetchesRepo.stubs(:fetch)
 
     Git::SyncsTracks.expects(:sync).never
 
@@ -29,6 +42,7 @@ class SyncRepoUpdateJobTest < ActiveJob::TestCase
   test "records sync time after performing" do
     repo_update = create(:repo_update, slug: "website-copy")
     Git::SyncsWebsiteCopy.stubs(:call)
+    Git::FetchesRepo.stubs(:fetch)
 
     SyncRepoUpdateJob.perform_now(repo_update.id)
 


### PR DESCRIPTION
Since the processor needs the latest version of the repo to sync, the
repo must be fetched.