### PR TITLE
Improve approval flow

### DIFF
--- a/app/controllers/mentor/discussion_posts_controller.rb
+++ b/app/controllers/mentor/discussion_posts_controller.rb
@@ -6,10 +6,7 @@ class Mentor::DiscussionPostsController < MentorController
     return head 403 unless current_user.mentoring_track?(@solution.exercise.track)
     return head 403 if current_user == @iteration.solution.user
 
-    if params['button'] == 'approved'
-      @approved = true
-      @solution.update(approved_by: current_user)
-    end
+    ApproveSolution.(@solution, current_user) if params['button'] == 'approved'
 
     @post = CreatesMentorDiscussionPost.create!(@iteration, current_user, params[:discussion_post][:content])
     @user_track = UserTrack.where(user: current_user, track: @iteration.solution.exercise.track).first

--- a/app/controllers/mentor/solutions_controller.rb
+++ b/app/controllers/mentor/solutions_controller.rb
@@ -25,6 +25,7 @@ class Mentor::SolutionsController < MentorController
     end
 
     ClearsNotifications.clear!(current_user, @solution)
+    ClearsNotifications.clear!(current_user, @iteration)
   end
 
   def approve

--- a/app/controllers/mentor/solutions_controller.rb
+++ b/app/controllers/mentor/solutions_controller.rb
@@ -1,6 +1,8 @@
 class Mentor::SolutionsController < MentorController
+  before_action :set_solution
+  before_action :check_mentor_may_mentor_solution!
+
   def show
-    @solution = Solution.find_by_uuid!(params[:id])
     @exercise = @solution.exercise
     @track = @exercise.track
 
@@ -26,20 +28,28 @@ class Mentor::SolutionsController < MentorController
   end
 
   def approve
-    @solution = Solution.find_by_uuid!(params[:id])
-    @solution.update(approved_by: current_user)
+    ApproveSolution.(@solution, current_user)
   end
 
   def ignore
-    @solution = Solution.find_by_uuid!(params[:id])
     IgnoredSolutionMentorship.find_or_create_by(user: current_user, solution: @solution)
     redirect_to [:mentor, :dashboard]
   end
 
   def abandon
-    @solution = Solution.find_by_uuid!(params[:id])
     @mentor_solution = SolutionMentorship.where(user: current_user, solution: @solution).first
     @mentor_solution.update(abandoned: true)
     redirect_to [:mentor, :dashboard]
+  end
+
+  private
+
+  def set_solution
+    @solution = Solution.find_by_uuid!(params[:id])
+  end
+
+  def check_mentor_may_mentor_solution!
+    return head 403 unless current_user.mentoring_track?(@solution.exercise.track)
+    return head 403 if current_user == @solution.user
   end
 end

--- a/app/controllers/my/solutions_controller.rb
+++ b/app/controllers/my/solutions_controller.rb
@@ -135,6 +135,8 @@ class My::SolutionsController < MyController
     @post_user_tracks = UserTrack.where(user_id: @iteration.discussion_posts.map(&:user_id), track: @track).
                              each_with_object({}) { |ut, h| h["#{ut.user_id}|#{ut.track_id}"] = ut }
 
+    ClearsNotifications.clear!(current_user, @iteration)
+
     render :show
   end
 end

--- a/app/controllers/teams/teams/my_solutions_controller.rb
+++ b/app/controllers/teams/teams/my_solutions_controller.rb
@@ -62,5 +62,7 @@ class Teams::Teams::MySolutionsController < Teams::Teams::BaseController
     @iteration = @solution.iterations.offset(params[:iteration_idx].to_i - 1).first if params[:iteration_idx].to_i > 0
     @iteration = @solution.iterations.last unless @iteration
     @iteration_idx = @solution.iterations.where("id < ?", @iteration.id).count + 1
+
+    ClearsNotifications.clear!(current_user, @iteration)
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -27,9 +27,9 @@ module NotificationsHelper
       notification.about.user.avatar_url
 
     when 'solution_approved'
-      # Your own face
-      # about = solution
-      notification.about.user.avatar_url
+      # Mentor's face
+      # trigger = mentor
+      notification.trigger.avatar_url
     end
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -2,10 +2,33 @@ module NotificationsHelper
   def notification_image(notification)
     case notification.type
     when 'new_discussion_post'
+      # Face of the discussion post user
+      # trigger = discussion post
       notification.trigger.user.avatar_url
+
     when 'new_discussion_post_for_mentor'
+      # Face of the discussion post user
+      # trigger = discussion post
       notification.trigger.user.avatar_url
+
     when 'new_iteration_for_mentor'
+      # Face of the iteration user
+      # about = solution
+      notification.about.user.avatar_url
+
+    when 'new_reaction'
+      # Face of the reacting user
+      # trigger = reaction
+      notification.trigger.user.avatar_url
+
+    when 'exercise_auto_approved'
+      # Your own face
+      # about = solution
+      notification.about.user.avatar_url
+
+    when 'solution_approved'
+      # Your own face
+      # about = solution
       notification.about.user.avatar_url
     end
   end

--- a/app/mailers/user_notifications_mailer.rb
+++ b/app/mailers/user_notifications_mailer.rb
@@ -10,4 +10,15 @@ class UserNotificationsMailer < ApplicationMailer
       subject: "[Exercism] A mentor has commented on your solution to #{track_title}/#{exercise_title}"
     )
   end
+
+  def solution_approved(user, solution)
+    @user = user
+    @solution = solution
+    exercise_title = @solution.exercise.title
+    track_title = @solution.track.title
+    mail(
+      to: @user.email,
+      subject: "[Exercism] A mentor has approved your solution to #{track_title}/#{exercise_title}"
+    )
+  end
 end

--- a/app/services/approve_solution.rb
+++ b/app/services/approve_solution.rb
@@ -1,0 +1,45 @@
+class ApproveSolution
+  include Mandate
+  include HTMLGenerationHelpers
+
+  attr_reader :solution, :mentor
+  def initialize(solution, mentor)
+    @solution = solution
+    @mentor = mentor
+  end
+
+  def call
+    return false unless mentor_may_approve?
+
+    solution.update(approved_by: mentor)
+
+    mentorship = CreatesSolutionMentorship.create(solution, mentor)
+    solution.update!(last_updated_by_mentor_at: Time.current)
+    mentorship.update!(requires_action: false)
+    notify_solution_user
+  end
+
+  private
+
+  def notify_solution_user
+    CreatesNotification.create!(
+      solution.user,
+      :solution_approved,
+      "#{strong mentor.handle} has approved your solution to #{strong solution.exercise.title} on the #{strong solution.exercise.track.title} track.",
+      routes.my_solution_url(solution),
+      trigger: mentor,
+      about: solution
+    )
+
+    DeliversEmail.deliver!(
+      solution.user,
+      :solution_approved,
+      solution
+    )
+  end
+
+  def mentor_may_approve?
+    mentor.mentoring_track?(solution.exercise.track)
+  end
+end
+

--- a/app/services/approve_solution.rb
+++ b/app/services/approve_solution.rb
@@ -42,4 +42,3 @@ class ApproveSolution
     mentor.mentoring_track?(solution.exercise.track)
   end
 end
-

--- a/app/services/create_team_discussion_post.rb
+++ b/app/services/create_team_discussion_post.rb
@@ -1,8 +1,10 @@
 class CreateTeamDiscussionPost < CreatesDiscussionPost
   include Mandate
 
+  attr_reader :user
   def initialize(iteration, user, content)
-    super
+    @user = user
+    super(iteration, user, content)
   end
 
   def call

--- a/app/services/creates_discussion_post.rb
+++ b/app/services/creates_discussion_post.rb
@@ -1,4 +1,6 @@
 class CreatesDiscussionPost
+  include HTMLGenerationHelpers
+
   attr_reader :iteration, :author, :content, :discussion_post
   def initialize(iteration, author, content)
     @iteration = iteration
@@ -23,9 +25,5 @@ class CreatesDiscussionPost
 
   def solution
     iteration.solution
-  end
-
-  def strong(text)
-    "<strong>#{text}</strong>"
   end
 end

--- a/app/services/creates_discussion_post.rb
+++ b/app/services/creates_discussion_post.rb
@@ -1,8 +1,8 @@
 class CreatesDiscussionPost
-  attr_reader :iteration, :user, :content, :discussion_post
-  def initialize(iteration, user, content)
+  attr_reader :iteration, :author, :content, :discussion_post
+  def initialize(iteration, author, content)
     @iteration = iteration
-    @user = user
+    @author = author
     @content = content
   end
 
@@ -11,7 +11,7 @@ class CreatesDiscussionPost
   def create_discussion_post!
     @discussion_post ||= DiscussionPost.create!(
       iteration: iteration,
-      user: user,
+      user: author,
       content: content,
       html: html
     )

--- a/app/services/creates_iteration.rb
+++ b/app/services/creates_iteration.rb
@@ -43,7 +43,8 @@ class CreatesIteration
         "<strong>#{solution.exercise.track.title}</strong> track has been "\
         "auto approved.",
         Rails.application.routes.url_helpers.my_solution_url(solution),
-        about: solution)
+        about: solution
+      )
     else
       solution.mentorships.update_all(requires_action: true)
       notify_mentors

--- a/app/services/creates_mentor_discussion_post.rb
+++ b/app/services/creates_mentor_discussion_post.rb
@@ -60,8 +60,4 @@ class CreatesMentorDiscussionPost < CreatesDiscussionPost
   def solution
     iteration.solution
   end
-
-  def routes
-    @routes ||= Rails.application.routes.url_helpers
-  end
 end

--- a/app/services/creates_mentor_discussion_post.rb
+++ b/app/services/creates_mentor_discussion_post.rb
@@ -39,7 +39,7 @@ class CreatesMentorDiscussionPost < CreatesDiscussionPost
       # We want this to be the solution not the post
       # to allow for clearing without a mentor having to
       # go into every single iteration
-      about: solution
+      about: iteration
     )
 
     DeliversEmail.deliver!(

--- a/app/services/creates_notification.rb
+++ b/app/services/creates_notification.rb
@@ -6,12 +6,16 @@ class CreatesNotification
     end
   end
 
+  # When adding to this list ensure you've also added to:
+  # - app/helpers/notifications_helper.rb
+
   VALID_NOTIFICATION_TYPES = %i{
+    exercise_auto_approved
     new_discussion_post
     new_reaction
     new_discussion_post_for_mentor
     new_iteration_for_mentor
-    exercise_auto_approved
+    solution_approved
   }
 
   def self.create!(*args)

--- a/app/services/creates_user_discussion_post.rb
+++ b/app/services/creates_user_discussion_post.rb
@@ -39,7 +39,7 @@ class CreatesUserDiscussionPost < CreatesDiscussionPost
         # We want this to be the solution not the post
         # to allow for clearing without a mentor having to
         # go into every single iteration
-        about: solution
+        about: iteration
       )
       DeliversEmail.deliver!(
         mentor,

--- a/app/services/creates_user_discussion_post.rb
+++ b/app/services/creates_user_discussion_post.rb
@@ -52,8 +52,4 @@ class CreatesUserDiscussionPost < CreatesDiscussionPost
   def user_may_comment?
     user == solution.user
   end
-
-  def routes
-    @routes ||= Rails.application.routes.url_helpers
-  end
 end

--- a/app/services/creates_user_discussion_post.rb
+++ b/app/services/creates_user_discussion_post.rb
@@ -3,8 +3,10 @@ class CreatesUserDiscussionPost < CreatesDiscussionPost
     new(*args).create!
   end
 
+  attr_reader :user
   def initialize(iteration, user, content)
-    super
+    @user = user
+    super(iteration, user, content)
   end
 
   # Note: This whole method is pretty racey.

--- a/app/services/delivers_email.rb
+++ b/app/services/delivers_email.rb
@@ -30,6 +30,9 @@ class DeliversEmail
     case mail_type
     when :new_discussion_post
       [:user_notifications, :new_discussion_post]
+    when :solution_approved
+      [:user_notifications, :solution_approved]
+
     when :new_discussion_post_for_mentor
       [:mentor_notifications, :new_discussion_post]
     when :new_iteration_for_mentor

--- a/app/services/html_generation_helpers.rb
+++ b/app/services/html_generation_helpers.rb
@@ -1,0 +1,9 @@
+module HTMLGenerationHelpers
+  def strong(text)
+    "<strong>#{text}</strong>"
+  end
+
+  def routes
+    Rails.application.routes.url_helpers
+  end
+end

--- a/app/views/mentor/discussion_posts/create.js.haml
+++ b/app/views/mentor/discussion_posts/create.js.haml
@@ -6,7 +6,7 @@ Prism.highlightAll()
 
 $('.pass-button').remove()
 
--if @approved
+-if @solution.approved?
   $('.approved').show()
   $('.approve-button').remove()
   $('.approve-and-comment-button').remove()

--- a/app/views/my/communication_preferences/edit.html.haml
+++ b/app/views/my/communication_preferences/edit.html.haml
@@ -29,6 +29,10 @@
         =f.check_box :email_on_new_discussion_post
         %span Email me when a mentor comments on my solution
 
+      =f.label :email_on_solution_approved do
+        =f.check_box :email_on_new_discussion_post
+        %span Email me when a mentor approves my solution
+
       %h2 General Communications
       =f.label :receive_product_updates do
         =f.check_box :receive_product_updates

--- a/app/views/my/communication_preferences/edit.html.haml
+++ b/app/views/my/communication_preferences/edit.html.haml
@@ -30,7 +30,7 @@
         %span Email me when a mentor comments on my solution
 
       =f.label :email_on_solution_approved do
-        =f.check_box :email_on_new_discussion_post
+        =f.check_box :email_on_solution_approved
         %span Email me when a mentor approves my solution
 
       %h2 General Communications

--- a/app/views/onboardings/_general.html.haml
+++ b/app/views/onboardings/_general.html.haml
@@ -34,6 +34,11 @@
     =f.label :email_on_new_discussion_post do
       =f.check_box :email_on_new_discussion_post, checked: true
       .text Email me when a mentor comments on my solution
+
+    =f.label :email_on_solution_approved do
+      =f.check_box :email_on_solution_approved, checked: true
+      .text Email me when a mentor approves my solution
+
   .field
     =f.label :receive_product_updates do
       =f.check_box :receive_product_updates, checked: true

--- a/app/views/user_notifications_mailer/solution_approved.html.haml
+++ b/app/views/user_notifications_mailer/solution_approved.html.haml
@@ -1,0 +1,6 @@
+.content
+  %p Hi there,
+  %p
+    A mentor has approved your solution to #{@solution.exercise.title} on the #{@solution.exercise.track.title} track.
+    You can #{link_to "view it here", [:my, @solution]}.
+

--- a/app/views/user_notifications_mailer/solution_approved.html.haml
+++ b/app/views/user_notifications_mailer/solution_approved.html.haml
@@ -3,4 +3,3 @@
   %p
     A mentor has approved your solution to #{@solution.exercise.title} on the #{@solution.exercise.track.title} track.
     You can #{link_to "view it here", [:my, @solution]}.
-

--- a/app/views/user_notifications_mailer/solution_approved.text.haml
+++ b/app/views/user_notifications_mailer/solution_approved.text.haml
@@ -1,0 +1,3 @@
+Hi there,
+
+A mentor has approved your solution to #{@solution.exercise.title} on the #{@solution.exercise.track.title} track. You can view it here: #{my_solution_url(@solution)}

--- a/db/migrate/20180722190707_add_email_on_solution_approved_to_users.rb
+++ b/db/migrate/20180722190707_add_email_on_solution_approved_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailOnSolutionApprovedToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :communication_preferences, :email_on_solution_approved, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_13_164812) do
+ActiveRecord::Schema.define(version: 2018_07_22_190707) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2018_07_13_164812) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "receive_product_updates", default: true, null: false
+    t.boolean "email_on_solution_approved", default: true, null: false
     t.index ["user_id"], name: "fk_rails_65642a5510"
   end
 
@@ -266,7 +267,18 @@ ActiveRecord::Schema.define(version: 2018_07_13_164812) do
     t.datetime "updated_at", null: false
     t.boolean "mentoring_enabled"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
+    t.index ["approved_by_id"], name: "ihid-5"
+    t.index ["completed_at"], name: "ihid-6"
     t.index ["exercise_id", "user_id"], name: "index_solutions_on_exercise_id_and_user_id", unique: true
+    t.index ["last_updated_by_user_at"], name: "ihid-3"
+    t.index ["num_mentors", "exercise_id", "user_id"], name: "fix-4"
+    t.index ["num_mentors", "exercise_id"], name: "fix-2"
+    t.index ["num_mentors", "last_updated_by_user_at"], name: "ihid-4"
+    t.index ["num_mentors", "user_id", "exercise_id"], name: "fix-5"
+    t.index ["num_mentors", "user_id"], name: "fix-3"
+    t.index ["num_mentors"], name: "ihid-2"
+    t.index ["user_id", "exercise_id", "num_mentors"], name: "fix-6"
+    t.index ["user_id", "exercise_id"], name: "fix-1"
     t.index ["user_id"], name: "fk_rails_f83c42cef4"
     t.index ["uuid"], name: "index_solutions_on_uuid"
   end
@@ -380,6 +392,7 @@ ActiveRecord::Schema.define(version: 2018_07_13_164812) do
     t.datetime "updated_at", null: false
     t.boolean "independent_mode"
     t.datetime "archived_at"
+    t.index ["independent_mode"], name: "ihid-1"
     t.index ["track_id", "user_id"], name: "index_user_tracks_on_track_id_and_user_id", unique: true
     t.index ["user_id"], name: "fk_rails_99e944edbc"
   end

--- a/test/controllers/mentor/discussion_posts_controller_test.rb
+++ b/test/controllers/mentor/discussion_posts_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Mentor::DiscussionPostsControllerTest < ActionDispatch::IntegrationTest
+
+  test "approve calls service" do
+    mentor = create :user
+    track = create :track
+    exercise = create :exercise, track: track
+    create :track_mentorship, user: mentor, track: track
+    solution = create :solution, exercise: exercise
+    iteration = create :iteration, solution: solution
+    content = "The big fat foobar"
+
+    sign_in!(mentor)
+
+    CreatesMentorDiscussionPost.expects(:create!).with(iteration, mentor, content).returns(create(:discussion_post))
+    ApproveSolution.expects(:call).with(solution, mentor)
+    post mentor_discussion_posts_url(iteration_id: iteration,
+                                     discussion_post: {content: content},
+                                     button: "approved"
+                                    ), as: :js
+    assert_response :success
+  end
+end

--- a/test/controllers/mentor/solutions_controller_test.rb
+++ b/test/controllers/mentor/solutions_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
+
+  test "approve calls service" do
+    mentor = create :user
+    track = create :track
+    exercise = create :exercise, track: track
+    create :track_mentorship, user: mentor, track: track
+    solution = create :solution, exercise: exercise
+
+    sign_in!(mentor)
+
+    ApproveSolution.expects(:call).with(solution, mentor)
+    patch approve_mentor_solution_url(solution), as: :js
+    assert_response :success
+  end
+end

--- a/test/controllers/mentor/solutions_controller_test.rb
+++ b/test/controllers/mentor/solutions_controller_test.rb
@@ -15,4 +15,22 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
     patch approve_mentor_solution_url(solution), as: :js
     assert_response :success
   end
+
+  test "show clears notifications" do
+    mentor = create :user
+    track = create :track
+    exercise = create :exercise, track: track
+    create :track_mentorship, user: mentor, track: track
+    solution = create :solution, exercise: exercise
+    iteration = create :iteration, solution: solution
+
+    sign_in!(mentor)
+
+    ClearsNotifications.expects(:clear!).with(mentor, solution)
+    ClearsNotifications.expects(:clear!).with(mentor, iteration)
+
+    get mentor_solution_url(solution)
+    assert_response :success
+  end
+
 end

--- a/test/controllers/my/solutions_controller_test.rb
+++ b/test/controllers/my/solutions_controller_test.rb
@@ -35,6 +35,17 @@ class SolutionsControllerTest < ActionDispatch::IntegrationTest
       assert_correct_page page
     end
   end
+    test "clears notifications" do
+      sign_in!
+      solution = create :solution, user: @current_user
+      iteration = create :iteration, solution: solution
+      create :user_track, user: @current_user, track: solution.exercise.track
+
+      ClearsNotifications.expects(:clear!).with(@current_user, solution)
+      ClearsNotifications.expects(:clear!).with(@current_user, iteration)
+
+      get my_solution_url(solution)
+    end
 
   test "reflects properly" do
     sign_in!

--- a/test/mailers/user_notifications_mailer_test.rb
+++ b/test/mailers/user_notifications_mailer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class NotificationsMailerTest < ActionMailer::TestCase
+class UserNotificationsMailerTest < ActionMailer::TestCase
    test "new_discussion_post" do
     discussion_post = create :discussion_post
     user = discussion_post.iteration.solution.user
@@ -19,5 +19,24 @@ class NotificationsMailerTest < ActionMailer::TestCase
     assert_equal ["hello@exercism.io"], email.from
     assert_equal [user.email], email.to
     assert_equal "[Exercism] A mentor has commented on your solution to #{track_title}/#{exercise_title}", email.subject
+  end
+
+   test "solution_approved" do
+    solution = create :solution
+    user = solution.user
+    mentor = solution.approved_by
+
+    exercise_title = solution.exercise.title
+    track_title = solution.track.title
+
+    email = UserNotificationsMailer.solution_approved(user, solution)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ["hello@exercism.io"], email.from
+    assert_equal [user.email], email.to
+    assert_equal "[Exercism] A mentor has approved your solution to #{track_title}/#{exercise_title}", email.subject
   end
 end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -31,8 +31,8 @@ class ExerciseTest < ActiveSupport::TestCase
            completed_at: Date.new(2016, 12, 25))
 
     assert_equal(
-      [other_core_exercise, side_exercise],
-      Exercise.locked_for(user)
+      [other_core_exercise, side_exercise].sort,
+      Exercise.locked_for(user).sort
     )
   end
 end

--- a/test/services/approve_solution_test.rb
+++ b/test/services/approve_solution_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
+class ApprovesSolutionTest < ActiveSupport::TestCase
   test "approves solution" do
     Timecop.freeze do
       solution = create :solution, last_updated_by_user_at: nil

--- a/test/services/approve_solution_test.rb
+++ b/test/services/approve_solution_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
+  test "approves solution" do
+    Timecop.freeze do
+      solution = create :solution, last_updated_by_user_at: nil
+
+      mentor = create :user
+      create :track_mentorship, user: mentor, track: solution.exercise.track
+      create :solution_mentorship, solution: solution, user: mentor
+
+      ApproveSolution.(solution, mentor)
+
+      solution.reload
+      assert_equal mentor, solution.approved_by
+      assert_nil solution.last_updated_by_user_at
+      assert_equal DateTime.now.to_i, solution.last_updated_by_mentor_at.to_i
+    end
+  end
+
+  test "fails for non-mentor" do
+    refute ApproveSolution.(create(:solution), create(:user))
+  end
+
+  test "fails for mentor of different track" do
+    mentor = create :user
+    create :track_mentorship, user: mentor
+    different_track_solution = create(:solution)
+    refute ApproveSolution.(different_track_solution, mentor)
+  end
+
+  test "notifies and emails user upon mentor post" do
+    solution = create :solution
+    user = solution.user
+
+    # Setup mentor
+    mentor = create :user
+    create :track_mentorship, user: mentor, track: solution.exercise.track
+    create :solution_mentorship, solution: solution, user: mentor
+
+    CreatesNotification.expects(:create!).with do |*args|
+      assert_equal user, args[0]
+      assert_equal :solution_approved, args[1]
+      assert_equal "<strong>#{mentor.handle}</strong> has approved your solution to <strong>#{solution.exercise.title}</strong> on the <strong>#{solution.exercise.track.title}</strong> track.", args[2]
+      assert_equal "https://test.exercism.io/my/solutions/#{solution.uuid}", args[3]
+      assert_equal mentor, args[4][:trigger]
+      assert_equal solution, args[4][:about]
+    end
+
+    DeliversEmail.expects(:deliver!).with do |*args|
+      assert_equal user, args[0]
+      assert_equal :solution_approved, args[1]
+      assert_equal solution, args[2]
+    end
+
+    ApproveSolution.(solution, mentor)
+  end
+
+  test "creates solution_mentorship" do
+    solution = create :solution
+    mentor = create :user
+    create :track_mentorship, user: mentor, track: solution.exercise.track
+
+    CreatesSolutionMentorship.expects(:create).with(solution, mentor).returns(mock(update!: false))
+    ApproveSolution.(solution, mentor)
+  end
+
+  test "cancels a mentor's requires_action when they post" do
+    solution = create :solution
+    mentor = create :user
+    create :track_mentorship, user: mentor, track: solution.exercise.track
+    mentorship = create :solution_mentorship, user: mentor, solution: solution, requires_action: true
+
+    ApproveSolution.(solution, mentor)
+
+    mentorship.reload
+    refute mentorship.requires_action
+  end
+end
+
+

--- a/test/services/creates_mentor_discussion_post_test.rb
+++ b/test/services/creates_mentor_discussion_post_test.rb
@@ -55,11 +55,11 @@ class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
       assert_equal solution, args[4][:about]
     end
 
-    # DeliversEmail.expects(:deliver!).with do |*args|
-    #   assert_equal user, args[0]
-    #   assert_equal :new_discussion_post, args[1]
-    #   assert_equal DiscussionPost, args[2].class
-    # end
+    DeliversEmail.expects(:deliver!).with do |*args|
+      assert_equal user, args[0]
+      assert_equal :new_discussion_post, args[1]
+      assert_equal DiscussionPost, args[2].class
+    end
 
     CreatesMentorDiscussionPost.create!(iteration, mentor1, "foooebar")
   end

--- a/test/services/creates_mentor_discussion_post_test.rb
+++ b/test/services/creates_mentor_discussion_post_test.rb
@@ -40,11 +40,8 @@ class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
 
     # Setup mentors
     mentor1 = create :user
-    mentor2 = create :user
     create :track_mentorship, user: mentor1, track: solution.exercise.track
-    create :track_mentorship, user: mentor2, track: solution.exercise.track
     create :solution_mentorship, solution: solution, user: mentor1
-    create :solution_mentorship, solution: solution, user: mentor2
 
     CreatesNotification.expects(:create!).with do |*args|
       assert_equal user, args[0]

--- a/test/services/creates_mentor_discussion_post_test.rb
+++ b/test/services/creates_mentor_discussion_post_test.rb
@@ -49,7 +49,7 @@ class CreatesMentorDiscussionPostTest < ActiveSupport::TestCase
       assert_equal "<strong>#{mentor1.handle}</strong> has commented on your solution to <strong>#{solution.exercise.title}</strong> on the <strong>#{solution.exercise.track.title}</strong> track.", args[2]
       assert_equal "https://test.exercism.io/my/solutions/#{solution.uuid}/iterations/#{iteration.id}", args[3]
       assert_equal DiscussionPost, args[4][:trigger].class
-      assert_equal solution, args[4][:about]
+      assert_equal iteration, args[4][:about]
     end
 
     DeliversEmail.expects(:deliver!).with do |*args|

--- a/test/services/creates_user_discussion_post_test.rb
+++ b/test/services/creates_user_discussion_post_test.rb
@@ -35,7 +35,7 @@ class CreatesUserDiscussionPostTest < ActiveSupport::TestCase
       assert_equal :new_discussion_post_for_mentor, args[1]
       assert_equal "<strong>#{user.handle}</strong> has posted a comment on a solution you are mentoring", args[2]
       assert_equal "https://test.exercism.io/mentor/solutions/#{solution.uuid}", args[3]
-      assert_equal solution, args[4][:about]
+      assert_equal iteration, args[4][:about]
     end
 
     DeliversEmail.expects(:deliver!).twice.with do |*args|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,3 +52,7 @@ class ActionDispatch::IntegrationTest
     repo
   end
 end
+
+ActionDispatch::IntegrationTest.register_encoder :js,
+  param_encoder: -> params { params },
+  response_parser: -> body { body }


### PR DESCRIPTION
This PR does a few things
- It adds a new notification for when someone's solution is approved
- It adds a corrosponding mailer
- It adds extra behaviour for when people approve without comments, such as properly assigning the solution to them.
- It changes mentor's comment notifications so they're cleared when a mentor looks at the iteration with the comment on, not a different iteration.
- It does some minor refactoring / tidy up.

Fixes https://github.com/exercism/exercism.io/issues/3880
Fixes https://github.com/exercism/exercism.io/issues/3981
Fixes https://github.com/exercism/exercism.io/issues/3978

Probably also fixes loads of other issues I've not managed to find at a quick grok.