### PR TITLE
Handle Sparkpost failures gracefully

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,11 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "The Exercism Team <hello@exercism.io>"
   layout 'mailer'
+
+  class UnableToConnectToSMTPServerError < StandardError
+  end
+
+  rescue_from EOFError do |exception|
+    raise UnableToConnectToSMTPServerError, "Unable to connect to SMTP server. Please check https://twitter.com/sparkpostops"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,6 +149,10 @@ class User < ApplicationRecord
     false
   end
 
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
+
   private
 
   def avatar_thumbnail_url

--- a/lib/tasks/temporary/bootstrap_users.rake
+++ b/lib/tasks/temporary/bootstrap_users.rake
@@ -1,0 +1,8 @@
+namespace :temporary do
+  desc "Bootstrap users without auth tokens"
+  task :bootstrap_users => :environment do
+    users_without_auth_tokens = User.where.not(id: AuthToken.select(:user_id))
+
+    users_without_auth_tokens.each { |user| BootstrapUser.(account) }
+  end
+end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ApplicationMailerTest < ActionMailer::TestCase
+  test "rescues EOFError" do
+    assert_raises "Unable to connect to SMTP server. Please check https://twitter.com/sparkpostops" do
+      ErrorMailer.eof_error.deliver_now
+    end
+  end
+end
+
+class ErrorMailer < ApplicationMailer
+  def eof_error
+    raise EOFError
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4249.
Closes https://github.com/exercism/exercism/issues/4248.

## Description
When Sparkpost goes down, it raises an `EOFError`. This PR handles this error gracefully.

## Solution
1. Raise a clearer error when Sparkpost goes down.
2. Send Devise emails via Sidekiq in order to take advantage of Sidekiq's auto retry feature.
3. Create auth token and user even if email fails to send. This was the reason why the auth token wasn't created for some users!
4. Add a rake task to create auth tokens for users without auth tokens.