### PR TITLE
Allow vertical resizing of textareas using markdown

### DIFF
--- a/app/assets/javascripts/blog-comment.js
+++ b/app/assets/javascripts/blog-comment.js
@@ -19,7 +19,8 @@ BlogComment.prototype.startEditing = function(e) {
   if (!this.editorInitialized) {
     this.node.find('textarea').markdown({
       iconlibrary: 'fa',
-      hiddenButtons: 'cmdHeading cmdImage cmdPreview'
+      hiddenButtons: 'cmdHeading cmdImage cmdPreview',
+      resize: 'vertical'
     })
 
     this.editorInitialized = true;

--- a/app/assets/javascripts/blog_post.coffee
+++ b/app/assets/javascripts/blog_post.coffee
@@ -24,6 +24,7 @@ window.setupBlogPost = (blogcommentId) ->
     $textarea.markdown
       iconlibrary: 'fa'
       hiddenButtons: 'cmdHeading cmdImage cmdPreview'
+      resize: 'vertical'
 
     $textarea.val(getLocalStoragecomment())
     $textarea.keyup()

--- a/app/assets/javascripts/discussion-post.js
+++ b/app/assets/javascripts/discussion-post.js
@@ -19,7 +19,8 @@ DiscussionPost.prototype.startEditing = function(e) {
   if (!this.editorInitialized) {
     this.node.find('textarea').markdown({
       iconlibrary: 'fa',
-      hiddenButtons: 'cmdHeading cmdImage cmdPreview'
+      hiddenButtons: 'cmdHeading cmdImage cmdPreview',
+      resize: 'vertical'
     })
 
     this.editorInitialized = true;

--- a/app/assets/javascripts/solution.coffee
+++ b/app/assets/javascripts/solution.coffee
@@ -24,6 +24,7 @@ window.setupSolution = (solutionID, iterationID) ->
     $textarea.markdown
       iconlibrary: 'fa'
       hiddenButtons: 'cmdHeading cmdImage cmdPreview'
+      resize: 'vertical'
 
     $textarea.val(getLocalStoragePost())
     $textarea.keyup()


### PR DESCRIPTION
Closes exercism/exercism#4606. I figured it would be a good idea to apply this to all of the textareas that are using the markdown editor.

Screenshot:

![screenshot from 2019-01-19 23-18-09](https://user-images.githubusercontent.com/1254212/51435269-f3c90400-1c41-11e9-8a11-347e4e144a4e.png)
