### PR TITLE
Fix bug in switching from independent to mentoring mode

### DIFF
--- a/app/services/fix_unlocking_in_user_track.rb
+++ b/app/services/fix_unlocking_in_user_track.rb
@@ -44,12 +44,16 @@ class FixUnlockingInUserTrack
                                     pluck(:id)
 
     # Make sure there is one unlocked core
-    next_exercise = track.exercises.core.
-                                    not_completed_for(user).
-                                    order(:position).
-                                    first
+    next_core_exercise = track.exercises.core.
+                                         not_completed_for(user).
+                                         order(:position).
+                                         first
 
-    keep_solution_ids << UnlockCoreExercise.(user, next_exercise).try(:id) if next_exercise
+    # We can just use UnlockCoreExercise here, but it's more efficent to do the extra lookup
+    if next_core_exercise
+      next_core_solution = Solution.where(user: user, exercise: next_core_exercise).first
+      keep_solution_ids << (next_core_solution.try(:id) || UnlockCoreExercise.(user, next_core_exercise).try(:id))
+    end
 
     # Delete all unsubmitted exercises that we haven't just
     # agreed to unlocked

--- a/app/services/fix_unlocking_in_user_track.rb
+++ b/app/services/fix_unlocking_in_user_track.rb
@@ -35,7 +35,7 @@ class FixUnlockingInUserTrack
                                   where.not(id: existing_exercise_ids.to_a).
                                   map { |e|CreateSolution.(user, e).id }
 
-    # Check all the bonus exercises are avalaible but don't unlock them.
+    # Check all the bonus exercises are avaliable but don't unlock them.
     keep_solution_ids += user_track.solutions.
                                     where(exercise_id:
                                             track.exercises.
@@ -48,6 +48,7 @@ class FixUnlockingInUserTrack
                                     not_completed_for(user).
                                     order(:position).
                                     first
+
     keep_solution_ids << UnlockCoreExercise.(user, next_exercise).try(:id) if next_exercise
 
     # Delete all unsubmitted exercises that we haven't just

--- a/app/services/switch_track_to_mentored_mode.rb
+++ b/app/services/switch_track_to_mentored_mode.rb
@@ -9,8 +9,14 @@ class SwitchTrackToMentoredMode
 
     FixUnlockingInUserTrack.(user_track)
 
-    # Set all core solutions to have mentoring
-    user_track.solutions.core.update_all(mentoring_requested_at: Time.current)
+    # Set at least one core solution to have mentoring
+    unless user_track.solutions.core.where.not(mentoring_requested_at: nil).exists?
+      user_track.solutions.core.
+        joins(:exercise).
+        order('exercises.position ASC').
+        first.
+        try {|s| s.update(mentoring_requested_at: Time.current) }
+    end
   end
 
   memoize

--- a/app/services/unlock_next_core_exercise.rb
+++ b/app/services/unlock_next_core_exercise.rb
@@ -4,7 +4,10 @@ class UnlockNextCoreExercise
   initialize_with :track, :user
 
   def call
-    return core_exercise_in_progress if core_exercise_in_progress
+    if existing_core_exercise
+      existing_core_exercise.update(mentoring_requested_at: Time.now) unless existing_core_exercise.mentoring_requested_at
+      return existing_core_exercise
+    end
 
     next_exercise = track.exercises.core.
                                     locked_for(user).
@@ -22,7 +25,7 @@ class UnlockNextCoreExercise
   private
 
   memoize
-  def core_exercise_in_progress
+  def existing_core_exercise
     user.
       solutions.
       joins(:exercise).

--- a/test/services/switch_track_to_mentored_mode_test.rb
+++ b/test/services/switch_track_to_mentored_mode_test.rb
@@ -1,28 +1,59 @@
 require 'test_helper'
 
 class SwitchTrackToMentoredModeTest < ActiveSupport::TestCase
-  test "sets core solutions to be mentored" do
+  test "sets one core solutions to be mentored" do
     user = create :user
     track = create :track
-    core_exercise = create :exercise, track: track, core: true
+    core_exercise_1 = create :exercise, track: track, core: true
+    core_exercise_2 = create :exercise, track: track, core: true
     side_exercise = create :exercise, track: track, core: false
 
-    core_solution = create :solution, user: user, exercise: core_exercise, mentoring_requested_at: nil, track_in_independent_mode: true
+    core_solution_1 = create :solution, user: user, exercise: core_exercise_1, mentoring_requested_at: nil, track_in_independent_mode: true
+    core_solution_2 = create :solution, user: user, exercise: core_exercise_2, mentoring_requested_at: nil, track_in_independent_mode: true
     side_solution = create :solution, user: user, exercise: side_exercise, mentoring_requested_at: nil, track_in_independent_mode: true
+
+    create :iteration, solution: core_solution_1
+    create :iteration, solution: core_solution_2
+    create :iteration, solution: side_solution
 
     user_track = create :user_track, user: user, track: track
 
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
     SwitchTrackToMentoredMode.(user, track)
 
-    [user_track, core_solution, side_solution].each(&:reload)
+    [user_track, core_solution_1, core_solution_2, side_solution].each(&:reload)
 
     refute user_track.independent_mode?
-    assert core_solution.mentoring_requested?
+    assert core_solution_1.mentoring_requested?
+    refute core_solution_2.mentoring_requested?
     refute side_solution.mentoring_requested?
 
-    refute core_solution.track_in_independent_mode?
+    refute core_solution_1.track_in_independent_mode?
+    refute core_solution_2.track_in_independent_mode?
     refute side_solution.track_in_independent_mode?
+  end
+
+  test "don't let multiple core solutions be mentored" do
+    user = create :user
+    track = create :track
+    exercise_1 = create :exercise, track: track, core: true
+    exercise_2 = create :exercise, track: track, core: true
+
+    solution_1 = create :solution, user: user, exercise: exercise_1, mentoring_requested_at: nil, track_in_independent_mode: true
+    solution_2 = create :solution, user: user, exercise: exercise_2, mentoring_requested_at: Time.current, track_in_independent_mode: true
+
+    create :iteration, solution: solution_1
+    create :iteration, solution: solution_2
+
+    user_track = create :user_track, user: user, track: track
+
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    SwitchTrackToMentoredMode.(user, track)
+
+    [solution_1, solution_2].each(&:reload)
+
+    refute solution_1.mentoring_requested?
+    assert solution_2.mentoring_requested?
   end
 
   test "calls FixUnlockingInUserTrack" do

--- a/test/services/unlock_next_core_exercise_test.rb
+++ b/test/services/unlock_next_core_exercise_test.rb
@@ -4,20 +4,51 @@ class UnlockNextCoreExerciseTest < ActiveSupport::TestCase
   test "unlocks a new core exercise only when all in progress core exercises are completed" do
     track = create(:track)
     user = create(:user)
-    core_exercise = create(:exercise, track: track, core: true, position: 1)
-    old_core_exercise = create(:exercise, track: track, core: true)
+    old_core_exercise = create(:exercise, track: track, core: true, position: 1)
     next_core_exercise = create(:exercise, track: track, core: true, position: 2)
+    another_core_exercise = create(:exercise, track: track, core: true, position: 3)
     create(:solution,
            user: user,
            exercise: old_core_exercise,
-           completed_at: nil)
-    create(:solution,
-           user: user,
-           exercise: core_exercise,
            completed_at: Date.new(2016, 12, 25))
+    next_solution = mock
+    UnlockCoreExercise.expects(:call).with(user, next_core_exercise).returns(next_solution)
+    UnlockCoreExercise.expects(:call).with(user, another_core_exercise).never
+
+    assert_equal next_solution, UnlockNextCoreExercise.(track, user)
+  end
+
+  test "returns existing solution if it exists and sets mentoring_requested_at" do
+    Timecop.freeze do
+      track = create(:track)
+      user = create(:user)
+      next_core_exercise = create(:exercise, track: track, core: true, position: 2)
+      next_core_solution = create(:solution,
+             user: user,
+             exercise: next_core_exercise,
+             completed_at: nil,
+             mentoring_requested_at: nil)
+      UnlockCoreExercise.expects(:call).with(user, next_core_exercise).never
+
+      assert_equal next_core_solution, UnlockNextCoreExercise.(track, user)
+      assert_equal Time.current.to_i, next_core_solution.reload.mentoring_requested_at.to_i
+    end
+  end
+
+  test "does not override mentoring_requested_at" do
+    mentoring_requested_at = Time.current - 6.weeks
+    track = create(:track)
+    user = create(:user)
+    next_core_exercise = create(:exercise, track: track, core: true, position: 2)
+    next_core_solution = create(:solution,
+           user: user,
+           exercise: next_core_exercise,
+           completed_at: nil,
+           mentoring_requested_at: mentoring_requested_at)
     UnlockCoreExercise.expects(:call).with(user, next_core_exercise).never
 
-    UnlockNextCoreExercise.(track, user)
+    assert_equal next_core_solution, UnlockNextCoreExercise.(track, user)
+    assert_equal mentoring_requested_at.to_i, next_core_solution.reload.mentoring_requested_at.to_i
   end
 
   test "unlocks next core exercise" do


### PR DESCRIPTION
(cc @ErikSchierboom @sshine)

Note to self. Once this is deployed, run:

```ruby
User.find(231415).solutions.joins(:exercise).where("exercises.track": Track.find_by_slug("csharp")).submitted.not_completed.where("exercises.core": true).where.not(mentoring_requested_at: nil).where(approved_by_id: nil).order("position ASC").offset(1).update_all("mentoring_requested_at = NULL")
```