### PR TITLE
Add website error to iteration analyses

### DIFF
--- a/app/services/analysis_services/process_analysis.rb
+++ b/app/services/analysis_services/process_analysis.rb
@@ -12,13 +12,15 @@ module AnalysisServices
       create_database_record
       handle_analysis
       remove_system_lock
+
+      record
     end
 
     private
-    attr_reader :iteration, :analysis_status, :analysis
+    attr_reader :iteration, :analysis_status, :analysis, :record
 
     def create_database_record
-      IterationAnalysis.create!(
+      @record = IterationAnalysis.create!(
         iteration: iteration,
         status: analysis_status,
         analysis: analysis
@@ -38,6 +40,9 @@ module AnalysisServices
       else
         # We currently don't do anything with non-approved solutions
       end
+
+    rescue => e
+      @record.update(website_error: e.message)
     end
 
     def remove_system_lock

--- a/app/views/mentor/analyses/index.html.haml
+++ b/app/views/mentor/analyses/index.html.haml
@@ -24,7 +24,10 @@
           %td= track.slug
           %td= exercise.slug
           %td
-            %code= analysis.status
+            -if analysis.website_error.present?
+              %code errored
+            -else
+              %code= analysis.status
           %td
             %code= analysis.analysis.try {|a|a['status'] }
           %td= link_to "View", mentor_analysis_path(analysis)

--- a/app/views/mentor/analyses/show.html.haml
+++ b/app/views/mentor/analyses/show.html.haml
@@ -27,6 +27,12 @@
       %pre
         %code= JSON.pretty_generate(@analysis.analysis)
 
+    -if @analysis.website_error.present?
+      .analysis
+        %h2 Website Error
+        %pre
+          %code= @analysis.website_error
+
     .code
       %h2 Submission
       -if iteration.files.size == 1

--- a/db/migrate/20190703133313_add_website_error_to_iteration_analyses.rb
+++ b/db/migrate/20190703133313_add_website_error_to_iteration_analyses.rb
@@ -1,0 +1,5 @@
+class AddWebsiteErrorToIterationAnalyses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :iteration_analyses, :website_error, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_175744) do
+ActiveRecord::Schema.define(version: 2019_07_03_133313) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_175744) do
     t.json "analysis"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "website_error"
     t.index ["iteration_id"], name: "fk_rails_c60c42383b"
   end
 

--- a/test/services/analysis_services/process_analysis_test.rb
+++ b/test/services/analysis_services/process_analysis_test.rb
@@ -118,8 +118,11 @@ module AnalysisServices
       solution = create :solution
       iteration = create :iteration, solution: solution
 
+      error_msg = "some_error"
+      BuildComments.expects(:call).raises(RuntimeError, error_msg)
+
       record = ProcessAnalysis.(iteration, SUCCESS_STATUS, data)
-      assert_equal "undefined method `[]' for nil:NilClass", record.website_error
+      assert_equal error_msg, record.website_error
     end
   end
 end

--- a/test/services/analysis_services/process_analysis_test.rb
+++ b/test/services/analysis_services/process_analysis_test.rb
@@ -109,7 +109,7 @@ module AnalysisServices
       ProcessAnalysis.(iteration, SUCCESS_STATUS, data)
     end
 
-    test "explodes if the comment doesn't work" do
+    test "stores error if the comment doesn't work" do
       data = {
         'status' => "approve",
         'comments' => [{"comment" => "foo"}]
@@ -118,9 +118,8 @@ module AnalysisServices
       solution = create :solution
       iteration = create :iteration, solution: solution
 
-      assert_raises do
-        ProcessAnalysis.(iteration, SUCCESS_STATUS, data)
-      end
+      record = ProcessAnalysis.(iteration, SUCCESS_STATUS, data)
+      assert_equal "undefined method `[]' for nil:NilClass", record.website_error
     end
   end
 end


### PR DESCRIPTION
This stores a website error that occurs when parsing an iteration analysis and shows it in the admin dashboard.

<img width="1207" alt="Screenshot 2019-07-03 at 14 41 13" src="https://user-images.githubusercontent.com/286476/60596343-b7790280-9da0-11e9-89ef-0bf9bf20c08c.png">
<img width="1154" alt="Screenshot 2019-07-03 at 14 41 18" src="https://user-images.githubusercontent.com/286476/60596344-b8119900-9da0-11e9-869c-28904df3b8a6.png">
