### PR TITLE
Delete related solution models when deleting a solution

### DIFF
--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -7,6 +7,8 @@ class Solution < ApplicationRecord
   has_many :discussion_posts, through: :iterations
 
   has_many :mentorships, class_name: "SolutionMentorship", dependent: :destroy
+  has_many :ignored_mentorships, class_name: "IgnoredSolutionMentorship", dependent: :destroy
+  has_many :solution_locks, dependent: :destroy
   has_many :mentors, through: :mentorships, source: :user
 
   has_many :reactions, dependent: :destroy

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -75,4 +75,14 @@ class SolutionTest < ActiveSupport::TestCase
     solution = create :solution, published_at: Time.now
     assert_equal solution.display_published_at, solution.published_at
   end
+
+  test "deletes cleanly with associated models" do
+    solution = create(:solution)
+    create(:solution_lock, solution: solution)
+    create(:solution_mentorship, solution: solution)
+    create(:ignored_solution_mentorship, solution: solution)
+    create(:reaction, solution: solution)
+
+    solution.destroy!
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4191.
Closes https://github.com/exercism/exercism/issues/4268.
Closes https://github.com/exercism/exercism/issues/4136.

## Problem
When leaving a track, it throws an error. Upon looking into Bugsnag, we get the following error:

```
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`exercism`.`ignored_solution_mentorships`, CONSTRAINT `fk_rails_31331ef022` FOREIGN KEY (`solution_id`) REFERENCES `solutions` (`id`)): DELETE FROM `solutions` WHERE `solutions`.`id` = 589244 (ActiveRecord::StatementInvalid)
```

This happens because we also delete the solutions when leaving the track. When we delete solutions, we forget to delete the related models to it thus it raises a foreign key constraint error.

## Solution
We need to delete the related models to solutions.