### PR TITLE
Changed solution page to only show one continue

### DIFF
--- a/app/views/my/solutions/_show_rhs.html.haml
+++ b/app/views/my/solutions/_show_rhs.html.haml
@@ -6,7 +6,7 @@
   -if @solution.completed?
     =render "show_completed"
 
-  -elsif @solution.approved?
+  -elsif @solution.approved? && !@exercise.auto_approve?
     =render "show_approved"
 
   .discussion


### PR DESCRIPTION
The solution page would show two continue buttons/widgets if the exercise was automatically approved