### PR TITLE
Catch exceptions in syncing and looping services

### DIFF
--- a/app/services/git/fetches_updated_repos.rb
+++ b/app/services/git/fetches_updated_repos.rb
@@ -18,7 +18,13 @@ class Git::FetchesUpdatedRepos
   end
 
   def fetch
-    repo_updates.each { |update| FetchRepoUpdateJob.perform_now(update.id) }
+    repo_updates.each do |update|
+      begin
+        FetchRepoUpdateJob.perform_now(update.id)
+      rescue => exception
+        Bugsnag.notify(exception)
+      end
+    end
   end
 
   private

--- a/app/services/git/syncs_updated_repos.rb
+++ b/app/services/git/syncs_updated_repos.rb
@@ -22,7 +22,13 @@ class Git::SyncsUpdatedRepos
 
   def sync
     stdout.puts "Syncing outstanding repos"
-    repo_updates.each { |update| SyncRepoUpdateJob.perform_now(update.id) }
+    repo_updates.each do |update|
+      begin
+        SyncRepoUpdateJob.perform_now(update.id)
+      rescue => exception
+        Bugsnag.notify(exception)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
When the exceptions aren't caught, the syncing and fetching stops.