### PR TITLE
Ensure seed track list is up to date

### DIFF
--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -21,7 +21,6 @@ class Git::SeedsTracks
     https://github.com/exercism/d
     https://github.com/exercism/dart
     https://github.com/exercism/delphi
-    https://github.com/exercism/ecmascript
     https://github.com/exercism/elisp
     https://github.com/exercism/elixir
     https://github.com/exercism/elm
@@ -47,6 +46,7 @@ class Git::SeedsTracks
     https://github.com/exercism/ocaml
     https://github.com/exercism/perl5
     https://github.com/exercism/perl6
+    https://github.com/exercism/pharo
     https://github.com/exercism/php
     https://github.com/exercism/plsql
     https://github.com/exercism/pony


### PR DESCRIPTION
This removes the deprecated ecmascript track, and adds the missing pharo track.

Ref: https://github.com/exercism/cli/issues/732#issuecomment-420118625