### PR TITLE
Fixes for incorrect handles

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,4 +1,6 @@
 module NotificationsHelper
+  include UserHelper
+
   def notification_image(notification)
     case notification.type
     when 'new_discussion_post'
@@ -9,12 +11,12 @@ module NotificationsHelper
     when 'new_discussion_post_for_mentor'
       # Face of the discussion post user
       # trigger = discussion post
-      notification.trigger.user.avatar_url
+      display_avatar_url(notification.trigger.user, notification.trigger.solution.user_track)
 
     when 'new_iteration_for_mentor'
       # Face of the iteration user
       # about = solution
-      notification.about.user.avatar_url
+      display_avatar_url(notification.about.user, notification.about.user_track)
 
     when 'new_reaction'
       # Face of the reacting user

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -21,10 +21,10 @@ module UserHelper
 
   def display_avatar_url(user, user_track = nil)
     avatar_url = if user_track && user_track.anonymous?
-        user_track.avatar_url
+        user_track.avatar_url.present?? user_track.avatar_url : asset_path("anonymous.png")
       else
         user.avatar_url
       end
-    avatar_url.present?? avatar_url : "anonymous.png"
+    avatar_url.present?? avatar_url : asset_path("anonymous.png")
   end
 end

--- a/app/services/create_iteration.rb
+++ b/app/services/create_iteration.rb
@@ -3,6 +3,7 @@ end
 
 class CreateIteration
   include Mandate
+  include UserHelper
 
   initialize_with :solution, :files
 
@@ -74,7 +75,7 @@ class CreateIteration
       CreateNotification.(
         mentor,
         :new_iteration_for_mentor,
-        "<strong>#{user.handle}</strong> has posted a new iteration on a solution you are mentoring",
+        "<strong>#{display_handle(solution.user, solution.user_track)}</strong> has posted a new iteration on a solution you are mentoring",
         routes.mentor_solution_url(solution),
         trigger: iteration,
 

--- a/app/services/creates_user_discussion_post.rb
+++ b/app/services/creates_user_discussion_post.rb
@@ -1,4 +1,6 @@
 class CreatesUserDiscussionPost < CreatesDiscussionPost
+  include UserHelper
+
   def self.create!(*args)
     new(*args).create!
   end
@@ -32,7 +34,7 @@ class CreatesUserDiscussionPost < CreatesDiscussionPost
       CreateNotification.(
         mentor,
         :new_discussion_post_for_mentor,
-        "#{strong solution.user.handle} has posted a comment on a solution you are mentoring",
+        "#{strong display_handle(solution.user, solution.user_track)} has posted a comment on a solution you are mentoring",
         routes.mentor_solution_url(solution),
         trigger: discussion_post,
 

--- a/test/helpers/notifications_helper_test.rb
+++ b/test/helpers/notifications_helper_test.rb
@@ -5,8 +5,10 @@ class NotificationsHelperTest < ActionView::TestCase
     user = create :user
 
     solution = create :solution, user: user
-    notification1 = create :notification, type: 'new_discussion_post', trigger: solution
-    notification2 = create :notification, type: 'new_discussion_post_for_mentor', trigger: solution
+    iteration = create :iteration, solution: solution
+    discussion_post = create :discussion_post, user: user, iteration: iteration
+    notification1 = create :notification, type: 'new_discussion_post', trigger: discussion_post
+    notification2 = create :notification, type: 'new_discussion_post_for_mentor', trigger: discussion_post
     notification3 = create :notification, type: 'new_iteration_for_mentor', about: solution
 
     assert_dom_equal user.avatar_url, notification_image(notification1)

--- a/test/mailers/mentor_notifications_mailer_test.rb
+++ b/test/mailers/mentor_notifications_mailer_test.rb
@@ -37,6 +37,8 @@ class MentorNotificationsMailerTest < ActionMailer::TestCase
     str = "A student you are mentoring (#{handle}) has posted"
     assert_body_includes email, str
     assert_text_includes email, str
+    assert_body_not_includes email, user.handle
+    assert_text_not_includes email, user.handle
   end
 
   test "new_iteration" do
@@ -75,5 +77,7 @@ class MentorNotificationsMailerTest < ActionMailer::TestCase
     str = "A student you are mentoring (#{handle}) has posted"
     assert_body_includes email, str
     assert_text_includes email, str
+    assert_body_not_includes email, user.handle
+    assert_text_not_includes email, user.handle
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,14 @@ class ActionMailer::TestCase
   def assert_text_includes(email, string)
     assert email.text_part.body.to_s.include?(string)
   end
+
+  def assert_body_not_includes(email, string)
+    assert !email.html_part.body.to_s.gsub("\n", ' ').include?(string)
+  end
+
+  def assert_text_not_includes(email, string)
+    assert !email.text_part.body.to_s.include?(string)
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
Fixes exercism/exercism#4281

Includes fixes for
- incorrect handles in notifications
- incorrect user image url in notifications
- use default 'anonymous' image in notifications when user_track profile image is missing
- fixed broken reference to 'anonymous' image in notifications

(Mailers are already using the correct handles)