### PR TITLE
Temporary removal of placeholder completion message

### DIFF
--- a/app/views/my/tracks/_finished_modal.html.haml
+++ b/app/views/my/tracks/_finished_modal.html.haml
@@ -2,5 +2,5 @@
 %h2 Well done!
 %h3 You've completed the #{@track.title} Track
 
-%p lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum.
+-# %p lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum.
 =link_to "Continue", "#", class: "pure-button close-modal"


### PR DESCRIPTION
Upon completing a track, the user is shown a placeholder "lorem ipsum" message (exercism/exercism#3839).
I've commented out the placeholder message to avoid confusion, but it will need to eventually be replaced by either a global message, or track specific message.