### PR TITLE
Add median wait time for exercises and tracks

### DIFF
--- a/app/queries/mentored_solutions_query.rb
+++ b/app/queries/mentored_solutions_query.rb
@@ -13,6 +13,7 @@ class MentoredSolutionsQuery
       where(track_in_independent_mode: false).
       where("num_mentors > 0").
       where.not(discussion_posts: { user_id: User::SYSTEM_USER_ID }).
+      where.not('discussion_posts.user_id = solutions.user_id').
       group(:solution_id)
   end
 end

--- a/app/queries/mentored_solutions_query.rb
+++ b/app/queries/mentored_solutions_query.rb
@@ -1,0 +1,18 @@
+class MentoredSolutionsQuery
+  include Mandate
+
+  def call
+    Solution.
+      select(
+        "solutions.*,"\
+        "MIN(discussion_posts.created_at) as first_mentored_at,"\
+        "(TIMESTAMPDIFF(SECOND, mentoring_requested_at, MIN(discussion_posts.created_at))) as wait_time"
+      ).
+      joins(:discussion_posts).
+      where.not(mentoring_requested_at: nil).
+      where(track_in_independent_mode: false).
+      where("num_mentors > 1").
+      where.not(discussion_posts: { user_id: User::SYSTEM_USER_ID }).
+      group(:solution_id)
+  end
+end

--- a/app/queries/mentored_solutions_query.rb
+++ b/app/queries/mentored_solutions_query.rb
@@ -11,7 +11,7 @@ class MentoredSolutionsQuery
       joins(:discussion_posts).
       where.not(mentoring_requested_at: nil).
       where(track_in_independent_mode: false).
-      where("num_mentors > 1").
+      where("num_mentors > 0").
       where.not(discussion_posts: { user_id: User::SYSTEM_USER_ID }).
       group(:solution_id)
   end

--- a/app/services/exercise_services/update_median_wait_time.rb
+++ b/app/services/exercise_services/update_median_wait_time.rb
@@ -1,0 +1,68 @@
+module ExerciseServices
+  class UpdateMedianWaitTime
+    include Mandate
+
+    def call
+      ActiveRecord::Base.connection.execute(
+        <<~SQL
+          UPDATE `exercises`
+          INNER JOIN (#{exercise_wait_times.to_sql}) wait_times
+          ON wait_times.exercise_id = exercises.id
+          SET exercises.median_wait_time = wait_times.median_wait_time
+        SQL
+      )
+    end
+
+    private
+
+    def exercise_wait_times
+      Exercise.
+        select("exercise_id, AVG(wait_time) as median_wait_time").
+        from(mentored_solutions_grouped_by_exercise).
+        where("group_position BETWEEN group_total_count / 2.0 AND (group_total_count / 2.0 + 1)").
+        group(:exercise_id)
+    end
+
+    def mentored_solutions_grouped_by_exercise
+      Solution.
+        select(
+          <<~SQL
+            mentored_solutions.exercise_id,
+            wait_time,
+            @group_position := CASE
+              WHEN @current_group = mentored_solutions.exercise_id THEN @group_position + 1
+              ELSE (@current_group := mentored_solutions.exercise_id) AND 1
+            END AS group_position,
+            group_total_count
+          SQL
+        ).
+        from(
+          <<~SQL
+            (SELECT @group_position := 0, @current_group := 0) s,
+            (#{mentored_solutions.to_sql}) mentored_solutions
+          SQL
+        ).
+        joins(
+          <<~SQL
+            INNER JOIN (#{mentored_solutions_count.to_sql}) mentored_solutions_count
+            ON mentored_solutions_count.exercise_id = mentored_solutions.exercise_id
+          SQL
+        ).
+        order("mentored_solutions.exercise_id, mentored_solutions.wait_time")
+    end
+
+    def mentored_solutions_count
+      Solution.
+        select("exercise_id, COUNT(*) as group_total_count").
+        from(mentored_solutions).
+        group(:exercise_id)
+    end
+
+    def mentored_solutions
+      MentoredSolutionsQuery.().
+        not_legacy.
+        having("first_mentored_at >= ?", 4.weeks.ago)
+    end
+  end
+end
+

--- a/app/services/track_services/update_median_wait_time.rb
+++ b/app/services/track_services/update_median_wait_time.rb
@@ -1,0 +1,71 @@
+module TrackServices
+  class UpdateMedianWaitTime
+    include Mandate
+
+    def call
+      ActiveRecord::Base.connection.execute(
+        <<~SQL
+          UPDATE `tracks`
+          INNER JOIN (#{track_wait_times.to_sql}) wait_times
+          ON wait_times.track_id = tracks.id
+          SET tracks.median_wait_time = wait_times.median_wait_time
+        SQL
+      )
+    end
+
+    private
+
+    def track_wait_times
+      Track.
+        select("track_id, AVG(wait_time) as median_wait_time").
+        from(mentored_solutions_grouped_by_track).
+        where("group_position BETWEEN group_total_count / 2.0 AND (group_total_count / 2.0 + 1)").
+        group(:track_id)
+    end
+
+    def mentored_solutions_grouped_by_track
+      Solution.
+        select(
+          <<~SQL
+            mentored_solutions.track_id,
+            wait_time,
+            @group_position := CASE
+              WHEN @current_group = mentored_solutions.track_id THEN @group_position + 1
+              ELSE (@current_group := mentored_solutions.track_id) AND 1
+            END AS group_position,
+            group_total_count
+          SQL
+        ).
+        from(
+          <<~SQL
+            (SELECT @group_position := 0, @current_group := 0) s,
+            (#{mentored_solutions.to_sql}) mentored_solutions
+          SQL
+        ).
+        joins(
+          <<~SQL
+            INNER JOIN (#{mentored_solutions_count.to_sql}) mentored_solutions_count
+            ON mentored_solutions_count.track_id = mentored_solutions.track_id
+          SQL
+        ).
+        order("mentored_solutions.track_id, mentored_solutions.wait_time")
+    end
+
+    def mentored_solutions_count
+      Solution.
+        select("track_id, COUNT(*) as group_total_count").
+        from(mentored_solutions).
+        group(:track_id)
+    end
+
+    def mentored_solutions
+      MentoredSolutionsQuery.().
+        select("exercises.track_id").
+        not_legacy.
+        joins(:exercise).
+        merge(Exercise.core).
+        having("first_mentored_at >= ?", 4.weeks.ago)
+    end
+  end
+end
+

--- a/db/migrate/20190627052503_add_median_wait_time_to_exercises.rb
+++ b/db/migrate/20190627052503_add_median_wait_time_to_exercises.rb
@@ -1,0 +1,5 @@
+class AddMedianWaitTimeToExercises < ActiveRecord::Migration[5.2]
+  def change
+    add_column :exercises, :median_wait_time, :integer
+  end
+end

--- a/db/migrate/20190628060134_add_median_wait_time_to_tracks.rb
+++ b/db/migrate/20190628060134_add_median_wait_time_to_tracks.rb
@@ -1,0 +1,5 @@
+class AddMedianWaitTimeToTracks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tracks, :median_wait_time, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,6 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.datetime "updated_at", null: false
     t.boolean "active", default: true, null: false
     t.index ["user_id", "active"], name: "index_auth_tokens_on_user_id_and_active"
-    t.index ["user_id"], name: "fk_rails_0d66c22f4c"
   end
 
   create_table "blog_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -164,6 +163,7 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "median_wait_time"
     t.index ["track_id"], name: "fk_rails_a796d89c21"
     t.index ["unlocked_by_id"], name: "fk_rails_03ec4ffbf3"
   end
@@ -233,16 +233,6 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.string "alumnus"
     t.index ["track_id"], name: "fk_rails_ed46fd11a4"
     t.index ["user_id"], name: "fk_rails_5b1168410c"
-  end
-
-  create_table "mentor_profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.text "bio"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.decimal "average_rating", precision: 3, scale: 2
-    t.integer "num_solutions_mentored", default: 0, null: false
-    t.index ["user_id"], name: "fk_rails_9a3e3e5b86"
   end
 
   create_table "mentors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -389,14 +379,9 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.integer "num_comments", limit: 2, default: 0, null: false
     t.integer "num_stars", limit: 2, default: 0, null: false
     t.datetime "reminder_sent_at"
-    t.index ["approved_by_id", "completed_at", "mentoring_requested_at", "num_mentors", "id"], name: "ihid_fix_8"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
-    t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "num_mentors", "id"], name: "ihid_fix_11"
     t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "num_mentors", "id"], name: "mentor_selection_idx_3"
-    t.index ["exercise_id", "id", "approved_by_id", "completed_at", "mentoring_requested_at", "num_mentors"], name: "ihid_fix_10"
     t.index ["exercise_id", "user_id"], name: "index_solutions_on_exercise_id_and_user_id", unique: true
-    t.index ["exercise_id"], name: "fk_rails_8c0841e614"
-    t.index ["id", "approved_by_id", "completed_at", "mentoring_requested_at", "num_mentors"], name: "ihid_fix_9"
     t.index ["num_mentors", "independent_mode", "created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["num_mentors", "track_in_independent_mode", "created_at", "exercise_id"], name: "mentor_selection_idx_2"
     t.index ["user_id"], name: "fk_rails_f83c42cef4"
@@ -421,7 +406,6 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["team_id", "user_id"], name: "index_team_memberships_on_team_id_and_user_id", unique: true
-    t.index ["team_id"], name: "fk_rails_61c29b529e"
     t.index ["user_id"], name: "fk_rails_5aba9331a7"
   end
 
@@ -484,7 +468,6 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.datetime "updated_at", null: false
     t.index ["track_id"], name: "fk_rails_4a81f96f88"
     t.index ["user_id", "track_id"], name: "index_track_mentorships_on_user_id_and_track_id", unique: true
-    t.index ["user_id"], name: "fk_rails_283ecc719a"
   end
 
   create_table "tracks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -578,10 +561,11 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
   add_foreign_key "iteration_files", "iterations"
   add_foreign_key "maintainers", "tracks"
   add_foreign_key "maintainers", "users"
-  add_foreign_key "mentor_profiles", "users"
   add_foreign_key "mentors", "tracks"
   add_foreign_key "notifications", "users"
   add_foreign_key "profiles", "users"
+  add_foreign_key "reactions", "solutions"
+  add_foreign_key "reactions", "users"
   add_foreign_key "repo_update_fetches", "repo_updates"
   add_foreign_key "solution_locks", "solutions"
   add_foreign_key "solution_locks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -485,6 +485,7 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "active", default: true, null: false
+    t.integer "median_wait_time"
   end
 
   create_table "user_email_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|

--- a/lib/tasks/exercises.rake
+++ b/lib/tasks/exercises.rake
@@ -1,0 +1,6 @@
+namespace :exercises do
+  desc "Update exercise median wait times"
+  task :update_median_wait_time => :environment do
+    ExerciseServices::UpdateMedianWaitTime.()
+  end
+end

--- a/lib/tasks/tracks.rake
+++ b/lib/tasks/tracks.rake
@@ -1,0 +1,6 @@
+namespace :tracks do
+  desc "Update track median wait times"
+  task :update_median_wait_time => :environment do
+    TrackServices::UpdateMedianWaitTime.()
+  end
+end

--- a/test/queries/mentored_solutions_query_test.rb
+++ b/test/queries/mentored_solutions_query_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class MentoredSolutionsQueryTest < ActiveSupport::TestCase
+  test "excludes solutions where mentoring is not requested" do
+    solution = create(:solution,
+                      mentoring_requested_at: nil,
+                      track_in_independent_mode: false,
+                      num_mentors: 2)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post, user: create(:user), iteration: iteration)
+
+    assert_empty MentoredSolutionsQuery.()
+  end
+
+  test "excludes solutions where track is in independent mode" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: true,
+                      num_mentors: 2)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post, user: create(:user), iteration: iteration)
+
+    assert_empty MentoredSolutionsQuery.()
+  end
+
+  test "excludes solutions where number of mentors less than 2" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: false,
+                      num_mentors: 1)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post, user: create(:user), iteration: iteration)
+
+    assert_empty MentoredSolutionsQuery.()
+  end
+
+  test "excludes solutions with discussions by the system user only" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: false,
+                      num_mentors: 2)
+    system = create(:user, :system)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post,
+           user: system,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 25))
+
+    assert_empty MentoredSolutionsQuery.()
+  end
+
+  test "marks first_mentored_at as the time a human adds a discussion post" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: false,
+                      num_mentors: 2)
+    system = create(:user, :system)
+    human = create(:user, id: 2)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post,
+           user: system,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 25))
+    create(:discussion_post,
+           user: human,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 26))
+    create(:discussion_post,
+           user: human,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 27))
+
+    solution = MentoredSolutionsQuery.().first
+
+    assert_equal Date.new(2016, 12, 26), solution.first_mentored_at
+  end
+
+  test "computes wait time" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: false,
+                      num_mentors: 2)
+    human = create(:user, id: 2)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post,
+           user: human,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 26))
+
+    solution = MentoredSolutionsQuery.().first
+
+    assert_equal 1.day, solution.wait_time
+  end
+end

--- a/test/queries/mentored_solutions_query_test.rb
+++ b/test/queries/mentored_solutions_query_test.rb
@@ -5,7 +5,7 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     solution = create(:solution,
                       mentoring_requested_at: nil,
                       track_in_independent_mode: false,
-                      num_mentors: 2)
+                      num_mentors: 1)
     iteration = create(:iteration, solution: solution)
     create(:discussion_post, user: create(:user), iteration: iteration)
 
@@ -16,18 +16,18 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: true,
-                      num_mentors: 2)
+                      num_mentors: 1)
     iteration = create(:iteration, solution: solution)
     create(:discussion_post, user: create(:user), iteration: iteration)
 
     assert_empty MentoredSolutionsQuery.()
   end
 
-  test "excludes solutions where number of mentors less than 2" do
+  test "excludes solutions where number of mentors less than 1" do
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: false,
-                      num_mentors: 1)
+                      num_mentors: 0)
     iteration = create(:iteration, solution: solution)
     create(:discussion_post, user: create(:user), iteration: iteration)
 
@@ -38,7 +38,7 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: false,
-                      num_mentors: 2)
+                      num_mentors: 1)
     system = create(:user, :system)
     iteration = create(:iteration, solution: solution)
     create(:discussion_post,
@@ -53,7 +53,7 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: false,
-                      num_mentors: 2)
+                      num_mentors: 1)
     system = create(:user, :system)
     human = create(:user, id: 2)
     iteration = create(:iteration, solution: solution)
@@ -79,7 +79,7 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: false,
-                      num_mentors: 2)
+                      num_mentors: 1)
     human = create(:user, id: 2)
     iteration = create(:iteration, solution: solution)
     create(:discussion_post,

--- a/test/queries/mentored_solutions_query_test.rb
+++ b/test/queries/mentored_solutions_query_test.rb
@@ -49,24 +49,42 @@ class MentoredSolutionsQueryTest < ActiveSupport::TestCase
     assert_empty MentoredSolutionsQuery.()
   end
 
-  test "marks first_mentored_at as the time a human adds a discussion post" do
+  test "excludes solutions with discussions by the submitting user only" do
+    solution = create(:solution,
+                      mentoring_requested_at: Time.utc(2016, 12, 25),
+                      track_in_independent_mode: false,
+                      num_mentors: 1)
+    iteration = create(:iteration, solution: solution)
+    create(:discussion_post,
+           user: iteration.solution.user,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 25))
+
+    assert_empty MentoredSolutionsQuery.()
+  end
+
+  test "marks first_mentored_at as the time a mentor adds a discussion post" do
     solution = create(:solution,
                       mentoring_requested_at: Time.utc(2016, 12, 25),
                       track_in_independent_mode: false,
                       num_mentors: 1)
     system = create(:user, :system)
-    human = create(:user, id: 2)
+    mentor = create(:user, id: 2)
     iteration = create(:iteration, solution: solution)
+    create(:discussion_post,
+           user: iteration.solution.user,
+           iteration: iteration,
+           created_at: Date.new(2016, 12, 24))
     create(:discussion_post,
            user: system,
            iteration: iteration,
            created_at: Date.new(2016, 12, 25))
     create(:discussion_post,
-           user: human,
+           user: mentor,
            iteration: iteration,
            created_at: Date.new(2016, 12, 26))
     create(:discussion_post,
-           user: human,
+           user: mentor,
            iteration: iteration,
            created_at: Date.new(2016, 12, 27))
 

--- a/test/services/exercise_services/update_median_wait_time_test.rb
+++ b/test/services/exercise_services/update_median_wait_time_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module ExerciseServices
+  class UpdateMedianWaitTimeTest < ActiveSupport::TestCase
+    test "updates median wait time for each exercise" do
+      exercise1 = create(:exercise)
+      create_solution_with_wait_time(wait_time: 2.days, exercise: exercise1)
+      create_solution_with_wait_time(wait_time: 3.days, exercise: exercise1)
+      create_solution_with_wait_time(wait_time: 4.days, exercise: exercise1)
+      exercise2 = create(:exercise)
+      create_solution_with_wait_time(wait_time: 2.days, exercise: exercise2)
+      create_solution_with_wait_time(wait_time: 3.days, exercise: exercise2)
+      create_solution_with_wait_time(wait_time: 4.days, exercise: exercise2)
+      create_solution_with_wait_time(wait_time: 5.days, exercise: exercise2)
+
+      ExerciseServices::UpdateMedianWaitTime.()
+
+      exercise1.reload
+      assert_equal 3.days, exercise1.median_wait_time
+      exercise2.reload
+      assert_equal 3.5.days, exercise2.median_wait_time
+    end
+
+    private
+
+    def create_solution_with_wait_time(wait_time:, exercise:)
+      time = Time.current
+      solution = create(:solution,
+                        exercise: exercise,
+                        mentoring_requested_at: time - wait_time,
+                        track_in_independent_mode: false,
+                        num_mentors: 2)
+      iteration = create(:iteration, solution: solution)
+      create(:discussion_post, iteration: iteration, created_at: time)
+    end
+  end
+end

--- a/test/services/exercise_services/update_median_wait_time_test.rb
+++ b/test/services/exercise_services/update_median_wait_time_test.rb
@@ -29,7 +29,7 @@ module ExerciseServices
                         exercise: exercise,
                         mentoring_requested_at: time - wait_time,
                         track_in_independent_mode: false,
-                        num_mentors: 2)
+                        num_mentors: 1)
       iteration = create(:iteration, solution: solution)
       create(:discussion_post, iteration: iteration, created_at: time)
     end

--- a/test/services/track_services/update_median_wait_time_test.rb
+++ b/test/services/track_services/update_median_wait_time_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+module TrackServices
+  class UpdateMedianWaitTimeTest < ActiveSupport::TestCase
+    test "updates median wait time for each track" do
+      track1 = create(:track)
+      create_solution_with_wait_time(wait_time: 2.days, track: track1)
+      create_solution_with_wait_time(wait_time: 3.days, track: track1)
+      create_solution_with_wait_time(wait_time: 4.days, track: track1)
+      create_solution_with_wait_time(wait_time: 4.days, track: track1, core: false)
+      track2 = create(:track)
+      create_solution_with_wait_time(wait_time: 2.days, track: track2)
+      create_solution_with_wait_time(wait_time: 3.days, track: track2)
+      create_solution_with_wait_time(wait_time: 4.days, track: track2)
+      create_solution_with_wait_time(wait_time: 5.days, track: track2)
+
+      TrackServices::UpdateMedianWaitTime.()
+
+      track1.reload
+      assert_equal 3.days, track1.median_wait_time
+      track2.reload
+      assert_equal 3.5.days, track2.median_wait_time
+    end
+
+    private
+
+    def create_solution_with_wait_time(wait_time:, track:, core: true)
+      time = Time.current
+      exercise = create(:exercise, track: track, core: core)
+      solution = create(:solution,
+                        exercise: exercise,
+                        mentoring_requested_at: time - wait_time,
+                        track_in_independent_mode: false,
+                        num_mentors: 2)
+      iteration = create(:iteration, solution: solution)
+      create(:discussion_post, iteration: iteration, created_at: time)
+    end
+  end
+end

--- a/test/services/track_services/update_median_wait_time_test.rb
+++ b/test/services/track_services/update_median_wait_time_test.rb
@@ -31,7 +31,7 @@ module TrackServices
                         exercise: exercise,
                         mentoring_requested_at: time - wait_time,
                         track_in_independent_mode: false,
-                        num_mentors: 2)
+                        num_mentors: 1)
       iteration = create(:iteration, solution: solution)
       create(:discussion_post, iteration: iteration, created_at: time)
     end


### PR DESCRIPTION
## Description
This PR adds a rake task `exercises:update_median_wait_time` and `tracks:update_median_wait_time` to update the median wait times for exercises and tracks. As described [here](https://github.com/exercism/wip/issues/2), the median wait time is computed by getting the median of the wait times of the solutions for the exercise. For tracks, the median wait time is computed by getting the median of the wait times of the solutions for all core exercises in the track. The wait time for a solution is the time from when the student first asks for mentorship to the time when the mentor first comments on the solution.

Furthermore, solutions that are considered to be part of the median wait time computation should have the ff traits:
-  mentoring was requested on the solution
- solution's track should be in independent mode
- solution should have more than 1 mentor
- solution was first mentored 4 weeks ago
- solution is not legacy (created after migrating to V2)

## Questions
1. Should we include solutions that haven't been mentored within the 4 week period? Or not including it is the reason we chose to use the median instead of the average?
2. To qualify the solution for computation, why should we check if it has more than 1 mentor?