### PR TITLE
Remove default scope on exercise model and make it part of model relation

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -15,7 +15,6 @@ class Exercise < ApplicationRecord
   has_many :solutions
   has_many :iterations, through: :solutions
 
-  default_scope -> { order('position ASC, title ASC') }
   scope :active, -> { where(active: true) }
   scope :core, -> { where(core: true) }
   scope :side, -> { where(core: false) }

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -5,7 +5,7 @@ class Track < ApplicationRecord
 
   has_many :testimonials
   has_many :user_tracks
-  has_many :exercises
+  has_many :exercises, -> { order position: :asc, title: :asc }
   has_many :solutions, through: :exercises
   has_many :iterations, through: :solutions
   has_many :mentorships, class_name: "TrackMentorship"


### PR DESCRIPTION
According to some, [default_scope is evil](https://rails-bestpractices.com/posts/2013/06/15/default_scope-is-evil/). In any case, I think it would make sense to remove the default scope from the exercise model and instead add the scope to the has_many :exercises relation on the track model. [This test](https://github.com/exercism/website/blob/master/test/system/exercises_test.rb#L4) already ensures that the exercises are being ordered correctly so I don't think this change would necessitate any new tests. 