### PR TITLE
Fix missing 'Cancel mentoring request' button

### DIFF
--- a/app/views/my/solutions/_show_finished_independent.html.haml
+++ b/app/views/my/solutions/_show_finished_independent.html.haml
@@ -26,7 +26,7 @@
       -else
         %p
           %strong Request mentor feedback (disabled).
-          Mentoring is disabled by default in Independent Mode. However, you can request feedback on a maximum of one solution at a time.
+          Mentoring is disabled by default in Independent Mode. However, you can request feedback on a maximum of one solution at a time. You currently have no slots free.
         =link_to "Request mentor feedback", "#", class: 'pure-button disabled', disabled: true
 
     =render "my/solutions/widgets/community_solutions"

--- a/app/views/my/solutions/_show_rhs.html.haml
+++ b/app/views/my/solutions/_show_rhs.html.haml
@@ -11,22 +11,40 @@
   -elsif @solution.approved? && !@exercise.auto_approve?
     =render "show_approved"
 
-  -elsif @solution.exercise.side? && @solution.mentorships.active.count == 0 && @solution.mentor_discussion_posts.count == 0 && !@solution.exercise.auto_approve?
-    .finished-section
-      .title-block
-        %h3
-          =icon("clock-circle", "Clock")
-          You have requested mentoring for this exercise.
-      .next-block
-        .next-option
-          %p
-            %strong A mentor will be with you as soon as they can.
-            As side exercises don't block progression, they normally take longer to receive mentoring on than core exercises. For some tracks this might be a few hours but for the busiest tracks it might be a few days.
-        .next-option
-          %p
-            %strong Don't want mentoring after all?
-            Changed your mind and decided you don't want mentoring on this exercise? Want to free up your mentoring allowance for a different exercise? No problem!
-          =link_to "Cancel mentoring request", [:cancel_mentoring_request, :my, @solution], class: 'pure-button', method: :patch
+  -elsif @solution.mentorships.active.count == 0 && @solution.mentor_discussion_posts.count == 0 && !@solution.exercise.auto_approve?
+    -if @solution.user_track.independent_mode?
+      .finished-section
+        .title-block
+          %h3
+            =icon("clock-circle", "Clock")
+            You have requested mentoring for this exercise.
+        .next-block
+          .next-option
+            %p
+              %strong A mentor will be with you as soon as they can.
+              Exercises in independent mode normally take longer to receive mentoring on than those in mentored mode. For some tracks this might be a few hours but for the busiest tracks it might be a few days.
+          .next-option
+            %p
+              %strong Don't want mentoring after all?
+              Changed your mind and decided you don't want mentoring on this exercise? Want to free up your mentoring allowance for a different exercise? No problem!
+            =link_to "Cancel mentoring request", [:cancel_mentoring_request, :my, @solution], class: 'pure-button', method: :patch
+
+    -elsif @solution.exercise.side?
+      .finished-section
+        .title-block
+          %h3
+            =icon("clock-circle", "Clock")
+            You have requested mentoring for this exercise.
+        .next-block
+          .next-option
+            %p
+              %strong A mentor will be with you as soon as they can.
+              As side exercises don't block progression, they normally take longer to receive mentoring on than core exercises. For some tracks this might be a few hours but for the busiest tracks it might be a few days.
+          .next-option
+            %p
+              %strong Don't want mentoring after all?
+              Changed your mind and decided you don't want mentoring on this exercise? Want to free up your mentoring allowance for a different exercise? No problem!
+            =link_to "Cancel mentoring request", [:cancel_mentoring_request, :my, @solution], class: 'pure-button', method: :patch
 
   .discussion
     %h3.rhs-heading Mentor discussion

--- a/test/system/my/solution_discussion_section_test.rb
+++ b/test/system/my/solution_discussion_section_test.rb
@@ -6,6 +6,7 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
   COMPLETE_TEXT = "Complete this solution."
   PUBLISH_TEXT = "Publish this solution."
   CANCEL_MENTORING_TEXT = "Don't want mentoring after all?"
+  CANCEL_MENTORING_BTN_TEXT = "Cancel mentoring request"
 
   setup do
     Git::ExercismRepo.stubs(current_head: "dummy-sha1")
@@ -78,6 +79,8 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
     refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
     assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+
   end
 
   test "mentored mode / side solution with mentoring requested and abaondoned mentor" do
@@ -98,6 +101,8 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
     refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
     assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+
   end
 
   test "mentored mode / side solution with mentoring requested and non-mentor comment" do
@@ -117,6 +122,8 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
     refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
     assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+
   end
 
   test "mentored section with auto approve" do
@@ -195,8 +202,8 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     refute_selector ".discussion form"
   end
 
-  test "independent mode - requested mentoring" do
-    solution = create(:solution, user: @user, mentoring_requested_at: Time.current)
+  test "independent mode - core - requested mentoring" do
+    solution = create(:solution, user: @user, mentoring_requested_at: Time.current, exercise: create(:exercise, core: true))
     create :iteration, solution: solution
     create(:user_track, track: solution.track, user: @user, independent_mode: true)
 
@@ -204,7 +211,25 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     assert_selector ".discussion h3", text: "Mentor discussion"
     assert_selector ".discussion form"
+
+    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
   end
+
+  test "independent mode - side - requested mentoring" do
+    solution = create(:solution, user: @user, mentoring_requested_at: Time.current, exercise: create(:exercise, core: false))
+    create :iteration, solution: solution
+    create(:user_track, track: solution.track, user: @user, independent_mode: true)
+
+    visit my_solution_path(solution)
+
+    assert_selector ".discussion h3", text: "Mentor discussion"
+    assert_selector ".discussion form"
+
+    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+  end
+
 
   test "independent mode / not requested mentoring" do
     solution = create(:solution, user: @user, mentoring_requested_at: nil)


### PR DESCRIPTION
This is a partial fix for https://github.com/exercism/exercism/issues/4704 and https://github.com/exercism/exercism/issues/4432

It adds the "cancel mentoring" button, which was missing in core exercises in independent mode.

I still haven't found evidence that there is an automatic mentoring bug (as opposed to people accidentally requesting mentoring, which this offers a fix for).

There is a separate potential issue I need to think about, with removing the "Complete option" in independent mode, and just adding a general "Complete" option (as we don't really care about a mentor having to "Approve" in independent mode).