### PR TITLE
Add better error messages to the API

### DIFF
--- a/app/controllers/api/files_controller.rb
+++ b/app/controllers/api/files_controller.rb
@@ -7,7 +7,7 @@ class API::FilesController < APIController
     end
 
     unless current_user.may_view_solution?(@solution)
-      return render_403(:user_may_not_download_solution, "You may not download this solution")
+      return render_403(:solution_not_accessible)
     end
 
     if @solution.iterations.last

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -23,19 +23,25 @@ class APIController < ApplicationController
     render json: {}, status: 401
   end
 
-  def render_403(type, message)
-    render_error(403, type, message)
+  def render_403(type)
+    render_error(403, type)
   end
 
   def render_404(type = :resource_not_found, data = {})
-    render_error(404, type, type.to_s.humanize, data)
+    render_error(404, type, data)
   end
 
   def render_solution_not_found
     render_404(:solution_not_found)
   end
 
-  def render_error(status, type, message, data = {})
+  def render_solution_not_accessible
+    render_403(:solution_not_accessible)
+  end
+
+  def render_error(status, type, data = {})
+    message = I18n.t("api.errors.#{type}")
+
     render json: {
       error: {
         type: type,

--- a/app/controllers/my/solutions_controller.rb
+++ b/app/controllers/my/solutions_controller.rb
@@ -6,7 +6,7 @@ class My::SolutionsController < MyController
     user_track = UserTrack.where(user: current_user, track: track).first
     exercise = track.exercises.find(params[:exercise_id])
 
-    if current_user.may_unlock_exercise?(user_track, exercise)
+    if current_user.may_unlock_exercise?(exercise, user_track: user_track)
       solution = CreateSolution.(current_user, exercise)
       redirect_to [:my, solution]
     else

--- a/app/models/concerns/solution_base.rb
+++ b/app/models/concerns/solution_base.rb
@@ -3,14 +3,10 @@ require 'active_support/concern'
 module SolutionBase
   extend ActiveSupport::Concern
 
-  def self.find_by_uuid!(uuid, user_id = nil)
-    scope = Solution
-    scope = scope.where(user_id: user_id) if user_id
-    scope.find_by_uuid!(uuid)
+  def self.find_by_uuid!(uuid)
+    Solution.find_by_uuid!(uuid)
   rescue ActiveRecord::RecordNotFound
-    scope = TeamSolution
-    scope = scope.where(user_id: user_id) if user_id
-    scope.find_by_uuid!(uuid)
+    TeamSolution.find_by_uuid!(uuid)
   end
 
   included do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,7 @@ class User < ApplicationRecord
     user_tracks.where(track_id: track.id).first
   end
 
-  def may_unlock_exercise?(user_track, exercise)
+  def may_unlock_exercise?(exercise, user_track: user_track_for(exercise.track))
     # If one of:
     # - we're in indepdenent mode
     # - this is a side exercise that has no unlocked_by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,15 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  api:
+    errors:
+      duplicate_iteration: "No files you submitted have changed since your last iteration"
+      exercise_not_found: "The exercise you specified could not be found"
+      resource_not_found: "This URL was not recognised"
+      solution_not_found: "This solution could not be found"
+      solution_not_accessible: "You do not have permission to view this solution"
+      solution_not_unlocked: "You have not unlocked this exercise"
+      team_not_found: "The team could not be found"
+      track_ambiguous: "Please specify a track ID"
+      track_not_found: "The track you specified does not exist"
+      track_not_joined: "You have not joined this track"

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -15,6 +15,7 @@ class API::SolutionsControllerTest < API::TestBase
     assert_response 401
   end
 
+  ### Errors: Track Not Found
   test "latest should return 404 when the track doesn't exist" do
     setup_user
     exercise = create :exercise, core: true
@@ -22,13 +23,14 @@ class API::SolutionsControllerTest < API::TestBase
     assert_response 404
     expected = {error: {
       type: "track_not_found",
-      message: "Track not found",
+      message: "The track you specified does not exist",
       fallback_url: tracks_url
     }}
     actual = JSON.parse(response.body, symbolize_names: true)
     assert_equal expected, actual
   end
 
+  ### Errors: Exercise Not Found
   test "latest should return 404 when there is no exercise" do
     setup_user
     track = create :track
@@ -36,22 +38,59 @@ class API::SolutionsControllerTest < API::TestBase
     assert_response 404
     expected = {error: {
       type: "exercise_not_found",
-      message: "Exercise not found",
+      message: "The exercise you specified could not be found",
       fallback_url: track_url(track)
     }}
     actual = JSON.parse(response.body, symbolize_names: true)
     assert_equal expected, actual
   end
 
-  test "latest should return 200 when the track can be guessed" do
+  test "latest should return 404 when there is no valid exercise and no track specified" do
     setup_user
-    exercise = create :exercise, core: true
-    create :solution, user: @current_user, exercise: exercise
-    create :user_track, user: @current_user, track: exercise.track
-    get latest_api_solutions_path(exercise_id: exercise.slug), headers: @headers, as: :json
-    assert_response 200
+    get latest_api_solutions_path(exercise_id: SecureRandom.uuid), headers: @headers, as: :json
+    assert_response 404
+    expected = {error: {
+      type: "exercise_not_found",
+      message: "The exercise you specified could not be found"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
+  ### Errors: Track Not Joined
+  test "latest should return 403 when the track isn't joined" do
+    setup_user
+    track = create :track
+    exercise = create :exercise, core: true, track: track
+    get latest_api_solutions_path(exercise_id: exercise.slug, track_id: track.slug), headers: @headers, as: :json
+    assert_response 403
+    expected = {error: {
+      type: "track_not_joined",
+      message: "You have not joined this track"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  ### Errors: Solution Not Unlocked
+  test "index should return 403 when solution is missing" do
+    setup_user
+    track = create :track
+    create :user_track, user: @current_user, track: track
+    exercise = create :exercise, track: track, core: true
+
+    get latest_api_solutions_path(track_id: track.slug, exercise_id: exercise.slug), headers: @headers, as: :json
+
+    assert_response 403
+    expected = {error: {
+      type: "solution_not_unlocked",
+      message: I18n.t('api.errors.solution_not_unlocked')
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  # Errors: Track Ambiguous
   test "latest should return array of possible tracks if multiple are possible" do
     setup_user
     exercise1 = create :exercise, core: true
@@ -66,22 +105,45 @@ class API::SolutionsControllerTest < API::TestBase
     assert_response 400
     expected = {error: {
       type: "track_ambiguous",
-      message: "Please specify a track id",
+      message: "Please specify a track ID",
       possible_track_ids: [exercise1.track.slug, exercise2.track.slug]
     }}
     actual = JSON.parse(response.body, symbolize_names: true)
     assert_equal expected, actual
   end
 
-  test "index should return 404 when solution is missing" do
+  # Errors: Track Ambiguous
+  test "latest should return array of possible tracks if multiple are possible with no solutions" do
     setup_user
-    track = create :track
-    exercise = create :exercise, track: track, core: true
+    track1 = create :track
+    track2 = create :track
+    create :user_track, user: @current_user, track: track1
+    create :user_track, user: @current_user, track: track2
 
-    get latest_api_solutions_path(track_id: track.slug, exercise_id: exercise.slug), headers: @headers, as: :json
+    exercise1 = create :exercise, core: false, track: track1
+    create :exercise, slug: exercise1.slug, core: false, track: track2
+    create :exercise, core: false, track: track1
 
-    assert_response 404
+    get latest_api_solutions_path(exercise_id: exercise1.slug), headers: @headers, as: :json
+    assert_response 400
+    expected = {error: {
+      type: "track_ambiguous",
+      message: "Please specify a track ID",
+      possible_track_ids: [track1.slug, track2.slug]
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
+
+  test "latest should return 200 when the track can be guessed" do
+    setup_user
+    exercise = create :exercise, core: true
+    create :solution, user: @current_user, exercise: exercise
+    create :user_track, user: @current_user, track: exercise.track
+    get latest_api_solutions_path(exercise_id: exercise.slug), headers: @headers, as: :json
+    assert_response 200
+  end
+
 
   test "latest should return 200 for a locked exercise in independent mode" do
     setup_user
@@ -94,7 +156,7 @@ class API::SolutionsControllerTest < API::TestBase
     assert_response 200
   end
 
-  test "latest should return 200 if user is solution_user" do
+  test "permissions: latest should return 200 if user is solution_user" do
     Timecop.freeze do
       setup_user
       exercise = create :exercise, core: true
@@ -110,30 +172,43 @@ class API::SolutionsControllerTest < API::TestBase
     end
   end
 
-  test "latest should return 404 if user is mentor" do
+  test "permissions: latest should return 403 if user is mentor" do
     setup_user
     exercise = create :exercise, core: true
     track = exercise.track
     create :track_mentorship, user: @current_user, track: track
     solution = create :solution, exercise: exercise
-    create :user_track, user: solution.user, track: track
+    create :user_track, user: @current_user, track: track
 
     get latest_api_solutions_path(track_id: track.slug, exercise_id: exercise.slug), headers: @headers, as: :json
-    assert_response 404
+
+    assert_response 403
+    expected = {error: {
+      type: "solution_not_unlocked",
+      message: I18n.t('api.errors.solution_not_unlocked')
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
-  test "latest should return 404 even if solution is published" do
+  test "permissions: latest should return 403 even if solution is published" do
     setup_user
     exercise = create :exercise, core: true
     track = exercise.track
     solution = create :solution, exercise: exercise, published_at: DateTime.yesterday
-    create :user_track, user: solution.user, track: track
+    create :user_track, user: @current_user, track: track
 
     get latest_api_solutions_path(track_id: track.slug, exercise_id: exercise.slug), headers: @headers, as: :json
-    assert_response 404
+    assert_response 403
+    expected = {error: {
+      type: "solution_not_unlocked",
+      message: I18n.t('api.errors.solution_not_unlocked')
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
-  test "latest should return 404 for a normal user when the solution is not published" do
+  test "permissions: latest should return 403 for a normal user when the solution is not published" do
     setup_user
     exercise = create :exercise, core: true
     track = exercise.track
@@ -141,13 +216,14 @@ class API::SolutionsControllerTest < API::TestBase
     create :user_track, user: solution.user, track: track
 
     get latest_api_solutions_path(track_id: track.slug, exercise_id: exercise.slug), headers: @headers, as: :json
-    assert_response 404
+    assert_response 403
   end
 
   test "latest should return solution when solution is unlocked" do
     setup_user
     exercise = create :exercise, core: true
     track = exercise.track
+    create :user_track, user: @current_user, track: track
     solution = create :solution, user: @current_user, exercise: exercise
 
     expected = {foo: 'bar'}
@@ -226,6 +302,12 @@ class API::SolutionsControllerTest < API::TestBase
     setup_user
     get api_solution_path(999), headers: @headers, as: :json
     assert_response 404
+    expected = {error: {
+      type: "solution_not_found",
+      message: "This solution could not be found"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
   test "show should return 200 for solution if user is solution_user" do
@@ -314,6 +396,12 @@ class API::SolutionsControllerTest < API::TestBase
 
     get api_solution_path(solution), headers: @headers, as: :json
     assert_response 403
+    expected = {error: {
+      type: "solution_not_accessible",
+      message: "You do not have permission to view this solution"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
   test "show should return solution when solution is unlocked" do
@@ -351,7 +439,13 @@ class API::SolutionsControllerTest < API::TestBase
     setup_user
     solution = create :solution
     patch api_solution_path(solution), headers: @headers, as: :json
-    assert_response 404
+    assert_response 403
+    expected = {error: {
+      type: "solution_not_accessible",
+      message: "You do not have permission to view this solution"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 
   test "update should create iteration" do
@@ -410,6 +504,11 @@ class API::SolutionsControllerTest < API::TestBase
           as: :json
 
     assert_response 400
-    assert_equal 'duplicate_iteration', JSON.parse(response.body, symbolize_names: true)[:error][:type]
+    expected = {error: {
+      type: "duplicate_iteration",
+      message: "No files you submitted have changed since your last iteration"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
   end
 end

--- a/test/controllers/api/test_base.rb
+++ b/test/controllers/api/test_base.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 
-class API::TestBase < ActionDispatch::IntegrationTest
-  def setup_user
-    @current_user = create :user
-    @current_user.confirm
-    auth_token = create :auth_token, user: @current_user
-    @headers = {'Authorization' => "Token token=#{auth_token.token}"}
+module API
+  class TestBase < ActionDispatch::IntegrationTest
+    def setup_user
+      @current_user = create :user
+      @current_user.confirm
+      auth_token = create :auth_token, user: @current_user
+      @headers = {'Authorization' => "Token token=#{auth_token.token}"}
+    end
   end
 end

--- a/test/controllers/api/unknown_route_test.rb
+++ b/test/controllers/api/unknown_route_test.rb
@@ -19,7 +19,7 @@ class API::UnknownRouteTest < API::TestBase
       setup_user
       get route, headers: @headers, as: :json
       assert_response 404
-      expected = {"error"=>{"type"=>"resource_not_found", "message"=>"Resource not found"}}
+      expected = {"error"=>{"type"=>"resource_not_found", "message"=>"This URL was not recognised"}}
       assert_equal expected, JSON.parse(response.body)
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -139,14 +139,14 @@ class UserTest < ActiveSupport::TestCase
     side_exercise_with_unlock = create :exercise, track: track, core: false, unlocked_by: core_exercise
     side_exercise_without_unlock = create :exercise, track: track, core: false
 
-    refute user.may_unlock_exercise?(user_track, core_exercise)
-    refute user.may_unlock_exercise?(user_track, side_exercise_with_unlock)
-    assert user.may_unlock_exercise?(user_track, side_exercise_without_unlock)
+    refute user.may_unlock_exercise?(core_exercise)
+    refute user.may_unlock_exercise?(side_exercise_with_unlock)
+    assert user.may_unlock_exercise?(side_exercise_without_unlock)
 
     user_track.update(independent_mode: true)
-    assert user.may_unlock_exercise?(user_track, core_exercise)
-    assert user.may_unlock_exercise?(user_track, side_exercise_with_unlock)
-    assert user.may_unlock_exercise?(user_track, side_exercise_without_unlock)
+    assert user.may_unlock_exercise?(core_exercise)
+    assert user.may_unlock_exercise?(side_exercise_with_unlock)
+    assert user.may_unlock_exercise?(side_exercise_without_unlock)
   end
 
   test "avatar_url" do


### PR DESCRIPTION
I've implemented this using Rails `I18n` functionality. Each error code that the API returns has a corresponding message in the I18n file.

I think this implements my bit of https://github.com/exercism/exercism/issues/4164#issuecomment-412716159
Closes https://github.com/exercism/exercism/issues/4159