### PR TITLE
Change company on footer

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -51,7 +51,7 @@
               =link_to "https://github.com/exercism", class: "icon", "aria-label": "Exercism on GitHub" do
                 =graphical_icon :github
       .legal
-        .copyright © #{Time.current.year} Exercism, Inc
+        .copyright © #{Time.current.year} Exercism
         .created-by
           Made with
           =icon :heart

--- a/app/views/layouts/_teams_footer.html.haml
+++ b/app/views/layouts/_teams_footer.html.haml
@@ -36,7 +36,7 @@
             =graphical_icon :github
 
       .legal
-        .copyright © #{Time.current.year} Exercism, Inc
+        .copyright © #{Time.current.year} Exercism
         .created-by
           Made with
           =icon :heart

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -22,7 +22,7 @@
             .signoff The Exercism Team
             =image_tag image_url("mailers/footer-bar.png"), class: 'footer-image', alt: ''
             .footer
-              This email sent by Exercism, Inc
+              This email sent by Exercism
             .footer
               =link_to "Visit Exercism", root_url
               -if @user && @unsubscribe_key
@@ -32,4 +32,4 @@
                 &middot;
                 =link_to "Change your notification settings", unsubscribe_url(token: @user.communication_preferences.token)
             .footer
-              Exercism, Inc &middot; 1605 George Dieter Dr #576 &middot; El Paso, TX 79936
+              Exercism &middot; Unit G3; The Franklin, 81 Bournville Lane, B30 2BZ, Birmingham

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -3,7 +3,7 @@ The Exercism Team
 
 ---
 
-This email was sent by Exercism, Inc
+This email was sent by Exercism
 
 <% if @user && @unsubscribe_key %>
 You can unsubscribe from this email at <%= unsubscribe_url(token: @user.communication_preferences.token, key: @unsubscribe_key) %>
@@ -12,4 +12,4 @@ You can unsubscribe from this email at <%= unsubscribe_url(token: @user.communic
 You can change your notification settings at <%= unsubscribe_url(token: @user.communication_preferences.token) %>
 <% end %>
 
-Exercism, Inc - 1605 George Dieter Dr #576 - El Paso, TX 79936
+Exercism - Unit G3; The Franklin, 81 Bournville Lane, B30 2BZ, Birmingham


### PR DESCRIPTION
Change the company on the footer of the website to point to the new not-for-profit to avoid confusion.