### PR TITLE
Add capistrano checks gem

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -12,6 +12,7 @@ require 'capistrano/yarn'
 require 'capistrano/rails'
 require 'capistrano/rvm'
 require 'capistrano/bundler'
+require "capistrano/checks"
 require 'capistrano/rails/migrations'
 require 'capistrano/rails/assets'
 

--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,7 @@ group :test do
   gem 'chromedriver-helper'
   gem 'webmock'
 end
+
+group :development, :production do
+  gem 'capistrano-checks'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     capistrano-bundler (1.3.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
+    capistrano-checks (1.0.0)
+      capistrano (>= 3.1)
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -375,6 +377,7 @@ DEPENDENCIES
   bullet
   byebug
   capistrano (~> 3.6)
+  capistrano-checks
   capistrano-rails (~> 1.1)
   capistrano-rvm
   capistrano-yarn


### PR DESCRIPTION
This gem (which I wrote) blocks deployments if `rails server` will fail when Eager Loading is enabled. This will stop 504s like the one we had the other day.