### PR TITLE
Fix typo in communication preferences panel

### DIFF
--- a/app/views/my/communication_preferences/edit.html.haml
+++ b/app/views/my/communication_preferences/edit.html.haml
@@ -22,7 +22,7 @@
 
         =f.label :email_on_new_iteration_for_mentor do
           =f.check_box :email_on_new_iteration_for_mentor
-          %span Email me when a student posts a new iteratin to a solution I'm mentoring
+          %span Email me when a student posts a new iteration to a solution I'm mentoring
 
       %h2 Usage Emails
       =f.label :email_on_new_discussion_post do


### PR DESCRIPTION
Small typo in the communication preferences panel, under settings.