### PR TITLE
Fix typo on dashboard's next solutions section

### DIFF
--- a/app/views/mentor/dashboard/_next_solutions_section.html.haml
+++ b/app/views/mentor/dashboard/_next_solutions_section.html.haml
@@ -5,7 +5,7 @@
     -if params[:next_exercise_id]
       These are new solutions that need feedback. 
     -else
-      These are new solutions that need feedback. They are ordered algorithmically with the most important at the top. Please use the filters on the right-hand side if you would like to mentor a specific exercise (e.g. you would like to mentor an simple exercise, or want to batch-clear one exercise).
+      These are new solutions that need feedback. They are ordered algorithmically with the most important at the top. Please use the filters on the right-hand side if you would like to mentor a specific exercise (e.g. you would like to mentor a simple exercise, or want to batch-clear one exercise).
 
   =render "next_solutions", next_solutions: @next_solutions, user_tracks: @user_tracks
 .no-next-solutions{style: @next_solutions.empty?? "display:block" : "display:none"}


### PR DESCRIPTION
Noticed the typo on my Mentor Dashboard.

![screen shot 2019-03-07 at 00 53 36](https://user-images.githubusercontent.com/31735/53924288-76334900-4073-11e9-8ffe-a9bfca6b9ba9.png)
