### PR TITLE
Add Bullet to test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   gem 'timecop'
   gem 'chromedriver-helper'
   gem 'webmock'
+  gem 'bullet'
 end
 
 group :development, :production do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,12 +2,14 @@ require "test_helper"
 require "support/selectize_helpers"
 require "support/stub_repo_cache"
 require "support/selenium_helpers"
+require "support/bullet_helpers"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Devise::Test::IntegrationHelpers
   include SelectizeHelpers
   include StubRepoCache
   include SeleniumHelpers
+  include BulletHelpers
 
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400], options: SeleniumHelpers.options
 

--- a/test/support/bullet_helpers.rb
+++ b/test/support/bullet_helpers.rb
@@ -1,0 +1,18 @@
+module BulletHelpers
+  def with_bullet
+    begin
+      Bullet.enable = true
+      Bullet.raise = true # raise an error if N+1 query occurs
+      Bullet.counter_cache_enable = false
+      Bullet.unused_eager_loading_enable = false
+      Bullet.start_request
+      yield
+    ensure
+      Bullet.end_request
+      Bullet.enable = false
+      Bullet.counter_cache_enable = true
+      Bullet.unused_eager_loading_enable = true
+      Bullet.raise = false
+    end
+  end
+end


### PR DESCRIPTION
This allows us to record N+1 queries during our tests with Bullet. Tests will fail
once an N+1 query is detected.