### PR TITLE
Added keyup event after loading localstorage comment

### DIFF
--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -60,6 +60,7 @@ window.setupSolution = (solutionID, iterationID) ->
       hiddenButtons: 'cmdHeading cmdImage cmdPreview'
 
     $textarea.val(getLocalStoragePost())
+    $textarea.keyup()
 
     $textarea.bind "keyup change input", ->
       setLocalStoragePost($textarea.val())


### PR DESCRIPTION
This triggers the keyup listener on the comment box, to change the "Approve" button to "Approve and comment" if not empty