### PR TITLE
Fix profile web urls

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,13 @@ module ApplicationHelper
     return false if current_user.admin? || current_user.test_user?
     true
   end
+
+  def url_with_protocol(url)
+    return url if url.starts_with? "https://"
+    if url.starts_with? "http://"
+      url.sub("http://", "https://")
+    else
+      "https://#{url}"
+    end
+  end
 end

--- a/app/views/my/profile/_edit_modal.html.haml
+++ b/app/views/my/profile/_edit_modal.html.haml
@@ -28,7 +28,7 @@
           =f.text_field :github, placeholder: "handle"
         .field
           %i.fa.fa-linkedin
-          =f.text_field :linkedin, placeholder: "Your Linkedin"
+          =f.text_field :linkedin, placeholder: "Your Linkedin Public Profile URL"
         .field.medium
           %i.fa.fa-medium
           =f.text_field :medium, placeholder: "handle"

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -57,7 +57,7 @@
                 %span Twitter
 
             -if @profile.linkedin.present?
-              =link_to "https://" + @profile.linkedin, target: "_blank", class: 'external-link' do
+              =link_to url_with_protocol(@profile.linkedin), target: "_blank", class: 'external-link' do
                 =graphical_icon 'linkedin fa-fw'
                 %span LinkedIn
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -62,7 +62,7 @@
                 %span LinkedIn
 
             -if @profile.medium.present?
-              =link_to "https://medium.com/#{@profile.medium}", target: "_blank", class: 'external-link' do
+              =link_to "https://medium.com/@#{@profile.medium}", target: "_blank", class: 'external-link' do
                 =graphical_icon 'medium fa-fw'
                 %span Medium
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -57,7 +57,7 @@
                 %span Twitter
 
             -if @profile.linkedin.present?
-              =link_to @profile.linkedin, target: "_blank", class: 'external-link' do
+              =link_to "https://" + @profile.linkedin, target: "_blank", class: 'external-link' do
                 =graphical_icon 'linkedin fa-fw'
                 %span LinkedIn
 

--- a/test/helpers/application_helper.rb
+++ b/test/helpers/application_helper.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "url_with_protocol adds https to the url" do
+    assert_equal "https://linkedin.com/in/alice",
+                 url_with_protocol("linkedin.com/in/alice")
+  end
+
+  test "url_with_protocol returns http url with https" do
+    assert_equal "https://linkedin.com/in/alice",
+                 url_with_protocol("http://linkedin.com/in/alice")
+  end
+
+  test "url_with_protocol returns https url without change" do
+    assert_equal "https://linkedin.com/in/alice",
+                 url_with_protocol("https://linkedin.com/in/alice")
+  end
+end


### PR DESCRIPTION
* Fix linkedin URL tag to consider it is an external URL.
* Change text in linkedin URL input field to mention full URL.
* Fix medium URLs in profile.

Closes https://github.com/exercism/exercism.io/issues/4082