### PR TITLE
Cache bundler on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ cache:
   node_modules: true
   directories:
     - vendor/bundle
-
+branches:
+  only:
+  - master
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t simplecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sudo mysql -e "ALTER DATABASE exercism_reboot_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" -u root
   - sudo mysql -e "GRANT ALL PRIVILEGES ON exercism_reboot_test.* TO 'exercism_reboot'@'localhost'" -u root
 install:
-  - "bundle install"
+  - "bundle install --jobs=3 --retry=3 --deployment"
   - "npm install"
   - "bundle exec rake db:test:prepare"
 script:


### PR DESCRIPTION
## Description
As I was going through the PRs, I noticed that we take too much time running the tests on CI and this further impacts us when I have PRs piled up that I want to merge. The two longest processes are:

1. Running `bundle install`.
2. Running system tests.

This PR fixes (1) by caching the bundler produced files.

## Results
### Before (10 mins to run tests)
<img width="930" alt="Screen Shot 2019-07-03 at 10 55 04 AM" src="https://user-images.githubusercontent.com/1901520/60560609-0b74ee80-9d83-11e9-899d-cd7a86bf3d1f.png">

### After (5 mins to run tests)
<img width="920" alt="Screen Shot 2019-07-03 at 11 03 29 AM" src="https://user-images.githubusercontent.com/1901520/60560610-0c0d8500-9d83-11e9-9983-ac664e48e538.png">

## Other information
1. In order to enable caching, I also needed to turn on the "Build pushed branches" setting as outlined in the Travis CI docs. As we've turned this on, we need to modify `.travis.yml` to only build the master branch when pushed (PRs are an exception, we still build them). This will allows us to use the master branch's cache for subsequent PRs to master.
2. I also opted to turn on auto cancellation of builds in order for Travis CI to only build the latest commits in the branch. This will help us free up workers if we push frequently to branches.