### PR TITLE
Configure purs files (PureScript) to be formatted with Haskell.

### DIFF
--- a/config/initializers/prism.rb
+++ b/config/initializers/prism.rb
@@ -224,7 +224,7 @@ Exercism::PrismFileMappings = {
   "groovy": %w{groovy grt gtpl gvy},
   "haml": %w{haml haml.deface},
   "handlebars": %w{handlebars hbs},
-  "haskell": %w{hs hsc idr},
+  "haskell": %w{hs hsc idr purs},
   "haxe": %w{hx hxsl},
   "http": %w{http},
   "icon": %w{},


### PR DESCRIPTION
Prism has no special support for formatting PureScript code, but the Haskell
formatter works quite well. So we can format *.purs files with it.

Fixes https://github.com/exercism/exercism/issues/4063