### PR TITLE
 only show v2 welcome modal once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 /server_identity
 
 storage/
+
+/test/tmp/*
+!/test/tmp/.gitkeep

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -98,8 +98,8 @@
   :javascript
     setupLandingPage()
 
--unless session[:announcement_modal_shown]
-  - session[:announcement_modal_shown] = true
+-unless cookies[:v2_welcome_modal_shown]
+  - cookies[:v2_welcome_modal_shown] = { value: true, expires: Time.utc(2020) }
   -content_for :js do
     :javascript
       showModal('announcement', '#{j render "announcement"}')


### PR DESCRIPTION
I figure that by 2020 we probably won't still be showing that modal.

bonus: git wasn't ignoring temporary test artifacts