### PR TITLE
Make widget title the same height as selectbox

### DIFF
--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -17,7 +17,7 @@
 @mixin font-size($size: 16, $line_height: null) {
     font-size: $size  + px;
     @if $line_height == null {
-        $line_height: 1.428 * $size;
+        $line_height: floor(1.428 * $size);
     }
     line-height: $line_height + px;
 }


### PR DESCRIPTION
The alignment of the selectbox widget using Firefox (macOS) is not aligned properly. The title has a different height than te selectbox. This is because there is a difference in the way browsers handle line heights with decimal points. Most browsers truncate it to the whole number. While Firefox tries to round it up or down.

**Old**
<img width="206" alt="afbeelding" src="https://user-images.githubusercontent.com/7275740/53306052-db738700-3888-11e9-83ed-bb25cab57344.png">

**New**
<img width="206" alt="afbeelding" src="https://user-images.githubusercontent.com/7275740/53306059-e9c1a300-3888-11e9-9ff0-a86e6625342b.png">
