### PR TITLE
Sync mentors without GitHub profiles

### DIFF
--- a/app/models/git/github_profile.rb
+++ b/app/models/git/github_profile.rb
@@ -1,11 +1,20 @@
 class Git::GithubProfile
 
+  class NotFoundError < StandardError
+  end
+
   def self.for_user(username)
     client = Octokit::Client.new(
       client_id: Rails.application.secrets.github_key,
       client_secret: Rails.application.secrets.github_secret
     )
-    user = client.user(username)
+
+    begin
+      user = client.user(username)
+    rescue Octokit::NotFound
+      raise NotFoundError
+    end
+
     self.new(user)
   end
 

--- a/app/models/git/null_github_profile.rb
+++ b/app/models/git/null_github_profile.rb
@@ -1,0 +1,17 @@
+class Git::NullGithubProfile
+  def name
+    nil
+  end
+
+  def bio
+    nil
+  end
+
+  def avatar_url
+    nil
+  end
+
+  def link_url
+    nil
+  end
+end

--- a/app/services/git/syncs_mentors.rb
+++ b/app/services/git/syncs_mentors.rb
@@ -31,7 +31,11 @@ class Git::SyncsMentors
       github_username: mentor_data[:github_username]
     )
 
-    github_profile = Git::GithubProfile.for_user(mentor_data[:github_username])
+    github_profile = begin
+                       Git::GithubProfile.for_user(mentor_data[:github_username])
+                     rescue Git::GithubProfile::NotFoundError
+                       Git::NullGithubProfile.new
+                     end
 
     mentor.tap do |mentor|
       mentor.assign_attributes(

--- a/test/models/git/null_github_profile_test.rb
+++ b/test/models/git/null_github_profile_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Git::NullGithubProfileTest < ActiveSupport::TestCase
+  test "name returns nil" do
+    assert_nil Git::NullGithubProfile.new.name
+  end
+
+  test "bio returns nil" do
+    assert_nil Git::NullGithubProfile.new.bio
+  end
+
+  test "avatar_url returns nil" do
+    assert_nil Git::NullGithubProfile.new.avatar_url
+  end
+
+  test "link_url returns nil" do
+    assert_nil Git::NullGithubProfile.new.link_url
+  end
+end


### PR DESCRIPTION
## Description
This allows mentor syncing to continue even with wrong GitHub profiles.