### PR TITLE
Add rel='nofollow' to new links in markdown to discourage spam

### DIFF
--- a/app/services/parse_markdown.rb
+++ b/app/services/parse_markdown.rb
@@ -37,6 +37,7 @@ class ParseMarkdown
       if node.title && !node.title.empty?
         out(' title="', escape_html(node.title), '"')
       end
+      out(' rel="nofollow"')
       out('>', :children, '</a>')
     end
 

--- a/test/services/parse_markdown_test.rb
+++ b/test/services/parse_markdown_test.rb
@@ -8,7 +8,7 @@ class ParseMarkdownTest < ActiveSupport::TestCase
 <li>Either method pairs with adjectives (which I did),</li>
 <li>Some sort of data structure (e.g. a hash might look like)</li>
 </ol>
-<p><a href="http://example.com" target="_blank">Some link</a></p>
+<p><a href="http://example.com" target="_blank" rel="nofollow">Some link</a></p>
 <p>Watch this:</p>
 <pre><code class="language-plain">$ go home
 </code></pre>}


### PR DESCRIPTION
Currently user-generated links count as helping the SEO rank of destination websites.  Adding rel="nofollow" should reduce the incentive for spam commenters.  I can add a test but I wanted to float this as an idea, first.