### PR TITLE
Fixed bug where preview would not clear after comment

### DIFF
--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -49,7 +49,9 @@ window.setupSolution = ->
         Prism.highlightAll()
 
     $(".new-discussion-post-form").on "ajax:success", ->
+      $('.new-discussion-post-form textarea').val("")
       $('.new-discussion-post-form .preview-area').html('')
+      Prism.highlightAll()
 
   #$window.resize(setupLayout)
   #setupLayout()

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -48,6 +48,9 @@ window.setupSolution = ->
         $('.new-discussion-post-form .preview-area').html(x)
         Prism.highlightAll()
 
+    $(".new-discussion-post-form").on "ajax:success", ->
+      $('.new-discussion-post-form .preview-area').html('')
+
   #$window.resize(setupLayout)
   #setupLayout()
   setupSolutionTabs()

--- a/app/views/mentor/discussion_posts/create.js.haml
+++ b/app/views/mentor/discussion_posts/create.js.haml
@@ -1,8 +1,5 @@
 var newPost = '#{j discussion_post_widget(@post, @solution, @user_track)}';
 $('.discussion .posts').show().append(newPost)
-$('.new-discussion-post-form textarea').val("")
-$('.discussion .write-tab').click()
-Prism.highlightAll()
 #{yield(:js).gsub(/<\/?script>/, "")}
 
 $('.pass-button').remove()

--- a/app/views/my/discussion_posts/create.js.haml
+++ b/app/views/my/discussion_posts/create.js.haml
@@ -1,8 +1,5 @@
 var newPost = '#{j discussion_post_widget(@post, @iteration.solution, @user_track)}';
 $('.discussion .posts').show().append(newPost)
 $('.discussion .next-steps').hide()
-$('.new-discussion-post-form textarea').val("")
 window.location.href = "#discussion-post-#{@post.id}"
-$('.discussion .write-tab').click()
-Prism.highlightAll()
 #{yield(:js).gsub(/<\/?script>/, "")}

--- a/test/system/mentor/solution_buttons_test.rb
+++ b/test/system/mentor/solution_buttons_test.rb
@@ -32,4 +32,19 @@ class SolutionButtonsTest < ApplicationSystemTestCase
     refute_selector ".approve-button"
     assert_selector ".comment-button"
   end
+
+  test "comment button clears preview tab" do
+    create :solution_mentorship, solution: @solution, user: @mentor
+
+    visit mentor_solution_path(@solution)
+
+    assert_selector ".comment-button"
+    assert_selector ".markdown"
+    refute_selector ".preview"
+    find(".new-discussion-post-form textarea").set("An example mentor comment to test the comment button!")
+    find(".preview-tab").click
+    within(".preview-area") { assert_text "An example mentor comment to test the comment button!" }
+    click_on "Comment"
+    within(".preview-area") { assert_text "", { exact: true } }
+  end
 end

--- a/test/system/my/solution_discussion_section_test.rb
+++ b/test/system/my/solution_discussion_section_test.rb
@@ -158,4 +158,22 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     assert_selector ".completed-section .next-option strong", text: REQUEST_MENTORING_TEXT
     refute_selector ".discussion"
   end
+
+  test "comment button clears preview tab" do
+    solution = create(:solution, user: @user, track_in_independent_mode: false, independent_mode: false)
+    create :iteration, solution: solution
+    create(:user_track, track: solution.track, user: @user)
+
+    visit my_solution_path(solution)
+
+    assert_selector ".comment-button"
+    assert_selector ".markdown"
+    refute_selector ".preview"
+
+    find(".new-discussion-post-form textarea").set("An example mentor comment to test the comment button!")
+    find(".preview-tab").click
+    within(".preview-area") { assert_text "An example mentor comment to test the comment button!" }
+    click_on "Comment"
+    within(".preview-area") { assert_text "", { exact: true } }
+  end
 end


### PR DESCRIPTION
The preview area for markdown comments would not clear after a comment had been added.

Also, I've added a system test for this issue.

Closes exercism/exercism#4192