### PR TITLE
Added support for testing with a remote selenium instance

### DIFF
--- a/config/selenium.yml
+++ b/config/selenium.yml
@@ -1,0 +1,4 @@
+test:
+  - hub_url: <%= ENV['TESTS_SELENIUM_HUB_URL'] %>
+  - default_host: <%= ENV['TESTS_DEFAULT_HOST'] %>
+  - teams_host: <%= ENV['TESTS_TEAMS_HOST'] ? "http://#{ENV["TESTS_TEAMS_HOST"]}" : "http://teams.lvh.me" %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,13 +1,21 @@
 require "test_helper"
 require "support/selectize_helpers"
 require "support/stub_repo_cache"
+require "support/selenium_helpers"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Devise::Test::IntegrationHelpers
   include SelectizeHelpers
   include StubRepoCache
+  include SeleniumHelpers
 
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400], options: SeleniumHelpers.options
+
+  if SeleniumHelpers.default_host.present?
+    Capybara.server_host = '0.0.0.0'
+    Capybara.server_port = '3010'
+    Capybara.app_host = "http://#{SeleniumHelpers.default_host}:3010"
+  end
 
   protected
 
@@ -15,5 +23,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     @current_user = user || create(:user, accepted_terms_at: DateTime.new(2000,1,1), accepted_privacy_policy_at: DateTime.new(2000,1,1))
     @current_user.confirm
     sign_in @current_user
+  end
+
+  def setup
+    if SeleniumHelpers.default_host.present?
+      host! "http://#{SeleniumHelpers.default_host}:3010"
+    end
+    super
   end
 end

--- a/test/support/selenium_helpers.rb
+++ b/test/support/selenium_helpers.rb
@@ -1,0 +1,18 @@
+SELENIUM_HELPERS_CONFIG = Rails.application.config_for("selenium").reduce({}, :merge).freeze
+module SeleniumHelpers
+  def self.hub_url
+    SELENIUM_HELPERS_CONFIG["hub_url"]
+  end
+
+  def self.options
+    self.hub_url.nil? ? {} : {url: self.hub_url}
+  end
+
+  def self.default_host
+    SELENIUM_HELPERS_CONFIG["default_host"]
+  end
+
+  def self.teams_host
+    SELENIUM_HELPERS_CONFIG["teams_host"]
+  end
+end

--- a/test/system/generate_team_join_url_test.rb
+++ b/test/system/generate_team_join_url_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class GenerateTeamJoinUrlTest < ApplicationSystemTestCase
   test "generates a team join url" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
     team_admin = create(:user)
     team = create(:team, token: "TOKEN", url_join_allowed: false)
     create(:team_membership,

--- a/test/system/join_team_via_url_test.rb
+++ b/test/system/join_team_via_url_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class JoinTeamViaUrlTest < ApplicationSystemTestCase
   test "join team via url" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
     user = create(:user)
     team = create(:team,
                   token: "TOKEN",

--- a/test/system/teams/accept_invite_test.rb
+++ b/test/system/teams/accept_invite_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Teams::AcceptInviteTest < ApplicationSystemTestCase
   test "user accepts invite" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
 
     user = create(:user, email: "test@example.com")
     team = create(:team, name: "Team A")

--- a/test/system/teams/reject_invite_test.rb
+++ b/test/system/teams/reject_invite_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Teams::RejectInviteTest < ApplicationSystemTestCase
   test "user rejects invite" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
 
     user = create(:user, email: "test@example.com")
     team = create(:team, name: "Team A")

--- a/test/system/teams/remove_invite_test.rb
+++ b/test/system/teams/remove_invite_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Teams::RemoveInviteTest < ApplicationSystemTestCase
   test "team admin removes team invitation" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
 
     team_admin = create(:user)
     team = create(:team)

--- a/test/system/teams/remove_member_test.rb
+++ b/test/system/teams/remove_member_test.rb
@@ -3,7 +3,7 @@ require 'application_system_test_case'
 class Teams::RemoveMemberTest < ApplicationSystemTestCase
   test "team admin removes member from team" do
     original_host = Capybara.app_host
-    Capybara.app_host = "http://teams.lvh.me"
+    Capybara.app_host = SeleniumHelpers.teams_host
 
     team_admin = create(:user)
     team = create(:team)


### PR DESCRIPTION
This PR adds support for running system tests where Selenium may be on a different host (eg. with Docker - https://github.com/jackhughesweb/exercism-docker ).

By default, testing will continue to work with the assumption of Selenium running on localhost. To use remote testing, set the following environment variables:
```yml
- TESTS_DEFAULT_HOST: 'exercism.local'
- TESTS_TEAMS_HOST: 'teams.exercism.local'
- TESTS_SELENIUM_HUB_URL: 'http://selenium:4444/wd/hub'
```