### PR TITLE
Display information about unlocked exercises

### DIFF
--- a/app/assets/javascripts/my-track-mentored.js
+++ b/app/assets/javascripts/my-track-mentored.js
@@ -1,0 +1,16 @@
+window.setupMyTrackMentored = function() {
+  const $unlockedExercises = $(".core-exercises .unlocked-exercises")
+  $unlockedExercises.find("a.unlocked-exercise").each(function(idx, el){
+    const $el = $(el)
+    const title = $el.data("title")
+    const status = $el.data("status")
+    const section = $unlockedExercises.siblings("h3")
+    $el.hover(
+      function(){
+        section.html("<strong>" + title + "</strong>: " + status)
+      },
+      function(){
+        section.text("You've unlocked extra exercises!")
+      })
+  });
+}

--- a/app/assets/javascripts/my-track-mentored.js
+++ b/app/assets/javascripts/my-track-mentored.js
@@ -1,10 +1,9 @@
 window.setupMyTrackMentored = function() {
-  const $unlockedExercises = $(".core-exercises .unlocked-exercises")
-  $unlockedExercises.find("a.unlocked-exercise").each(function(idx, el){
+  $(".core-exercises .unlocked-exercises a.unlocked-exercise").each(function(idx, el){
     const $el = $(el)
     const title = $el.data("title")
     const status = $el.data("status")
-    const section = $unlockedExercises.siblings("h3")
+    const section = $el.parents(".unlocked-exercises").siblings("h3")
     $el.hover(
       function(){
         section.html("<strong>" + title + "</strong>: " + status)

--- a/app/assets/stylesheets/pages/my-track/show.scss
+++ b/app/assets/stylesheets/pages/my-track/show.scss
@@ -311,6 +311,9 @@ body.namespace-my.controller-tracks.action-show {
                 font-weight:$regular;
                 padding:7px 20px;
                 @include font-size(13,13);
+                strong {
+                    font-weight:$bold;
+                }
             }
             .unlocked-exercises {
                 padding:10px 20px 5px;

--- a/app/views/my/tracks/_core_exercises.html.haml
+++ b/app/views/my/tracks/_core_exercises.html.haml
@@ -29,6 +29,22 @@
                 =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[nil][0,10]
               =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[exercise.id]
 
+          =content_for :js do
+            :javascript
+              $("a.unlocked-exercise").each(function(idx, el){
+                const title = $(el).data("title")
+                const status = $(el).data("status")
+                const section = $(el).parents(".unlocked-exercises").siblings("h3")
+                $(el).hover(
+                  function(){
+                    section.text(title + ": " + status)
+                  },
+                  function(){
+                    section.text("You've unlocked extra exercises!")
+                  })
+              });
+
+
     - elsif exercise.unlocked?
       .exercise-wrapper.in-progress
         .circle= graphical_image exercise.white_icon_url

--- a/app/views/my/tracks/_core_exercises.html.haml
+++ b/app/views/my/tracks/_core_exercises.html.haml
@@ -29,22 +29,6 @@
                 =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[nil][0,10]
               =render "unlocked_exercises", unlocked_exercises_and_solutions: @side_exercises_and_solutions_by_unlocked_by[exercise.id]
 
-          =content_for :js do
-            :javascript
-              $("a.unlocked-exercise").each(function(idx, el){
-                const title = $(el).data("title")
-                const status = $(el).data("status")
-                const section = $(el).parents(".unlocked-exercises").siblings("h3")
-                $(el).hover(
-                  function(){
-                    section.text(title + ": " + status)
-                  },
-                  function(){
-                    section.text("You've unlocked extra exercises!")
-                  })
-              });
-
-
     - elsif exercise.unlocked?
       .exercise-wrapper.in-progress
         .circle= graphical_image exercise.white_icon_url

--- a/app/views/my/tracks/_show_mentored_mode.html.haml
+++ b/app/views/my/tracks/_show_mentored_mode.html.haml
@@ -46,3 +46,7 @@
 
 =render "show_side_exercises", exercises_and_solutions: @side_exercises_and_solutions
 
+=content_for :js do
+  :javascript
+    setupMyTrackMentored()
+

--- a/app/views/my/tracks/_unlocked_exercises.html.haml
+++ b/app/views/my/tracks/_unlocked_exercises.html.haml
@@ -1,9 +1,10 @@
 -unlocked_exercises_and_solutions.each do |exercise, solution|
   -if solution
-    = link_to [:my, solution], class: "unlocked-exercise" do
+    - status = solution.completed? ? "Completed" : "In progress"
+    = link_to [:my, solution], class: "unlocked-exercise", data: { status: status, title: exercise.title } do
       =graphical_image exercise.turquoise_icon_url, class: 'normal'
       =graphical_image exercise.white_icon_url, class: 'hover'
   -else
-    = link_to [:my, :solutions, track_id: exercise.track, exercise_id: exercise], method: :post, class: 'unlocked-exercise' do
+    = link_to [:my, :solutions, track_id: exercise.track, exercise_id: exercise], method: :post, class: 'unlocked-exercise', data: { status: "Unstarted", title: exercise.title } do
       =graphical_image exercise.turquoise_icon_url, class: 'normal'
       =graphical_image exercise.white_icon_url, class: 'hover'

--- a/app/views/my/tracks/_unlocked_exercises.html.haml
+++ b/app/views/my/tracks/_unlocked_exercises.html.haml
@@ -1,10 +1,18 @@
 -unlocked_exercises_and_solutions.each do |exercise, solution|
   -if solution
-    - status = solution.completed? ? "Completed" : "In progress"
+    -if solution.completed?
+      - status = "Completed"
+    -elsif solution.approved?
+      - status = "Approved"
+    -elsif solution.in_progress?
+      - status = "In progress"
+    -else
+      -status = "Unlocked"
+
     = link_to [:my, solution], class: "unlocked-exercise", data: { status: status, title: exercise.title } do
       =graphical_image exercise.turquoise_icon_url, class: 'normal'
       =graphical_image exercise.white_icon_url, class: 'hover'
   -else
-    = link_to [:my, :solutions, track_id: exercise.track, exercise_id: exercise], method: :post, class: 'unlocked-exercise', data: { status: "Unstarted", title: exercise.title } do
+    = link_to [:my, :solutions, track_id: exercise.track, exercise_id: exercise], method: :post, class: 'unlocked-exercise', data: { status: "Unlocked", title: exercise.title } do
       =graphical_image exercise.turquoise_icon_url, class: 'normal'
       =graphical_image exercise.white_icon_url, class: 'hover'

--- a/test/system/my/core_exercises_test.rb
+++ b/test/system/my/core_exercises_test.rb
@@ -1,6 +1,6 @@
 require 'application_system_test_case'
 
-class My::SideExercisesTest < ApplicationSystemTestCase
+class My::CoreExercisesTest < ApplicationSystemTestCase
   setup do
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
     Git::ExercismRepo.stubs(pages: [])
@@ -36,5 +36,4 @@ class My::SideExercisesTest < ApplicationSystemTestCase
     visit my_track_path(@track)
     assert_selector ".core-exercises .exercise-wrapper.in-progress .status", text: "APPROVED"
   end
-
 end

--- a/test/system/my/side_exercise_hover_test.rb
+++ b/test/system/my/side_exercise_hover_test.rb
@@ -58,5 +58,19 @@ class My::SideExercisesHoverTest < ApplicationSystemTestCase
     assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: Completed"
   end
 
+  test "hover only affects the relevant selector" do
+    # Add another approved solution
+    other_core_exercise = create :exercise, track: @track, core: true
+    create :solution, exercise: other_core_exercise, user: @user, completed_at: Time.current
+    create :exercise, track: @track, unlocked_by: other_core_exercise, title: "side-2"
+
+    visit my_track_path(@track)
+    find(".core-exercises #exercise-#{@core_exercise.slug}+.unlocked-exercises-section a.unlocked-exercise").hover
+    assert_selector ".core-exercises #exercise-#{@core_exercise.slug}+.unlocked-exercises-section h3", text: "side-1: Unlocked"
+
+    assert_selector ".core-exercises #exercise-#{other_core_exercise.slug}+.unlocked-exercises-section h3", text: "You've unlocked extra exercises!"
+  end
+
+
 
 end

--- a/test/system/my/side_exercise_hover_test.rb
+++ b/test/system/my/side_exercise_hover_test.rb
@@ -1,0 +1,62 @@
+require 'application_system_test_case'
+
+class My::CoreExercisesTest < ApplicationSystemTestCase
+  setup do
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    Git::ExercismRepo.stubs(pages: [])
+
+    @user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    @track = create :track
+    @core_exercise = create :exercise, track: @track, core: true
+    @side_exercise = create :exercise, track: @track, unlocked_by: @core_exercise, title: "side-1"
+    @core_solution = create :solution, exercise: @core_exercise, user: @user, completed_at: Time.current
+
+    create :user_track, user: @user, track: @track, independent_mode: false
+    sign_in!(@user)
+  end
+
+  test "default state" do
+    visit my_track_path(@track)
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "You've unlocked extra exercises!"
+  end
+
+  test "hover in bonus state" do
+    visit my_track_path(@track)
+    find(".core-exercises .unlocked-exercises a.unlocked-exercise").hover
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: Unlocked"
+  end
+
+  test "hover unlocked state" do
+    @solution = create :solution, exercise: @side_exercise, user: @user
+    visit my_track_path(@track)
+    find(".core-exercises .unlocked-exercises a.unlocked-exercise").hover
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: Unlocked"
+  end
+
+  test "hover in progress state" do
+    @solution = create :solution, exercise: @side_exercise, user: @user, downloaded_at: Time.current
+    visit my_track_path(@track)
+    find(".core-exercises .unlocked-exercises a.unlocked-exercise").hover
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: In progress"
+  end
+
+  test "hover in approved state" do
+    @solution = create :solution, exercise: @side_exercise, user: @user, approved_by: create(:user)
+    visit my_track_path(@track)
+    find(".core-exercises .unlocked-exercises a.unlocked-exercise").hover
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: Approved"
+  end
+
+  test "hover in completed state" do
+    # We need this else the "completed" state of the track kicks in
+    create :exercise, track: @track, core: true
+    @solution = create :solution, exercise: @side_exercise, user: @user, completed_at: Time.current
+    visit my_track_path(@track)
+    find(".core-exercises .unlocked-exercises a.unlocked-exercise").hover
+    assert_selector ".core-exercises .unlocked-exercises-section h3", text: "side-1: Completed"
+  end
+
+
+end

--- a/test/system/my/side_exercise_hover_test.rb
+++ b/test/system/my/side_exercise_hover_test.rb
@@ -1,6 +1,6 @@
 require 'application_system_test_case'
 
-class My::CoreExercisesTest < ApplicationSystemTestCase
+class My::SideExercisesHoverTest < ApplicationSystemTestCase
   setup do
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
     Git::ExercismRepo.stubs(pages: [])

--- a/test/system/my/side_exercises_test.rb
+++ b/test/system/my/side_exercises_test.rb
@@ -1,6 +1,6 @@
 require 'application_system_test_case'
 
-class My::CoreExercisesTest < ApplicationSystemTestCase
+class My::SideExercisesTest < ApplicationSystemTestCase
   setup do
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
     Git::ExercismRepo.stubs(pages: [])


### PR DESCRIPTION
Hi!

## What this addresses:

I discovered the issue through the `community-pr-welcome` tag here: https://github.com/exercism/exercism/issues/3967

Where @kytrinyx linked to an issue from a depricated repo here: https://github.com/exercism/DEPRECATED.v2-feedback/issues/160

Where @ErikSchierboom originally suggested the additional info.

It seems that this issue was re-reported by @ErikSchierboom here: https://github.com/exercism/exercism/issues/4016. On this issue - @nicolechalmers posted a beautiful design that @ErikSchierboom excitedly approved! This issue is labeled as `rgsoc-2018`. I'm not entirely sure what that label is about.

In any case, it _seems_ like there is consensus that this improvement should be done. Here is a screenshot of it rendered locally:

![2018-08-07 at 10 10 pm](https://user-images.githubusercontent.com/7566896/43818033-93412536-9a91-11e8-987d-ba8f5a4818c3.png)


## Open question:

* I don't know the correct phrasing for an a solution that has not yet been started. I chose the word "unstarted" - but I'm not sure it's really the right phrasing.
  * **Option:** "ready to start" may be better in terms of growth mindset
  * **Maybe:** there is an agreed upon term that I wasn't able to track down in the code base. You all would know best.

Please feel free to push commits updating the wording!


## An apology

I'm sorry there isn't testing here like the other PRs I submitted. I'm happy to write tests for this, but:
  * I ran out of time this evening 😴
  * and there is still an open question about behavior 😕


❤️ Hope it looks OK! ❤️
