### PR TITLE
Pull problem specifications repo fixture for tests

### DIFF
--- a/test/services/git/syncs_track_test.rb
+++ b/test/services/git/syncs_track_test.rb
@@ -2,6 +2,7 @@ require_relative '../../test_helper'
 
 class Git::SyncsTracksTest < ActiveSupport::TestCase
   test "updates track metadata" do
+    Git::ProblemSpecifications.stubs(:repo_url).returns("file://#{Rails.root}/test/fixtures/problem-specifications")
     track = create(:track, repo_url: "file://#{Rails.root}/test/fixtures/track", active: false)
 
     stub_repo_cache! do
@@ -12,6 +13,7 @@ class Git::SyncsTracksTest < ActiveSupport::TestCase
   end
 
   test "updates exercise unlocked_by" do
+    Git::ProblemSpecifications.stubs(:repo_url).returns("file://#{Rails.root}/test/fixtures/problem-specifications")
     track = create(:track, repo_url: "file://#{Rails.root}/test/fixtures/track", active: false)
     slugs = create(:exercise, track: track)
     hello_world = create(:exercise,


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4103.

## Problem

The ff tests fail when ran with no internet:

test/services/git/syncs_track_test.rb:14
test/services/git/syncs_track_test.rb:4

`Git::SyncsTrack` has a step where it needs to fetch the Problem Specifications repository.

## Solution

Stub the Problem Specification repository's URL to point to our test fixture.