### PR TITLE
Update font for wider native support

### DIFF
--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -1,7 +1,9 @@
 @import 'variables';
 
 @mixin normal-font {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", 'Helvetica Neue', Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    // See https://css-tricks.com/snippets/css/system-font-stack/ for general details
+    // See https://www.chromestatus.com/feature/5640395337760768 for system-ui font
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-weight: $regular;
 }
 


### PR DESCRIPTION
This adds the new `system-ui` property, but leaves `-apple-system, BlinkMacSystemFont`, which it replaces, because browser support for `system-ui` isn't wide enough yet. It also adds in some extra fonts for Linux (generally), Ubuntu and Gnome.

It should make no visible difference on Mac.