### PR TITLE
Turn off textarea autocomplete

### DIFF
--- a/app/views/widgets/_discussion_post.html.haml
+++ b/app/views/widgets/_discussion_post.html.haml
@@ -36,7 +36,7 @@
 
     .editable-text-editor
       = form_for post, url: my_discussion_post_path(post), remote: true do |f|
-        = f.text_area :content
+        = f.text_area :content, autocomplete: "off"
         .buttons
           = f.submit "Save changes", class: "pure-button update-button", data: { "disable-with": "Saving..." }
           = link_to "Cancel", "#", class: "pure-button cancel-button js-show-editable-text"


### PR DESCRIPTION
Closes https://github.com/exercism/bugs/issues/15.

When Firefox deals with multiple forms on the same page, especially with the fields having the same name attribute, it seems that autocompletion for the fields are broken.

It also makes sense that when editing comments, hitting the "Edit" button should load the textarea's value from the server and not from the browser's cache.