### PR TITLE
Init Dockerfile and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ruby:2.5
+
+# Specify warking directoy
+WORKDIR /opt/rails
+
+# Copy project to container
+COPY . .
+
+# Set identity file
+RUN echo "host" > server_identity
+
+# Setup this environment to development
+ENV RAILS_ENV "development"
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install dependencies: cmake for gem rugged and nodejs for rails.
+# Requires some workaround to remove util `cmdtest` that provides a bin yarn
+# and prepare and install yarn...
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -sS 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install -y yarn nodejs cmake
+
+# Install ruby libraries
+RUN bundle install
+
+# Install JavaScript libraries
+RUN bin/rails yarn:install
+RUN bundle exec rake bin/setup
+
+EXPOSE 3000
+
+# Run the development server
+CMD ["bin/rails", "server"]

--- a/README.md
+++ b/README.md
@@ -20,41 +20,59 @@ mysql -e "GRANT ALL PRIVILEGES ON exercism_reboot_test.* TO 'exercism_reboot'@'l
 
 ### Running the application
 
+To setup a local development environment you'll have either to prepare your
+local system with a ruby environment (ruby, rubygems, bundler) and JavaScript
+runtime nodejs include package manager yarn or use [docker-compose]. Later
+requires some basic knowledge about [Docker] and a Docker installation.
 
-#### For the first time
+[Docker]: https://www.docker.com/what-docker "What is Docker?"
+[docker-compose]: https://docs.docker.com/compose/ "Docker Compose"
+
+#### For the First Time
+
 Set a server identity:
 
 ```bash
 $ echo "host" > server_identity
 ```
 
-You need Ruby and the `bundler` gem installed (`gem install bundler`). Then the following *should* get you a working rails server
+You need Ruby and the `bundler` gem installed (`gem install bundler`). Then the
+following *should* get you a working rails server.
+
 ```
 bundle install
 bundle exec rake bin/setup
 bundle exec rails r "Git::UpdatesRepos.update"
-bundle exec rails s
+bundle exec rails s # shorthand for bundle exec rails server
 ```
 
-Something like this will get a working webserver on http://http://lvh.me:3000
+Something like this will get a working webserver on http://lvh.me:3000
 Note: Teams will be avaliable on http://teams.lvh.me:3000
 
-#### On future runs
+#### On Future Runs
 
-You can just run:
+You can just run: `bundle exec rails s[erver]`
+
+#### Docker Compose Development Setup
 
 ```
-bundle exec rails s
+$ echo "host" > server_identity # Set server identity file
+$ docker-compose -p exercism up # Start the local development environment
+$ docker-compose -p exercism exec rails bin/rails exercism:setup # Setup database and git repos
+
+$ docker-compose -p exercism down # Remove local environment
+$ docker rmi exercism_rails # Cleanup build docker image
 ```
 
 ### Notes
 
-We recommend using `lvh.me` which is a DNS redirect to localhost, but which we honour cookies on.
+We recommend using `lvh.me` which is a DNS redirect to localhost, but which we
+honour cookies on.
 
 
-### Deleting an account
+### Deleting an Account
 
- To delete a user, run `user.destroy.`
+To delete a user, run `user.destroy`.
 
 The user record is deleted, as well as associated objects except the ff:
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
   #collation: utf8_unicode_ci
   username: exercism_reboot
   password: exercism_reboot
-  host: localhost
+  host: <%= ENV['MYSQL_HOST'] || 'localhost' %>
   variables:
     sql_mode: traditional
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  mysql:
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=1
+      - MYSQL_DATABASE=exercism_reboot_development
+      - MYSQL_USER=exercism_reboot
+      - MYSQL_PASSWORD=exercism_reboot
+    image: "mariadb:10.3"
+    restart: always
+    command:
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"
+  rails:
+    build: .
+    volumes:
+      - .:/opt/rails
+    environment:
+      MYSQL_HOST: 'mysql'
+    depends_on:
+      - mysql
+    ports:
+      - "3000:3000/tcp"

--- a/lib/tasks/exercism.rake
+++ b/lib/tasks/exercism.rake
@@ -1,0 +1,10 @@
+namespace :exercism do
+  desc 'Initiate exercism website'
+  task :setup => :environment do
+    identity_file = Rails.root.join 'server_identity'
+    File.write identity_file, 'host' unless File.exists? identity_file
+    %w(db:migrate yarn:install git:update_repos).each do |task|
+      Rake::Task[task].invoke
+    end
+  end
+end


### PR DESCRIPTION
For some dependencies I struggled to setup a local (Fedora Linux) development environment so I created a docker-compose setup. This should help providing a quick, simple and stable way to get the Exercism website running locally for any contributor familiar with Docker.

- [x] Dockerfile to setup a rails environment
- [x] docker-compose configuration for local development environment
- [x] Rake task for exercism setup steps
- [x] Ensure database uses `utf8mb4` character set

Note: The create `server_identity` file and yarn install steps are redundant in the Dockerfile and afterwards `exercism:setup` rake task, necessary because the data is overwritten by the volume mount, but this makes the Dockerfile independent.