### PR TITLE
Add steps to setup OAuth for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Note: Teams will be avaliable on http://teams.lvh.me:3000
 
 We recommend using `lvh.me` which is a DNS redirect to localhost, but which we honour cookies on.
 
+### OAuth setup
+
+In order to login via OAuth on development, [create a new OAuth application on GitHub](https://github.com/settings/applications/new).
+
+Fill in the form with the following details:
+
+- Application Name: Exercism (Dev)
+- Homepage URL: https://lvh.me:3000
+- Authorization Callback URL: http://lvh.me:3000/users/auth/github/callback
+
+The hostname and port would depend on your development setup.
+
+Once created, paste in the GitHub key and secret into `config/secrets.yml`.
+
 ## Extra scripts and useful notes
 
 ### Deleting an account

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,8 +3,8 @@
 
 development:
   secret_key_base: eac22c825e9b855087133488eec19eeff644b8bb25f7e6e359e847a2c2fe4366ff72e1543ce15ef9f2dc2b4bf6f095a5682d7b03af81f2706f888c74f06ba1ab
-  github_key: f19303e181ab6a2b6413
-  github_secret: d077b52d7432e3f95d474b64af2a32f1e7a36ac5
+  github_key: CHANGEME
+  github_secret: CHANGEME
 
 test:
   secret_key_base: 60785574a657542ba208c881c80b06b30cf6b4d6ad57a2bb2deb4e0de315fa1256dc74bad3d4dd483a37f467c75412a143344e11ace332e8ab2eff254ef05f2c


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/340.

In order to accommodate for the difference in development environments, it is better for users to set up their own OAuth app. I've added instructions and the correct URLs to use in order for OAuth to work properly.