### PR TITLE
[WIP] Restore community commenting feature

### DIFF
--- a/app/assets/stylesheets/pages/solution-page.scss
+++ b/app/assets/stylesheets/pages/solution-page.scss
@@ -224,7 +224,7 @@
             padding:8px 10px;
             font-weight:$regular;
         }
-        a {
+        a, div {
             float:left;
             padding:10px 9px;
             color:#666;
@@ -389,6 +389,31 @@
                         margin-bottom:0;
                     }
                 }
+            }
+        }
+        .react, .react * {
+            float:none;
+        }
+        .react {
+            width:100%;
+            input[type=radio] {
+                display:none;
+            }
+        }
+        .react .react-icon {
+            display:inline-block;
+        }
+        .comment-button {
+            margin-top:5px;
+            border-radius:2px;
+            padding:8px 25px;
+            background:$color-1;
+            color:#fff;
+            float:right;
+            &.faded {
+                background:#fff;
+                border:1px solid #aaa;
+                color:#666;
             }
         }
     }

--- a/app/controllers/my/reactions_controller.rb
+++ b/app/controllers/my/reactions_controller.rb
@@ -14,4 +14,15 @@ class My::ReactionsController < MyController
     @comments = @solution.reactions.with_comments.includes(user: [:profile, { avatar_attachment: :blob }])
     @reaction_counts = @solution.reactions.group(:emotion).count.to_h
   end
+
+  def comment
+    @solution = Solution.published.find_by_uuid!(params[:solution_id])
+
+    @emotion = Reaction.where(user: current_user, solution: @solution).first.try(:emotion) if user_signed_in?
+    @emotion ||= params[:emotion] if Reaction.emotions.keys.include? params[:emotion]
+    @emotion ||= "legacy"
+
+    @reaction = Reaction.create!(user: current_user, solution: @solution, emotion: @emotion, comment: params[:comment])
+    @comments = @solution.reactions.with_comments.includes(user: [:profile, { avatar_attachment: :blob }])
+  end
 end

--- a/app/views/my/reactions/comment.js.haml
+++ b/app/views/my/reactions/comment.js.haml
@@ -1,0 +1,6 @@
+-if @reaction.persisted?
+  $('.new-discussion-post-form textarea').val("")
+  $('.new-discussion-post-form .preview-area').html('')
+  Prism.highlightAll()
+
+$("#solution-page .community-comments").replaceWith("#{j render "solutions/community_comments"}")

--- a/app/views/solutions/_community_comments.html.haml
+++ b/app/views/solutions/_community_comments.html.haml
@@ -1,0 +1,29 @@
+-if @comments.size > 0
+  .community-comments
+    -@comments.each do |reaction|
+      .comment.pure-g
+        .pure-u-2-24
+          -if reaction.emotion == "like"
+            =icon 'thumbs-up'
+          -elsif reaction.emotion == "love"
+            =icon 'heart'
+          -elsif reaction.emotion == "genius"
+            =graphical_image "genius-turquoise.png"
+          -else reaction.emotion == "legacy"
+            =icon 'comment'
+
+        .pure-u-22-24.content
+          .when #{time_ago_in_words(reaction.created_at)} ago
+          .who
+            %strong #{reaction.user.handle}
+            says
+          .text= simple_format reaction.comment
+-else
+  .community-comments
+    .comment.pure-g
+      .pure-u-2-24
+        =icon 'comment'
+
+      .pure-u-22-24.content
+        .text 
+          %strong No comments have been added for this solution

--- a/app/views/solutions/show.html.haml
+++ b/app/views/solutions/show.html.haml
@@ -84,32 +84,59 @@
               %li What compromises have been made?
               %li Are there new concepts here that I could read more about to develop my understanding?
 
-  -if @comments.size > 0
-    .comments-section
-      .lo-container
-        .pure-g
-          .pure-u-1-2
-            %h2 Community comments
-            .h2-subtitle See what others have said about this solution
-            -@comments.each do |reaction|
-              .comment.pure-g
-                .pure-u-2-24
-                  -if reaction.emotion == "like"
-                    =icon 'thumbs-up'
-                  -elsif reaction.emotion == "love"
-                    =icon 'heart'
-                  -elsif reaction.emotion == "genius"
-                    =graphical_image "genius-turquoise.png"
-                  -else reaction.emotion == "legacy"
-                    =icon 'comment'
+  .comments-section
+    .lo-container
+      .pure-g
+        .pure-u-1-2
+          %h2 Community comments
+          .h2-subtitle See what others have said about this solution
+          =render 'community_comments'
+          -if user_signed_in?
+            %h2 Add a community comment
+            .h2-subtitle Share feedback on this solution
+            .new-discussion-post
+              =form_for [:comment, :my, Reaction.new], url: comment_my_reaction_url, remote: true, html: {class: "new-discussion-post-form"} do |f|
+                =hidden_field_tag :solution_id, @solution.uuid
 
-                .pure-u-22-24.content
-                  .when #{time_ago_in_words(reaction.created_at)} ago
-                  .who
-                    %strong #{reaction.user.handle}
-                    says
-                  .text= simple_format reaction.comment
+                .tabs-and-panes.selected-1
+                  .tabs
+                    .tab.tab-1.write-tab{data: {tab: "markdown"}} Write
+                    .tab.tab-2.preview-tab{data: {tab: "preview"}} Preview
+                  .panes
+                    .pane.pane-1.markdown
+                      =text_area_tag :comment
+                    .pane.pane-2.preview
+                      .preview-area
+                .react.react-comments
+                  .general.react-icon.selected
+                    =radio_button_tag :emotion, 'legacy', true
+                    .hover Comment
+                    =icon 'comment fa-fw', 'Comment'
+                  .like.react-icon
+                    =radio_button_tag :emotion, 'like', false
+                    .hover Well done
+                    =icon 'thumbs-up fa-fw', 'Thumbs up'
+                  .love.react-icon
+                    =radio_button_tag :emotion, 'love', false
+                    .hover Love it!
+                    =icon 'heart fa-fw', 'Heart'
+                  .genius.react-icon
+                    =radio_button_tag :emotion, 'genius', false
+                    .hover Genius!
+                    =graphical_image "genius.png", class: 'not-selected'
+                    =graphical_image "genius-turquoise.png", class: 'selected'    
+
+                  =button_tag "Comment", class: 'pure-button button comment-button'
 
 -content_for :js do
   :javascript
-    window.setupSolutionTabs()
+    setupSolution()
+
+    $('.react-comments .react-icon').on('click', function(){
+      $react = $(this)
+      $('.react-comments .react-icon').removeClass('selected')
+      $react.addClass('selected')
+      $react.find('input[type=radio]').prop('checked', 'checked')
+      $('.react-comments input[type=radio]').change()
+    })
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,7 +129,11 @@ Rails.application.routes.draw do
 
       resources :iterations, only: [:show]
     end
-    resources :reactions, only: [:index, :create]
+    resources :reactions, only: [:index, :create] do
+      member do
+        post :comment
+      end
+    end
 
     resources :discussion_posts, only: [:create, :update, :destroy]
     resources :notifications, only: [:index] do


### PR DESCRIPTION
Fixes exercism/exercism#3921

Todo:
- [ ] Edit/delete comments
- [ ] Decide whether an 'emotion/reaction' change should change the 'emotion' of the first comment by a user - should this change to update all comments or none? (Comments after the first have their own emotion, which is a 'legacy' comment icon by default)
- [ ] Copy/text needed to replace:
    - [ ] "No comments have been added for this solution"
    - [ ] "Add a community comment"
    - [ ] "Share feedback on this solution"
- [ ] Decide whether a comment should trigger a notification, if so/not, need to update reaction counts anyway
- [ ] Add (system) tests
