### PR TITLE
Don't setup mentor_requested_at if there are no iterations

### DIFF
--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -46,6 +46,10 @@ class Solution < ApplicationRecord
     where("EXISTS(SELECT TRUE FROM iterations WHERE iterations.solution_id = solutions.id)")
   }
 
+  scope :not_submitted, -> {
+    where("NOT EXISTS(SELECT TRUE FROM iterations WHERE iterations.solution_id = solutions.id)")
+  }
+
   scope :has_a_mentor, -> {
      where("EXISTS(SELECT TRUE FROM solution_mentorships WHERE solution_mentorships.solution_id = solutions.id)")
   }

--- a/app/services/switch_track_to_mentored_mode.rb
+++ b/app/services/switch_track_to_mentored_mode.rb
@@ -12,6 +12,7 @@ class SwitchTrackToMentoredMode
     # Set at least one core solution to have mentoring
     unless user_track.solutions.core.where.not(mentoring_requested_at: nil).exists?
       user_track.solutions.core.
+        submitted.
         joins(:exercise).
         order('exercises.position ASC').
         first.

--- a/app/services/switch_track_to_mentored_mode.rb
+++ b/app/services/switch_track_to_mentored_mode.rb
@@ -8,16 +8,6 @@ class SwitchTrackToMentoredMode
     user_track.solutions.update_all(track_in_independent_mode: false)
 
     FixUnlockingInUserTrack.(user_track)
-
-    # Set at least one core solution to have mentoring
-    unless user_track.solutions.core.where.not(mentoring_requested_at: nil).exists?
-      user_track.solutions.core.
-        submitted.
-        joins(:exercise).
-        order('exercises.position ASC').
-        first.
-        try {|s| s.update(mentoring_requested_at: Time.current) }
-    end
   end
 
   memoize

--- a/app/services/unlock_next_core_exercise.rb
+++ b/app/services/unlock_next_core_exercise.rb
@@ -4,9 +4,11 @@ class UnlockNextCoreExercise
   initialize_with :track, :user
 
   def call
-    if existing_core_exercise
-      existing_core_exercise.update(mentoring_requested_at: Time.now) unless existing_core_exercise.mentoring_requested_at
-      return existing_core_exercise
+    if existing_core_solution
+      if existing_core_solution.iterations.exists? && !existing_core_solution.mentoring_requested?
+        existing_core_solution.update(mentoring_requested_at: Time.now)
+      end
+      return existing_core_solution
     end
 
     next_exercise = track.exercises.core.
@@ -25,7 +27,7 @@ class UnlockNextCoreExercise
   private
 
   memoize
-  def existing_core_exercise
+  def existing_core_solution
     user.
       solutions.
       joins(:exercise).

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -63,7 +63,7 @@ class SolutionTest < ActiveSupport::TestCase
     assert_equal [unstarted_solution], Solution.not_started
   end
 
-  test "submitted" do
+  test "submitted and not_submitted" do
     user_track = create :user_track
     submitted_solution = create :solution, user: user_track.user, exercise: create(:exercise, track: user_track.track)
     create :iteration, solution: submitted_solution
@@ -71,6 +71,7 @@ class SolutionTest < ActiveSupport::TestCase
     downloaded_solution = create :solution, user: user_track.user, exercise: create(:exercise, track: user_track.track), downloaded_at: Time.now
 
     assert_equal [submitted_solution], Solution.submitted
+    assert_equal [unsubmitted_solution, downloaded_solution], Solution.not_submitted
   end
 
   test "has_a_mentor" do

--- a/test/services/fix_unlocking_in_user_track_test.rb
+++ b/test/services/fix_unlocking_in_user_track_test.rb
@@ -23,17 +23,17 @@ class FixUnlockingInUserTrackTest < ActiveSupport::TestCase
     c3 = create :exercise, track: track, core: true, position: 3
     c2 = create :exercise, track: track, core: true, position: 2
     c1 = create :exercise, track: track, core: true, position: 1
-    c1s1 = create :exercise, track: track, unlocked_by: c1
-    c1s2 = create :exercise, track: track, unlocked_by: c1
-    c2s1 = create :exercise, track: track, unlocked_by: c2
-    c3s1 = create :exercise, track: track, unlocked_by: c3
+    c1e1 = create :exercise, track: track, unlocked_by: c1
+    c1e2 = create :exercise, track: track, unlocked_by: c1
+    c2e1 = create :exercise, track: track, unlocked_by: c2
+    c3e1 = create :exercise, track: track, unlocked_by: c3
     bonus1 = create :exercise, track: track
     bonus2 = create :exercise, track: track
 
     # A solution that's got a iteration
     # This should be persisted
-    c3s1_sol = create :solution, exercise: c3s1, user: user
-    create :iteration, solution: c3s1_sol
+    c3e1_sol = create :solution, exercise: c3e1, user: user
+    create :iteration, solution: c3e1_sol
 
     # A completed core
     # This should be persisted
@@ -42,11 +42,11 @@ class FixUnlockingInUserTrackTest < ActiveSupport::TestCase
 
     # An unlocked side
     # This should be persisted
-    c1s2_sol = create :solution, exercise: c1s2, user: user
+    c1e2_sol = create :solution, exercise: c1e2, user: user
 
     # A different unlocked side that shouldn't be unlocked
     # This should not be persisted as it's not been started and it shouldn't be unlocked
-    c2s1_sol = create :solution, exercise: c2s1, user: user
+    c2e1_sol = create :solution, exercise: c2e1, user: user
 
     # A bonus exercise. This one should be maintained
     # but one shouldn't be created for bonus2, as that can be
@@ -62,12 +62,49 @@ class FixUnlockingInUserTrackTest < ActiveSupport::TestCase
 
     actual = user_track.solutions
     assert actual.include?(c1_sol)
-    assert actual.include?(c1s2_sol)
-    assert actual.include?(c3s1_sol)
+    assert actual.include?(c1e2_sol)
+    assert actual.include?(c3e1_sol)
     assert actual.include?(bonus1_sol)
 
-    expected_exercises = [ c1, c2, c1s1, c1s2, c3s1, bonus1 ].map(&:id).sort
+    expected_exercises = [ c1, c2, c1e1, c1e2, c3e1, bonus1 ].map(&:id).sort
     assert_equal expected_exercises, user_track.solutions.map(&:exercise_id).sort
+
+    refute Solution.where(user: user, exercise: c2).first.mentoring_requested_at?
+
     #p Benchmark.measure { 1000.times { FixUnlockingInUserTrack.(user_track) } }.real
+  end
+
+  test "submitted core solutions have mentoring_requested_at set" do
+    git_sha = SecureRandom.uuid
+    Git::ExercismRepo.stubs(current_head: git_sha)
+
+    user = create :user
+    track = create :track
+    c1 = create :exercise, track: track, core: true, position: 1
+    c2 = create :exercise, track: track, core: true, position: 2
+    c3 = create :exercise, track: track, core: true, position: 3
+    c4 = create :exercise, track: track, core: true, position: 4
+
+    c1_sol = create :solution, exercise: c1, approved_by: create(:user), completed_at: Time.now - 1.day, user: user
+    create :iteration, solution: c1_sol
+
+    c3_sol = create :solution, exercise: c3, user: user 
+    create :iteration, solution: c3_sol
+
+    c4_sol = create :solution, exercise: c4, user: user
+    create :iteration, solution: c4_sol
+
+    user_track = create :user_track, user: user, track: track
+    FixUnlockingInUserTrack.(user_track)
+
+    actual = user_track.solutions
+    assert actual.include?(c1_sol)
+    assert actual.include?(c3_sol)
+
+    expected_exercises = [c1,c3,c4].map(&:id).sort
+    assert_equal expected_exercises, user_track.solutions.map(&:exercise_id).sort
+
+    assert Solution.find_by(user: user, exercise: c3).mentoring_requested_at?
+    assert Solution.find_by(user: user, exercise: c4).mentoring_requested_at?
   end
 end

--- a/test/services/switch_track_to_mentored_mode_test.rb
+++ b/test/services/switch_track_to_mentored_mode_test.rb
@@ -25,7 +25,7 @@ class SwitchTrackToMentoredModeTest < ActiveSupport::TestCase
 
     refute user_track.independent_mode?
     assert core_solution_1.mentoring_requested?
-    refute core_solution_2.mentoring_requested?
+    assert core_solution_2.mentoring_requested?
     refute side_solution.mentoring_requested?
 
     refute core_solution_1.track_in_independent_mode?
@@ -48,29 +48,6 @@ class SwitchTrackToMentoredModeTest < ActiveSupport::TestCase
     refute user_track.independent_mode?
     refute core_solution.mentoring_requested?
     refute core_solution.track_in_independent_mode?
-  end
-
-  test "don't let multiple core solutions be mentored" do
-    user = create :user
-    track = create :track
-    exercise_1 = create :exercise, track: track, core: true
-    exercise_2 = create :exercise, track: track, core: true
-
-    solution_1 = create :solution, user: user, exercise: exercise_1, mentoring_requested_at: nil, track_in_independent_mode: true
-    solution_2 = create :solution, user: user, exercise: exercise_2, mentoring_requested_at: Time.current, track_in_independent_mode: true
-
-    create :iteration, solution: solution_1
-    create :iteration, solution: solution_2
-
-    user_track = create :user_track, user: user, track: track
-
-    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
-    SwitchTrackToMentoredMode.(user, track)
-
-    [solution_1, solution_2].each(&:reload)
-
-    refute solution_1.mentoring_requested?
-    assert solution_2.mentoring_requested?
   end
 
   test "calls FixUnlockingInUserTrack" do

--- a/test/services/unlock_next_core_exercise_test.rb
+++ b/test/services/unlock_next_core_exercise_test.rb
@@ -18,7 +18,25 @@ class UnlockNextCoreExerciseTest < ActiveSupport::TestCase
     assert_equal next_solution, UnlockNextCoreExercise.(track, user)
   end
 
-  test "returns existing solution if it exists and sets mentoring_requested_at" do
+  test "if existing solution exists set mentoring_requested_at and return" do
+    Timecop.freeze do
+      track = create(:track)
+      user = create(:user)
+      next_core_exercise = create(:exercise, track: track, core: true, position: 2)
+      next_core_solution = create(:solution,
+             user: user,
+             exercise: next_core_exercise,
+             completed_at: nil,
+             mentoring_requested_at: nil)
+      create(:iteration, solution: next_core_solution)
+      UnlockCoreExercise.expects(:call).with(user, next_core_exercise).never
+
+      assert_equal next_core_solution, UnlockNextCoreExercise.(track, user)
+      assert_equal Time.current.to_i, next_core_solution.reload.mentoring_requested_at.to_i
+    end
+  end
+
+  test "if existing solution don't set mentoring_requested_at if no iterations" do
     Timecop.freeze do
       track = create(:track)
       user = create(:user)
@@ -31,7 +49,7 @@ class UnlockNextCoreExerciseTest < ActiveSupport::TestCase
       UnlockCoreExercise.expects(:call).with(user, next_core_exercise).never
 
       assert_equal next_core_solution, UnlockNextCoreExercise.(track, user)
-      assert_equal Time.current.to_i, next_core_solution.reload.mentoring_requested_at.to_i
+      assert_nil next_core_solution.reload.mentoring_requested_at
     end
   end
 


### PR DESCRIPTION
When unlocking next core exercise or switching the mentored mode, do not set `mentoring_requested_at` unless the user has submitted the request.

This needs running:
```ruby
Solution.
  where("NOT EXISTS(SELECT TRUE FROM iterations WHERE iterations.solution_id = solutions.id)").
  where.not(mentoring_requested_at: nil).
  update_all(mentoring_requested_at: nil)
```