### PR TITLE
Don't insert bullet point after horizontal rule in markdown editor

### DIFF
--- a/app/assets/javascripts/libs/bootstrap-markdown.js
+++ b/app/assets/javascripts/libs/bootstrap-markdown.js
@@ -874,6 +874,10 @@
             }
           }
 
+          if (chars.slice(priorNewlineIndex + 1, priorNewlineIndex + 4).join('') == '---') {
+            break;
+          }
+
           var charFollowingLastLineBreak = chars[priorNewlineIndex + 1];
           if (charFollowingLastLineBreak === '-') {
             this.addBullet(enterIndex);


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4188.

## Description
If we type in a horizontal rule in the markdown editor, a bullet point is inserted automatically after hitting Enter.

## Solution
The problem lies within our markdown editor library. I've submitted [a PR](https://github.com/toopay/bootstrap-markdown/pull/323) to fix this, but since we keep a local copy of the library, I decided to change it here, too. We can update our local copy to match the library once the PR gets merged in.

## Screencast
### Before
![aug-20-2018 18-02-03](https://user-images.githubusercontent.com/1901520/44334448-1cd34600-a4a4-11e8-970d-5853e2b22f88.gif)
### After
![aug-20-2018 18-08-37](https://user-images.githubusercontent.com/1901520/44334449-1d6bdc80-a4a4-11e8-8578-2a361ce3ec06.gif)

