### PR TITLE
Don't include team solutions in mentor analyses page

### DIFF
--- a/app/controllers/mentor/analyses_controller.rb
+++ b/app/controllers/mentor/analyses_controller.rb
@@ -1,6 +1,6 @@
 class Mentor::AnalysesController < MentorController
   def index
-    @tracks = Track.where(id: IterationAnalysis.joins(iteration: {person_solution: :exercise}).select("exercises.track_id"))
+    @tracks = Track.where(id: IterationAnalysis.joins(iteration: {person_solution: :exercise}).where('iterations.solution_type': "Solution").select("exercises.track_id"))
 
     @track_id = params[:track_id]
     @analyses = IterationAnalysis.includes(iteration: {solution: {exercise: :track}}).


### PR DESCRIPTION
Fixes https://github.com/exercism/exercism/issues/4933

We need to not accidently eager load team solutions. We should probably think about how to extract this out - I'll check to see if the problem is anywhere else and deal with it if so. For now, this quickly fixes a bug. I've not added a test because none of this has test coverage yet and I won't have time to add coverage this week, but want to get the fix live.