### PR TITLE
Add "system comments"

### DIFF
--- a/app/assets/stylesheets/widgets/discussion-post.scss
+++ b/app/assets/stylesheets/widgets/discussion-post.scss
@@ -17,6 +17,7 @@
         margin-right:3%;
         float:left;
         width:8%;
+        min-height:20px;
         display:block;
         border-radius:3px;
     }
@@ -28,7 +29,7 @@
 
     .post-header {
         overflow:hidden;
-        margin-bottom:10px;
+        margin-bottom:5px;
         .user-handle {
             display:inline-block;
             color:#333;

--- a/app/controllers/mentor/solutions_controller.rb
+++ b/app/controllers/mentor/solutions_controller.rb
@@ -44,11 +44,13 @@ class Mentor::SolutionsController < MentorController
   end
 
   def abandon
-    mentor_solution = SolutionMentorship.where(user: current_user, solution: @solution).first
-    if mentor_solution.nil?
-      mentor_solution = CreateSolutionMentorship.(@solution, current_user)
+    mentorship = SolutionMentorship.where(user: current_user, solution: @solution).first
+    if mentorship
+      AbandonSolutionMentorship.(mentorship, :left_conversation)
+    else
+      mentorship = CreateSolutionMentorship.(@solution, current_user)
+      AbandonSolutionMentorship.(mentorship, nil)
     end
-    AbandonSolutionMentorship.(mentor_solution)
 
     redirect_to [:mentor, :dashboard]
   end

--- a/app/helpers/widgets_helper.rb
+++ b/app/helpers/widgets_helper.rb
@@ -40,8 +40,12 @@ module WidgetsHelper
   end
 
   def discussion_post_widget(post, solution, user_track)
-    render "widgets/discussion_post", post: post,
-                                      solution: solution,
-                                      user_track: user_track
+    if post.user_id == User::SYSTEM_USER_ID
+      render "widgets/system_discussion_post", post: post
+    else
+      render "widgets/discussion_post", post: post,
+                                        solution: solution,
+                                        user_track: user_track
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   DEFAULT_AVATAR = "anonymous.png"
+  SYSTEM_USER_ID = 1
 
   # Remove this so devise can't use it.
   def self.validates_uniqueness_of(*args)
@@ -61,6 +62,10 @@ class User < ApplicationRecord
         user.handle = data["info"]["nickname"] if user.handle.blank?
       end
     end
+  end
+
+  def User.system_user
+    User.find(SYSTEM_USER_ID)
   end
 
   after_create do

--- a/app/services/abandon_overdue_solution_mentorships.rb
+++ b/app/services/abandon_overdue_solution_mentorships.rb
@@ -4,7 +4,7 @@ class AbandonOverdueSolutionMentorships
   def call
     SolutionMentorship.where("requires_action_since < ?", Time.current - 7.days).
                        each do |mentorship|
-      AbandonSolutionMentorship.(mentorship)
+      AbandonSolutionMentorship.(mentorship, :timed_out)
     end
   end
 end

--- a/app/services/abandon_solution_mentorship.rb
+++ b/app/services/abandon_solution_mentorship.rb
@@ -1,11 +1,42 @@
 class AbandonSolutionMentorship
   include Mandate
 
-  initialize_with :solution_mentorship
+  initialize_with :solution_mentorship, :message_type
 
   def call
+    create_system_discussion_post
     solution_mentorship.update!(abandoned: true)
-    CacheSolutionNumMentors.(solution_mentorship.solution)
+    CacheSolutionNumMentors.(solution)
+  end
+
+  def create_system_discussion_post
+    return if message_type === nil
+
+    i18n_message = case message_type
+      when :timed_out
+        'system_messages.mentor_timed_out'
+      when :left_conversation
+        'system_messages.mentor_left_conversation'
+      else
+        raise "Unknown message type"
+      end
+
+    # Content is maintained in a JSON format so that this HTML can be
+    # regenerated later if the message content changes
+    content = {i18n_message: i18n_message, handle: solution_mentorship.user.handle}.to_json
+    interpolated_message = I18n.t(i18n_message, handle: solution_mentorship.user.handle)
+
+    DiscussionPost.create!(
+      iteration: solution.iterations.last,
+      user: User.system_user,
+      content: content,
+      html: ParseMarkdown.(interpolated_message)
+    )
+  end
+
+  private
+  def solution
+    solution_mentorship.solution
   end
 end
 

--- a/app/views/widgets/_system_discussion_post.html.haml
+++ b/app/views/widgets/_system_discussion_post.html.haml
@@ -1,0 +1,8 @@
+.widget-discussion-post{id: "discussion-post-#{post.id}"}
+  =image "icon.png", "Exercism", class: 'avatar'
+  .post-body
+    .post-header
+      .user-handle System Message
+      .created-at posted #{time_ago_in_words(post.created_at)} ago
+
+    .post-html= raw post.html

--- a/app/views/widgets/_system_discussion_post.html.haml
+++ b/app/views/widgets/_system_discussion_post.html.haml
@@ -2,7 +2,7 @@
   =image "icon.png", "Exercism", class: 'avatar'
   .post-body
     .post-header
-      .user-handle System Message
+      .user-handle Automated Message
       .created-at posted #{time_ago_in_words(post.created_at)} ago
 
     .post-html= raw post.html

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,3 +43,7 @@ en:
       track_not_found: "The track you specified does not exist"
       track_not_joined: "You have not joined this track"
       file_not_found: "The file was not found"
+
+  system_messages:
+    mentor_timed_out: "Mentor '%{handle}' has being removed from this conversation due to inactivity. This solution will be placed into the queue for a new mentor to review."
+    mentor_left_conversation: "Mentor '%{handle}' has left this conversation. This solution will be placed into the queue for a new mentor to review."

--- a/test/controllers/mentor/solutions_controller_test.rb
+++ b/test/controllers/mentor/solutions_controller_test.rb
@@ -41,7 +41,8 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in!(mentor)
 
-    AbandonSolutionMentorship.expects(:call).with do |mentorship|
+    AbandonSolutionMentorship.expects(:call).with do |mentorship, message_type|
+      assert_nil message_type
       assert mentorship.is_a?(SolutionMentorship)
       assert_equal mentor, mentorship.user
       assert_equal solution, mentorship.solution
@@ -62,7 +63,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in!(mentor)
 
-    AbandonSolutionMentorship.expects(:call).with(mentorship)
+    AbandonSolutionMentorship.expects(:call).with(mentorship, :left_conversation)
     patch abandon_mentor_solution_url(solution), as: :js
     assert_redirected_to mentor_dashboard_path
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -146,6 +146,10 @@ FactoryBot.define do
     factory :user_mentor do
       is_mentor { true }
     end
+
+    factory :system_user do
+      id { User::SYSTEM_USER_ID }
+    end
   end
 
   factory :solution do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -263,4 +263,11 @@ class UserTest < ActiveSupport::TestCase
     user = User.find(user.id) # Clear the cache
     assert_equal 3.67, user.mentor_rating
   end
+
+  test "User#system_user" do
+    other_user = create :user, id: 5
+    system_user = create :user, id: User::SYSTEM_USER_ID
+
+    assert_equal system_user, User.system_user
+  end
 end

--- a/test/services/abandon_overdue_solution_mentorships_test.rb
+++ b/test/services/abandon_overdue_solution_mentorships_test.rb
@@ -6,7 +6,7 @@ class AbandomOverdueSolutionMentorshipsTest < ActiveSupport::TestCase
     new_mentorship = create :solution_mentorship, requires_action_since: Time.current - 6.days
     completed_mentorship = create :solution_mentorship, requires_action_since: nil
 
-    AbandonSolutionMentorship.expects(:call).with(overdue_mentorship)
+    AbandonSolutionMentorship.expects(:call).with(overdue_mentorship, :timed_out)
     AbandonOverdueSolutionMentorships.()
   end
 end

--- a/test/services/abandon_solution_mentorship_test.rb
+++ b/test/services/abandon_solution_mentorship_test.rb
@@ -1,15 +1,68 @@
 require 'test_helper'
 
 class AbandonSolutionMentorshipTest < ActiveSupport::TestCase
-  test "works with existing mentorship" do
-    mentor = create :user_mentor
+  test "works with mentorship when mentor times-out" do
+    create :system_user
+
+    mentor = create :user_mentor, handle: 'freddie'
     solution = create :solution
+    iteration = create :iteration, solution: solution
     mentorship = create :solution_mentorship, user: mentor, solution: solution
 
-    AbandonSolutionMentorship.(mentorship)
+    AbandonSolutionMentorship.(mentorship, :timed_out)
 
     [solution, mentorship].each(&:reload)
     assert mentorship.abandoned
     assert_equal 0, solution.num_mentors
+
+    # Check discussion post has been created
+    content = {'i18n_message' => 'system_messages.mentor_timed_out', 'handle' => mentor.handle}
+    html = ParseMarkdown.("Mentor 'freddie' has being removed from this conversation due to inactivity. This solution will be placed into the queue for a new mentor to review.")
+
+    dp = DiscussionPost.last
+    assert_equal User.system_user, dp.user
+    assert_equal iteration, dp.iteration
+    assert_equal content, JSON.parse(dp.content)
+    assert_equal html, dp.html
+  end
+
+  test "works with mentorship when mentor leaves conversation" do
+    create :system_user
+
+    mentor = create :user_mentor, handle: 'bobby'
+    solution = create :solution
+    iteration = create :iteration, solution: solution
+    mentorship = create :solution_mentorship, user: mentor, solution: solution
+
+    AbandonSolutionMentorship.(mentorship, :left_conversation)
+
+    [solution, mentorship].each(&:reload)
+    assert mentorship.abandoned
+    assert_equal 0, solution.num_mentors
+
+    content = {'i18n_message' => 'system_messages.mentor_left_conversation', 'handle' => mentor.handle}
+    html = ParseMarkdown.("Mentor 'bobby' has left this conversation. This solution will be placed into the queue for a new mentor to review.")
+    dp = DiscussionPost.last
+    assert_equal User.system_user, dp.user
+    assert_equal iteration, dp.iteration
+    assert_equal content, JSON.parse(dp.content)
+    assert_equal html, dp.html
+  end
+
+  test "works with mentorship for other reason" do
+    create :system_user
+
+    mentor = create :user_mentor
+    solution = create :solution
+    iteration = create :iteration, solution: solution
+    mentorship = create :solution_mentorship, user: mentor, solution: solution
+
+    AbandonSolutionMentorship.(mentorship, nil)
+
+    [solution, mentorship].each(&:reload)
+    assert mentorship.abandoned
+    assert_equal 0, solution.num_mentors
+
+    refute DiscussionPost.where(iteration: iteration).exists?
   end
 end

--- a/test/system/mentor/solution_locks_test.rb
+++ b/test/system/mentor/solution_locks_test.rb
@@ -80,6 +80,8 @@ class SolutionLocksTest < ApplicationSystemTestCase
   end
 
   test "mentor can leave solution without adding a comment" do
+    create :system_user
+
     visit mentor_dashboard_path
     assert page.has_link?(nil, {href: mentor_solution_path(@solution)})
 
@@ -100,6 +102,8 @@ class SolutionLocksTest < ApplicationSystemTestCase
   end
 
   test "mentor can leave solution after adding a comment" do
+    create :system_user
+
     visit mentor_dashboard_path
     assert page.has_link?(nil, {href: mentor_solution_path(@solution)})
 


### PR DESCRIPTION
I've added system comments, which allow us to post information to a discussion thread in the case of mentors leaving/joining conversations, or other scenarios I've not yet considered. They look like this:

<img width="562" alt="screenshot 2019-01-16 at 15 32 53" src="https://user-images.githubusercontent.com/286476/51285579-3ff71880-19a4-11e9-9570-4d350a2e3c25.png">

Note that this deliberately does **not** email people. We can change that decision later if we want to, but for now I feel that it's better not to spam people with "activity" messages, just "content" messages.

This currently supports messages in the following two situations:
- A mentor manually abandons a solution having commented
- A mentor is timed out from not responding to a solution

Nothing happens if a mentor manually abandons a solution having not commented.