### PR TITLE
Remove use of const in JS which doesn't compile upon deploy

### DIFF
--- a/app/assets/javascripts/my-track-mentored.js
+++ b/app/assets/javascripts/my-track-mentored.js
@@ -1,9 +1,9 @@
 window.setupMyTrackMentored = function() {
   $(".core-exercises .unlocked-exercises a.unlocked-exercise").each(function(idx, el){
-    const $el = $(el)
-    const title = $el.data("title")
-    const status = $el.data("status")
-    const section = $el.parents(".unlocked-exercises").siblings("h3")
+    var $el = $(el)
+    var title = $el.data("title")
+    var status = $el.data("status")
+    var section = $el.parents(".unlocked-exercises").siblings("h3")
     $el.hover(
       function(){
         section.html("<strong>" + title + "</strong>: " + status)


### PR DESCRIPTION
Deployment failed with:
```
Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
/opt/exercism/shared/bundle/ruby/2.3.0/gems/uglifier-4.1.12/lib/uglifier.rb:234:in `parse_result'
/opt/exercism/shared/bundle/ruby/2.3.0/gems/uglifier-4.1.12/lib/uglifier.rb:216:in `run_uglifyjs'
/opt/exercism/shared/bundle/ruby/2.3.0/gems/uglifier-4.1.12/lib/uglifier.rb:168:in `compile'
/opt/exercism/shared/bundle/ruby/2.3.0/gems/sprockets-3.7.2/lib/sprockets/uglifier_compressor.rb:53:in `call'
....
```

This aims to fix that by subbing `var` for `const`.