### PR TITLE
Split settings page into two separate pages

### DIFF
--- a/app/assets/stylesheets/pages/my-communication-preferences.css.scss
+++ b/app/assets/stylesheets/pages/my-communication-preferences.css.scss
@@ -2,9 +2,6 @@
 @import 'mixins';
 
 #my-communication-preferences-page {
-    #nav {
-        margin-bottom:30px;
-    }
     .lhs {
         border-right:1px solid #eee;
         padding-right:30px;

--- a/app/assets/stylesheets/pages/my-settings.scss
+++ b/app/assets/stylesheets/pages/my-settings.scss
@@ -2,9 +2,6 @@
 @import 'mixins';
 
 #my-settings-page {
-    #nav {
-        margin-bottom:30px;
-    }
     #notice, #alert, #errors {
         margin-top: -20px;
         margin-bottom: 20px;

--- a/app/assets/stylesheets/pages/my-settings.scss
+++ b/app/assets/stylesheets/pages/my-settings.scss
@@ -1,17 +1,10 @@
 @import 'variables';
 @import 'mixins';
 
-#my-settings-page {
+#my-settings-page, #my-track-settings-page {
     #notice, #alert, #errors {
         margin-top: -20px;
         margin-bottom: 20px;
-    }
-    .lhs {
-        border-right:1px solid #eee;
-        padding-right:30px;
-    }
-    .rhs {
-        padding-left:30px;
     }
     h1 {
         @include font-size(25, 25);
@@ -29,6 +22,9 @@
         border-bottom:1px solid #ddd;
         padding-bottom:20px;
         margin-bottom:20px;
+        &:last-child {
+            border-bottom:none;
+        }
     }
     p,
     .token-explanation {
@@ -47,6 +43,7 @@
 
     }
     .widget-code-snippet {
+        display:inline-block;
         input {
             width:252px;
         }

--- a/app/assets/stylesheets/settings-bar.scss
+++ b/app/assets/stylesheets/settings-bar.scss
@@ -1,0 +1,19 @@
+@import 'variables';
+@import 'mixins';
+
+#settings-bar.lo-settings-bar {
+    margin-bottom:20px;
+    background:#eee;
+    a {
+        text-decoration:none;
+        padding:7px 0;
+        display:inline-block;
+        color:#666;
+        margin-right:20px;
+        &.selected {
+            color:$color-2;
+            font-weight:$bold;
+            border-bottom:3px solid $color-2;
+        }
+    }
+}

--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -1,36 +1,4 @@
 class My::SettingsController < MyController
-  def show
-    setup_show
-  end
-
-  def update_user_tracks
-    @user_tracks = current_user.user_tracks.includes(:track)
-    mapped_user_tracks = @user_tracks.each_with_object({}) {|ut, h|h[ut.id] = ut }
-
-    errors = []
-    params[:user_tracks].each do |id, data|
-      anon = data[:anonymous].to_i == 1
-      handle = data[:handle].present?? data[:handle] : nil
-
-      success = mapped_user_tracks[id.to_i].update(
-        anonymous: anon, handle: handle
-      )
-      errors << handle if !success && anon
-    end
-
-    errors.uniq!
-
-    if errors.empty?
-      flash.notice = "Your track settings have been updated"
-    elsif errors.size == 1
-      flash.alert = "The handle #{errors[0]} is already taken"
-    else
-      flash.alert = "The handles #{errors.to_sentence} are already taken"
-    end
-
-    render action: :show
-  end
-
   def update
     if params[:user][:password].present?
       return unless update_password
@@ -71,9 +39,5 @@ class My::SettingsController < MyController
       render action: :show
       return false
     end
-  end
-
-  def setup_show
-    @user_tracks = current_user.user_tracks.includes(:track)
   end
 end

--- a/app/controllers/my/track_settings_controller.rb
+++ b/app/controllers/my/track_settings_controller.rb
@@ -1,0 +1,43 @@
+class My::TrackSettingsController < MyController
+  def show
+    setup_show
+  end
+
+  def update_user_tracks
+    @user_tracks = current_user.user_tracks.includes(:track)
+    mapped_user_tracks = @user_tracks.each_with_object({}) {|ut, h|h[ut.id] = ut }
+
+    errors = []
+    params[:user_tracks].each do |id, data|
+      anon = data[:anonymous].to_i == 1
+      handle = data[:handle].present?? data[:handle] : nil
+
+      success = mapped_user_tracks[id.to_i].update(
+        anonymous: anon, handle: handle
+      )
+      errors << handle if !success && anon
+    end
+
+    errors.uniq!
+
+    if errors.empty?
+      flash.notice = "Your track settings have been updated"
+    elsif errors.size == 1
+      flash.alert = "The handle #{errors[0]} is already taken"
+    else
+      flash.alert = "The handles #{errors.to_sentence} are already taken"
+    end
+
+    render action: :show
+  end
+
+  def update
+    redirect_to action: :show
+  end
+
+  private
+
+  def setup_show
+    @user_tracks = current_user.user_tracks.includes(:track)
+  end
+end

--- a/app/controllers/my/track_settings_controller.rb
+++ b/app/controllers/my/track_settings_controller.rb
@@ -3,7 +3,7 @@ class My::TrackSettingsController < MyController
     setup_show
   end
 
-  def update_user_tracks
+  def update
     @user_tracks = current_user.user_tracks.includes(:track)
     mapped_user_tracks = @user_tracks.each_with_object({}) {|ut, h|h[ut.id] = ut }
 
@@ -29,10 +29,6 @@ class My::TrackSettingsController < MyController
     end
 
     render action: :show
-  end
-
-  def update
-    redirect_to action: :show
   end
 
   private

--- a/app/controllers/my/track_settings_controller.rb
+++ b/app/controllers/my/track_settings_controller.rb
@@ -1,6 +1,6 @@
 class My::TrackSettingsController < MyController
-  def show
-    setup_show
+  def edit
+    setup_edit
   end
 
   def update
@@ -28,12 +28,12 @@ class My::TrackSettingsController < MyController
       flash.alert = "The handles #{errors.to_sentence} are already taken"
     end
 
-    render action: :show
+    render action: :edit
   end
 
   private
 
-  def setup_show
+  def setup_edit
     @user_tracks = current_user.user_tracks.includes(:track)
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -3,6 +3,8 @@ module SettingsHelper
     selected = case controller_name
       when "communication_preferences"
         :preferences
+      when "track_settings"
+        :track_settings
       else
         :settings
       end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,11 @@
+module SettingsHelper
+  def settings_bar
+    selected = case controller_name
+      when "communication_preferences"
+        :preferences
+      else
+        :settings
+      end
+    render "layouts/settings_bar", selected: selected
+  end
+end

--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -32,5 +32,4 @@
           = link_to "Mentor dashboard", [:mentor, :dashboard]
         .hr
         = link_to "Settings", [:my, :settings]
-        = link_to "Preferences", [:edit, :my, :settings, :communication_preferences]
         = link_to "Sign out", destroy_user_session_path, method: :delete

--- a/app/views/layouts/_settings_bar.html.haml
+++ b/app/views/layouts/_settings_bar.html.haml
@@ -1,0 +1,4 @@
+#settings-bar.lo-settings-bar
+  .lo-container
+    =link_to "Account Settings", my_settings_path, class: (selected == :settings ? "selected" : "")
+    =link_to "Preferences", edit_my_settings_communication_preferences_path, class: (selected == :preferences ? "selected" : "")

--- a/app/views/layouts/_settings_bar.html.haml
+++ b/app/views/layouts/_settings_bar.html.haml
@@ -1,5 +1,5 @@
 #settings-bar.lo-settings-bar
   .lo-container
     =link_to "Account Settings", my_settings_path, class: (selected == :settings ? "selected" : "")
-    =link_to "Track Settings", my_settings_track_settings_path, class: (selected == :track_settings ? "selected" : "")
+    =link_to "Track Settings", edit_my_settings_track_settings_path, class: (selected == :track_settings ? "selected" : "")
     =link_to "Preferences", edit_my_settings_communication_preferences_path, class: (selected == :preferences ? "selected" : "")

--- a/app/views/layouts/_settings_bar.html.haml
+++ b/app/views/layouts/_settings_bar.html.haml
@@ -1,4 +1,5 @@
 #settings-bar.lo-settings-bar
   .lo-container
     =link_to "Account Settings", my_settings_path, class: (selected == :settings ? "selected" : "")
+    =link_to "Track Settings", my_settings_track_settings_path, class: (selected == :track_settings ? "selected" : "")
     =link_to "Preferences", edit_my_settings_communication_preferences_path, class: (selected == :preferences ? "selected" : "")

--- a/app/views/my/communication_preferences/edit.html.haml
+++ b/app/views/my/communication_preferences/edit.html.haml
@@ -1,9 +1,5 @@
 #my-communication-preferences-page
-  #nav.lo-nav-bar
-    .lo-container
-      =link_to "Settings", my_settings_path
-      =nav_divider
-      %span Communication preferences
+  =settings_bar
 
   .lo-container
     =notice_and_alert

--- a/app/views/my/settings/show.html.haml
+++ b/app/views/my/settings/show.html.haml
@@ -1,9 +1,5 @@
 #my-settings-page
-  #nav.lo-nav-bar
-    .lo-container
-      /=link_to "Dashboard", root_path
-      /=nav_divider
-      %span Settings
+  =settings_bar
 
   = notice_and_alert(current_user)
   .lo-container

--- a/app/views/my/settings/show.html.haml
+++ b/app/views/my/settings/show.html.haml
@@ -4,40 +4,38 @@
   = notice_and_alert(current_user)
   .lo-container
     %h1 Account settings
-    .pure-g
-      .pure-u-1
-        .settings-section
-          %h2 CLI token
-          .token-explanation Your authentication token for the CLI is:
-          =render "widgets/code_snippet", code: current_user.auth_token
+    .settings-section
+      %h2 CLI token
+      .token-explanation Your authentication token for the CLI is:
+      =render "widgets/code_snippet", code: current_user.auth_token
 
-        .settings-section
-          %h2 Change your password
-          %p You can change your password at any point.
+    .settings-section
+      %h2 Change your password
+      %p You can change your password at any point.
 
-          =form_for current_user, url: [:my, :settings] do |f|
-            -unless current_user.provider?
-              .field
-                =label_tag :old_password, "Enter your current password"
-                =password_field_tag :old_password
+      =form_for current_user, url: [:my, :settings] do |f|
+        -unless current_user.provider?
+          .field
+            =label_tag :old_password, "Enter your current password"
+            =password_field_tag :old_password
 
-            .field
-              =f.label :password, "Enter your new password"
-              =f.password_field :password, placeholder: "Enter your new password"
+        .field
+          =f.label :password, "Enter your new password"
+          =f.password_field :password, placeholder: "Enter your new password"
 
-            .field
-              =f.password_field :password_confirmation, placeholder: "Confirm your current password"
+        .field
+          =f.password_field :password_confirmation, placeholder: "Confirm your current password"
 
-            =button_tag "Update password", class: 'pure-button'
+        =button_tag "Update password", class: 'pure-button'
 
-        .settings-section
-          %h2 Change your handle
-          %p We recommend only changing your handle in rare circumstances as it is confusing for mentors if it changes reguarly.
-          %p Note that you can change the name that appears on your profile seperately by using the "Edit profile" button in your profile.
+    .settings-section
+      %h2 Change your handle
+      %p We recommend only changing your handle in rare circumstances as it is confusing for mentors if it changes reguarly.
+      %p Note that you can change the name that appears on your profile seperately by using the "Edit profile" button in your profile.
 
-          =form_for current_user, url: [:my, :settings] do |f|
-            .field
-              =f.label :handle, "Enter your new handle"
-              =f.text_field :handle
+      =form_for current_user, url: [:my, :settings] do |f|
+        .field
+          =f.label :handle, "Enter your new handle"
+          =f.text_field :handle
 
-            =button_tag "Update handle", class: 'pure-button'
+        =button_tag "Update handle", class: 'pure-button'

--- a/app/views/my/settings/show.html.haml
+++ b/app/views/my/settings/show.html.haml
@@ -5,7 +5,7 @@
   .lo-container
     %h1 Account settings
     .pure-g
-      .pure-u-1-3.lhs
+      .pure-u-1
         .settings-section
           %h2 CLI token
           .token-explanation Your authentication token for the CLI is:
@@ -41,53 +41,3 @@
               =f.text_field :handle
 
             =button_tag "Update handle", class: 'pure-button'
-
-      .pure-u-2-3.rhs
-        %h2 Privacy
-        %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
-        =form_tag [:update_user_tracks, :my, :settings], method: :patch do |f|
-          %table.tracks
-            %tr
-              %th Track
-              %th Use alias?
-              %th How you will appear
-            -@user_tracks.each do |user_track|
-              %tr.track
-                %td.title #{user_track.track.title} Track
-                %td.anonymous
-                  =check_box_tag "user_tracks[#{user_track.id}][anonymous]", 1, user_track.anonymous?, class: 'anonymous-toggle'
-                  .toggles
-                    =icon 'toggle-on'
-                    =icon 'toggle-off'
-                %td
-                  .default{style: user_track.anonymous?? "display:none" : ""}
-                    =image current_user.avatar_url, "Avatar of #{current_user.handle}"
-                    .handle= current_user.handle
-                  .anon{style: user_track.anonymous?? "" : "display:none"}
-                    =image "anonymous.png", "Anonymous avatar"
-                    =text_field_tag "user_tracks[#{user_track.id}][handle]", user_track.handle, class: 'handle', placeholder: "Choose an alias for this track", required: user_track.anonymous?
-                %td
-                  -if user_track.errors.present?
-                    .error Not saved
-
-          =button_tag "Update privacy settings", class: 'pure-button'
-
--content_for :js do
-  :javascript
-    $('.anonymous-toggle').change(function(){
-      var $checkbox = $(this)
-      var $handle = $checkbox.parent().next().find('input.handle')
-      var $default = $checkbox.parent().next().find('.default')
-      var $anon = $checkbox.parent().next().find('.anon')
-      var anon = $checkbox.prop('checked')
-
-      if(anon) {
-        $default.hide()
-        $anon.show()
-      } else {
-        $default.show()
-        $anon.hide()
-        $anon.find("input").val("")
-      }
-      $handle.attr('required', anon)
-    })

--- a/app/views/my/track_settings/edit.html.haml
+++ b/app/views/my/track_settings/edit.html.haml
@@ -6,7 +6,7 @@
     %h1 Track settings
     %h2 Privacy
     %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
-    =form_tag [:update, :my, :settings, :track_settings], method: :patch do |f|
+    =form_tag [:my, :settings, :track_settings], method: :patch do |f|
       %table.tracks
         %tr
           %th Track

--- a/app/views/my/track_settings/show.html.haml
+++ b/app/views/my/track_settings/show.html.haml
@@ -8,7 +8,7 @@
       .pure-u-1
         %h2 Privacy
         %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
-        =form_tag [:update_user_tracks, :my, :settings, :track_settings], method: :patch do |f|
+        =form_tag [:update, :my, :settings, :track_settings], method: :patch do |f|
           %table.tracks
             %tr
               %th Track

--- a/app/views/my/track_settings/show.html.haml
+++ b/app/views/my/track_settings/show.html.haml
@@ -4,36 +4,34 @@
   = notice_and_alert(current_user)
   .lo-container
     %h1 Track settings
-    .pure-g
-      .pure-u-1
-        %h2 Privacy
-        %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
-        =form_tag [:update, :my, :settings, :track_settings], method: :patch do |f|
-          %table.tracks
-            %tr
-              %th Track
-              %th Use alias?
-              %th How you will appear
-            -@user_tracks.each do |user_track|
-              %tr.track{:data => {:track => user_track.track.title}}
-                %td.title #{user_track.track.title} Track
-                %td.anonymous
-                  =check_box_tag "user_tracks[#{user_track.id}][anonymous]", 1, user_track.anonymous?, class: 'anonymous-toggle'
-                  .toggles
-                    =icon 'toggle-on'
-                    =icon 'toggle-off'
-                %td
-                  .default{style: user_track.anonymous?? "display:none" : ""}
-                    =image current_user.avatar_url, "Avatar of #{current_user.handle}"
-                    .handle= current_user.handle
-                  .anon{style: user_track.anonymous?? "" : "display:none"}
-                    =image "anonymous.png", "Anonymous avatar"
-                    =text_field_tag "user_tracks[#{user_track.id}][handle]", user_track.handle, class: 'handle', placeholder: "Choose an alias for this track", required: user_track.anonymous?
-                %td
-                  -if user_track.errors.present?
-                    .error Not saved
+    %h2 Privacy
+    %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
+    =form_tag [:update, :my, :settings, :track_settings], method: :patch do |f|
+      %table.tracks
+        %tr
+          %th Track
+          %th Use alias?
+          %th How you will appear
+        -@user_tracks.each do |user_track|
+          %tr.track{:data => {:track => user_track.track.title}}
+            %td.title #{user_track.track.title} Track
+            %td.anonymous
+              =check_box_tag "user_tracks[#{user_track.id}][anonymous]", 1, user_track.anonymous?, class: 'anonymous-toggle'
+              .toggles
+                =icon 'toggle-on'
+                =icon 'toggle-off'
+            %td
+              .default{style: user_track.anonymous?? "display:none" : ""}
+                =image current_user.avatar_url, "Avatar of #{current_user.handle}"
+                .handle= current_user.handle
+              .anon{style: user_track.anonymous?? "" : "display:none"}
+                =image "anonymous.png", "Anonymous avatar"
+                =text_field_tag "user_tracks[#{user_track.id}][handle]", user_track.handle, class: 'handle', placeholder: "Choose an alias for this track", required: user_track.anonymous?
+            %td
+              -if user_track.errors.present?
+                .error Not saved
 
-          =button_tag "Update privacy settings", class: 'pure-button'
+      =button_tag "Update privacy settings", class: 'pure-button'
 
 -content_for :js do
   :javascript

--- a/app/views/my/track_settings/show.html.haml
+++ b/app/views/my/track_settings/show.html.haml
@@ -1,0 +1,56 @@
+#my-track-settings-page
+  =settings_bar
+
+  = notice_and_alert(current_user)
+  .lo-container
+    %h1 Track settings
+    .pure-g
+      .pure-u-1
+        %h2 Privacy
+        %p You can use different aliases on tracks where you wish to be anonymous. By default your handle and photo will appear next to solutions.
+        =form_tag [:update_user_tracks, :my, :settings, :track_settings], method: :patch do |f|
+          %table.tracks
+            %tr
+              %th Track
+              %th Use alias?
+              %th How you will appear
+            -@user_tracks.each do |user_track|
+              %tr.track
+                %td.title #{user_track.track.title} Track
+                %td.anonymous
+                  =check_box_tag "user_tracks[#{user_track.id}][anonymous]", 1, user_track.anonymous?, class: 'anonymous-toggle'
+                  .toggles
+                    =icon 'toggle-on'
+                    =icon 'toggle-off'
+                %td
+                  .default{style: user_track.anonymous?? "display:none" : ""}
+                    =image current_user.avatar_url, "Avatar of #{current_user.handle}"
+                    .handle= current_user.handle
+                  .anon{style: user_track.anonymous?? "" : "display:none"}
+                    =image "anonymous.png", "Anonymous avatar"
+                    =text_field_tag "user_tracks[#{user_track.id}][handle]", user_track.handle, class: 'handle', placeholder: "Choose an alias for this track", required: user_track.anonymous?
+                %td
+                  -if user_track.errors.present?
+                    .error Not saved
+
+          =button_tag "Update privacy settings", class: 'pure-button'
+
+-content_for :js do
+  :javascript
+    $('.anonymous-toggle').change(function(){
+      var $checkbox = $(this)
+      var $handle = $checkbox.parent().next().find('input.handle')
+      var $default = $checkbox.parent().next().find('.default')
+      var $anon = $checkbox.parent().next().find('.anon')
+      var anon = $checkbox.prop('checked')
+
+      if(anon) {
+        $default.hide()
+        $anon.show()
+      } else {
+        $default.show()
+        $anon.hide()
+        $anon.find("input").val("")
+      }
+      $handle.attr('required', anon)
+    })

--- a/app/views/my/track_settings/show.html.haml
+++ b/app/views/my/track_settings/show.html.haml
@@ -15,7 +15,7 @@
               %th Use alias?
               %th How you will appear
             -@user_tracks.each do |user_track|
-              %tr.track
+              %tr.track{:data => {:track => user_track.track.title}}
                 %td.title #{user_track.track.title} Track
                 %td.anonymous
                   =check_box_tag "user_tracks[#{user_track.id}][anonymous]", 1, user_track.anonymous?, class: 'anonymous-toggle'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,8 +139,10 @@ Rails.application.routes.draw do
     resource :profile, controller: "profile"
 
     resource :settings do
-      patch :update_user_tracks
       resource :communication_preferences, only: [:edit, :update]
+      resource :track_settings, only: [:show, :update] do
+        patch :update_user_tracks
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,7 @@ Rails.application.routes.draw do
 
     resource :settings do
       resource :communication_preferences, only: [:edit, :update]
-      resource :track_settings, only: [:show, :update]
+      resource :track_settings, only: [:edit, :update]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,9 +140,7 @@ Rails.application.routes.draw do
 
     resource :settings do
       resource :communication_preferences, only: [:edit, :update]
-      resource :track_settings, only: [:show, :update] do
-        patch :update_user_tracks
-      end
+      resource :track_settings, only: [:show, :update]
     end
   end
 

--- a/test/system/my/communication_preferences_test.rb
+++ b/test/system/my/communication_preferences_test.rb
@@ -1,0 +1,19 @@
+require 'application_system_test_case'
+
+class My::SettingsTest < ApplicationSystemTestCase
+  setup do
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    @user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    BootstrapUser.(@user)
+    sign_in!(@user)
+  end
+
+  test "can navigate to communication preferences" do
+    visit my_settings_path
+    assert page.has_link?(href: edit_my_settings_communication_preferences_path)
+    click_on "Preferences"
+    assert_current_path edit_my_settings_communication_preferences_path
+  end
+end

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -1,0 +1,52 @@
+require 'application_system_test_case'
+
+class My::SettingsTest < ApplicationSystemTestCase
+  setup do
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    @user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    BootstrapUser.(@user)
+    sign_in!(@user)
+  end
+
+  test "shows CLI token" do
+    visit my_settings_path
+    assert ".download-code" do
+        assert "[value=?]", @user.auth_token
+    end
+  end
+
+  test "can change password successfully" do
+    visit my_settings_path
+
+    assert_selector "#old_password"
+    assert_selector "#user_password"
+    assert_selector "#user_password_confirmation"
+
+    old_password = FactoryBot.attributes_for(:user)[:password]
+
+    fill_in "Enter your current password", with: old_password
+    fill_in "Enter your new password", with: "password"
+    fill_in "Confirm your current password", with: "password"
+
+    click_on "Update password"
+
+    assert_selector "#notice", text: "Password updated successfully" 
+  end
+
+  test "can change handle successfully" do
+    visit my_settings_path
+
+    assert_selector "#user_handle"
+
+    new_handle = SecureRandom.uuid
+    fill_in "Enter your new handle", with: new_handle
+
+    click_on "Update handle"
+
+    assert_selector "#notice", text: "Handle updated successfully" 
+    @user.reload
+    assert_equal @user.handle, new_handle
+  end
+end

--- a/test/system/my/track_settings_test.rb
+++ b/test/system/my/track_settings_test.rb
@@ -12,16 +12,16 @@ class My::TrackSettingsTest < ApplicationSystemTestCase
 
   test "can navigate to track settings" do
     visit my_settings_path
-    assert page.has_link?(href: my_settings_track_settings_path)
+    assert page.has_link?(href: edit_my_settings_track_settings_path)
     click_on "Track Settings"
-    assert_current_path my_settings_track_settings_path
+    assert_current_path edit_my_settings_track_settings_path
   end
 
   test "can set track to use anonymous handle" do
     @user_track = create(:user_track, user: @user)
     anon_handle = SecureRandom.uuid
 
-    visit my_settings_track_settings_path
+    visit edit_my_settings_track_settings_path
 
     assert_not_equal true, @user_track.anonymous
     find("tr[data-track=#{@user_track.track.title}] input[type=checkbox]", visible: false).click
@@ -41,7 +41,7 @@ class My::TrackSettingsTest < ApplicationSystemTestCase
     anon_handle = SecureRandom.uuid
     @user_track.update_attributes(anonymous: true, handle: anon_handle)
 
-    visit my_settings_track_settings_path
+    visit edit_my_settings_track_settings_path
 
     assert_equal true, @user_track.anonymous
     find("tr[data-track=#{@user_track.track.title}] input[type=checkbox]", visible: false).click

--- a/test/system/my/track_settings_test.rb
+++ b/test/system/my/track_settings_test.rb
@@ -1,0 +1,56 @@
+require 'application_system_test_case'
+
+class My::TrackSettingsTest < ApplicationSystemTestCase
+  setup do
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    @user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    BootstrapUser.(@user)
+    sign_in!(@user)
+  end
+
+  test "can navigate to track settings" do
+    visit my_settings_path
+    assert page.has_link?(href: my_settings_track_settings_path)
+    click_on "Track Settings"
+    assert_current_path my_settings_track_settings_path
+  end
+
+  test "can set track to use anonymous handle" do
+    @user_track = create(:user_track, user: @user)
+    anon_handle = SecureRandom.uuid
+
+    visit my_settings_track_settings_path
+
+    assert_not_equal true, @user_track.anonymous
+    find("tr[data-track=#{@user_track.track.title}] input[type=checkbox]", visible: false).click
+    find("tr[data-track=#{@user_track.track.title}] input[type=text]", visible: false).set(anon_handle)
+
+    click_on "Update privacy settings"
+
+    assert_selector "#notice", text: "Your track settings have been updated" 
+
+    @user_track.reload
+    assert_equal true, @user_track.anonymous
+    assert_equal anon_handle, @user_track.handle
+  end
+
+  test "can set track to stop using anonymous handle" do
+    @user_track = create(:user_track, user: @user)
+    anon_handle = SecureRandom.uuid
+    @user_track.update_attributes(anonymous: true, handle: anon_handle)
+
+    visit my_settings_track_settings_path
+
+    assert_equal true, @user_track.anonymous
+    find("tr[data-track=#{@user_track.track.title}] input[type=checkbox]", visible: false).click
+
+    click_on "Update privacy settings"
+
+    assert_selector "#notice", text: "Your track settings have been updated" 
+
+    @user_track.reload
+    assert_not_equal true, @user_track.anonymous
+  end
+end


### PR DESCRIPTION
Changes include:
- Moving privacy options to a new page
- Replacing the navigation bar on each settings page with links to the other pages
- Removing the "Preferences" option in the drop down menu
- Adding tests for these pages