### PR TITLE
Seperate out build single automated comment

### DIFF
--- a/app/models/iteration_analysis.rb
+++ b/app/models/iteration_analysis.rb
@@ -20,9 +20,13 @@ class IterationAnalysis < ApplicationRecord
   end
 
   def built_comments
-    AnalysisServices::BuildComments.new(analysis_comments_data).comments
-  rescue
-    []
+    analysis_comments_data.map { |comment_data|
+      begin
+        AnalysisServices::BuildComment.(comment_data)
+      rescue
+        nil
+      end
+    }.compact
   end
 
   def analysis

--- a/app/services/analysis_services/build_comment.rb
+++ b/app/services/analysis_services/build_comment.rb
@@ -1,0 +1,22 @@
+module AnalysisServices
+  class BuildComment
+    include Mandate
+
+    initialize_with :comment_data
+
+    def call
+      template, params =
+        if comment_data.is_a?(Hash)
+          [ comment_data['comment'], (comment_data['params'] || {}).symbolize_keys ]
+        else
+          [comment_data, {}]
+        end
+
+        repo.automated_comment_for(template) % params
+    end
+
+    def repo
+      Git::WebsiteContent.head
+    end
+  end
+end

--- a/app/services/analysis_services/build_comments.rb
+++ b/app/services/analysis_services/build_comments.rb
@@ -7,24 +7,13 @@ module AnalysisServices
     def call
       return nil unless comments_data.size > 0
 
-      intro + comments.join("\n\n---\n\n")
-    end
-
-    def comments
-      repo = Git::WebsiteContent.head
-      comments_data.map do |comment_data|
-        template, params =
-          if comment_data.is_a?(Hash)
-            [ comment_data['comment'], (comment_data['params'] || {}).symbolize_keys ]
-          else
-            [comment_data, {}]
-          end
-
-          repo.automated_comment_for(template) % params
-      end
+      intro + comments
     end
 
     private
+    def comments
+      comments_data.map { |cd| BuildComment.(cd) }.join("\n\n---\n\n")
+    end
 
     def intro
       text = if comments_data.size == 1
@@ -38,5 +27,3 @@ module AnalysisServices
 
   end
 end
-
-

--- a/test/services/analysis_services/build_comment_test.rb
+++ b/test/services/analysis_services/build_comment_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+module AnalysisServices
+  class PostCommentsTest < ActiveSupport::TestCase
+    test "generates comment correctly" do
+      system_user = create :user, :system
+      iteration = create :iteration
+
+      templates = {"tests.comment" => "the comment"}
+
+      website_copy = mock
+      website_copy.expects(:automated_comment_for).with("tests.comment").returns(templates["tests.comment"])
+      Git::WebsiteContent.stubs(head: website_copy)
+
+      comment_data = { 'comment' => "tests.comment" }
+      expected = "the comment"
+      assert_equal expected, BuildComment.(comment_data)
+    end
+  end
+end

--- a/test/services/analysis_services/build_comments_test.rb
+++ b/test/services/analysis_services/build_comments_test.rb
@@ -10,7 +10,7 @@ module AnalysisServices
 
       website_copy = mock
       website_copy.expects(:automated_comment_for).with("tests.first-comment").returns(templates["tests.first-comment"])
-      Git::WebsiteContent.expects(:head).returns(website_copy)
+      Git::WebsiteContent.stubs(head: website_copy)
 
       comments_data = [{
         'comment' => "tests.first-comment"
@@ -30,7 +30,7 @@ module AnalysisServices
       website_copy = mock
       website_copy.expects(:automated_comment_for).with("tests.first-comment").returns(templates["tests.first-comment"])
       website_copy.expects(:automated_comment_for).with("tests.second-comment").returns(templates["tests.second-comment"])
-      Git::WebsiteContent.expects(:head).returns(website_copy)
+      Git::WebsiteContent.stubs(head: website_copy)
 
       comments_data = [
         {
@@ -56,7 +56,7 @@ module AnalysisServices
       website_copy = mock
       website_copy.expects(:automated_comment_for).with("tests.first-comment").returns(templates["tests.first-comment"])
       website_copy.expects(:automated_comment_for).with("tests.second-comment").returns(templates["tests.second-comment"])
-      Git::WebsiteContent.expects(:head).returns(website_copy)
+      Git::WebsiteContent.stubs(head: website_copy)
 
       comments_data = [
         "tests.first-comment",


### PR DESCRIPTION
This enables us to rescue individual comment failures in one place and still explode if any fail in others.