### PR TITLE
Fixed broken "Publish your solution" link

### DIFF
--- a/app/views/my/solutions/show.html.haml
+++ b/app/views/my/solutions/show.html.haml
@@ -22,7 +22,7 @@
           -else
             .notification
               Well done! Your solution is completed.
-              =link_to "Publish your solution", [:publish, :my, @solution], method: :patch
+              =link_to "Publish your solution", [:publish, :my, @solution, publish: 1], method: :patch
 
         -elsif @solution.approved?
           -if @solution.exercise.auto_approve?


### PR DESCRIPTION
When first having the option to publish a solution, there is a hidden field in the form which sets `publish: 1`: https://github.com/exercism/website/blob/366a6d45f8c5edd11755b7fc80d245c384d108cf/app/views/my/solutions/reflection/_publish_solution_form.html.haml#L4

This is checked in the controller (will only publish if the publish field is set): https://github.com/exercism/website/blob/a2d48b43e1ac1a285a11d4668aaa8b713c9604d5/app/controllers/my/solutions_controller.rb#L105

If the user does not publish immediately, and uses the "Publish your solution" link later, this functionality does not work as the `publish` parameter is not set - this pull request adds the parameter