### PR TITLE
Add optional rel='nofollow' to links

### DIFF
--- a/app/services/create_solution_comment.rb
+++ b/app/services/create_solution_comment.rb
@@ -22,7 +22,7 @@ class CreateSolutionComment < CreatesDiscussionPost
   attr_reader :comment
 
   def html
-    ParseMarkdown.(content)
+    ParseMarkdown.(content, nofollow_links: true)
   end
 
   def update_solution_comments_counter

--- a/app/services/parse_markdown.rb
+++ b/app/services/parse_markdown.rb
@@ -3,9 +3,9 @@ require 'commonmarker'
 class ParseMarkdown
   include Mandate
 
-  attr_reader :text
-  def initialize(text)
+  def initialize(text, nofollow_links: false)
     @text = text.to_s
+    @nofollow_links = nofollow_links
   end
 
   def call
@@ -13,6 +13,7 @@ class ParseMarkdown
   end
 
   private
+  attr_reader :text, :nofollow_links
 
   def sanitized_html
     @sanitized_html ||= Loofah.fragment(raw_html).scrub!(:escape).to_s
@@ -20,7 +21,7 @@ class ParseMarkdown
 
   def raw_html
     @raw_html ||= begin
-      renderer = Renderer.new(options: [:UNSAFE])
+      renderer = Renderer.new(options: [:UNSAFE], nofollow_links: nofollow_links)
       html = CommonMarker.render_doc(preprocessed_text, :DEFAULT, [:table, :tagfilter])
       renderer.render(html)
     end
@@ -32,11 +33,20 @@ class ParseMarkdown
   end
 
   class Renderer < CommonMarker::HtmlRenderer
+    def initialize(options: , nofollow_links: false)
+      super(options: options)
+      @nofollow_links = nofollow_links
+    end
+
+    private
+    attr_reader :nofollow_links
+
     def link(node)
       out('<a href="', node.url.nil? ? '' : escape_href(node.url), '" target="_blank"')
       if node.title && !node.title.empty?
         out(' title="', escape_html(node.title), '"')
       end
+      out(' rel="nofollow"') if nofollow_links
       out('>', :children, '</a>')
     end
 

--- a/test/services/create_solution_comment_test.rb
+++ b/test/services/create_solution_comment_test.rb
@@ -4,8 +4,8 @@ class CreateSolutionCommentTest < ActiveSupport::TestCase
   test "creates correctly" do
     solution = create :solution
     user = create :user
-    content = "foobar"
-    html = "<p>foobar</p>"
+    content = "[Some link](http://example.com)"
+    html = %q{<p><a href="http://example.com" target="_blank" rel="nofollow">Some link</a></p>}
 
     comment = CreateSolutionComment.(solution, user, content)
 

--- a/test/services/parse_markdown_test.rb
+++ b/test/services/parse_markdown_test.rb
@@ -91,4 +91,12 @@ Done})
     HTML
     assert_equal expected, ParseMarkdown.(table)
   end
+
+  test "resepects rel_nofollow" do
+    normal = %q{<p><a href="http://example.com" target="_blank">Some link</a></p>}
+    rel_nofollow = %q{<p><a href="http://example.com" target="_blank" rel="nofollow">Some link</a></p>}
+
+    assert_equal normal.chomp, ParseMarkdown.(%q{[Some link](http://example.com)}).chomp
+    assert_equal rel_nofollow.chomp, ParseMarkdown.(%q{[Some link](http://example.com)}, nofollow_links: true).chomp
+  end
 end


### PR DESCRIPTION
Currently user-generated links count as helping the SEO rank of destination websites. Adding rel="nofollow" should reduce the incentive for spam commenters.

This replaces #695.