### PR TITLE
Consider mentor count when rendering mentor info on the track page

### DIFF
--- a/app/views/tracks/_overview.html.haml
+++ b/app/views/tracks/_overview.html.haml
@@ -4,11 +4,7 @@
       .pure-u-1-3
         .icon
           =image "track-page-mentors.png", "Track mentors"
-        %h3 #{number_with_delimiter @track.mentors.size}
-        -if @track.mentors.size == 1
-          Mentor
-        -else
-          Mentors
+        %h3 #{number_with_delimiter @track.mentors.size} #{"Mentor".pluralize(@track.mentors.size)}
         .info Our mentors are friendly, experienced #{@track.title} developers who will help teach you new techniques and tricks.
 
       .pure-u-1-3

--- a/app/views/tracks/_overview.html.haml
+++ b/app/views/tracks/_overview.html.haml
@@ -4,7 +4,11 @@
       .pure-u-1-3
         .icon
           =image "track-page-mentors.png", "Track mentors"
-        %h3 #{number_with_delimiter @track.mentors.size} Mentors
+        %h3 #{number_with_delimiter @track.mentors.size}
+        -if @track.mentors.size == 1
+          Mentor
+        -else
+          Mentors
         .info Our mentors are friendly, experienced #{@track.title} developers who will help teach you new techniques and tricks.
 
       .pure-u-1-3


### PR DESCRIPTION
Just a small change. 
If the current track has 1 mentor `Mentor` will be rendered instead of `Mentors`