### PR TITLE
Changed track progress to use core_position, and fill in current circle

### DIFF
--- a/app/views/my/solutions/_nav_and_header.html.haml
+++ b/app/views/my/solutions/_nav_and_header.html.haml
@@ -21,16 +21,19 @@
         -if @user_track.independent_mode?
           %h3 In Independent Mode
         -else
-          %h3 Track progress:
-          -num_core_exercises = @track.exercises.core.count
-          -num_completed_exercises = @user_track.num_completed_core_exercises
-          -num_available_exercises = @user_track.num_avaliable_core_exercises + num_completed_exercises
+          -if @exercise.side?
+            %h3 Side exercise
+          -else
+            %h3 Track progress:
+            -num_core_exercises = @track.exercises.core.count
+            -num_completed_exercises = @user_track.num_completed_core_exercises
+            -num_available_exercises = @user_track.num_avaliable_core_exercises + num_completed_exercises
 
-          .dots
-            -num_core_exercises.times do |i|
-              -if i < num_completed_exercises
-                .dot.completed
-              -elsif i < num_available_exercises
-                .dot.current
-              -else
-                .dot.locked
+            .dots
+              -num_core_exercises.times do |i|
+                -if i < num_completed_exercises
+                  .dot.completed
+                -elsif i < num_available_exercises
+                  .dot.current
+                -else
+                  .dot.locked

--- a/app/views/my/solutions/_nav_and_header.html.haml
+++ b/app/views/my/solutions/_nav_and_header.html.haml
@@ -24,13 +24,13 @@
           %h3 Track progress:
           -num_core_exercises = @track.exercises.core.count
           -num_completed_exercises = @user_track.num_completed_core_exercises
-          -exercise_idx = @track.exercises.core.where("position < ?", @exercise.position).count
+          -num_available_exercises = @user_track.num_avaliable_core_exercises + num_completed_exercises
 
           .dots
             -num_core_exercises.times do |i|
-              -if i == exercise_idx
-                .dot.current
-              -elsif i < num_completed_exercises
+              -if i < num_completed_exercises
                 .dot.completed
+              -elsif i < num_available_exercises
+                .dot.current
               -else
                 .dot.locked


### PR DESCRIPTION
Fixes exercism/exercism#4199

I've changed the track progress to use a new core_position method, which will obtain the position value for the current core exercise (either the current if core, or the unlocked_by if not core).

Also, I've changed the dots to fill in the current dot if the current exercise has been completed