### PR TITLE
Show exercise median wait time

### DIFF
--- a/app/views/my/solutions/_next_steps.html.haml
+++ b/app/views/my/solutions/_next_steps.html.haml
@@ -9,7 +9,8 @@
   %p Well done on submitting your iteration. A mentor will check out your work and leave a comment here on your solution soon.
   %p
     There are currently #{@queue_position[:track] - 1} solutions ahead of this in the #{@track.title} queue, and #{@queue_position[:exercise] - 1} ahead in the #{@exercise.title} queue.
-    The median waiting time for mentoring on this exercise is #{time_ago_in_words(@exercise.median_wait_time.seconds.from_now)}.
+    -if @exercise.median_wait_time.present?
+      The median waiting time for mentoring on this exercise is #{time_ago_in_words(@exercise.median_wait_time.seconds.from_now)}.
     #{link_to "Learn more about how mentor queues work", how_do_mentor_queues_work_help_page_path}.
   %p
     In the meantime why not try a different exercise on the

--- a/app/views/my/solutions/_next_steps.html.haml
+++ b/app/views/my/solutions/_next_steps.html.haml
@@ -7,7 +7,10 @@
   .title ↳ Next steps
 
   %p Well done on submitting your iteration. A mentor will check out your work and leave a comment here on your solution soon.
-  %p There are currently #{@queue_position[:track] - 1} solutions ahead of this in the #{@track.title} queue, and #{@queue_position[:exercise] - 1} ahead in the #{@exercise.title} queue. #{link_to "Learn more about how mentor queues work", how_do_mentor_queues_work_help_page_path}.
+  %p
+    There are currently #{@queue_position[:track] - 1} solutions ahead of this in the #{@track.title} queue, and #{@queue_position[:exercise] - 1} ahead in the #{@exercise.title} queue.
+    The median waiting time for mentoring on this exercise is #{time_ago_in_words(@exercise.median_wait_time.seconds.from_now)}.
+    #{link_to "Learn more about how mentor queues work", how_do_mentor_queues_work_help_page_path}.
   %p
     In the meantime why not try a different exercise on the
     =link_to "#{@track.title} track", [:my, @track]

--- a/test/system/my/solutions_information_bar_test.rb
+++ b/test/system/my/solutions_information_bar_test.rb
@@ -14,11 +14,14 @@ class My::SolutionsInformationBarTest < ApplicationSystemTestCase
   end
 
   test "On core exercise submission" do
-    @exercise.update(core: true, median_wait_time: 3600)
-
+    @exercise.update(core: true, median_wait_time: nil)
     sign_in!(@user)
     visit my_solution_path(@solution)
+    refute_text "The median waiting time"
 
+    @exercise.update(median_wait_time: 3600)
+    sign_in!(@user)
+    visit my_solution_path(@solution)
     assert_text "The median waiting time for mentoring on this exercise is about 1 hour."
   end
 

--- a/test/system/my/solutions_information_bar_test.rb
+++ b/test/system/my/solutions_information_bar_test.rb
@@ -13,6 +13,15 @@ class My::SolutionsInformationBarTest < ApplicationSystemTestCase
     Git::Exercise.any_instance.stubs(test_suite: [])
   end
 
+  test "On core exercise submission" do
+    @exercise.update(core: true, median_wait_time: 3600)
+
+    sign_in!(@user)
+    visit my_solution_path(@solution)
+
+    assert_text "The median waiting time for mentoring on this exercise is about 1 hour."
+  end
+
   test "On submission" do
     sign_in!(@user)
     visit my_solution_path(@solution)


### PR DESCRIPTION
Closes https://github.com/exercism/wip/issues/16.

For tests like this, we can also refactor them to use view tests instead of system tests in order to speed up CI builds.