### PR TITLE
Update the preview-area's style

### DIFF
--- a/app/assets/stylesheets/new-editable-text.scss
+++ b/app/assets/stylesheets/new-editable-text.scss
@@ -14,7 +14,7 @@
             border:1px solid #ddd;
         }
         .preview-area {
-            height:248px;
+            height:100%;
             overflow:auto;
             padding:15px;
         }


### PR DESCRIPTION
Updated the preview-area's height. There is no need to scroll on long answers in a tiny box of 248px, so it will match the total size of the markdown preview.