### PR TITLE
Remove duplicate header

### DIFF
--- a/app/models/git/exercise.rb
+++ b/app/models/git/exercise.rb
@@ -1,13 +1,16 @@
 class Git::Exercise
-  attr_reader :track, :git_slug, :git_sha
+  attr_reader :track, :title, :git_slug, :git_sha
   def initialize(exercise, git_slug, git_sha)
     @track = exercise.track
+    @title = exercise.title
     @git_slug = git_slug
     @git_sha = git_sha
   end
 
   def instructions
-    ParseMarkdown.(exercise_reader.readme)
+    lines = exercise_reader.readme.lines
+    lines.shift if /^#\s*#{@title}\s*$/.match? lines.first
+    ParseMarkdown.(lines.join("\n"))
   end
 
   def test_suite

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -1,9 +1,35 @@
 require 'test_helper'
 
-# TODOGIT
 class GitExerciseTest < ActiveSupport::TestCase
-  test "test instructions" do
-    skip
+  test "test instructions leaves title if it doesn't match" do
+    exercise = create :exercise, title: 'foobar'
+
+    readme_lines = ["# barfoo", "### Something else", "Here"]
+
+    readme = mock(lines: readme_lines)
+    exercise_reader = mock(readme: readme)
+
+    git_exercise = Git::Exercise.new(exercise, nil, nil)
+    git_exercise.expects(:exercise_reader).returns(exercise_reader)
+
+    expected = ParseMarkdown.(readme_lines.join("\n"))
+    assert_equal expected, git_exercise.instructions
+  end
+
+  test "test instructions removes title if it matches" do
+    exercise = create :exercise, title: 'foobar'
+
+    original_readme_lines = ["# foobar", "### Something else", "Here"]
+    modified_readme_lines = ["### Something else", "Here"]
+
+    readme = mock(lines: original_readme_lines)
+    exercise_reader = mock(readme: readme)
+
+    git_exercise = Git::Exercise.new(exercise, nil, nil)
+    git_exercise.expects(:exercise_reader).returns(exercise_reader)
+
+    expected = ParseMarkdown.(modified_readme_lines.join("\n"))
+    assert_equal expected, git_exercise.instructions
   end
 
   test "test returns test_suite" do


### PR DESCRIPTION
This is a possible solution to exercism/exercism#3812. Basically, it removes the first line from the markdown if the first line consists of nothing more than a '#' character followed by the title of the exercise.