### PR TITLE
Added test for unreacting, and fixed for a reaction with comment

### DIFF
--- a/app/services/create_reaction.rb
+++ b/app/services/create_reaction.rb
@@ -7,7 +7,11 @@ class CreateReaction
     @reaction = Reaction.where(user: user, solution: solution).first
     if reaction
       if emotion == reaction.emotion
-        destroy_reaction unless reaction.comment.present?
+        if reaction.comment.present?
+          update_reaction('legacy')
+        else
+          destroy_reaction
+        end
       else
         update_reaction
       end
@@ -39,8 +43,8 @@ class CreateReaction
     update_solution_reaction_counter
   end
 
-  def update_reaction
-    reaction.update!(emotion: emotion)
+  def update_reaction(emotion_new = emotion)
+    reaction.update!(emotion: emotion_new)
   end
 
   def destroy_reaction

--- a/test/controllers/my/reactions_controller_test.rb
+++ b/test/controllers/my/reactions_controller_test.rb
@@ -51,7 +51,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal @current_user, reaction.user
     assert_equal comment, reaction.comment
-    assert_equal "love", reaction.emotion
+    assert_equal "legacy", reaction.emotion
   end
 
   test "index only shows published solutions" do

--- a/test/services/create_reaction_test.rb
+++ b/test/services/create_reaction_test.rb
@@ -82,7 +82,7 @@ class CreatesReactionTest < ActiveSupport::TestCase
     assert reaction.persisted?
     assert_equal solution, reaction.solution
     assert_equal user, reaction.user
-    assert_equal emotion, reaction.emotion
+    assert_equal 'legacy', reaction.emotion
     assert_equal 1, solution.num_reactions
   end
 end

--- a/test/system/solutions_test.rb
+++ b/test/system/solutions_test.rb
@@ -33,4 +33,43 @@ class SolutionsTest < ApplicationSystemTestCase
     sign_in!(user)
     visit track_exercise_solutions_path(solution.track, solution.exercise)
   end
+
+  test "can react to a solution" do
+    user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    solution = create(:solution, published_at: Time.now)
+
+    sign_in!(user)
+    visit solution_path(solution)
+
+    assert_equal 0, solution.reactions.count
+
+    assert_selector ".react", text: "React to this solution"
+    find(".react .like").click
+    assert_selector ".react .like.selected"
+
+    solution.reload
+    assert_equal 1, solution.reactions.count
+  end
+
+  test "can unreact to a solution" do
+    user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    solution = create(:solution, published_at: Time.now)
+    reaction = create(:reaction, user: user, solution: solution, emotion: :like)
+
+    sign_in!(user)
+    visit solution_path(solution)
+
+    assert_equal 1, solution.reactions.count
+
+    assert_selector ".react", text: "React to this solution"
+    find(".react .like.selected").click
+    assert_no_selector ".react .like.selected", wait: 10
+
+    solution.reload
+    assert_equal 0, solution.reactions.count
+  end
 end

--- a/test/system/solutions_test.rb
+++ b/test/system/solutions_test.rb
@@ -58,7 +58,7 @@ class SolutionsTest < ApplicationSystemTestCase
                   accepted_terms_at: Date.new(2016, 12, 25),
                   accepted_privacy_policy_at: Date.new(2016, 12, 25))
     solution = create(:solution, published_at: Time.now)
-    reaction = create(:reaction, user: user, solution: solution, emotion: :like)
+    reaction = create(:reaction, user: user, solution: solution, emotion: :like, comment: nil)
 
     sign_in!(user)
     visit solution_path(solution)
@@ -71,5 +71,27 @@ class SolutionsTest < ApplicationSystemTestCase
 
     solution.reload
     assert_equal 0, solution.reactions.count
+  end
+
+  test "can unreact to a solution with a comment" do
+    user = create(:user,
+                  accepted_terms_at: Date.new(2016, 12, 25),
+                  accepted_privacy_policy_at: Date.new(2016, 12, 25))
+    solution = create(:solution, published_at: Time.now)
+    reaction = create(:reaction, user: user, solution: solution, emotion: :like)
+
+    sign_in!(user)
+    visit solution_path(solution)
+
+    assert_equal 1, solution.reactions.count
+    assert_equal "like", solution.reactions.first.emotion
+
+    assert_selector ".react", text: "React to this solution"
+    find(".react .like.selected").click
+    assert_no_selector ".react .like.selected", wait: 10
+
+    solution.reload
+    assert_equal 1, solution.reactions.count
+    assert_equal "legacy", solution.reactions.first.emotion
   end
 end


### PR DESCRIPTION
Fixes exercism/exercism#4218

- Added system tests for reacting and unreacting - the feature itself already exists
- Allow unreacting on a reaction with a comment, by setting the emotion as 'legacy' to appear as a comment-only reaction