### PR TITLE
Fix formatting errors in readme files

### DIFF
--- a/app/models/git/exercise.rb
+++ b/app/models/git/exercise.rb
@@ -8,7 +8,7 @@ class Git::Exercise
   end
 
   def instructions
-    lines = exercise_reader.readme.lines
+    lines = exercise_reader.readme.split("\n")
     lines.shift if /^#\s*#{@title}\s*$/.match? lines.first
     ParseMarkdown.(lines.join("\n"))
   end

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -6,7 +6,7 @@ class GitExerciseTest < ActiveSupport::TestCase
 
     readme_lines = ["# barfoo", "### Something else", "Here"]
 
-    readme = mock(lines: readme_lines)
+    readme = mock(split: readme_lines)
     exercise_reader = mock(readme: readme)
 
     git_exercise = Git::Exercise.new(exercise, nil, nil)
@@ -22,7 +22,7 @@ class GitExerciseTest < ActiveSupport::TestCase
     original_readme_lines = ["# foobar", "### Something else", "Here"]
     modified_readme_lines = ["### Something else", "Here"]
 
-    readme = mock(lines: original_readme_lines)
+    readme = mock(split: original_readme_lines)
     exercise_reader = mock(readme: readme)
 
     git_exercise = Git::Exercise.new(exercise, nil, nil)


### PR DESCRIPTION
Since my previous pull request to get rid of duplicate headers was merged, a lot of the readme files have formatting errors on the website because of the presence of extra newline characters. For instance:
![readme](https://user-images.githubusercontent.com/1254212/44124714-909842c2-9ffc-11e8-87fb-f1859d842eb2.png)

I was able to fix this by calling split("\n") instead of the lines method to split the readme markdown into lines. This way the website doesn't end up with all of the formatting errors.
