### PR TITLE
Send user to the correct iteration in the solution notificaiton

### DIFF
--- a/app/controllers/my/iterations_controller.rb
+++ b/app/controllers/my/iterations_controller.rb
@@ -1,0 +1,17 @@
+class My::IterationsController < MyController
+  def show
+    redirect_to my_solution_path(solution, iteration_idx: iteration_idx)
+  end
+
+  private
+
+  def solution
+    @solution ||= current_user.solutions.find_by_uuid!(params[:solution_id])
+  end
+
+  def iteration_idx
+    iteration = solution.iterations.find(params[:id])
+
+    solution.iterations.index(iteration) + 1
+  end
+end

--- a/app/services/creates_mentor_discussion_post.rb
+++ b/app/services/creates_mentor_discussion_post.rb
@@ -32,7 +32,7 @@ class CreatesMentorDiscussionPost < CreatesDiscussionPost
       solution.user,
       :new_discussion_post,
       "#{strong user.handle} has commented on your solution to #{strong solution.exercise.title} on the #{strong solution.exercise.track.title} track.",
-      routes.my_solution_url(solution),
+      routes.my_solution_iteration_url(solution, iteration),
       trigger: discussion_post,
 
       # We want this to be the solution not the post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
         patch :reflect
         patch :publish
       end
+
+      resources :iterations, only: [:show]
     end
     resources :reactions, only: [:index, :create]
 

--- a/test/controllers/my/iterations_controller_test.rb
+++ b/test/controllers/my/iterations_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class My::IterationsControllerTest < ActionDispatch::IntegrationTest
+  test "redirects to the correct iteration index" do
+    user = create(:user, accepted_terms_at: Date.new(2016, 12, 25), accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    solution = create(:solution, user: user)
+    iteration = create(:iteration, solution: solution)
+    iteration2 = create(:iteration, solution: solution)
+
+    sign_in!(user)
+    get my_solution_iteration_path(solution, iteration)
+
+    assert_redirected_to my_solution_path(solution, iteration_idx: 1)
+  end
+end

--- a/test/services/creates_mentor_discussion_post_test.rb
+++ b/test/services/creates_mentor_discussion_post_test.rb
@@ -50,7 +50,7 @@ class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
       assert_equal user, args[0]
       assert_equal :new_discussion_post, args[1]
       assert_equal "<strong>#{mentor1.handle}</strong> has commented on your solution to <strong>#{solution.exercise.title}</strong> on the <strong>#{solution.exercise.track.title}</strong> track.", args[2]
-      assert_equal "https://test.exercism.io/my/solutions/#{solution.uuid}", args[3]
+      assert_equal "https://test.exercism.io/my/solutions/#{solution.uuid}/iterations/#{iteration.id}", args[3]
       assert_equal DiscussionPost, args[4][:trigger].class
       assert_equal solution, args[4][:about]
     end


### PR DESCRIPTION
Closes https://github.com/exercism/v2-feedback/issues/177.
Closes https://github.com/exercism/guest-contributors/issues/10.

## Description
This PR sends the user to the correct iteration of the solution instead of the latest iteration of the solution when they've received a notification.