### PR TITLE
Fix test that breaks after spring hour change

### DIFF
--- a/test/helpers/time_ago_in_words_helper_test.rb
+++ b/test/helpers/time_ago_in_words_helper_test.rb
@@ -2,15 +2,15 @@ require "test_helper"
 
 class TimeAgoInWordsHelperTest < ActionView::TestCase
   test "time_ago_in_words calculates time in days, not months" do
-    assert_equal "33 days", time_ago_in_words(Time.now - 33.days)
+    assert_equal "33 days", time_ago_in_words(33.days.ago)
   end
 
   test "time_ago_in_words calculates time in days" do
-    assert_equal "2 days", time_ago_in_words(Time.now - 2.days)
+    assert_equal "2 days", time_ago_in_words(2.days.ago)
   end
 
   test "time_ago_in_words calculates time less than one day in hours or minutes" do
-    assert_equal "about 2 hours", time_ago_in_words(Time.now - 2.hours)
+    assert_equal "about 2 hours", time_ago_in_words(2.hours.ago)
   end
 
   test "time_ago_in_words correctly calculates one day plus one second" do
@@ -26,6 +26,6 @@ class TimeAgoInWordsHelperTest < ActionView::TestCase
   end
 
   test "time_ago_in_words calculates time in years, not days" do
-    assert_equal "about 1 year", time_ago_in_words(Time.now - 366.days)
+    assert_equal "about 1 year", time_ago_in_words(366.days.ago)
   end
 end


### PR DESCRIPTION
In England, Daylight saving time ended 31st of March. This meant the
`time_ago_in_words calculates time in days, not months` test was
returning 32 days for me, not 33 days.

Here's how it worked.
If I ran the test at 2019-04-06 22:00.
Time.now = 2019-04-06 22:00.
33.days = ActiveSupport::Duration object of 33 days
Time.now - 33.days = 2019-03-06 22:00.
2019-04-06 22:00 - 2019-03-06 22:00 = 32 days 23 hours.

I fix it by having the test rewind in a manner which doesn't take into
account time jumps.

I think it is the test that is wrong, not the code.
If someone did something 32 days and 23 hours ago, it wouldn't be
accurate to say it was 33 days ago. Although possibly we could round up
if it's nearly a full day.