### PR TITLE
Temporarily removing exercise time labels

### DIFF
--- a/app/views/exercises/index.html.haml
+++ b/app/views/exercises/index.html.haml
@@ -37,7 +37,8 @@
                 -length_word = exercise_length_word(exercise)
                 -difficulty_word = exercise_difficulty_word(exercise)
                 .stats
-                  .length{class: length_word}= length_word
+                  -# TODO: Uncomment this when exercise_length_word has been fix to no longer return medium by default
+                  -# .length{class: length_word}= length_word
                   .difficulty{class: difficulty_word}= difficulty_word
                 %h3= exercise.title
                 .details

--- a/app/views/exercises/show.html.haml
+++ b/app/views/exercises/show.html.haml
@@ -28,7 +28,8 @@
       -length_word = exercise_length_word(@exercise)
       -difficulty_word = exercise_difficulty_word(@exercise)
       .difficulty{class: difficulty_word}= difficulty_word
-      .length{class: length_word}= length_word
+      -# TODO: Uncomment this when exercise_length_word has been fix to no longer return medium by default
+      -# .length{class: length_word}= length_word
 
       %p.blurb= @exercise.blurb
       .topics

--- a/app/views/my/side_exercises/_exercise.html.haml
+++ b/app/views/my/side_exercises/_exercise.html.haml
@@ -19,7 +19,8 @@
   -length_word = exercise_length_word(exercise)
   -difficulty_word = exercise_difficulty_word(exercise)
   .stats
-    .length{class: length_word}= length_word
+    -# TODO: Uncomment this when exercise_length_word has been fix to no longer return medium by default
+    -# .length{class: length_word}= length_word
     .difficulty{class: difficulty_word}= difficulty_word
   .topics
     -if exercise.topic_names.size > 0

--- a/app/views/teams/teams/my_solutions/_possible_exercises.html.haml
+++ b/app/views/teams/teams/my_solutions/_possible_exercises.html.haml
@@ -10,7 +10,8 @@
         -length_word = exercise_length_word(exercise)
         -difficulty_word = exercise_difficulty_word(exercise)
         .stats
-          .length{class: length_word}= length_word
+          -# TODO: Uncomment this when exercise_length_word has been fix to no longer return medium by default
+          -# .length{class: length_word}= length_word
           .difficulty{class: difficulty_word}= difficulty_word
 
 =button_tag "Start exercise", class: 'pure-button'


### PR DESCRIPTION
Resolves https://github.com/exercism/exercism.io/issues/3804

Instead of deleting the code to show the length of exercises, I am just commenting it out for now so that once the data for `exercise.length` is set, this feature can be toggled on again.

I tried fixing the `exercise_length_word` method however looking at the data my local instance has a length of 1.

```
execises = Exercise.all.pluck(:length)
```

### Before
<img width="1120" alt="2018-08-03_13-05-36" src="https://user-images.githubusercontent.com/1518902/43664968-8b9a9004-9723-11e8-820d-4f2ddf533b8d.png">

### After
<img width="1122" alt="2018-08-03_13-13-27" src="https://user-images.githubusercontent.com/1518902/43664973-926befa4-9723-11e8-8eaa-be164e065dce.png">