### PR TITLE
Hide "Syncing maintainers" output when running tests

### DIFF
--- a/app/services/git/sync_track.rb
+++ b/app/services/git/sync_track.rb
@@ -140,7 +140,7 @@ class Git::SyncTrack
   end
 
   def sync_maintainers
-    puts "Syncing Maintainers"
+    puts "Syncing Maintainers" unless Rails.env.test?
     Git::SyncMaintainers.(track, repo.maintainer_config)
   end
 


### PR DESCRIPTION
Currently, when running tests I see the "Syncing Maintainers" outputted on newlines three times. This pull request hides that output when the code is run in a test environment.

![screenshot from 2018-11-21 22-15-40](https://user-images.githubusercontent.com/1254212/48879853-b67bfd80-eddb-11e8-8ce1-d6f8db8551bd.png)
