### PR TITLE
Don't show new blog comment form to non-signed-in users

### DIFF
--- a/app/views/blog_posts/_comments.html.haml
+++ b/app/views/blog_posts/_comments.html.haml
@@ -9,7 +9,8 @@
       -else user_signed_in?
         .no-comments There are no comments yet. Be the first to add one.
 
-    = render "new_comment", blog_post: @blog_post
+    -if user_signed_in?
+      = render "new_comment", blog_post: @blog_post
 
     -content_for :js do
       :javascript

--- a/test/system/blog_comments_test.rb
+++ b/test/system/blog_comments_test.rb
@@ -110,6 +110,15 @@ class BlogCommentsTest < ApplicationSystemTestCase
     assert_equal "", find(".new-editable-text textarea").value
   end
 
+  test "not logged in user should should not see new comment box with existing solutions" do
+    blog_post = create(:blog_post)
+    create :blog_comment, blog_post: blog_post
+
+    visit blog_post_path(blog_post)
+
+    refute_selector ".new-editable-text"
+  end
+
   test "user without submitted solutions should not see new comment box" do
     user = create(:user, :onboarded)
     blog_post = create(:blog_post)


### PR DESCRIPTION
We might want to guard this in the actual policy, but I've done it here for now as it addresses the bugsnag.