### PR TITLE
Use git sha for solution when the exercise is first downloaded

### DIFF
--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -13,7 +13,12 @@ class API::SolutionsController < APIController
     end
 
     responder = API::SolutionResponder.new(solution, current_user)
-    solution.update(downloaded_at: Time.current) if current_user == solution.user
+
+    if current_user == solution.user
+      solution.update(git_sha: solution.track_head) unless solution.downloaded?
+      solution.update(downloaded_at: Time.current)
+    end
+
     render json: responder.to_hash
   end
 

--- a/app/models/concerns/solution_base.rb
+++ b/app/models/concerns/solution_base.rb
@@ -13,6 +13,9 @@ module SolutionBase
     belongs_to :user
     belongs_to :exercise
 
+    delegate :track, to: :exercise
+    delegate :head, to: :track, prefix: true
+
     before_create do
       # Search engines derive meaning by using hyphens
       # as word-boundaries in URLs. Since we use the
@@ -42,6 +45,11 @@ module SolutionBase
   def git_exercise
     @git_exercise ||= Git::Exercise.new(exercise, git_slug, git_sha)
   end
+
+  def downloaded?
+    !!downloaded_at
+  end
+
 
   #class_methods do
   #  ...

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -13,7 +13,7 @@ class Solution < ApplicationRecord
 
   has_many :reactions, dependent: :destroy
 
-  delegate :auto_approve?, :track, to: :exercise
+  delegate :auto_approve?, to: :exercise
 
   def self.completed
     where.not(completed_at: nil)
@@ -72,10 +72,6 @@ class Solution < ApplicationRecord
 
   def approved?
     !!approved_by
-  end
-
-  def downloaded?
-    !!downloaded_at
   end
 
   def in_progress?

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -15,6 +15,8 @@ class Track < ApplicationRecord
 
   scope :active, ->{ where(active: true) }
 
+  delegate :head, to: :repo
+
   [:bordered_green_icon_url,
    :bordered_turquoise_icon_url,
    :hex_green_icon_url,


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4241.

Is this correct or should we update the git sha every time we download the exercise?