### PR TITLE
Add soft deletion for user

### DIFF
--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -19,7 +19,8 @@ class My::SettingsController < MyController
       return redirect_to action: :confirm_delete_account
     end
 
-    current_user.destroy
+    UserServices::Delete.(current_user)
+    sign_out(current_user)
     redirect_to root_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,7 +200,7 @@ class User < ApplicationRecord
   end
 
   def deleted?
-    !User.where(id: id).exists?
+    deleted_at.present?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,6 +199,10 @@ class User < ApplicationRecord
     solution_stars.where(solution: solution).exists?
   end
 
+  def deleted?
+    !User.where(id: id).exists?
+  end
+
   private
 
   def avatar_thumbnail_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,8 @@ class User < ApplicationRecord
 
   has_many :track_mentorships, dependent: :destroy
   has_many :mentored_tracks, through: :track_mentorships, source: :track
-  has_many :track_mantainerships, class_name: "Maintainer", dependent: :nullify
-  has_many :maintained_tracks, through: :track_mantainerships, source: :track
+  has_many :track_maintainerships, class_name: "Maintainer", dependent: :nullify
+  has_many :maintained_tracks, through: :track_maintainerships, source: :track
 
   has_many :solution_mentorships, dependent: :destroy
   has_many :mentored_solutions, through: :solution_mentorships, source: :solution

--- a/app/services/user_services/delete.rb
+++ b/app/services/user_services/delete.rb
@@ -2,14 +2,19 @@ module UserServices
   class Delete
     include Mandate
 
-    initialize_with :user
+    def initialize(user, time: Time.current)
+      @user = user
+      @time = time
+    end
 
     def call
       redact_user_details
       delete_user_associations
+      mark_as_deleted
     end
 
     private
+    attr_reader :user, :time
 
     def redact_user_details
       user.skip_reconfirmation!
@@ -61,6 +66,10 @@ module UserServices
       user.email_log.destroy if user.email_log
       user.profile.destroy if user.profile
       user.communication_preferences.destroy if user.communication_preferences
+    end
+
+    def mark_as_deleted
+      user.update!(deleted_at: time)
     end
   end
 end

--- a/app/services/user_services/delete.rb
+++ b/app/services/user_services/delete.rb
@@ -36,8 +36,6 @@ module UserServices
         provider: nil,
         uid: nil,
         admin: false,
-        accepted_privacy_policy_at: nil,
-        accepted_terms_at: nil,
         dark_code_theme: false,
         is_mentor: false,
         default_allow_comments: nil,

--- a/app/services/user_services/delete.rb
+++ b/app/services/user_services/delete.rb
@@ -1,0 +1,41 @@
+module UserServices
+  class Delete
+    include Mandate
+
+    initialize_with :user
+
+    def call
+      redact_user_details
+    end
+
+    private
+
+    def redact_user_details
+      user.skip_reconfirmation!
+      user.update!(
+        name: "Deleted User",
+        handle: "deleteduser#{SecureRandom.uuid}",
+        bio: nil,
+        email: "deleteduser+#{SecureRandom.uuid}@exercism.io",
+        remember_created_at: nil,
+        sign_in_count: 0,
+        current_sign_in_at: nil,
+        last_sign_in_at: nil,
+        current_sign_in_ip: nil,
+        last_sign_in_ip: nil,
+        confirmation_token: nil,
+        confirmed_at: nil,
+        confirmation_sent_at: nil,
+        unconfirmed_email: nil,
+        provider: nil,
+        uid: nil,
+        admin: false,
+        accepted_privacy_policy_at: nil,
+        accepted_terms_at: nil,
+        dark_code_theme: false,
+        is_mentor: false,
+        default_allow_comments: nil,
+      )
+    end
+  end
+end

--- a/app/services/user_services/delete.rb
+++ b/app/services/user_services/delete.rb
@@ -6,6 +6,7 @@ module UserServices
 
     def call
       redact_user_details
+      delete_user_associations
     end
 
     private
@@ -36,6 +37,30 @@ module UserServices
         is_mentor: false,
         default_allow_comments: nil,
       )
+    end
+
+    def delete_user_associations
+      user.auth_tokens.destroy_all
+      user.notifications.destroy_all
+      user.team_memberships.destroy_all
+      user.team_sent_invitations.destroy_all
+      user.user_tracks.destroy_all
+      user.solutions.destroy_all
+      user.team_solutions.destroy_all
+      user.track_mentorships.destroy_all
+      user.track_maintainerships.update_all(user_id: nil)
+      user.solution_mentorships.destroy_all
+      user.solution_locks.destroy_all
+      user.ignored_solution_mentorships.destroy_all
+      user.discussion_posts.update_all(user_id: nil)
+      user.solution_comments.destroy_all
+      user.blog_comments.destroy_all
+      user.solution_stars.destroy_all
+      user.avatar.purge
+
+      user.email_log.destroy if user.email_log
+      user.profile.destroy if user.profile
+      user.communication_preferences.destroy if user.communication_preferences
     end
   end
 end

--- a/db/migrate/20190724042815_add_deleted_at_to_user.rb
+++ b/db/migrate/20190724042815_add_deleted_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_03_133313) do
+ActiveRecord::Schema.define(version: 2019_07_24_042815) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -540,6 +540,7 @@ ActiveRecord::Schema.define(version: 2019_07_03_133313) do
     t.boolean "dark_code_theme", default: false, null: false
     t.boolean "is_mentor", default: false, null: false
     t.boolean "default_allow_comments"
+    t.datetime "deleted_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["handle"], name: "index_users_on_handle", unique: true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -343,4 +343,14 @@ class UserTest < ActiveSupport::TestCase
 
     refute_nil user.communication_preferences
   end
+
+  test "user is deleted when deleted_at is present" do
+    user = create(:user, deleted_at: Time.current)
+
+    assert user.deleted?
+
+    user.deleted_at = nil
+
+    refute user.deleted?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -337,4 +337,10 @@ class UserTest < ActiveSupport::TestCase
     create :solution_star, user: user, solution: solution
     assert user.reload.starred_solution?(solution)
   end
+
+  test "communication preferences is created automatically" do
+    user = create(:user)
+
+    refute_nil user.communication_preferences
+  end
 end

--- a/test/services/user_services/delete_test.rb
+++ b/test/services/user_services/delete_test.rb
@@ -112,7 +112,7 @@ module UserServices
 
       UserServices::Delete.(user, time: time)
 
-      assert_equal time, user.deleted_at
+      assert user.deleted?
     end
   end
 end

--- a/test/services/user_services/delete_test.rb
+++ b/test/services/user_services/delete_test.rb
@@ -105,5 +105,14 @@ module UserServices
       assert_empty user.solution_stars
       refute user.avatar.attached?
     end
+
+    test "marks user as deleted" do
+      user = create(:user)
+      time = Date.new(2016, 12, 25)
+
+      UserServices::Delete.(user, time: time)
+
+      assert_equal time, user.deleted_at
+    end
   end
 end

--- a/test/services/user_services/delete_test.rb
+++ b/test/services/user_services/delete_test.rb
@@ -55,5 +55,55 @@ module UserServices
       refute user.is_mentor?
       assert_nil user.default_allow_comments
     end
+
+    test "deletes user associations" do
+      user = create(:user)
+      create(:auth_token, user: user)
+      create(:user_email_log, user: user)
+      create(:profile, user: user)
+      create(:notification, user: user)
+      create(:team_membership, user: user)
+      create(:team_invitation, invited_by: user)
+      create(:user_track, user: user)
+      create(:solution, user: user)
+      create(:team_solution, user: user)
+      create(:track_mentorship, user: user)
+      create(:maintainer, user: user)
+      create(:solution_mentorship, user: user)
+      create(:solution_lock, user: user)
+      create(:ignored_solution_mentorship, user: user)
+      create(:discussion_post, user: user)
+      create(:solution_comment, user: user)
+      create(:blog_comment, user: user)
+      create(:solution_star, user: user)
+      user.avatar.attach(
+        io: File.open("test/fixtures/test.png"),
+        filename: "test.png"
+      )
+
+      UserServices::Delete.(user)
+
+      user.reload
+      assert_empty user.auth_tokens
+      assert_nil user.communication_preferences
+      assert_nil user.email_log
+      assert_nil user.profile
+      assert_empty user.notifications
+      assert_empty user.team_memberships
+      assert_empty user.team_sent_invitations
+      assert_empty user.user_tracks
+      assert_empty user.solutions
+      assert_empty user.team_solutions
+      assert_empty user.track_mentorships
+      assert_empty user.track_maintainerships
+      assert_empty user.solution_mentorships
+      assert_empty user.solution_locks
+      assert_empty user.ignored_solution_mentorships
+      assert_empty user.discussion_posts
+      assert_empty user.solution_comments
+      assert_empty user.blog_comments
+      assert_empty user.solution_stars
+      refute user.avatar.attached?
+    end
   end
 end

--- a/test/services/user_services/delete_test.rb
+++ b/test/services/user_services/delete_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+module UserServices
+  class DeleteTest < ActiveSupport::TestCase
+    test "wipes user's details" do
+      user = create(:user,
+                    bio: "Short bio",
+                    reset_password_token: "token",
+                    reset_password_sent_at: Date.new(2016, 12, 25),
+                    remember_created_at: Date.new(2016, 12, 25),
+                    sign_in_count: 10,
+                    current_sign_in_at: Date.new(2016, 12, 25),
+                    last_sign_in_at: Date.new(2016, 12, 25),
+                    current_sign_in_ip: "IP",
+                    last_sign_in_ip: "IP",
+                    confirmation_token: "token",
+                    confirmed_at: Date.new(2016, 12, 25),
+                    confirmation_sent_at: Date.new(2016, 12, 25),
+                    unconfirmed_email: "email@gmail.com",
+                    provider: "provider",
+                    uid: "uid",
+                    admin: true,
+                    accepted_privacy_policy_at: Date.new(2016, 12, 25),
+                    accepted_terms_at: Date.new(2016, 12, 25),
+                    dark_code_theme: true,
+                    is_mentor: true,
+                    default_allow_comments: true,
+                   )
+
+      UserServices::Delete.(user)
+
+      user.reload
+      assert_equal "Deleted User", user.name
+      assert_match /deleteduser(.*)/, user.handle
+      assert_nil user.bio
+      assert_match /deleteduser\+(.*)@exercism\.io/, user.email
+      assert_nil user.reset_password_token
+      assert_nil user.reset_password_sent_at
+      assert_nil user.remember_created_at
+      assert_equal 0, user.sign_in_count
+      assert_nil user.current_sign_in_at
+      assert_nil user.last_sign_in_at
+      assert_nil user.current_sign_in_ip
+      assert_nil user.last_sign_in_ip
+      assert_nil user.confirmation_token
+      assert_nil user.confirmed_at
+      assert_nil user.confirmation_sent_at
+      assert_nil user.unconfirmed_email
+      assert_nil user.provider
+      assert_nil user.uid
+      refute user.admin?
+      assert_nil user.accepted_privacy_policy_at
+      assert_nil user.accepted_terms_at
+      refute user.dark_code_theme?
+      refute user.is_mentor?
+      assert_nil user.default_allow_comments
+    end
+  end
+end

--- a/test/services/user_services/delete_test.rb
+++ b/test/services/user_services/delete_test.rb
@@ -20,8 +20,6 @@ module UserServices
                     provider: "provider",
                     uid: "uid",
                     admin: true,
-                    accepted_privacy_policy_at: Date.new(2016, 12, 25),
-                    accepted_terms_at: Date.new(2016, 12, 25),
                     dark_code_theme: true,
                     is_mentor: true,
                     default_allow_comments: true,
@@ -49,8 +47,6 @@ module UserServices
       assert_nil user.provider
       assert_nil user.uid
       refute user.admin?
-      assert_nil user.accepted_privacy_policy_at
-      assert_nil user.accepted_terms_at
       refute user.dark_code_theme?
       refute user.is_mentor?
       assert_nil user.default_allow_comments

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -107,6 +107,7 @@ class My::SettingsTest < ApplicationSystemTestCase
     check "I understand"
     click_on "Delete my account"
 
+    @user.reload
     assert @user.deleted?
     assert_selector "body.user-signed_out"
   end

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -108,5 +108,6 @@ class My::SettingsTest < ApplicationSystemTestCase
     click_on "Delete my account"
 
     refute User.where(id: @user.id).exists?
+    assert_selector "body.user-signed_out"
   end
 end

--- a/test/system/my/settings_test.rb
+++ b/test/system/my/settings_test.rb
@@ -107,7 +107,7 @@ class My::SettingsTest < ApplicationSystemTestCase
     check "I understand"
     click_on "Delete my account"
 
-    refute User.where(id: @user.id).exists?
+    assert @user.deleted?
     assert_selector "body.user-signed_out"
   end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/bugs/issues/16.

According to the [Bugsnag report](https://app.bugsnag.com/exercism/exercism/errors/5c4de88587ed6900193413f4), users are unable to delete their accounts once they have approved a solution. As we want to keep foreign key integrity, I decided to implement a "soft-delete" functionality for our user model. Let me know what you think of this.