### PR TITLE
Fix CSS regressions for avatar on discussion post

### DIFF
--- a/app/assets/stylesheets/pages/mentor-solution.scss
+++ b/app/assets/stylesheets/pages/mentor-solution.scss
@@ -162,6 +162,7 @@
         }
         .pure-button {
             background:$color-1;
+            color:#fff;
             margin-bottom:15px;
             &.mentor-button {
                 margin-bottom:30px;

--- a/app/assets/stylesheets/widgets/discussion-post.scss
+++ b/app/assets/stylesheets/widgets/discussion-post.scss
@@ -25,8 +25,9 @@
     }
 
     .avatar {
-        max-width:40px;
-        min-height:20px;
+        width:35px;
+        height:35px;
+        margin-right:8px;
         border-radius:3px;
     }
 


### PR DESCRIPTION
https://github.com/exercism/website/pull/689 broken all avatar images so they looked like this:

<img width="815" alt="Screenshot 2019-08-04 at 15 43 17" src="https://user-images.githubusercontent.com/286476/62425086-fc10fa00-b6ce-11e9-8d5c-952db6b28273.png">

This fixes them so that they look like this:
<img width="358" alt="Screenshot 2019-08-04 at 15 46 33" src="https://user-images.githubusercontent.com/286476/62425091-0e8b3380-b6cf-11e9-9d70-2f213f520695.png">

@kntsoriano Can we work out how/why this PR was broken pls?