### PR TITLE
[WIP] Add mentoring management section to admin dashboard

### DIFF
--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,7 +1,15 @@
 class Admin::MentorsController < ApplicationController
+
   def index
-    @user = User.all()
-    @mentor = TrackMentorship.all()
+    @user_ids = TrackMentorship.distinct.pluck(:user_id)
+    @users = User.where(id: @user_ids).page(params[:page]).per(20)
+    @tracks = Hash.new
+    @user_ids.each do |user_id|
+      @tracks[user_id] = TrackMentorship.where(user_id: user_id).to_a().map {
+        |mentorship|
+        mentorship.track.title
+      } #.first().track.introduction
+    end
   end
 
   def show

--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,4 +1,10 @@
 class Admin::MentorsController < ApplicationController
   def index
+    @user = User.all()
+    @mentor = TrackMentorship.all()
   end
+
+  def show
+  end
+
 end

--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -2,13 +2,13 @@ class Admin::MentorsController < ApplicationController
 
   def index
     @user_ids = TrackMentorship.distinct.pluck(:user_id)
-    @users = User.where(id: @user_ids).page(params[:page]).per(20)
+    @users = User.where(id: @user_ids)
     @tracks = Hash.new
     @user_ids.each do |user_id|
       @tracks[user_id] = TrackMentorship.where(user_id: user_id).to_a().map {
         |mentorship|
         mentorship.track.title
-      } #.first().track.introduction
+      }
     end
   end
 

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,17 +1,29 @@
--# @users must contain the User rows whose id is in TrackMentorship table! 
+-# @users must contain the User rows whose id is in TrackMentorship table!
+-#
+-# %table
+-#   %tbody
+-#     %tr
+-#       %td Name:
+-#       %td Handle:
+-#     - @users.each do |user|
+-#       %tr
+-#         %td= user.name
+-#         %td= user.handle
 
 %table
   %tbody
     %tr
-      %td Name:
-      %td Handle:
-      %td Languages:
-    - @user.each do |user|
+      %th Name
+      %th Handle
+      %th Languages
+    - @users.each do |user|
       %tr
         %td= user.name
         %td= user.handle
-        %td= user.email
+        %td= @tracks[user.id].join(',')
 
 .danger-zone
   .lo-container
     =link_to "View", "#", class: 'pure-button leave-track-btn'
+
+=paginate @users

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,2 +1,17 @@
-%h1 Admin::Mentors#index
-%p Find me in app/views/admin/mentors/index.html.haml
+-# @users must contain the User rows whose id is in TrackMentorship table! 
+
+%table
+  %tbody
+    %tr
+      %td Name:
+      %td Handle:
+      %td Languages:
+    - @user.each do |user|
+      %tr
+        %td= user.name
+        %td= user.handle
+        %td= user.email
+
+.danger-zone
+  .lo-container
+    =link_to "View", "#", class: 'pure-button leave-track-btn'

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,15 +1,3 @@
--# @users must contain the User rows whose id is in TrackMentorship table!
--#
--# %table
--#   %tbody
--#     %tr
--#       %td Name:
--#       %td Handle:
--#     - @users.each do |user|
--#       %tr
--#         %td= user.name
--#         %td= user.handle
-
 %table
   %tbody
     %tr
@@ -22,8 +10,6 @@
         %td= user.handle
         %td= @tracks[user.id].join(',')
 
-.danger-zone
-  .lo-container
-    =link_to "View", "#", class: 'pure-button leave-track-btn'
 
-=paginate @users
+.lo-container
+  =link_to "View", "#", class: 'pure-button'


### PR DESCRIPTION
This is to display a list of mentors, their handles and tracks (languages) to the mentor management section of the admin dashboard. 

This will allow the admin team to monitor mentors and follow their development. It also includes a view button. Next we will add pagination.  This feature is described in exercism/guest-contributors#33. This PR resolves exercism/guest-contributors#29 and exercism/guest-contributors#30.
