### PR TITLE
API: Add error message for 404s on missing solution files

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,4 @@ en:
       track_ambiguous: "Please specify a track ID"
       track_not_found: "The track you specified does not exist"
       track_not_joined: "You have not joined this track"
+      file_not_found: "The file was not found"

--- a/test/controllers/api/files_controller_test.rb
+++ b/test/controllers/api/files_controller_test.rb
@@ -121,4 +121,23 @@ class API::FilesControllerTest < API::TestBase
     assert_response 200
     assert file.file_contents, response.body
   end
+
+  test "show should return 404 when file is missing" do
+    @mock_exercise = stub(read_file: nil)
+    @mock_repo = stub(exercise: @mock_exercise)
+    Git::ExercismRepo.stubs(new: @mock_repo)
+
+    setup_user
+    solution = create :solution, user: @current_user
+
+    get api_solution_file_path(solution.uuid, "foobar"), headers: @headers, as: :json
+    assert_response 404
+
+    expected = {error: {
+      type: "file_not_found",
+      message: "The file was not found"
+    }}
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
This PR adds the missing translations for the `file_not_found` API error type. Please have a look at https://github.com/exercism/exercism/issues/4517 for a description of the problem.

I'm not super confident about the test I added because I'm still unfamiliar with the code (this is my first PR on the app!). Guidance and suggestions are appreciated :+1: