### PR TITLE
Add BootstrapUser to seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 ihid = User.create!(name: "Jeremy Walker", handle: 'iHiD', email: "jeremy@thalamus.ai", password: 'password', admin: true)
+BootstrapUser.(ihid)
 
 # Seed tracks
 Git::SeedsTracks.seed!


### PR DESCRIPTION
The user created by seeds.rb does not call any methods in devise's registrations controller, and therefore does not have any access tokens generated - this causes the my-settings page to raise an error at line:

https://github.com/exercism/website/blob/a7af64811aa0573439479592b20e2a7aff5669df/app/models/user.rb#L69