### PR TITLE
Show the correct page when rejoining a track

### DIFF
--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -17,6 +17,7 @@ class My::TracksController < MyController
     @track = Track.find(params[:id])
     return redirect_to @track unless user_signed_in?
     return show_not_joined unless current_user.joined_track?(@track)
+    return show_not_joined if current_user.previously_joined_track?(@track)
     solutions = current_user.solutions.includes(:exercise).where('exercises.track_id': @track.id)
     mapped_solutions = solutions.each_with_object({}) {|s,h| h[s.exercise_id] = s }
 

--- a/test/system/join_track_test.rb
+++ b/test/system/join_track_test.rb
@@ -1,6 +1,10 @@
+require "application_system_test_case"
+
 class JoinTrackTest < ApplicationSystemTestCase
   test "user rejoins a track" do
-    user = create(:user)
+    user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
     track = create(:track,
                    title: "Ruby",
                    repo_url: "file://#{Rails.root}/test/fixtures/website-copy")
@@ -24,6 +28,6 @@ class JoinTrackTest < ApplicationSystemTestCase
       click_on "Join the Ruby track"
     end
 
-    within(".exercise.completed") { assert_text "Hello World" }
+    within(".exercise-wrapper.completed") { assert_text "Hello World" }
   end
 end


### PR DESCRIPTION
Issue: https://github.com/exercism/exercism.io/issues/3878

## Description
This PR fixes the bug described above by showing the "track join" page when a user has previously left a track.

## Discussion
1. This was previously written in a system test, but our CI hasn't caught it because we don't run system tests on there. Should we run system tests on our CI?
