### PR TITLE
Update track introduction text

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -31,7 +31,7 @@ class Track < ApplicationRecord
 
   def introduction
     i = super
-    i.present?? i : "TODO: The maintainers have not provided a description for this track."
+    i.present?? i : "TODO: The maintainers have not provided an introduction for this track."
   end
 
   def about


### PR DESCRIPTION
Partial fix for exercism/exercism#4550. I figured it makes more sense to indicate that the introduction, not the description, is missing. Currently, track pages such as [vimscript](https://exercism.io/my/tracks/vimscript) are displaying the message that the description is missing even though there is a description present, which would be confusing for users and not helpful for track maintainers.