### PR TITLE
Upgrade font-awesome to v5.2

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,8 @@
   %head
     =stylesheet_link_tag 'application', media: 'all'
     =stylesheet_link_tag '//fonts.googleapis.com/css?family=Dosis:600,700,800'
-    =stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'
+    =stylesheet_link_tag '//use.fontawesome.com/releases/v5.2.0/css/all.css'
+    =stylesheet_link_tag '//use.fontawesome.com/releases/v5.2.0/css/v4-shims.css'
 
     =render "layouts/meta_tags"
     =csrf_meta_tags

--- a/app/views/layouts/teams.html.haml
+++ b/app/views/layouts/teams.html.haml
@@ -3,7 +3,8 @@
   %head
     =stylesheet_link_tag 'application', media: 'all'
     =stylesheet_link_tag '//fonts.googleapis.com/css?family=Lato:100,300,400,700,900|Montserrat+Alternates:400,700|Dosis:600,700,800'
-    =stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'
+    =stylesheet_link_tag '//use.fontawesome.com/releases/v5.2.0/css/all.css'
+    =stylesheet_link_tag '//use.fontawesome.com/releases/v5.2.0/css/v4-shims.css'
 
     =render "layouts/meta_tags"
     =csrf_meta_tags


### PR DESCRIPTION
Using `v4-shims` to avoid renaming all icon classes from `fa` to `fas/fal/fab` in v5. This should keep the look and feel as is.

Ref: https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#shims

Closes https://github.com/exercism/exercism.io/issues/4071