### PR TITLE
Fixed broken resending of confirmation emails

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,14 +1,7 @@
 class ConfirmationsController < Devise::ConfirmationsController
   layout :layout_from_site_context
 
-  def create
-  end
-
   def required
   end
 
-  private
-
-  def after_resending_confirmation_instructions_path_for
-  end
 end


### PR DESCRIPTION
I've removed the `create` and `after_resending_confirmation_instructions_path_for` methods from `ConfirmationsController`, which neither called `super` nor took action to send any emails.

Fixes exercism/exercism.io#4152