### PR TITLE
Changed logged out track exercise count to reflect active exercises only

### DIFF
--- a/app/views/tracks/_overview.html.haml
+++ b/app/views/tracks/_overview.html.haml
@@ -22,7 +22,7 @@
       .pure-u-1-3
         .icon
           =image "track-page-exercises.png", "Track exercises"
-        %h3= pluralize @track.exercises.size, "Exercise"
+        %h3= pluralize @track.exercises.active.size, "Exercise"
         .info Hundreds of hours have gone into making these exercises fun, useful, and challenging to help you enjoy learning.
 
 


### PR DESCRIPTION
The track page (when logged out) displays the number of exercises, including deprecated exercises. 

This could be confusing for people joining the track, as the track will have less exercises than stated. Since this is the logged out page, it would not be possible to check if the user been has migrated from v1 to include the number of deprecated exercises.