### PR TITLE
Fix broken font

### DIFF
--- a/app/assets/stylesheets/widgets/panels.scss
+++ b/app/assets/stylesheets/widgets/panels.scss
@@ -1,28 +1,22 @@
-@import "purecss/build/pure-min";
-@import "purecss/build/grids-responsive-min";
 @import "mixins";
 
-.panels {
-    @extend .pure-g;
-
-    & > .lhs, .rhs {
-        @extend .pure-u-1;
-    }
-
-    & > .rhs {
+.widget-panels {
+    &> .rhs {
         overflow:hidden;
         margin-top:30px;
         margin-bottom:30px;
     }
 }
 
-.panels.panels--vertical-split {
-    & > .lhs, .rhs {
-        @extend .pure-u-md-1-2;
-    }
+.widget-panels.widget-panels--vertical-split {
+    @include width-medium() {
+        display:flex;
+        
+        &> .lhs, .rhs {
+            width:50%;
+        }
 
-    & > .rhs {
-        @include width-medium() {
+        &> .rhs {
             margin-top:0;
             margin-bottom:0;
             padding-left:50px;

--- a/app/helpers/panel_helper.rb
+++ b/app/helpers/panel_helper.rb
@@ -8,9 +8,9 @@ module PanelHelper
   private
 
   def panel_classes(vertical_split:)
-    classes = ["panels"]
+    classes = ["widget-panels"]
 
-    classes << "panels--vertical-split" if vertical_split
+    classes << "widget-panels--vertical-split" if vertical_split
 
     classes.join(" ")
   end


### PR DESCRIPTION
@kntsoriano #689 changed the font on the whole site, because it re-injected pure-css higher in the CSS stack. See screenshot for example.

<img width="1247" alt="Screenshot 2019-08-04 at 16 03 35" src="https://user-images.githubusercontent.com/286476/62425288-717dca00-b6d1-11e9-9ef4-17285e21eaab.png">

This PR removes the re-including of CSS and uses Flexbox instead.

Please can we also ensure that any top-level things are named `widget-panes`, as this PR would also have the inadvertent effect of adding styles to any CSS class on the site called `panes`. I should have caught this in PR review.