### PR TITLE
Improve logging configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'daemons'
 
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'lograge'
+
 group :production do
   gem "skylight"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     lmdb (0.4.8)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -310,6 +315,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.5.1)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -428,6 +435,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   lmdb
+  lograge
   loofah
   mandate
   minitest (~> 5.10, != 5.10.2)
@@ -456,4 +464,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,4 +18,28 @@ module Exercism
 
     config.active_job.queue_adapter = :delayed_job
   end
+
+  def self.configure_logging(config)
+    # Move production log into a system folder
+    log_prefix = Rails.env.production? ? "/var/log/exercism/exercism_" : "log/"
+
+    rails_log_file = "#{log_prefix}#{Rails.env}.log"
+    logger         = ActiveSupport::Logger.new(rails_log_file, "daily")
+    config.logger  = ActiveSupport::TaggedLogging.new(logger)
+
+    # Create a lograge event log
+    requests_log_file = "#{log_prefix}requests.log"
+    requests_logger   = ActiveSupport::Logger.new(requests_log_file, "daily")
+    event_logger      = ActiveSupport::TaggedLogging.new(requests_logger)
+
+    config.lograge.keep_original_rails_log = true
+    config.lograge.enabled = true
+    config.lograge.logger = event_logger
+    config.lograge.custom_options = lambda do |event|
+      {
+        remote_ip: event.payload[:remote_ip],
+        request_id: event.payload[:request_id]
+      }
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,28 +18,4 @@ module Exercism
 
     config.active_job.queue_adapter = :delayed_job
   end
-
-  def self.configure_logging(config)
-    # Move production log into a system folder
-    log_prefix = Rails.env.production? ? "/var/log/exercism/exercism_" : "log/"
-
-    rails_log_file = "#{log_prefix}#{Rails.env}.log"
-    logger         = ActiveSupport::Logger.new(rails_log_file, "daily")
-    config.logger  = ActiveSupport::TaggedLogging.new(logger)
-
-    # Create a lograge event log
-    requests_log_file = "#{log_prefix}requests.log"
-    requests_logger   = ActiveSupport::Logger.new(requests_log_file, "daily")
-    event_logger      = ActiveSupport::TaggedLogging.new(requests_logger)
-
-    config.lograge.keep_original_rails_log = true
-    config.lograge.enabled = true
-    config.lograge.logger = event_logger
-    config.lograge.custom_options = lambda do |event|
-      {
-        remote_ip: event.payload[:remote_ip],
-        request_id: event.payload[:request_id]
-      }
-    end
-  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,6 +65,8 @@ Rails.application.configure do
 
   config.active_storage.service = :local
 
+  Exercism::configure_logging(config)
+
   config.after_initialize do
     Bullet.enable = true
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,7 +65,6 @@ Rails.application.configure do
 
   config.active_storage.service = :local
 
-  Exercism::configure_logging(config)
 
   config.after_initialize do
     Bullet.enable = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,11 +88,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  Exercism::configure_logging(config)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,8 +88,6 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  Exercism::configure_logging(config)
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,7 +1,6 @@
 return unless Rails.env.development? || Rails.env.production?
 
 Rails.application.configure do
-
   # Move production log into a system folder
   log_prefix = Rails.env.production? ? "/var/log/exercism/exercism_" : "log/"
 
@@ -21,6 +20,12 @@ Rails.application.configure do
     {
       remote_ip: event.payload[:remote_ip],
       request_id: event.payload[:request_id]
+    }
+  end
+
+  config.lograge.custom_payload do |controller|
+    {
+      user_id: controller.current_user.try(:id)
     }
   end
 end

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,0 +1,26 @@
+return unless Rails.env.development? || Rails.env.production?
+
+Rails.application.configure do
+
+  # Move production log into a system folder
+  log_prefix = Rails.env.production? ? "/var/log/exercism/exercism_" : "log/"
+
+  rails_log_file = "#{log_prefix}#{Rails.env}.log"
+  logger         = ActiveSupport::Logger.new(rails_log_file, "daily")
+  config.logger  = ActiveSupport::TaggedLogging.new(logger)
+
+  # Create a lograge event log
+  requests_log_file = "#{log_prefix}requests.log"
+  requests_logger   = ActiveSupport::Logger.new(requests_log_file, "daily")
+  event_logger      = ActiveSupport::TaggedLogging.new(requests_logger)
+
+  config.lograge.keep_original_rails_log = true
+  config.lograge.enabled = true
+  config.lograge.logger = event_logger
+  config.lograge.custom_options = lambda do |event|
+    {
+      remote_ip: event.payload[:remote_ip],
+      request_id: event.payload[:request_id]
+    }
+  end
+end


### PR DESCRIPTION
This commit introduces the lograge gem, which provides a
one-request-per-line event stream, useful for log processing and
statistical analysis.

Additionally, the production log is now redirected to /var/log when
running in production mode. Both of these loggers now auto-rotate every
data so that our log collection daemons can archive and process smaller
files without the need to fire reload or restart signals at the
application.

Once deployed we'll handle archiving and deletion of the output files as
as system configuration.