### PR TITLE
Improve side exercise visibility

### DIFF
--- a/app/assets/stylesheets/pages/my-track.scss
+++ b/app/assets/stylesheets/pages/my-track.scss
@@ -86,23 +86,14 @@ body.namespace-my.controller-tracks.action-show {
             background:$background-grey-1;
             width:2px;
         }
-        .exercise {
-            display:block;
-            color:#333;
-            text-decoration:none;
-            border:1px solid $line-color-1;
-            border-radius:2px;
-            padding:20px 25px;
-            margin-bottom:15px;
-            margin-left:60px;
-            height:100px;
+        .exercise-wrapper {
             position:relative;
-            background:#fff;
+            margin-left:58px;
 
             &:after {
                 position:absolute;
                 content: "";
-                top:50%;
+                top:50px;
                 left:-36px;
                 width:35px;
                 height:1px;
@@ -117,56 +108,70 @@ body.namespace-my.controller-tracks.action-show {
                 width:50px;
                 height:50px;
                 background:#eee;
+                z-index:1;
             }
-            .status {
-                float:right;
-                @include font-size(12, 12);
-                letter-spacing:-0.5px;
-                text-transform:uppercase;
-                font-weight:$regular;
-                color:#ccc;
-            }
-            .position {
-                @include font-size(10, 10);
-                font-weight:$light;
-                letter-spacing:-0.0px;
-                color:#ccc;
-                margin-bottom:5px;
-                display:none;
-            }
-            .title {
-                font-weight:$bold;
-                @include font-size(20, 20);
-                color:#ccc;
-                margin-bottom:5px;
-            }
-            .blurb {
-                font-weight:$regular;
-                @include font-size(13, 16);
-                color:#ccc;
-                overflow:hidden;
-                max-height:32px;
-                max-width:400px;
-            }
-            .topics {
-                display:inline-block;
-                vertical-align:bottom;
-                max-width: 290px;
-                overflow: hidden;
-                max-height: 23px;
-                margin-bottom:0px;
 
-                .topic {
-                    display:inline-block;
-                    @include font-size(11, 11);
+            .exercise {
+                display:block;
+                color:#333;
+                text-decoration:none;
+                border:1px solid $line-color-1;
+                border-radius:2px;
+                padding:20px 25px;
+                margin-bottom:15px;
+                height:100px;
+                background:#fff;
+                .status {
+                    float:right;
+                    @include font-size(12, 12);
+                    letter-spacing:-0.5px;
+                    text-transform:uppercase;
                     font-weight:$regular;
-                    margin-left:10px;
-                    background:#eee;
-                    color:#999;
-                    padding:3px 6px 4px;
-                    border-radius:2px;
+                    color:#ccc;
+                }
+                .position {
+                    @include font-size(10, 10);
+                    font-weight:$light;
+                    letter-spacing:-0.0px;
+                    color:#ccc;
+                    margin-bottom:5px;
+                    display:none;
+                }
+                .title {
+                    font-weight:$bold;
+                    @include font-size(20, 20);
+                    color:#ccc;
+                    margin-bottom:5px;
+                }
+                .blurb {
+                    font-weight:$regular;
+                    @include font-size(13, 16);
+                    color:#ccc;
+                    overflow:hidden;
+                    max-height:32px;
+                    max-width:400px;
+                }
+                .topics {
+                    display:inline-block;
+                    vertical-align:bottom;
+                    max-width: 290px;
+                    overflow: hidden;
+                    max-height: 23px;
+                    margin-bottom:0px;
+
+                    .topic {
+                        display:inline-block;
+                        @include font-size(11, 11);
+                        font-weight:$regular;
+                        margin-left:10px;
+                        background:#eee;
+                        color:#999;
+                        padding:3px 6px 4px;
+                        border-radius:2px;
+                    }
                 }
             }
+
             &.locked {
                 .circle {
                     img {
@@ -177,9 +182,11 @@ body.namespace-my.controller-tracks.action-show {
                 }
             }
             &.in-progress {
-                border:1px solid $color-1;
-                box-shadow:0 0 0 1px $color-1;
-                background:#fff;
+                .exercise {
+                    border:1px solid $color-1;
+                    box-shadow:0 0 0 1px $color-1;
+                    background:#fff;
+                }
                 &:after {
                     left:-34px;
                     width:33px;
@@ -216,7 +223,12 @@ body.namespace-my.controller-tracks.action-show {
                 }
             }
             &.completed {
-                border-color:$color-1;
+                .exercise {
+                    border-color:$color-1;
+                    .status {
+                        color:$color-1;
+                    }
+                }
                 &:after {
                     background:$color-1;
                 }
@@ -229,36 +241,89 @@ body.namespace-my.controller-tracks.action-show {
                         margin:16px auto;
                     }
                 }
-                .status {
-                    color:$color-1;
-                }
             }
             &.in-progress, &.completed {
-                &:hover {
-                    background:rgba($color-1, 0.05);
-                }
+                .exercise {
+                    &:hover {
+                        background:rgba($color-1, 0.05);
+                    }
 
-                .title {
-                    color:#333;
-                }
-                .position {
-                    color:#999;
-                }
-                .blurb {
-                    color:#999;
+                    .title {
+                        color:#333;
+                    }
+                    .position {
+                        color:#999;
+                    }
+                    .blurb {
+                        color:#999;
+                    }
                 }
 
                 &:before {
                     position:absolute;
                     content: "";
-                    bottom:50%;
+                    top:-50px;
                     left:-61px;
                     height:92px;
                     width:2px;
                     background:$color-1;
                 }
             }
-
+            &.completed + .exercise-wrapper.in-progress {
+                &:before {
+                    margin-top: -200px;
+                    height: 300px;
+                }
+            }
+        }
+        .unlocked-exercises-section {
+            margin: 0 50px;
+            border: 1px solid rgba($color-2, 0.5);
+            border-radius:2px;
+            margin-bottom: 20px;
+            position:relative;
+            &:before {
+                width:1px;
+                left:50%;
+                top:-16px;
+                height:16px;
+                position:absolute;
+                content: "";
+                background:$color-2;
+            }
+            h3 {
+                color:rgba($color-2, 0.9);
+                text-align:center;
+                background:rgba($color-1, 0.04);
+                border-bottom:1px solid rgba($color-2, 0.1);
+                font-weight:$regular;
+                padding:7px 20px;
+                @include font-size(13,13);
+            }
+            .unlocked-exercises {
+                padding:10px 20px 5px;
+                text-align:center;
+                font-size: 0;
+            }
+            .unlocked-exercise {
+                display: inline-block;
+                margin: 0 5px 5px 0;
+                border: 1px solid rgba($color-2, 0.5);
+                background:#fff;
+                padding:6px;
+                border-radius:2px;
+                height:37px;
+                img {
+                    height:25px;
+                    display:inline;
+                }
+                .hover { display:none; }
+                &:hover {
+                    background:$color-2;
+                    .normal { display:none; }
+                    .hover { display:inline; }
+                }
+            }
         }
     }
     .progress-section {

--- a/app/assets/stylesheets/widgets/side-exercise.scss
+++ b/app/assets/stylesheets/widgets/side-exercise.scss
@@ -25,6 +25,7 @@
     }
     &.unlocked {
         .status { color: #999 }
+        border-color:rgba($color-2, 0.6);
     }
     &.in-progress {
         border:2px solid $color-2;

--- a/app/controllers/my/side_exercises_controller.rb
+++ b/app/controllers/my/side_exercises_controller.rb
@@ -21,7 +21,7 @@ class My::SideExercisesController < MyController
 
     exercises = exercises.joins(:exercise_topics).where("exercise_topics.topic_id": params[:topic_id]) if params[:topic_id].to_i > 0
     exercises = exercises.where(length: params[:length]) if params[:length].to_i > 0
-    solutions = current_user.solutions.each_with_object({}) {|s,h| h[s.exercise_id] = s }
+    solutions = current_user.solutions.includes(:exercise).where('exercises.track_id': @track.id).each_with_object({}) {|s,h| h[s.exercise_id] = s }
 
     @exercises_and_solutions = exercises.map{|ce|[ce, solutions[ce.id]]}
     if params[:status] == "unlocked"

--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -64,6 +64,7 @@ class My::TracksController < MyController
       @side_exercises_and_solutions = side_exercises.map{|e|[e, mapped_solutions[e.id]]}.sort_by{|e,s|
         "#{s ? (s.completed?? 0 : (s.in_progress?? 1 : 2)) : 3}#{!e.unlocked_by ? 0 : 1}"
       }
+      @side_exercises_and_solutions_by_unlocked_by = @side_exercises_and_solutions.each_with_object(Hash.new{|h,k|h[k] = []}){|(e,s), h| h[e.unlocked_by_id] << [e,s]}
 
       @num_side_exercises = @track.exercises.side.count
       @num_solved_core_exercises = solutions.select { |s| s.exercise.core? && s.exercise.track_id == @track.id && s.completed?}.size

--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -49,7 +49,7 @@ class My::TracksController < MyController
       end
 
       @core_exercises_and_solutions = core_exercises.
-        inject([[], [], []]) do |collection, exercise|
+        inject([[], [], []]) { |collection, exercise|
           if exercise.completed?
             collection[0] << exercise
           elsif exercise.unlocked?
@@ -59,9 +59,11 @@ class My::TracksController < MyController
           end
 
           collection
-        end.
+        }.
         flatten
-      @side_exercises_and_solutions = side_exercises.map{|e|[e, mapped_solutions[e.id]]}
+      @side_exercises_and_solutions = side_exercises.map{|e|[e, mapped_solutions[e.id]]}.sort_by{|e,s|
+        "#{s ? (s.completed?? 0 : (s.in_progress?? 1 : 2)) : 3}#{!e.unlocked_by ? 0 : 1}"
+      }
 
       @num_side_exercises = @track.exercises.side.count
       @num_solved_core_exercises = solutions.select { |s| s.exercise.core? && s.exercise.track_id == @track.id && s.completed?}.size

--- a/app/views/my/tracks/_core_exercises.html.haml
+++ b/app/views/my/tracks/_core_exercises.html.haml
@@ -2,35 +2,48 @@
   - num_core_exercises = core_exercises.size
   - core_exercises.each.with_index do |exercise, idx|
     - if exercise.completed?
-      = link_to [:my, exercise.solution], class: "exercise completed", id: "exercise-#{exercise.slug}" do
+      .exercise-wrapper.completed
         .circle= image_tag "tick-color-1.png"
-        .status Completed
-        .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
-        .title
-          = exercise.title
-          .topics
-            - exercise.topic_names.each do |topic_name|
-              .topic= topic_name
-        .blurb= exercise.blurb
+        = link_to [:my, exercise.solution], class: "exercise", id: "exercise-#{exercise.slug}" do
+          .status Completed
+          .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
+          .title
+            = exercise.title
+            .topics
+              - exercise.topic_names.each do |topic_name|
+                .topic= topic_name
+          .blurb= exercise.blurb
+
+        -if @side_exercises_and_solutions_by_unlocked_by[exercise.id].present? || (exercise.auto_approve? && @side_exercises_and_solutions_by_unlocked_by[nil].present?)
+          .unlocked-exercises-section
+            %h3 You've unlocked extra exercises!
+            .unlocked-exercises
+              -if exercise.auto_approve?
+                =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[nil][0,10]
+              =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[exercise.id]
+
     - elsif exercise.unlocked?
-      = link_to [:my, exercise.solution], class: "exercise in-progress", id: "exercise-#{exercise.slug}" do
+      .exercise-wrapper.in-progress
         .circle= image_tag exercise.white_icon_url
-        .status In Progress
-        .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
-        .title
-          = exercise.title
-          .topics
-            - exercise.topic_names.each do |topic_name|
-              .topic= topic_name
-        .blurb= exercise.blurb
+        = link_to [:my, exercise.solution], class: "exercise", id: "exercise-#{exercise.slug}" do
+          .status In Progress
+          .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
+          .title
+            = exercise.title
+            .topics
+              - exercise.topic_names.each do |topic_name|
+                .topic= topic_name
+          .blurb= exercise.blurb
+
     - elsif exercise.locked?
-      .exercise.locked{id: "exercise-#{exercise.slug}"}
+      .exercise-wrapper.locked
         .circle= image_tag exercise.dark_icon_url
-        .status Locked
-        .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
-        .title
-          = exercise.title
-          .topics
-            - exercise.topic_names.each do |topic_name|
-              .topic= topic_name
-        .blurb= exercise.blurb
+        .exercise{id: "exercise-#{exercise.slug}"}
+          .status Locked
+          .position Exercise #{idx + 1} of #{num_core_exercises} in #{exercise.track_title} Track
+          .title
+            = exercise.title
+            .topics
+              - exercise.topic_names.each do |topic_name|
+                .topic= topic_name
+          .blurb= exercise.blurb

--- a/app/views/my/tracks/_unlocked_exercises.html.haml
+++ b/app/views/my/tracks/_unlocked_exercises.html.haml
@@ -1,0 +1,9 @@
+-unlocked_exercises_and_solutions.each do |exercise, solution|
+  -if solution
+    = link_to [:my, solution], class: "unlocked-exercise" do
+      =image_tag exercise.turquoise_icon_url, class: 'normal'
+      =image_tag exercise.white_icon_url, class: 'hover'
+  -else
+    = link_to [:my, :solutions, track_id: exercise.track, exercise_id: exercise], method: :post, class: 'unlocked-exercise' do
+      =image_tag exercise.turquoise_icon_url, class: 'normal'
+      =image_tag exercise.white_icon_url, class: 'hover'


### PR DESCRIPTION
Brings side exercises to the top like this and adds a bolder border: 

<img width="1115" alt="screen shot 2018-07-19 at 00 27 55" src="https://user-images.githubusercontent.com/286476/42913058-9a598a90-8aea-11e8-9e82-fc38ba8b42a1.png">

Shows unlocked exercises:

<img width="1214" alt="screen shot 2018-07-19 at 01 43 16" src="https://user-images.githubusercontent.com/286476/42914977-25b8b64c-8af5-11e8-9df2-278f5701fd86.png">


We don't have green exercise icons - only turquoise ones so I've made it all turquoise. We might want to fix that.