### PR TITLE
Fix settings page bugs

### DIFF
--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -24,7 +24,6 @@ class My::SettingsController < MyController
       flash.notice = "Password updated successfully"
       return true
     else
-      setup_show
       render action: :show
       return false
     end

--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -34,7 +34,6 @@ class My::SettingsController < MyController
       flash.notice = "Handle updated successfully"
       return true
     else
-      setup_show
       render action: :show
       return false
     end

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -32,7 +32,21 @@ class My::SettingsTest < ApplicationSystemTestCase
 
     click_on "Update password"
 
-    assert_selector "#notice", text: "Password updated successfully" 
+    assert_selector "#notice", text: "Password updated successfully"
+  end
+
+  test "sees errors when changing password" do
+    visit my_settings_path
+
+    old_password = FactoryBot.attributes_for(:user)[:password]
+
+    fill_in "Enter your current password", with: old_password
+    fill_in "Enter your new password", with: "test"
+    fill_in "Confirm your current password", with: "test"
+
+    click_on "Update password"
+
+    assert_selector "#errors", text: "Password is too short (minimum is 6 characters)"
   end
 
   test "can change handle successfully" do

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -59,9 +59,20 @@ class My::SettingsTest < ApplicationSystemTestCase
 
     click_on "Update handle"
 
-    assert_selector "#notice", text: "Handle updated successfully" 
+    assert_selector "#notice", text: "Handle updated successfully"
     @user.reload
     assert_equal @user.handle, new_handle
+  end
+
+  test "sees errors when changing handle" do
+    user = create(:user, handle: "handle")
+
+    visit my_settings_path
+
+    fill_in "Enter your new handle", with: "handle"
+    click_on "Update handle"
+
+    assert_selector "#errors", text: "Handle is already taken"
   end
 
   test "CLI token field should be readonly" do


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4377.

The `setup_show` method isn't needed anymore because the show view doesn't need any object to be pulled from the database, except for `current_user`, which is included in views by default.