### PR TITLE
rename "Mentor this solution" to "Review this solution"

### DIFF
--- a/app/views/mentor/solutions/_claim-section.html.haml
+++ b/app/views/mentor/solutions/_claim-section.html.haml
@@ -11,7 +11,7 @@
   .request
     %h3 Give feedback on this solution
     %p Can you help this learner improve this solution? Do you feel it's ready to approve? Click the button below to start giving feedback.
-    =link_to "Mentor this solution", lock_mentor_solution_path(@solution), remote: true, method: :patch, class: 'pure-button mentor-button js-disable-on-click'
+    =link_to "Review this solution", lock_mentor_solution_path(@solution), remote: true, method: :patch, class: 'pure-button mentor-button js-disable-on-click'
 
     %h3 Don't feel like this one is for you?
     %p If you don't feel like you can help with this solution, you can pass it and we'll remove it from your "Next solutions" list.
@@ -24,4 +24,4 @@
       Another mentor has started giving feedback on this solution.
       You can still give feedback if you want to, but we recommend you apply your time to a different solution instead.
     =link_to "Go back to mentor dashboard", [:mentor, :dashboard], class: 'pure-button'
-    =link_to "Mentor this solution anyway", lock_mentor_solution_path(@solution, force: true), remote: true, method: :patch, class: 'pure-button mentor-button js-disable-on-click'
+    =link_to "Review this solution anyway", lock_mentor_solution_path(@solution, force: true), remote: true, method: :patch, class: 'pure-button mentor-button js-disable-on-click'

--- a/test/system/mentor/solution_locks_test.rb
+++ b/test/system/mentor/solution_locks_test.rb
@@ -39,7 +39,7 @@ class SolutionLocksTest < ApplicationSystemTestCase
     refute_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution"
+    click_on "Review this solution"
     assert_selector ".discussion"
     assert_selector ".new-discussion-post"
     refute_selector ".claim-section"
@@ -53,7 +53,7 @@ class SolutionLocksTest < ApplicationSystemTestCase
     assert_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution"
+    click_on "Review this solution"
     assert_selector ".discussion"
     assert_selector ".new-discussion-post"
     refute_selector ".claim-section"
@@ -68,12 +68,12 @@ class SolutionLocksTest < ApplicationSystemTestCase
     refute_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution"
+    click_on "Review this solution"
     assert_selector ".claim-section"
     refute_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution anyway"
+    click_on "Review this solution anyway"
     assert_selector ".discussion"
     assert_selector ".new-discussion-post"
     refute_selector ".claim-section"
@@ -89,7 +89,7 @@ class SolutionLocksTest < ApplicationSystemTestCase
     refute_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution"
+    click_on "Review this solution"
     assert_selector ".discussion"
     assert_selector ".new-discussion-post"
     refute_selector ".claim-section"
@@ -109,7 +109,7 @@ class SolutionLocksTest < ApplicationSystemTestCase
     refute_selector ".discussion"
     refute_selector ".new-discussion-post"
 
-    click_on "Mentor this solution"
+    click_on "Review this solution"
     assert_selector ".discussion"
     assert_selector ".new-discussion-post"
     refute_selector ".claim-section"


### PR DESCRIPTION
I find "Mentor this solution" quite weird since you normally "Mentor" a person, not a solution.
So I just replaced it with "Review", and changed the tests as well.

Haven't set it up all locally yet so I'm not 100% sure it's correct, but I think that was the only place to change from some ack magic.