### PR TITLE
Check onboarding whenever a user is logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,17 @@ class ApplicationController < ActionController::Base
   before_action :store_location
   before_action :set_site_context
 
+  # If someone has signed in, ensure they're onboarded
+  before_action :ensure_onboarded!, unless: :devise_controller?
+
   private
+
+  def ensure_onboarded!
+    return unless user_signed_in?
+    return if current_user.onboarded?
+
+    redirect_to onboarding_path
+  end
 
   # This saves the current user location for devise
   def store_location

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,15 +1,3 @@
 class MyController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_onboarded!
-
-  private
-
-  def ensure_onboarded!
-    return unless user_signed_in?
-    unless current_user.onboarded?
-      redirect_to onboarding_path
-      false
-    end
-    true
-  end
 end

--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,4 +1,6 @@
 class OnboardingsController < ApplicationController
+  skip_before_action :ensure_onboarded!
+
   before_action :authenticate_user!
   before_action :redirect_if_onboarded!
 

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "200 if admin" do
-    sign_in!(create :user, admin: true)
+    sign_in!(create :user, :onboarded, admin: true)
     get admin_dashboard_url
     assert_response :success
     assert_correct_page "admin-dashboard-page"

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -24,7 +24,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
   test "show should clear notifications" do
     blog_post = create :blog_post, published_at: DateTime.now - 1.week
-    user = create :user
+    user = create :user, :onboarded
 
     create :notification, about: blog_post, user: user
     create :notification, about: blog_post # A different user

--- a/test/controllers/mentor/dashboard_controller_test.rb
+++ b/test/controllers/mentor/dashboard_controller_test.rb
@@ -14,7 +14,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "redirects_correctly if mentor" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
 
     sign_in!(user)
     get mentor_dashboard_url
@@ -22,7 +22,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "302 to next_solutions if you've not mentored" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
 
     sign_in!(user)
     get your_solutions_mentor_dashboard_url
@@ -30,7 +30,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "200 in your_solutions if mentor with solutions" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
     create :solution_mentorship, user: user
 
     sign_in!(user)
@@ -40,7 +40,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "200 in next_solutions if mentor without solutions" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
     create :track_mentorship, user: user
 
     sign_in!(user)
@@ -50,7 +50,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "200 in next_solutions if mentor" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
     create :track_mentorship, user: user
     create :solution_mentorship, user: user
 
@@ -61,7 +61,7 @@ class Mentor::DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "redirects_to configure path without track" do
-    user = create :user, :mentor
+    user = create :user, :mentor, :onboarded
 
     sign_in!(user)
     get next_solutions_mentor_dashboard_url

--- a/test/controllers/mentor/discussion_posts_controller_test.rb
+++ b/test/controllers/mentor/discussion_posts_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Mentor::DiscussionPostsControllerTest < ActionDispatch::IntegrationTest
   test "approve calls service" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track

--- a/test/controllers/mentor/solutions_controller_test.rb
+++ b/test/controllers/mentor/solutions_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   test "show permissions" do
-    user = create :user
+    user = create :user, :onboarded
     solution = create :solution
     create :iteration, solution: solution
 
@@ -21,7 +21,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "approve calls service" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track
@@ -35,7 +35,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show sets anonmyous mode correctly" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track
@@ -65,7 +65,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show clears notifications" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track
@@ -82,7 +82,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "abandon works without solution mentorship" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track
@@ -103,7 +103,7 @@ class Mentor::SolutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "abandon works with solution mentorship" do
-    mentor = create :user, :mentor
+    mentor = create :user, :mentor, :onboarded
     track = create :track
     exercise = create :exercise, track: track
     create :track_mentorship, user: mentor, track: track

--- a/test/controllers/solution_comments_controller_test.rb
+++ b/test/controllers/solution_comments_controller_test.rb
@@ -9,7 +9,7 @@ class SolutionsCommentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "prevents forbidden users from commenting" do
-    user = create(:user)
+    user = create(:user, :onboarded)
     solution = create(:solution)
     AllowedToCommentPolicy.stubs(:allowed?).returns(false)
 

--- a/test/controllers/solutions_controller_test.rb
+++ b/test/controllers/solutions_controller_test.rb
@@ -12,6 +12,18 @@ class SolutionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:solutions), [solution]
   end
 
+  test "show should redirect_to onboarding unless onboarded" do
+    user = create :user # Not onboarded
+
+    sign_in!(user)
+    exercise = create :exercise
+    solution = create :solution, exercise: exercise, published_at: DateTime.now - 1.week
+    create :iteration, solution: solution
+
+    get track_exercise_solution_url(exercise.track, exercise, solution)
+    assert_redirected_to onboarding_path
+  end
+
   test "show should succeed for published solution" do
     exercise = create :exercise
     solution = create :solution, exercise: exercise, published_at: DateTime.now - 1.week
@@ -47,7 +59,7 @@ class SolutionsControllerTest < ActionDispatch::IntegrationTest
   test "show should clear notifications" do
     exercise = create :exercise
     solution = create :solution, exercise: exercise, published_at: DateTime.now - 1.week
-    user = create :user
+    user = create :user, :onboarded
     create :iteration, solution: solution
 
     create :notification, about: solution, user: user

--- a/test/integration/onboarding_flows_test.rb
+++ b/test/integration/onboarding_flows_test.rb
@@ -17,8 +17,6 @@ class OnboardingFlowsTest < ActionDispatch::IntegrationTest
     assert_redirected_to track_path(track)
     assert_response :redirect
     follow_redirect!
-    assert_redirected_to my_track_path(track)
-    follow_redirect!
 
     # This should redirect to onboarding.
     assert_redirected_to onboarding_path

--- a/test/system/mentor/configure_test.rb
+++ b/test/system/mentor/configure_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class MentorConfigureTest < ApplicationSystemTestCase
   test "mentor chooses tracks" do
-    user = create :user, :mentor
+    user = create :user, :mentor,:onboarded
     track_one = create(:track, title: "Ruby")
     track_two = create(:track, title: "Elm")
     track_three = create(:track, title: "Piet")

--- a/test/system/mentor/registration_test.rb
+++ b/test/system/mentor/registration_test.rb
@@ -4,7 +4,7 @@ class MentorRegistrationTest < ApplicationSystemTestCase
   test "signed in mentor flow works" do
     RestClient.expects(:post)
 
-    user = create :user
+    user = create :user, :onboarded
     ruby = create(:track, title: "Ruby")
     python = create(:track, title: "Python")
     exercise = create(:exercise, track: ruby)
@@ -35,7 +35,7 @@ class MentorRegistrationTest < ApplicationSystemTestCase
     RestClient.expects(:post)
 
     password = "foobar"
-    user = create :user, password: password
+    user = create :user, :onboarded, password: password
     user.confirm
 
     ruby = create(:track, title: "Ruby")
@@ -69,7 +69,7 @@ class MentorRegistrationTest < ApplicationSystemTestCase
   end
 
   test "user must submit one solution before becoming a mentor" do
-    user = create(:user)
+    user = create(:user, :onboarded)
     ruby = create(:track, title: "Ruby")
 
     sign_in!(user)

--- a/test/system/mentor/solution_buttons_test.rb
+++ b/test/system/mentor/solution_buttons_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class SolutionButtonsTest < ApplicationSystemTestCase
   setup do
-    @mentor = create(:user, :mentor)
+    @mentor = create(:user, :mentor, :onboarded)
     @track = create(:track, title: "Ruby")
     create :track_mentorship, user: @mentor, track: @track
 

--- a/test/system/mentor/solution_ignore_require_action_test.rb
+++ b/test/system/mentor/solution_ignore_require_action_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class SolutionIgnoreRequireActionTest < ApplicationSystemTestCase
   test "ignores require action" do
-    @mentor = create(:user, :mentor)
+    @mentor = create(:user, :mentor, :onboarded)
     @track = create(:track, title: "Ruby")
     create :track_mentorship, user: @mentor, track: @track
 

--- a/test/system/mentor/solution_locks_test.rb
+++ b/test/system/mentor/solution_locks_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class SolutionLocksTest < ApplicationSystemTestCase
   setup do
-    @mentor = create(:user, :mentor)
+    @mentor = create(:user, :mentor, :onboarded)
     @track = create(:track, title: "Ruby")
     create :track_mentorship, user: @mentor, track: @track
 

--- a/test/system/mentor/solution_test.rb
+++ b/test/system/mentor/solution_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class SolutionTest < ApplicationSystemTestCase
   setup do
-    @mentor = create(:user, :mentor)
+    @mentor = create(:user, :mentor, :onboarded)
     @track = create(:track, title: "Ruby")
     create :track_mentorship, user: @mentor, track: @track
 

--- a/test/system/profiles_test.rb
+++ b/test/system/profiles_test.rb
@@ -32,7 +32,7 @@ class ProfilesTest < ApplicationSystemTestCase
   end
 
   test "shows correct contributions count" do
-    user = create(:user)
+    user = create(:user, :onboarded)
     profile = create(:profile, user: user)
     4.times { create :solution_mentorship, user: user }
 

--- a/test/system/signout_test.rb
+++ b/test/system/signout_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class SignoutTest < ApplicationSystemTestCase
   test "user signs out" do
-    user = create :user
+    user = create :user, :onboarded
     sign_in! user
     visit my_tracks_path
     find('.misc-menu').hover


### PR DESCRIPTION
Currently, we only check that someone is onboarded on `my/...` controllers. This means that someone can post comments on others solutions (or even mentor) without agreeing to our T&Cs. 

This PR guards against that by ensuring that if someone is signed in, and hasn't onboarded, they are immediately redirected there.

I have updated the tests to add the `:onboarded` trait where necessary.