### PR TITLE
Delete solutions when leaving a track

### DIFF
--- a/app/views/my/tracks/_leave_track_modal.html.haml
+++ b/app/views/my/tracks/_leave_track_modal.html.haml
@@ -2,7 +2,11 @@
 .main-section
   %h2 Leave the #{track.title} Track
 
-  %p Leaving this track will remove it from your list of tracks and remove your progress. Are you sure you want to continue?
+  %p
+    Leaving this track will remove it from your list of tracks and
+    %strong permanently delete all your solutions.
+    An alternative, non-destructive option to pause tracks is coming soon.
+  %p Are you sure you want to continue?
   .buttons
     =link_to "Leave Track", leave_my_user_track_path(@user_track), method: :post, class: 'pure-button action-button'
     =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"


### PR DESCRIPTION
Closes https://github.com/exercism/exercism.io/issues/3986.

## Description
Instead of preserving solutions when leaving a track, delete them instead.