### PR TITLE
Add setup rake task and document Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Development Setup
 
-This is a Ruby on Rails (5.2) application backed by MySQL.
+This is a Ruby on Rails (5.2) application backed by MySQL. You can setup a
+local development environment with the steps below or use the Docker setup from
+[github.com/unused/exercism-docker](https://github.com/unused/exercism-docker).
 
 ### Database
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
   #collation: utf8_unicode_ci
   username: exercism_reboot
   password: exercism_reboot
-  host: localhost
+  host: <%= ENV['MYSQL_HOST'] || 'localhost' %>
   variables:
     sql_mode: traditional
 

--- a/lib/tasks/exercism.rake
+++ b/lib/tasks/exercism.rake
@@ -1,0 +1,10 @@
+namespace :exercism do
+  desc 'Initiate exercism website'
+  task :setup => :environment do
+    identity_file = Rails.root.join 'server_identity'
+    File.write identity_file, 'host' unless File.exists? identity_file
+    %w(db:migrate yarn:install git:update_repos).each do |task|
+      Rake::Task[task].invoke
+    end
+  end
+end


### PR DESCRIPTION
Follow up to #181 Init Dockerfile and docker-compose setup, using a [separated GitHub repository](https://github.com/unused/exercism-docker) and [pre-built Docker image](https://hub.docker.com/r/unused/exercism_rails/)

Use a single rake task for the setup tasks to simplify the project initialization and ensure better backward compatibility with setup changes.

Updates the README to point to a repository with a Docker & docker-compose environment prepared.