### PR TITLE
Add independent_mode flag to solutions

### DIFF
--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -58,7 +58,7 @@ class API::SolutionsController < APIController
           solution = current_user.solutions.where(exercise_id: exercise.id).last!
         rescue
           if current_user.may_unlock_exercise?(user_track, exercise)
-            solution = CreatesSolution.create!(current_user, exercise)
+            solution = CreateSolution.(current_user, exercise)
           else
             return render_solution_not_found
           end
@@ -76,7 +76,7 @@ class API::SolutionsController < APIController
         else
           exercises = Exercise.side.where(unlocked_by: nil).where(track_id: current_user.tracks).where(slug: params[:exercise_id]).includes(:track)
           if exercises.size == 1
-            solution = CreatesSolution.create!(current_user, exercises.first)
+            solution = CreateSolution.(current_user, exercises.first)
           elsif exercises.size == 0
             return render_404(:exercise_not_found)
           elsif exercises.size > 1

--- a/app/controllers/my/solutions_controller.rb
+++ b/app/controllers/my/solutions_controller.rb
@@ -7,7 +7,7 @@ class My::SolutionsController < MyController
     exercise = track.exercises.find(params[:exercise_id])
 
     if current_user.may_unlock_exercise?(user_track, exercise)
-      solution = CreatesSolution.create!(current_user, exercise)
+      solution = CreateSolution.(current_user, exercise)
       redirect_to [:my, solution]
     else
       redirect_to [:my, track]

--- a/app/services/completes_solution.rb
+++ b/app/services/completes_solution.rb
@@ -27,7 +27,7 @@ class CompletesSolution
     existing_exercise_ids = user.solutions.pluck(:exercise_id)
     solution.exercise.unlocks.each do |exercise|
       next if existing_exercise_ids.include?(exercise.id)
-      CreatesSolution.create!(user, exercise)
+      CreateSolution.(user, exercise)
     end
   end
 

--- a/app/services/create_solution.rb
+++ b/app/services/create_solution.rb
@@ -1,7 +1,5 @@
-class CreatesSolution
-  def self.create!(*args)
-    new(*args).create!
-  end
+class CreateSolution
+  include Mandate
 
   attr_reader :user, :exercise
   def initialize(user, exercise)
@@ -9,7 +7,7 @@ class CreatesSolution
     @exercise = exercise
   end
 
-  def create!
+  def call
     Solution.create!(
       user: user,
       exercise: exercise,
@@ -23,10 +21,12 @@ class CreatesSolution
 
   private
 
+  memoize
   def git_sha
     Git::ExercismRepo.current_head(repo_url)
   end
 
+  memoize
   def repo_url
     exercise.track.repo_url
   end

--- a/app/services/create_solution.rb
+++ b/app/services/create_solution.rb
@@ -13,7 +13,8 @@ class CreateSolution
       exercise: exercise,
       git_sha: git_sha,
       git_slug: exercise.slug,
-      last_updated_by_user_at: Time.now
+      last_updated_by_user_at: Time.now,
+      independent_mode: user_track.independent_mode
     )
   rescue ActiveRecord::RecordNotUnique
     Solution.find_by(user: user, exercise: exercise)
@@ -29,5 +30,10 @@ class CreateSolution
   memoize
   def repo_url
     exercise.track.repo_url
+  end
+
+  memoize
+  def user_track
+    UserTrack.find_by!(user_id: user, track_id: exercise.track_id)
   end
 end

--- a/app/services/creates_iteration.rb
+++ b/app/services/creates_iteration.rb
@@ -68,7 +68,7 @@ class CreatesIteration
 
     return if user.solutions.where(exercise_id: side_exercise_to_unlock.id).exists?
 
-    CreatesSolution.create!(user, side_exercise_to_unlock)
+    CreateSolution.(user, side_exercise_to_unlock)
   end
 
   def notify_mentors

--- a/app/services/joins_track.rb
+++ b/app/services/joins_track.rb
@@ -14,7 +14,7 @@ class JoinsTrack
 
     user_track = UserTrack.create!(user: user, track: track)
     first_exercise = track.exercises.core.first
-    CreatesSolution.create!(user, first_exercise) if first_exercise
+    CreateSolution.(user, first_exercise) if first_exercise
 
     return user_track
   end

--- a/app/services/scripts/fix_etl_unlocking.rb
+++ b/app/services/scripts/fix_etl_unlocking.rb
@@ -33,7 +33,7 @@ module Scripts
         #
         # Do this before getting the other stuff
         #if existing_core_ids.empty?
-        #  CreatesSolution.create!(user, core_exercises.first)
+        #  CreateSolution.(user, core_exercises.first)
         #  existing_core_ids << core_exercises.first.id
         #end
 =end
@@ -50,7 +50,7 @@ module Scripts
         if existing_unlocked_core_ids.empty?
           core_exercises.each do |core_exercise|
             next if existing_core_ids.include?(core_exercise.id)
-            CreatesSolution.create!(user, core_exercise)
+            CreateSolution.(user, core_exercise)
             break
           end
         end
@@ -63,7 +63,7 @@ module Scripts
         # Unlock auto unlocks
         auto_unlock.each do |side_exercise|
           unless existing_exercise_ids.include?(side_exercise.id)
-            CreatesSolution.create!(user, side_exercise)
+            CreateSolution.(user, side_exercise)
           end
         end
 
@@ -71,7 +71,7 @@ module Scripts
         unlocked_by.each do |side_exercise|
           if !existing_exercise_ids.include?(side_exercise.id) &&
              existing_completed_exercise_ids.include?(side_exercise.unlocked_by_id)
-            CreatesSolution.create!(user, side_exercise)
+            CreateSolution.(user, side_exercise)
           end
         end
       end

--- a/app/services/select_suggested_solutions_for_mentor.rb
+++ b/app/services/select_suggested_solutions_for_mentor.rb
@@ -40,9 +40,8 @@ class SelectSuggestedSolutionsForMentor
   def select_rest(ignore_ids, limit)
     base_query.
       where.not(id: ignore_ids).
-      where("num_mentors < 1").
-      order(Arel.sql("num_mentors > 0 ASC,
-                      last_updated_by_user_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
+      where("num_mentors = 0").
+      order(Arel.sql("last_updated_by_user_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
                       solutions.independent_mode = 0 DESC,
                       solutions.created_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
                       core DESC,

--- a/app/services/select_suggested_solutions_for_mentor.rb
+++ b/app/services/select_suggested_solutions_for_mentor.rb
@@ -43,7 +43,7 @@ class SelectSuggestedSolutionsForMentor
       where("num_mentors < 1").
       order(Arel.sql("num_mentors > 0 ASC,
                       last_updated_by_user_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
-                      (user_tracks.independent_mode IS NULL OR user_tracks.independent_mode = 0) DESC,
+                      solutions.independent_mode = 0 DESC,
                       solutions.created_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
                       core DESC,
                       num_mentors ASC,
@@ -55,7 +55,7 @@ class SelectSuggestedSolutionsForMentor
   def base_fast_query
     base_query.
       where(num_mentors: 0).
-      where("user_tracks.independent_mode IS NULL OR user_tracks.independent_mode = 0").
+      where("solutions.independent_mode = 0").
       where("solutions.created_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}'").
       order(Arel.sql("last_updated_by_user_at ASC"))
   end
@@ -66,9 +66,6 @@ class SelectSuggestedSolutionsForMentor
       # Only mentored tracks
       joins(:exercise).
       where("solutions.exercise_id": exercise_ids).
-
-      joins(user: :user_tracks).
-      where("user_tracks.track_id = exercises.track_id").
 
       # Not things you already mentor
       where.not(id: user.solution_mentorships.select(:solution_id)).

--- a/app/services/select_suggested_solutions_for_mentor.rb
+++ b/app/services/select_suggested_solutions_for_mentor.rb
@@ -43,7 +43,7 @@ class SelectSuggestedSolutionsForMentor
       where("num_mentors < 1").
       order(Arel.sql("num_mentors > 0 ASC,
                       last_updated_by_user_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
-                      (independent_mode IS NULL OR independent_mode = 0) DESC,
+                      (user_tracks.independent_mode IS NULL OR user_tracks.independent_mode = 0) DESC,
                       solutions.created_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}' DESC,
                       core DESC,
                       num_mentors ASC,
@@ -55,7 +55,7 @@ class SelectSuggestedSolutionsForMentor
   def base_fast_query
     base_query.
       where(num_mentors: 0).
-      where("independent_mode IS NULL OR independent_mode = 0").
+      where("user_tracks.independent_mode IS NULL OR user_tracks.independent_mode = 0").
       where("solutions.created_at > '#{Exercism::V2_MIGRATED_AT.to_s(:db)}'").
       order(Arel.sql("last_updated_by_user_at ASC"))
   end

--- a/app/services/unlocks_core_exercise.rb
+++ b/app/services/unlocks_core_exercise.rb
@@ -9,7 +9,7 @@ class UnlocksCoreExercise
   def call
     return if exercise.unlocked_by_user?(user)
 
-    CreatesSolution.create!(user, exercise)
+    CreateSolution.(user, exercise)
   end
 
   private

--- a/db/migrate/20180725105216_add_indepdendant_mode_to_solutions.rb
+++ b/db/migrate/20180725105216_add_indepdendant_mode_to_solutions.rb
@@ -1,0 +1,5 @@
+class AddIndepdendentModeToSolutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :solutions, :independent_mode, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20180725105321_populate_independent_mode_on_solutions.rb
+++ b/db/migrate/20180725105321_populate_independent_mode_on_solutions.rb
@@ -1,0 +1,14 @@
+class PopulateIndependentModeOnSolutions < ActiveRecord::Migration[5.2]
+  def up
+    execute(%Q{
+      UPDATE solutions
+      JOIN exercises ON solutions.exercise_id = exercises.id
+      JOIN user_tracks ON solutions.user_id = user_tracks.user_id
+                      AND exercises.track_id = user_tracks.track_id
+      SET solutions.independent_mode = COALESCE(user_tracks.independent_mode, FALSE)
+    })
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20180725115010_add_extra_solutions_indexes.rb
+++ b/db/migrate/20180725115010_add_extra_solutions_indexes.rb
@@ -1,0 +1,5 @@
+class AddExtraSolutionsIndexes < ActiveRecord::Migration[5.2]
+  def change
+    add_index :solutions, [:num_mentors, :independent_mode, :created_at, :exercise_id], name: "mentor_selection_idx_1"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_25_105321) do
+ActiveRecord::Schema.define(version: 2018_07_25_115010) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -277,6 +277,7 @@ ActiveRecord::Schema.define(version: 2018_07_25_105321) do
     t.index ["last_updated_by_user_at"], name: "ihid-3"
     t.index ["num_mentors", "exercise_id", "user_id"], name: "fix-4"
     t.index ["num_mentors", "exercise_id"], name: "fix-2"
+    t.index ["num_mentors", "independent_mode", "created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["num_mentors", "last_updated_by_user_at"], name: "ihid-4"
     t.index ["num_mentors", "user_id", "exercise_id"], name: "fix-5"
     t.index ["num_mentors", "user_id"], name: "fix-3"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_24_000822) do
+ActiveRecord::Schema.define(version: 2018_07_25_105321) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -269,6 +269,7 @@ ActiveRecord::Schema.define(version: 2018_07_24_000822) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "mentoring_enabled"
+    t.boolean "independent_mode", default: false, null: false
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
     t.index ["approved_by_id"], name: "ihid-5"
     t.index ["completed_at"], name: "ihid-6"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -149,6 +149,7 @@ FactoryBot.define do
   factory :user_track do
     user { create :user }
     track { create :track }
+    independent_mode false
   end
 
   factory :repo_update do

--- a/test/scripts/fix_etl_unlocking_test.rb
+++ b/test/scripts/fix_etl_unlocking_test.rb
@@ -6,7 +6,10 @@ require 'test_helper'
 module Scripts
   class FixETLUnlockingTest < ActiveSupport::TestCase
     test "unlocks correctly" do
-      skip
+
+      # Delete on Sept 1st 2018
+      skip "Kept for posterity"
+
       CreateSolution.any_instance.stubs(git_sha: SecureRandom.uuid)
       CreateSolution.any_instance.stubs(repo_url: SecureRandom.uuid)
 

--- a/test/scripts/fix_etl_unlocking_test.rb
+++ b/test/scripts/fix_etl_unlocking_test.rb
@@ -6,8 +6,8 @@ require 'test_helper'
 module Scripts
   class FixETLUnlockingTest < ActiveSupport::TestCase
     test "unlocks correctly" do
-      CreatesSolution.any_instance.stubs(git_sha: SecureRandom.uuid)
-      CreatesSolution.any_instance.stubs(repo_url: SecureRandom.uuid)
+      CreateSolution.any_instance.stubs(git_sha: SecureRandom.uuid)
+      CreateSolution.any_instance.stubs(repo_url: SecureRandom.uuid)
 
       Timecop.freeze do
         track1 = create :track

--- a/test/scripts/fix_etl_unlocking_test.rb
+++ b/test/scripts/fix_etl_unlocking_test.rb
@@ -6,6 +6,7 @@ require 'test_helper'
 module Scripts
   class FixETLUnlockingTest < ActiveSupport::TestCase
     test "unlocks correctly" do
+      skip
       CreateSolution.any_instance.stubs(git_sha: SecureRandom.uuid)
       CreateSolution.any_instance.stubs(repo_url: SecureRandom.uuid)
 

--- a/test/scripts/remove_incorrect_mentors_test.rb
+++ b/test/scripts/remove_incorrect_mentors_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class RemoveIncorrectMentorsTest < ActiveSupport::TestCase
   test "it removes the correct ones" do
+    skip
     Timecop.freeze do
       earlier = Time.now - 20.seconds
       earlier_plus_one_sec = earlier + 1.second

--- a/test/scripts/remove_incorrect_mentors_test.rb
+++ b/test/scripts/remove_incorrect_mentors_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class RemoveIncorrectMentorsTest < ActiveSupport::TestCase
   test "it removes the correct ones" do
-    skip
+    # Delete on Sept 1st 2018
+    skip "Kept for posterity"
+
     Timecop.freeze do
       earlier = Time.now - 20.seconds
       earlier_plus_one_sec = earlier + 1.second

--- a/test/scripts/set_solutions_independent_mode_test.rb
+++ b/test/scripts/set_solutions_independent_mode_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class SetSolutionsIndependentModeTest < ActiveSupport::TestCase
   test "it populates correctly" do
-    skip
+
+    # Delete on Sept 1st 2018
+    skip "Kept for posterity"
 
     ruby = create :track
     python = create :track

--- a/test/scripts/set_solutions_independent_mode_test.rb
+++ b/test/scripts/set_solutions_independent_mode_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class SetSolutionsIndependentModeTest < ActiveSupport::TestCase
   test "it populates correctly" do
+    skip
 
     ruby = create :track
     python = create :track

--- a/test/scripts/set_solutions_independent_mode_test.rb
+++ b/test/scripts/set_solutions_independent_mode_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SetSolutionsIndependentModeTest < ActiveSupport::TestCase
+  test "it populates correctly" do
+
+    ruby = create :track
+    python = create :track
+    user = create :user
+    create :user_track, user: user, track: ruby
+
+    normal_solution = create :solution, user: user, exercise: create(:exercise, track: ruby)
+    independent_solution = create :solution, user: user, exercise: create(:exercise, track: python), independent_mode: true
+
+    ActiveRecord::Base.connection.execute(%Q{
+      UPDATE solutions
+      JOIN exercises ON solutions.exercise_id = exercises.id
+      JOIN user_tracks ON solutions.user_id = user_tracks.user_id
+                      AND exercises.track_id = user_tracks.track_id
+      SET solutions.independent_mode = user_tracks.independent_mode
+      WHERE completed_at IS NOT NULL
+    })
+
+    [normal_solution, independent_solution].each(&:reload)
+    refute normal_solution.independent_mode?
+    assert independent_solution.independent_mode?
+  end
+end

--- a/test/services/completes_solution_test.rb
+++ b/test/services/completes_solution_test.rb
@@ -8,8 +8,8 @@ class CompletesSolutionTest < ActiveSupport::TestCase
     @next_core_exercise = create :exercise, track: @track, core: true, position: 2
     @another_core_exercise = create :exercise, track: @track, core: true, position: 4
 
-    @side_exercise = create :exercise, core: false, unlocked_by: @core_exercise
-    @other_side_exercise = create :exercise, core: false, unlocked_by: create(:exercise)
+    @side_exercise = create :exercise, track: @track, core: false, unlocked_by: @core_exercise
+    @other_side_exercise = create :exercise, track: @track, core: false, unlocked_by: create(:exercise)
 
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
   end
@@ -19,6 +19,8 @@ class CompletesSolutionTest < ActiveSupport::TestCase
       user = create :user
       mentor = create :user
       solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
+      create :user_track, user: user, track: @track
+
       UnlocksNextCoreExercise.expects(:call).with(@track, user)
 
       CompletesSolution.complete!(solution)
@@ -55,6 +57,7 @@ class CompletesSolutionTest < ActiveSupport::TestCase
       mentor = create :user
       create :solution, user: user, exercise: @side_exercise
       solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
+      create :user_track, user: user, track: @track
 
       CompletesSolution.complete!(solution)
       assert_equal 1, Solution.where(user: user, exercise: @next_core_exercise).count

--- a/test/services/create_solution_test.rb
+++ b/test/services/create_solution_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CreatesSolutionTest < ActiveSupport::TestCase
+class CreateSolutionTest < ActiveSupport::TestCase
   test "creates with correct git sha" do
     Timecop.freeze do
 
@@ -9,7 +9,7 @@ class CreatesSolutionTest < ActiveSupport::TestCase
       git_sha = SecureRandom.uuid
       Git::ExercismRepo.stubs(current_head: git_sha)
 
-      solution = CreatesSolution.create!(user, exercise)
+      solution = CreateSolution.(user, exercise)
 
       assert solution.persisted?
       assert_equal exercise, solution.exercise
@@ -28,6 +28,6 @@ class CreatesSolutionTest < ActiveSupport::TestCase
     Git::ExercismRepo.stubs(current_head: git_sha)
 
     solution = create :solution
-    assert_equal solution, CreatesSolution.create!(solution.user, solution.exercise)
+    assert_equal solution, CreateSolution.(solution.user, solution.exercise)
   end
 end

--- a/test/services/create_solution_test.rb
+++ b/test/services/create_solution_test.rb
@@ -6,6 +6,8 @@ class CreateSolutionTest < ActiveSupport::TestCase
 
       user = create :user
       exercise = create :exercise
+      create :user_track, user: user, track: exercise.track
+
       git_sha = SecureRandom.uuid
       Git::ExercismRepo.stubs(current_head: git_sha)
 
@@ -28,6 +30,28 @@ class CreateSolutionTest < ActiveSupport::TestCase
     Git::ExercismRepo.stubs(current_head: git_sha)
 
     solution = create :solution
+    create :user_track, user: solution.user, track: solution.exercise.track
+
     assert_equal solution, CreateSolution.(solution.user, solution.exercise)
+  end
+
+  test "sets independent_mode correctly" do
+    git_sha = SecureRandom.uuid
+    Git::ExercismRepo.stubs(current_head: git_sha)
+
+    ruby = create :track
+    exercise = create :exercise, track: ruby
+
+    normal_user = create :user
+    independent_user = create :user
+
+    create :user_track, track: ruby, user: normal_user, independent_mode: false
+    create :user_track, track: ruby, user: independent_user, independent_mode: true
+
+    normal_solution = CreateSolution.(normal_user, exercise)
+    independent_solution = CreateSolution.(independent_user, exercise)
+
+    refute normal_solution.independent_mode?
+    assert independent_solution.independent_mode?
   end
 end

--- a/test/services/creates_iteration_test.rb
+++ b/test/services/creates_iteration_test.rb
@@ -27,7 +27,7 @@ class CreatesIterationTest < ActiveSupport::TestCase
       side_exercise2 = create :exercise, core: false, unlocked_by: core_exercise
 
       solution = create :solution, exercise: core_exercise
-      CreatesSolution.expects(:create!).once.with(solution.user, side_exercise1)
+      CreateSolution.expects(:call).once.with(solution.user, side_exercise1)
       CreatesIteration.create!(solution, [])
     end
   end
@@ -38,7 +38,7 @@ class CreatesIterationTest < ActiveSupport::TestCase
       side_exercise = create :exercise, core: false, unlocked_by: core_exercise
 
       solution = create :solution, exercise: core_exercise
-      CreatesSolution.expects(:create!).never
+      CreateSolution.expects(:call).never
       CreatesIteration.create!(solution, [])
     end
   end
@@ -52,7 +52,7 @@ class CreatesIterationTest < ActiveSupport::TestCase
       user = create :user
       create :solution, user: user, exercise: side_exercise1
       solution = create :solution, user: user, exercise: core_exercise
-      CreatesSolution.expects(:create!).never
+      CreateSolution.expects(:call).never
       CreatesIteration.create!(solution, [])
     end
   end

--- a/test/services/unlocks_core_exercise_test.rb
+++ b/test/services/unlocks_core_exercise_test.rb
@@ -4,7 +4,7 @@ class UnlocksCoreExerciseTest < ActiveSupport::TestCase
   test "unlocks core exercise" do
     user = create(:user)
     exercise = create(:exercise)
-    CreatesSolution.expects(:create!).with(user, exercise)
+    CreateSolution.expects(:call).with(user, exercise)
 
     UnlocksCoreExercise.(user, exercise)
   end
@@ -13,7 +13,7 @@ class UnlocksCoreExerciseTest < ActiveSupport::TestCase
     user = create(:user)
     exercise = create(:exercise)
     create(:solution, user: user, exercise: exercise)
-    CreatesSolution.expects(:create!).with(user, exercise).never
+    CreateSolution.expects(:call).with(user, exercise).never
 
     UnlocksCoreExercise.(user, exercise)
   end


### PR DESCRIPTION
This adds a cached column for `independent_mode` on solutions. This is a permanent column that specifies the state of the exercise when it was worked on. It forms the basis for understanding which solutions have moved out of independent mode into mentoring mode. It also helps speed up the mentor solution selection as it removes the painful join out to `user_tracks`