### PR TITLE
Get rid of duplicate gem listing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'capybara', '~> 3.0'
   gem 'selenium-webdriver'
   gem 'factory_bot_rails'
+  gem 'bullet'
 end
 
 group :development do
@@ -60,7 +61,6 @@ group :development do
   gem 'capistrano-rvm'
   gem 'capistrano-yarn'
   gem 'letter_opener'
-  gem 'bullet'
 end
 
 group :test do
@@ -72,7 +72,6 @@ group :test do
   gem 'timecop'
   gem 'chromedriver-helper'
   gem 'webmock'
-  gem 'bullet'
 end
 
 group :development, :production do


### PR DESCRIPTION
While running bundle I got the following warning:

"Your Gemfile lists the gem bullet (>= 0) more than once.
You should probably keep only one of them."

This pull request deletes the 'bullet' entries in the development and test groups and creates a new listing in the shared development and test group.

