### PR TITLE
Add admin mentor page

### DIFF
--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,0 +1,4 @@
+class Admin::MentorsController < ApplicationController
+  def index
+  end
+end

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,0 +1,2 @@
+%h1 Admin::Mentors#index
+%p Find me in app/views/admin/mentors/index.html.haml

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     resources :solutions, only: [:show] do
       resources :iterations, only: [:show]
     end
+    resources :mentors, only: [:index]
   end
 
   # ###### #

--- a/test/controllers/admin/mentors_controller_test.rb
+++ b/test/controllers/admin/mentors_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class Admin::MentorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get Rails.application.routes.url_helpers.admin_mentors_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
Part 1 (issue#28) of issue#33 Build out admin section for mentors

This concerns the creation of a section for administrators of Exercism to get an overview of mentors on the site. 
see: https://github.com/exercism/guest-contributors/issues/28
see also: https://github.com/exercism/guest-contributors/issues/33