### PR TITLE
Add pagination to mentor's section of admin dashboard

### DIFF
--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,7 +1,15 @@
 class Admin::MentorsController < ApplicationController
+
   def index
-    @user = User.all()
-    @mentor = TrackMentorship.all()
+    @user_ids = TrackMentorship.distinct.pluck(:user_id)
+    @users = User.where(id: @user_ids).page(params[:page]).per(20)
+    @tracks = Hash.new
+    @user_ids.each do |user_id|
+      @tracks[user_id] = TrackMentorship.where(user_id: user_id).to_a().map {
+        |mentorship|
+        mentorship.track.title
+      } #.first().track.introduction
+    end
   end
 
   def show

--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,4 +1,10 @@
 class Admin::MentorsController < ApplicationController
   def index
+    @user = User.all()
+    @mentor = TrackMentorship.all()
   end
+
+  def show
+  end
+
 end

--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -2,13 +2,13 @@ class Admin::MentorsController < ApplicationController
 
   def index
     @user_ids = TrackMentorship.distinct.pluck(:user_id)
-    @users = User.where(id: @user_ids).page(params[:page]).per(20)
+    @users = User.where(id: @user_ids)
     @tracks = Hash.new
     @user_ids.each do |user_id|
       @tracks[user_id] = TrackMentorship.where(user_id: user_id).to_a().map {
         |mentorship|
         mentorship.track.title
-      } #.first().track.introduction
+      }
     end
   end
 

--- a/app/controllers/admin/mentors_controller.rb
+++ b/app/controllers/admin/mentors_controller.rb
@@ -1,8 +1,9 @@
 class Admin::MentorsController < ApplicationController
 
   def index
+    mentors_per_page = 30
     @user_ids = TrackMentorship.distinct.pluck(:user_id)
-    @users = User.where(id: @user_ids)
+    @users = User.where(id: @user_ids).page(params[:page]).per(mentors_per_page)
     @tracks = Hash.new
     @user_ids.each do |user_id|
       @tracks[user_id] = TrackMentorship.where(user_id: user_id).to_a().map {

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,17 +1,29 @@
--# @users must contain the User rows whose id is in TrackMentorship table! 
+-# @users must contain the User rows whose id is in TrackMentorship table!
+-#
+-# %table
+-#   %tbody
+-#     %tr
+-#       %td Name:
+-#       %td Handle:
+-#     - @users.each do |user|
+-#       %tr
+-#         %td= user.name
+-#         %td= user.handle
 
 %table
   %tbody
     %tr
-      %td Name:
-      %td Handle:
-      %td Languages:
-    - @user.each do |user|
+      %th Name
+      %th Handle
+      %th Languages
+    - @users.each do |user|
       %tr
         %td= user.name
         %td= user.handle
-        %td= user.email
+        %td= @tracks[user.id].join(',')
 
 .danger-zone
   .lo-container
     =link_to "View", "#", class: 'pure-button leave-track-btn'
+
+=paginate @users

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -13,3 +13,5 @@
 
 .lo-container
   =link_to "View", "#", class: 'pure-button'
+
+=paginate @users

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,2 +1,17 @@
-%h1 Admin::Mentors#index
-%p Find me in app/views/admin/mentors/index.html.haml
+-# @users must contain the User rows whose id is in TrackMentorship table! 
+
+%table
+  %tbody
+    %tr
+      %td Name:
+      %td Handle:
+      %td Languages:
+    - @user.each do |user|
+      %tr
+        %td= user.name
+        %td= user.handle
+        %td= user.email
+
+.danger-zone
+  .lo-container
+    =link_to "View", "#", class: 'pure-button leave-track-btn'

--- a/app/views/admin/mentors/index.html.haml
+++ b/app/views/admin/mentors/index.html.haml
@@ -1,15 +1,3 @@
--# @users must contain the User rows whose id is in TrackMentorship table!
--#
--# %table
--#   %tbody
--#     %tr
--#       %td Name:
--#       %td Handle:
--#     - @users.each do |user|
--#       %tr
--#         %td= user.name
--#         %td= user.handle
-
 %table
   %tbody
     %tr
@@ -22,8 +10,6 @@
         %td= user.handle
         %td= @tracks[user.id].join(',')
 
-.danger-zone
-  .lo-container
-    =link_to "View", "#", class: 'pure-button leave-track-btn'
 
-=paginate @users
+.lo-container
+  =link_to "View", "#", class: 'pure-button'


### PR DESCRIPTION
This is to add pagination to the mentor management section of the admin dashboard. We placed number of items per page in a variable and set it to 30 per page as requested. This feature is described in exercism/guest-contributors#33. This PR addresses exercism/guest-contributors#32. 