### PR TITLE
Add correct defaults for summary tag

### DIFF
--- a/app/assets/stylesheets/defaults.scss
+++ b/app/assets/stylesheets/defaults.scss
@@ -18,6 +18,10 @@ body {
     }
 }
 
+summary {
+  display: list-item;
+}
+
 button,
 input,
 select,


### PR DESCRIPTION
https://github.com/exercism/bugs/issues/2

It turns out that Pure.css uses a very outdated version of Normalize.css which caused this problem. It's part of their roadmap to upgrade Normalize.css, but it seems like that Pure hasn't had that much activity. We can open up a separate discussion to talk about this.