### PR TITLE
Saving new discussion posts to local storage

### DIFF
--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -45,7 +45,10 @@ window.setupSolution = (solutionID, iterationID) ->
     return content
 
   setLocalStoragePost = (content) =>
-    localStorage.setItem('discussionPost-' + solutionID + '-' + iterationID, content)
+    if content.length > 0
+      localStorage.setItem('discussionPost-' + solutionID + '-' + iterationID, content)
+    else 
+      localStorage.removeItem('discussionPost-' + solutionID + '-' + iterationID)
     updateStatusDiscussionPost(content)
 
   setupNewDiscussionPost = =>

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -10,7 +10,7 @@ window.setupSolutionTabs = ->
         tabId = c.replace("tab-", "") if c.startsWith("tab-")
 
       $container.addClass("selected-#{tabId}") if tabId
-window.setupSolution = ->
+window.setupSolution = (solutionID, iterationID) ->
   ###
     $window = $(window)
     setupLayout = =>
@@ -40,12 +40,12 @@ window.setupSolution = ->
       $(".new-discussion-post-form .btn-toolbar .saved").remove()
 
   getLocalStoragePost = =>
-    content = localStorage.getItem('discussionPost-' + window.location.pathname) || ""
+    content = localStorage.getItem('discussionPost-' + solutionID + '-' + iterationID) || ""
     updateStatusDiscussionPost(content)
     return content
 
   setLocalStoragePost = (content) =>
-    localStorage.setItem('discussionPost-' + window.location.pathname, content)
+    localStorage.setItem('discussionPost-' + solutionID + '-' + iterationID, content)
     updateStatusDiscussionPost(content)
 
   setupNewDiscussionPost = =>

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -47,7 +47,6 @@ window.setupSolution = ->
   setLocalStoragePost = (content) =>
     localStorage.setItem('discussionPost-' + window.location.pathname, content)
     updateStatusDiscussionPost(content)
-    return content
 
   setupNewDiscussionPost = =>
     $textarea = $(".new-discussion-post-form textarea")

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -33,12 +33,20 @@ window.setupSolution = ->
       else
         $lhs.removeClass('fixed')
   ###
+  updateStatusDiscussionPost = (content) =>
+    if content.length > 0 && $(".new-discussion-post-form .btn-toolbar .saved").length < 1
+      $(".new-discussion-post-form .btn-toolbar").append("<span class='saved'>Draft saved</span>")
+    if content.length < 1
+      $(".new-discussion-post-form .btn-toolbar .saved").remove()
+
   getLocalStoragePost = =>
     content = localStorage.getItem('discussionPost-' + window.location.pathname)
+    updateStatusDiscussionPost(content)
     return content
 
   setLocalStoragePost = (content) =>
     localStorage.setItem('discussionPost-' + window.location.pathname, content)
+    updateStatusDiscussionPost(content)
     return content
 
   setupNewDiscussionPost = =>

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -33,6 +33,13 @@ window.setupSolution = ->
       else
         $lhs.removeClass('fixed')
   ###
+  getLocalStoragePost = =>
+    content = localStorage.getItem('discussionPost-' + window.location.pathname)
+    return content
+
+  setLocalStoragePost = (content) =>
+    localStorage.setItem('discussionPost-' + window.location.pathname, content)
+    return content
 
   setupNewDiscussionPost = =>
     $textarea = $(".new-discussion-post-form textarea")
@@ -41,6 +48,11 @@ window.setupSolution = ->
     $textarea.markdown
       iconlibrary: 'fa'
       hiddenButtons: 'cmdHeading cmdImage cmdPreview'
+
+    $textarea.val(getLocalStoragePost())
+
+    $textarea.bind "keyup change input", ->
+      setLocalStoragePost($textarea.val())
 
     $('.preview-tab').click ->
       markdown = $textarea.val()
@@ -52,6 +64,7 @@ window.setupSolution = ->
       $('.new-discussion-post-form textarea').val("")
       $('.new-discussion-post-form .preview-area').html('')
       Prism.highlightAll()
+      setLocalStoragePost("")
 
   #$window.resize(setupLayout)
   #setupLayout()

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -40,7 +40,7 @@ window.setupSolution = ->
       $(".new-discussion-post-form .btn-toolbar .saved").remove()
 
   getLocalStoragePost = =>
-    content = localStorage.getItem('discussionPost-' + window.location.pathname)
+    content = localStorage.getItem('discussionPost-' + window.location.pathname) || ""
     updateStatusDiscussionPost(content)
     return content
 

--- a/app/views/mentor/solutions/show.html.haml
+++ b/app/views/mentor/solutions/show.html.haml
@@ -39,4 +39,4 @@
 
 -content_for :js do
   :javascript
-    setupSolution()
+    setupSolution("#{@solution.uuid}", #{@iteration.id})

--- a/app/views/my/solutions/_show_rhs.html.haml
+++ b/app/views/my/solutions/_show_rhs.html.haml
@@ -27,4 +27,4 @@
 
 -content_for :js do
   :javascript
-    setupSolution()
+    setupSolution("#{@solution.uuid}", #{@iteration.id})

--- a/app/views/teams/teams/my_solutions/show.html.haml
+++ b/app/views/teams/teams/my_solutions/show.html.haml
@@ -48,4 +48,4 @@
 
 -content_for :js do
   :javascript
-    setupSolution()
+    setupSolution("#{@solution.uuid}", #{@iteration.id})

--- a/app/views/teams/teams/solutions/show.html.haml
+++ b/app/views/teams/teams/solutions/show.html.haml
@@ -58,4 +58,4 @@
 
 -content_for :js do
   :javascript
-    setupSolution()
+    setupSolution("#{@solution.uuid}", #{@iteration.id})

--- a/test/system/my/solution_discussion_section_test.rb
+++ b/test/system/my/solution_discussion_section_test.rb
@@ -194,4 +194,28 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     click_on "Comment"
     within(".preview-area") { assert_text "", { exact: true } }
   end
+
+  test "localstorage saves comment draft" do
+    solution = create(:solution, user: @user, track_in_independent_mode: false, independent_mode: false)
+    create :iteration, solution: solution
+    create(:user_track, track: solution.track, user: @user)
+
+    visit my_solution_path(solution)
+
+    assert_selector ".comment-button"
+    assert_selector ".markdown"
+    refute_selector ".preview"
+
+    assert_equal "", find(".new-discussion-post-form textarea").value
+    find(".new-discussion-post-form textarea").set("An example mentor comment to test the comment button!")
+
+    visit my_solution_path(solution)
+
+    assert_equal "An example mentor comment to test the comment button!", find(".new-discussion-post-form textarea").value
+    find(".new-discussion-post-form textarea").set("")
+
+    visit my_solution_path(solution)
+
+    assert_equal "", find(".new-discussion-post-form textarea").value
+  end
 end


### PR DESCRIPTION
Changes include:
- Saving editor contents to local storage automatically
- Fetching contents on page load
- Clears saved draft after successful comment
- Added a notice on editors after saving a draft (for a non-empty draft) - see below
- Added a test for this feature

<img width="452" alt="screen shot 2018-08-30 at 11 10 00" src="https://user-images.githubusercontent.com/1905799/44850107-2010c380-ac54-11e8-9d8d-6b5c121d53ed.png">

Closes exercism/exercism#4312