### PR TITLE
Don't delete secrets.yml during deployment

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,14 +4,6 @@ server 'web1.exercism.io', user: fetch(:application), roles: %w{app web db git_f
 server 'web2.exercism.io', user: fetch(:application), roles: %w{app web db git_fetch}
 server 'processor.exercism.io', user: fetch(:application), roles: %w{app assets web db processor git_sync}
 
-namespace :deploy do
-  task :rm_stubs do
-    on roles(:app) do
-      execute "rm #{release_path.join("config/secrets.yml")}"
-    end
-  end
-end
-
 namespace :puma_service do
   task :restart do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
@@ -79,8 +71,6 @@ namespace :delayed_job do
     end
   end
 end
-
-before 'deploy:symlink:shared', 'deploy:rm_stubs'
 
 after "deploy:assets:precompile", "assets:upload"
 


### PR DESCRIPTION
Since we've removed `secrets.yml` from version control, we should also delete the step where we delete it during deployment. This is blocking me to deploy so I hope you can take a look at this as soon as possible.