### PR TITLE
Parse tables in markdown

### DIFF
--- a/app/services/parse_markdown.rb
+++ b/app/services/parse_markdown.rb
@@ -19,7 +19,7 @@ class ParseMarkdown
   end
 
   def raw_html
-    @raw_html ||= Renderer.new.render(CommonMarker.render_doc(preprocessed_text))
+    @raw_html ||= Renderer.new.render(CommonMarker.render_doc(preprocessed_text, :DEFAULT, [:table]))
   end
 
   def preprocessed_text

--- a/test/services/parse_markdown_test.rb
+++ b/test/services/parse_markdown_test.rb
@@ -35,4 +35,31 @@ $ go home
   test "doesn't blow up with nil" do
     assert_equal "", ParseMarkdown.(nil)
   end
+
+  test "parses tables" do
+    table = <<~TABLE
+      1   | 2
+      --- | ---
+      3   | 4
+    TABLE
+
+
+    expected = <<~HTML
+      <table>
+      <thead>
+      <tr>
+      <th>1</th>
+      <th>2</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td>3</td>
+      <td>4</td>
+      </tr>
+      </tbody>
+      </table>
+    HTML
+    assert_equal expected, ParseMarkdown.(table)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4294.

## Description
This PR turns on the table parsing extension in our Markdown parser.