### PR TITLE
Update number of exercises when sorting by track on profile page

### DIFF
--- a/app/views/profiles/solutions.js.haml
+++ b/app/views/profiles/solutions.js.haml
@@ -1,1 +1,3 @@
 $('.solutions').html('#{j render "solutions", solutions: @solutions, reaction_counts: @reaction_counts, comment_counts: @comment_counts}')
+
+$('.num-solutions').html('Showing #{pluralize @solutions.size, "solution"}')

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  test "successfully loads solutions for profile" do
+    sign_in!
+    user = @current_user
+    track = create(:track)
+
+    create(:user_track, track: track, user: user)
+    create(:profile, user: user)
+
+    solution = create(:solution,
+                       user: user,
+                       exercise: create(:exercise, title: "Exercise 1", track: track),
+                       published_at: Date.new(2016, 12, 25))
+
+    get solutions_profile_path(user.handle), params: {
+      track_id: track.id,
+      format: :js
+    },
+    xhr: true
+
+    assert_response :success
+    assert_equal assigns(:solutions), [solution]
+  end
+end


### PR DESCRIPTION
On the profile page if you select a track from the drop-down menu the "Showing x solutions" text does not change even though the number of solutions being displayed does. This pull request fixes that.