### PR TITLE
Remove deprecated Devise method

### DIFF
--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -20,7 +20,7 @@ class My::SettingsController < MyController
         password: params[:user][:password],
         password_confirmation: params[:user][:password_confirmation]
       )
-      sign_in(current_user, bypass: true)
+      bypass_sign_in current_user
       flash.notice = "Password updated successfully"
       return true
     else


### PR DESCRIPTION
Closes exercism/exercism#4330. There is already a system test for updating the user's password so I think that should cover this change. I also verified that it works locally.