### PR TITLE
Admit defeat and retreat to regroup and then (eventually) win 🙂

### DIFF
--- a/app/assets/stylesheets/pages/my-track/modals.scss
+++ b/app/assets/stylesheets/pages/my-track/modals.scss
@@ -138,9 +138,9 @@
         border:1px solid $color-1;
         padding: 10px 13px;
         font-weight:$regular;
+        width:100%;
 
         &.action-button {
-            width:100%;
             margin-bottom:15px;
             @include width-medium() {
                 width:69%;
@@ -152,7 +152,6 @@
             background:#fff;
             color:$color-1;
             font-weight:$fw-regular;
-            width:100%;
             @include width-medium() {
                 width:30%;
             }

--- a/app/assets/stylesheets/pages/my-track/modals.scss
+++ b/app/assets/stylesheets/pages/my-track/modals.scss
@@ -110,6 +110,7 @@
         border:1px solid $color-1;
         padding: 10px 13px;
         font-weight:$regular;
+        width:100%;
 
         &.normal-mode {
             width:59%;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,7 @@ class PagesController < ApplicationController
     "Report Abuse": :report_abuse,
     "Contact": :contact,
     "Contribute": :contribute,
-    "Mentored Mode vs Independent Mode": :mentored_mode_vs_independent_mode,
+    "Mentored Mode vs Practice Mode": :mentored_mode_vs_independent_mode,
 
     "Strategy": :strategy,
     "Roadmap": :roadmap,

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -62,6 +62,10 @@ class Solution < ApplicationRecord
     track_in_independent_mode === false
   end
 
+  def track_accepting_new_students?
+    track.accepting_new_students?
+  end
+
   def mentor_download_command
     "exercism download --uuid=#{uuid}"
   end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -41,4 +41,9 @@ class Track < ApplicationRecord
   def repo
     Git::ExercismRepo.new(repo_url)
   end
+
+  def accepting_new_students?
+    median_wait_time &&
+    median_wait_time < 604800 # 1 week
+  end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -44,6 +44,6 @@ class Track < ApplicationRecord
 
   def accepting_new_students?
     median_wait_time &&
-    median_wait_time < 604800 # 1 week
+    median_wait_time < 1.week
   end
 end

--- a/app/services/request_mentoring_on_solution.rb
+++ b/app/services/request_mentoring_on_solution.rb
@@ -6,7 +6,7 @@ class RequestMentoringOnSolution
   def call
     # We guard this for exercises that are promoted to core
     unless (user_track.mentored_mode? && solution.exercise.core?)
-      return unless solution.track.accepting_new_students?
+      return unless solution.track_accepting_new_students?
       return if user_track.mentoring_allowance_used_up?
     end
 

--- a/app/services/request_mentoring_on_solution.rb
+++ b/app/services/request_mentoring_on_solution.rb
@@ -6,6 +6,7 @@ class RequestMentoringOnSolution
   def call
     # We guard this for exercises that are promoted to core
     unless (user_track.mentored_mode? && solution.exercise.core?)
+      return unless solution.track.accepting_new_students?
       return if user_track.mentoring_allowance_used_up?
     end
 

--- a/app/services/switch_track_to_mentored_mode.rb
+++ b/app/services/switch_track_to_mentored_mode.rb
@@ -4,6 +4,8 @@ class SwitchTrackToMentoredMode
   initialize_with :user, :track
 
   def call
+    return unless track.accepting_new_students?
+
     user_track.update(independent_mode: false)
     user_track.solutions.update_all(track_in_independent_mode: false)
 

--- a/app/services/track_services/update_median_wait_time.rb
+++ b/app/services/track_services/update_median_wait_time.rb
@@ -68,4 +68,3 @@ module TrackServices
     end
   end
 end
-

--- a/app/views/mentor/dashboard/_solution.html.haml
+++ b/app/views/mentor/dashboard/_solution.html.haml
@@ -6,7 +6,7 @@
 =link_to [:mentor, solution], class: klass do
   .core Core
   .side Side
-  .independent IM
+  .independent PM
   .icons
     .exercise
       =image solution.exercise.turquoise_icon_url, solution.exercise.track.title

--- a/app/views/my/solutions/_information_bar.html.haml
+++ b/app/views/my/solutions/_information_bar.html.haml
@@ -58,7 +58,7 @@
   .notifications-bar
     .lo-container
       .notification
-        In Independent Mode you will
+        In Practice Mode you will
         %strong not
         receive mentoring by default.
         -if @user_track.mentoring_slots_remaining?

--- a/app/views/my/solutions/_nav_and_header.html.haml
+++ b/app/views/my/solutions/_nav_and_header.html.haml
@@ -18,7 +18,7 @@
         = link_to "#{@track.title} Track", [:my, @track]
       .track-progress
         -if @user_track.independent_mode?
-          %h3 In Independent Mode
+          %h3 In Practice Mode
         -else
           -if @exercise.side?
             %h3 Side exercise

--- a/app/views/my/solutions/_show_finished_independent.html.haml
+++ b/app/views/my/solutions/_show_finished_independent.html.haml
@@ -18,15 +18,22 @@
       =render "my/solutions/widgets/complete_prompt"
 
     .next-option
-      -if @user_track.mentoring_slots_remaining?
-        %p
-          %strong Request mentor feedback.
-          Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time.
-        =link_to "Request mentor feedback", request_mentoring_my_solution_path(@solution), method: :patch, class: 'pure-button'
+      -if @track.accepting_new_students?
+        -if @user_track.mentoring_slots_remaining?
+          %p
+            %strong Request mentor feedback.
+            Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time.
+          =link_to "Request mentor feedback", request_mentoring_my_solution_path(@solution), method: :patch, class: 'pure-button'
+        -else
+          %p
+            %strong Request mentor feedback (disabled).
+            Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time. You currently have no slots free.
+          =link_to "Request mentor feedback", "#", class: 'pure-button disabled', disabled: true
+
       -else
         %p
           %strong Request mentor feedback (disabled).
-          Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time. You currently have no slots free.
+          This track is currently oversubscribed so requests for mentoring are currently paused. Please check back later.
         =link_to "Request mentor feedback", "#", class: 'pure-button disabled', disabled: true
 
     =render "my/solutions/widgets/community_solutions"

--- a/app/views/my/solutions/_show_finished_independent.html.haml
+++ b/app/views/my/solutions/_show_finished_independent.html.haml
@@ -21,12 +21,12 @@
       -if @user_track.mentoring_slots_remaining?
         %p
           %strong Request mentor feedback.
-          Mentoring is disabled by default in Independent Mode. However, you can request feedback on a maximum of one solution at a time.
+          Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time.
         =link_to "Request mentor feedback", request_mentoring_my_solution_path(@solution), method: :patch, class: 'pure-button'
       -else
         %p
           %strong Request mentor feedback (disabled).
-          Mentoring is disabled by default in Independent Mode. However, you can request feedback on a maximum of one solution at a time. You currently have no slots free.
+          Mentoring is disabled by default in Practice Mode. However, you can request feedback on a maximum of one solution at a time. You currently have no slots free.
         =link_to "Request mentor feedback", "#", class: 'pure-button disabled', disabled: true
 
     =render "my/solutions/widgets/community_solutions"

--- a/app/views/my/solutions/_show_legacy.html.haml
+++ b/app/views/my/solutions/_show_legacy.html.haml
@@ -20,7 +20,7 @@
       -else
         %p
           %strong Request mentor feedback (disabled).
-          This solution has been imported from independent mode.
+          This solution has been imported from Practice Mode.
           Once your existing solutions have been mentored you will be able to request mentoring for this solution.
         =link_to "Request mentor feedback", "#", class: 'pure-button disabled', disabled: true
 

--- a/app/views/my/solutions/_show_rhs.html.haml
+++ b/app/views/my/solutions/_show_rhs.html.haml
@@ -22,7 +22,7 @@
           .next-option
             %p
               %strong A mentor will be with you as soon as they can.
-              Exercises in independent mode normally take longer to receive mentoring on than those in mentored mode. For some tracks this might be a few hours but for the busiest tracks it might be a few days.
+              Exercises in Practice Mode normally take longer to receive mentoring on than those in mentored mode. For some tracks this might be a few hours but for the busiest tracks it might be a few days.
           .next-option
             %p
               %strong Don't want mentoring after all?

--- a/app/views/my/solutions/confirm_unapproved_completion.html.haml
+++ b/app/views/my/solutions/confirm_unapproved_completion.html.haml
@@ -17,7 +17,7 @@
     %li you'll no longer get mentor feedback on this exercise
     %li you will be able to reactivate the exercise in the future
 
-  %p If you want to quickly move through the track without regular feedback, we recommend moving to Independent Mode, where you can choose which exercises to receive feedback on. You can do on the right-hand-side of the Track page.
+  %p If you want to quickly move through the track without regular feedback, we recommend moving to Practice Mode, where you can choose which exercises to receive feedback on. You can do on the right-hand-side of the Track page.
 
   =form_tag [:complete, :my, @solution], method: :patch, remote: true do
     =check_box_tag :agree, 1, false, required: true

--- a/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
+++ b/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
@@ -1,9 +1,9 @@
 =hex_green_track_icon(track)
 .main-section
-  %h2 Switch to Independent Mode
+  %h2 Switch to Practice Mode
   %h3 on the #{track.title} Track
 
-  %p In Independent Mode all of the exercises within a track are unlocked and students can work through them freely. Note that in this mode Mentor feedback is disabled. This mode is for people who want to do fast deep-dives into a track and is not recommended for those that want the full Exercism experience.
+  %p In Practice Mode all of the exercises within a track are unlocked and students can work through them freely. Note that in this mode Mentor feedback is disabled. This mode is for people who want to do fast deep-dives into a track and is not recommended for those that want the full Exercism experience.
   .buttons
-    =link_to "Switch to Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
+    =link_to "Switch to Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
     =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"

--- a/app/views/my/tracks/_change_to_mentored_mode_modal.html.haml
+++ b/app/views/my/tracks/_change_to_mentored_mode_modal.html.haml
@@ -3,7 +3,14 @@
   %h2 Switch to Mentored Mode
   %h3 on the #{track.title} track
 
-  %p In Mentored Mode you will receive mentor feedback on each solution. The track will also follow a structured route of progression. All your existing submissions on this Track will be saved but some exercises may become locked until you complete their prerequisite exercise.
-  .buttons
-    =link_to "Switch to Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
-    =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"
+  -if @track.accepting_new_students?
+    %p In Mentored Mode you will receive mentor feedback on each solution. The track will also follow a structured route of progression. All your existing submissions on this Track will be saved but some exercises may become locked until you complete their prerequisite exercise.
+    .buttons
+      =link_to "Switch to Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
+      =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"
+
+  -else
+    %p Sorry. This track is currently oversubscribed and only available in Practice Mode. Please check back next week.
+    .buttons
+      =link_to "Close", "#", class: "pure-button close-modal"
+

--- a/app/views/my/tracks/_show_mentored_mode.html.haml
+++ b/app/views/my/tracks/_show_mentored_mode.html.haml
@@ -43,7 +43,7 @@
             =link_to "Pause track", "#", class: 'pure-button pause-track-btn'
             =link_to "Leave track", "#", class: 'pure-button leave-track-btn'
             -if !@user_track.independent_mode?
-              =link_to "Switch to Independent Mode", "#", class: 'pure-button change-to-independent-btn'
+              =link_to "Switch to Practice Mode", "#", class: 'pure-button change-to-independent-btn'
 
 =render "show_side_exercises", exercises_and_solutions: @side_exercises_and_solutions
 

--- a/app/views/my/tracks/_started_modal.html.haml
+++ b/app/views/my/tracks/_started_modal.html.haml
@@ -7,14 +7,14 @@
     You can join this track in either
     %strong Mentored Mode,
     a structured approach centered around feedback, or
-    %strong Independent Mode,
+    %strong Practice Mode,
     which allows you to follow your own path at your own pace, but with limited feedback options. If you're unsure, we recommend starting with Mentored Mode. Which mode would you like to use? 
   .buttons
     =link_to "Mentored Mode (Recommended)", set_mentored_mode_my_user_track_path(@user_track), remote: true, method: :patch, class: 'pure-button mentored-mode-button js-disable-on-click'
-    =link_to "Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode-button'
+    =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode-button'
 
   .learn-more
-    You can learn more about Mentored and Independent Modes #{link_to "here", mentored_mode_vs_independent_mode_page_path, target: "_blank"}.
+    You can learn more about Mentored and Practice Modes #{link_to "here", mentored_mode_vs_independent_mode_page_path, target: "_blank"}.
 
 .start-section
   =hex_green_track_icon(track)

--- a/app/views/my/tracks/_started_modal.html.haml
+++ b/app/views/my/tracks/_started_modal.html.haml
@@ -3,15 +3,21 @@
   %h2 Welcome
   %h3 to the #{track.title} Track
 
-  %p
-    You can join this track in either
-    %strong Mentored Mode,
-    a structured approach centered around feedback, or
-    %strong Practice Mode,
-    which allows you to follow your own path at your own pace, but with limited feedback options. Which mode would you like to use? 
-  .buttons
-    =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), remote: true, method: :patch, class: 'pure-button mentored-mode-button js-disable-on-click'
-    =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode-button'
+  -if @track.accepting_new_students?
+    %p
+      You can join this track in either
+      %strong Mentored Mode,
+      a structured approach centered around feedback, or
+      %strong Practice Mode,
+      which allows you to follow your own path at your own pace, but with limited feedback options. Which mode would you like to use?
+    .buttons
+      =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), remote: true, method: :patch, class: 'pure-button mentored-mode-button js-disable-on-click'
+      =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode-button'
+  -else
+    %p This track is currently oversubscribed and only available in Practice Mode. Practice Mode let's you work through exercises at your own pace, exploring whichever concepts and challenges seem interesting, but won't have human mentors. 
+    %p You can use Practice Mode today and switch to Mentored Mode when it is accepting more students if you want mentoring.
+    .buttons
+      =link_to "Start Track in Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button'
 
   .learn-more
     You can learn more about Mentored and Practice Modes #{link_to "here", mentored_mode_vs_independent_mode_page_path, target: "_blank"}.

--- a/app/views/my/tracks/_started_modal.html.haml
+++ b/app/views/my/tracks/_started_modal.html.haml
@@ -8,9 +8,9 @@
     %strong Mentored Mode,
     a structured approach centered around feedback, or
     %strong Practice Mode,
-    which allows you to follow your own path at your own pace, but with limited feedback options. If you're unsure, we recommend starting with Mentored Mode. Which mode would you like to use? 
+    which allows you to follow your own path at your own pace, but with limited feedback options. Which mode would you like to use? 
   .buttons
-    =link_to "Mentored Mode (Recommended)", set_mentored_mode_my_user_track_path(@user_track), remote: true, method: :patch, class: 'pure-button mentored-mode-button js-disable-on-click'
+    =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), remote: true, method: :patch, class: 'pure-button mentored-mode-button js-disable-on-click'
     =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode-button'
 
   .learn-more

--- a/app/views/my/tracks/_v1_migration_modal.html.haml
+++ b/app/views/my/tracks/_v1_migration_modal.html.haml
@@ -4,6 +4,6 @@
   %h3 on the #{track.title} Track
 
   %p Hello! We've migrated your progress on the #{track.title} Track onto the new Exercism website.
-  %p Tracks on the new website can be completed in normal mode where you receive mentor feedback on your solutions, and Practice Mode - where you work by yourself and request feeback if you get stuck. We highly recommend normal mode, but the choice is yours!
-  =link_to "Mentored Mode (Recommended)", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: "pure-button normal-mode"
+  %p Tracks on the new website can be completed in Mentored Mode where you receive mentor feedback on your solutions, and Practice Mode - where you work by yourself and request feeback if you get stuck.
+  =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: "pure-button normal-mode"
   =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'

--- a/app/views/my/tracks/_v1_migration_modal.html.haml
+++ b/app/views/my/tracks/_v1_migration_modal.html.haml
@@ -4,6 +4,6 @@
   %h3 on the #{track.title} Track
 
   %p Hello! We've migrated your progress on the #{track.title} Track onto the new Exercism website.
-  %p Tracks on the new website can be completed in normal mode where you receive mentor feedback on your solutions, and independent mode - where you work by yourself and request feeback if you get stuck. We highly recommend normal mode, but the choice is yours!
+  %p Tracks on the new website can be completed in normal mode where you receive mentor feedback on your solutions, and Practice Mode - where you work by yourself and request feeback if you get stuck. We highly recommend normal mode, but the choice is yours!
   =link_to "Mentored Mode (Recommended)", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: "pure-button normal-mode"
-  =link_to "Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'
+  =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'

--- a/app/views/my/tracks/_v1_migration_modal.html.haml
+++ b/app/views/my/tracks/_v1_migration_modal.html.haml
@@ -3,7 +3,15 @@
   %h2 Getting started
   %h3 on the #{track.title} Track
 
-  %p Hello! We've migrated your progress on the #{track.title} Track onto the new Exercism website.
-  %p Tracks on the new website can be completed in Mentored Mode where you receive mentor feedback on your solutions, and Practice Mode - where you work by yourself and request feeback if you get stuck.
-  =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: "pure-button normal-mode"
-  =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'
+  -if @track.accepting_new_students?
+    %p Hello! We've migrated your progress on the #{track.title} Track onto the new Exercism website.
+    %p Tracks on the new website can be completed in Mentored Mode where you receive mentor feedback on your solutions, and Practice Mode - where you work by yourself and request feeback if you get stuck.
+    =link_to "Mentored Mode", set_mentored_mode_my_user_track_path(@user_track), method: :patch, class: "pure-button normal-mode"
+    =link_to "Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'
+  -else
+    %p This track is currently oversubscribed and only available in Practice Mode. Practice Mode let's you work through exercises at your own pace, exploring whichever concepts and challenges seem interesting, but won't have human mentors. 
+    %p You can use Practice Mode today and switch to Mentored Mode when it is accepting more students if you want mentoring.
+    .buttons
+      =link_to "Start Track in Practice Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button'
+
+

--- a/app/views/my/tracks/show.html.haml
+++ b/app/views/my/tracks/show.html.haml
@@ -12,7 +12,7 @@
         =bordered_green_track_icon(@track, class: 'logo')
         .status
           -if @user_track.independent_mode?
-            Independent Mode
+            Practice Mode
           -else
             Track in progress
     .lo-container

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -169,6 +169,7 @@ FactoryBot.define do
       puts "Hello World"
     }}
     repo_url { "file://#{Rails.root}/test/fixtures/track" }
+    median_wait_time { 30.hours }
   end
 
   factory :exercise do

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -211,4 +211,17 @@ class SolutionTest < ActiveSupport::TestCase
     lock.update(user: system_user)
     assert solution.reload.use_auto_analysis?
   end
+
+  test "track_accepting_new_students?" do
+    track = create(:track)
+    solution = create :solution, exercise: create(:exercise, track: track)
+
+    track.update(median_wait_time: 1.year)
+    refute track.accepting_new_students?
+    refute solution.reload.track_accepting_new_students?
+
+    track.update(median_wait_time: 1.day)
+    assert track.accepting_new_students?
+    assert solution.reload.track_accepting_new_students?
+  end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class TrackTest < ActiveSupport::TestCase
+  test "accepting_new_students?" do
+    track = build :track
+
+    track.median_wait_time = nil
+    refute track.accepting_new_students?
+
+    # Under 1 week
+    track.median_wait_time = 604799
+    assert track.accepting_new_students?
+
+    # Over 1 week
+    track.median_wait_time = 604801
+    refute track.accepting_new_students?
+  end
+end

--- a/test/services/request_mentoring_on_solution_test.rb
+++ b/test/services/request_mentoring_on_solution_test.rb
@@ -43,6 +43,23 @@ class CancelMentoringRequestForSolutionTest < ActiveSupport::TestCase
     end
   end
 
+  test "doesn't change if track isn't accepting students" do
+    Timecop.freeze do
+      create(:user, :system)
+      solution = create :solution, mentoring_requested_at: nil
+      ut = create :user_track, user: solution.user, track: solution.track
+      solution.track.stubs(accepting_new_students?: false)
+
+      RequestMentoringOnSolution.(solution)
+      assert_nil solution.mentoring_requested_at
+
+      solution.track.stubs(accepting_new_students?: true)
+      RequestMentoringOnSolution.(solution)
+      assert_equal Time.current.to_i, solution.mentoring_requested_at.to_i
+    end
+  end
+
+
   test "core non-independent exercises can always be mentored" do
     Timecop.freeze do
       create(:user, :system)

--- a/test/services/request_mentoring_on_solution_test.rb
+++ b/test/services/request_mentoring_on_solution_test.rb
@@ -59,7 +59,6 @@ class CancelMentoringRequestForSolutionTest < ActiveSupport::TestCase
     end
   end
 
-
   test "core non-independent exercises can always be mentored" do
     Timecop.freeze do
       create(:user, :system)

--- a/test/services/switch_track_to_mentored_mode_test.rb
+++ b/test/services/switch_track_to_mentored_mode_test.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
 class SwitchTrackToMentoredModeTest < ActiveSupport::TestCase
+  test "noop if tracks aren't accepting students" do
+    user = create :user
+    track = create :track
+    ut = create :user_track, user: user, track: track, independent_mode: nil
+
+    track.update(median_wait_time: 2.weeks)
+    SwitchTrackToMentoredMode.(user, track)
+    assert_nil ut.reload.independent_mode
+
+    track.update(median_wait_time: 2.days)
+    SwitchTrackToMentoredMode.(user, track)
+    refute ut.reload.independent_mode
+  end
+
   test "sets one core solutions to have mentoring_requested_at" do
     user = create :user
     track = create :track

--- a/test/system/join_track_system_test.rb
+++ b/test/system/join_track_system_test.rb
@@ -14,7 +14,7 @@ class JoinTrackSystemTest < ApplicationSystemTestCase
     click_on "Join the Ruby track"
 
     assert_selector("#modal.my-track-started")
-    click_on "Mentored Mode (Recommended)"
+    click_on "Mentored Mode"
     click_on "Continue"
 
     within(".exercise-wrapper") { assert_text "Hello World" }

--- a/test/system/join_track_system_test.rb
+++ b/test/system/join_track_system_test.rb
@@ -37,7 +37,7 @@ class JoinTrackSystemTest < ApplicationSystemTestCase
     click_on "Join the Ruby track"
 
     assert_selector("#modal.my-track-started")
-    click_on "Independent Mode"
+    click_on "Practice Mode"
 
     within(".widget-side-exercise") { assert_text "Hello World" }
     click_link("Hello World")

--- a/test/system/my/solution_discussion_section_test.rb
+++ b/test/system/my/solution_discussion_section_test.rb
@@ -3,6 +3,7 @@ require 'application_system_test_case'
 class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
   REQUEST_MENTORING_TEXT = "Request mentor feedback."
+  REQUEST_MENTORING_DISABLED_TEXT = "Request mentor feedback (disabled)."
   COMPLETE_TEXT = "Complete this solution."
   PUBLISH_TEXT = "Publish this solution."
   CANCEL_MENTORING_TEXT = "Don't want mentoring after all?"
@@ -40,9 +41,9 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    assert_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    assert_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
 
     refute_selector ".discussion"
   end
@@ -54,9 +55,9 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    assert_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    assert_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
 
     refute_selector ".discussion"
   end
@@ -73,12 +74,12 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     refute_selector ".next-steps"
 
-    refute_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
-    assert_selector ".finished-section .next-option strong", text: WHILE_YOU_WAIT_TEXT
-    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: WHILE_YOU_WAIT_TEXT
+    assert_selector ".finished-section a", exact_text: CANCEL_MENTORING_BTN_TEXT
   end
 
   test "mentored mode / side solution with mentoring requested and abaondoned mentor" do
@@ -94,12 +95,12 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     refute_selector ".next-steps"
 
-    refute_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
-    assert_selector ".finished-section .next-option strong", text: WHILE_YOU_WAIT_TEXT
-    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: WHILE_YOU_WAIT_TEXT
+    assert_selector ".finished-section a", exact_text: CANCEL_MENTORING_BTN_TEXT
 
   end
 
@@ -116,11 +117,11 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     refute_selector ".next-steps"
 
-    refute_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
-    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", exact_text: CANCEL_MENTORING_BTN_TEXT
 
   end
 
@@ -170,9 +171,9 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    assert_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    refute_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
 
     refute_selector ".next-steps"
     assert_selector ".discussion h3", text: "Mentor discussion"
@@ -188,9 +189,9 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    assert_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    refute_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
 
     refute_selector ".next-steps"
     assert_selector ".discussion h3", text: "Mentor discussion"
@@ -208,8 +209,8 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     assert_selector ".discussion h3", text: "Mentor discussion"
     assert_selector ".discussion form"
 
-    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
-    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", exact_text: CANCEL_MENTORING_BTN_TEXT
   end
 
   test "independent mode - side - requested mentoring" do
@@ -222,10 +223,9 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
     assert_selector ".discussion h3", text: "Mentor discussion"
     assert_selector ".discussion form"
 
-    assert_selector ".finished-section .next-option strong", text: CANCEL_MENTORING_TEXT
-    assert_selector ".finished-section a", text: CANCEL_MENTORING_BTN_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: CANCEL_MENTORING_TEXT
+    assert_selector ".finished-section a", exact_text: CANCEL_MENTORING_BTN_TEXT
   end
-
 
   test "independent mode / not requested mentoring" do
     solution = create(:solution, user: @user, mentoring_requested_at: nil)
@@ -234,10 +234,16 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    assert_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
     refute_selector ".discussion"
+
+    # Check this is overriden by Track#accepting_new_students?
+    Track.any_instance.stubs(accepting_new_students?: false)
+    visit my_solution_path(solution)
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_DISABLED_TEXT
   end
 
   test "independent mode / not requested mentoring - completed" do
@@ -247,10 +253,16 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    assert_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
     refute_selector ".discussion"
+
+    # Check this is overriden by Track#accepting_new_students?
+    Track.any_instance.stubs(accepting_new_students?: false)
+    visit my_solution_path(solution)
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_DISABLED_TEXT
   end
 
   test "independent mode / not requested mentoring - published" do
@@ -260,10 +272,16 @@ class My::SolutionDiscussionSectionTest < ApplicationSystemTestCase
 
     visit my_solution_path(solution)
 
-    refute_selector ".finished-section .next-option strong", text: COMPLETE_TEXT
-    refute_selector ".finished-section .next-option strong", text: PUBLISH_TEXT
-    assert_selector ".finished-section .next-option strong", text: REQUEST_MENTORING_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: COMPLETE_TEXT
+    refute_selector ".finished-section .next-option strong", exact_text: PUBLISH_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
     refute_selector ".discussion"
+
+    # Check this is overriden by Track#accepting_new_students?
+    Track.any_instance.stubs(accepting_new_students?: false)
+    visit my_solution_path(solution)
+    refute_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_TEXT
+    assert_selector ".finished-section .next-option strong", exact_text: REQUEST_MENTORING_DISABLED_TEXT
   end
 
   test "comment button clears preview tab" do

--- a/test/system/my/solutions_information_bar_test.rb
+++ b/test/system/my/solutions_information_bar_test.rb
@@ -134,7 +134,7 @@ class My::SolutionsInformationBarTest < ApplicationSystemTestCase
     sign_in!(@user)
     visit my_solution_path(@solution)
 
-    assert_selector ".notifications-bar .notification", text: "In Independent Mode you will not receive mentoring by default. You may request mentoring on 1 solution at a time."
+    assert_selector ".notifications-bar .notification", text: "In Practice Mode you will not receive mentoring by default. You may request mentoring on 1 solution at a time."
   end
 
   test "In independent mode without slots" do
@@ -144,7 +144,7 @@ class My::SolutionsInformationBarTest < ApplicationSystemTestCase
     sign_in!(@user)
     visit my_solution_path(@solution)
 
-    assert_selector ".notifications-bar .notification", text: "In Independent Mode you will not receive mentoring by default. You may request mentoring once your existing solutions have been mentored."
+    assert_selector ".notifications-bar .notification", text: "In Practice Mode you will not receive mentoring by default. You may request mentoring once your existing solutions have been mentored."
   end
 
   test "Legacy with mentoring requested" do

--- a/test/system/my/track_test.rb
+++ b/test/system/my/track_test.rb
@@ -56,6 +56,20 @@ class My::TrackTest < ApplicationSystemTestCase
     within(".progress-section") { refute_text /1\n[Ee]tra [Ee]xercises/ }
   end
 
+  test "shows oversubscribed modal tracks that are oversubscribed" do
+    track = create(:track, median_wait_time: 2.weeks)
+    exercise = create(:exercise, track: track, core: true)
+
+    user_track = create(:user_track, {
+      track: track,
+      user: @user,
+      independent_mode: nil
+    })
+
+    visit track_path(track)
+    within(".main-section") { assert_text "Start Track in Practice Mode" }
+  end
+
   test "shows migration modal for user tracks created before migration" do
     track = create(:track)
     exercise = create(:exercise, track: track, core: true)
@@ -68,6 +82,21 @@ class My::TrackTest < ApplicationSystemTestCase
     })
 
     visit track_path(track)
-    within(".main-section") { assert_text "Mentored Mode (Recommended)" }
+    within(".main-section") { assert_text "Mentored Mode" }
+  end
+
+  test "shows oversubscribed migration modal for user tracks created before migration" do
+    track = create(:track, median_wait_time: 2.weeks)
+    exercise = create(:exercise, track: track, core: true)
+
+    user_track = create(:user_track, {
+      track: track,
+      user: @user,
+      created_at: Exercism::V2_MIGRATED_AT - 1.day,
+      independent_mode: nil
+    })
+
+    visit track_path(track)
+    within(".main-section") { assert_text "Start Track in Practice Mode" }
   end
 end

--- a/test/system/user_switches_track_mode_test.rb
+++ b/test/system/user_switches_track_mode_test.rb
@@ -1,0 +1,47 @@
+require 'application_system_test_case'
+
+class UserSwitchesTrackModeTest < ApplicationSystemTestCase
+  test 'switches to mentored mode' do
+    user = create(:user, :onboarded)
+    track = create(:track, title: "Ruby")
+    user_track = create :user_track, user: user, track: track, independent_mode: true
+
+    sign_in!(user)
+    visit my_track_path(user_track.track)
+    click_on "Switch to Mentored Mode"
+    within("#modal") do
+      click_on "Switch to Mentored Mode"
+    end
+
+    refute user_track.reload.independent_mode?
+  end
+
+  test 'switch to mentor mode is disabled if track is oversubscribed' do
+    user = create(:user, :onboarded)
+    track = create(:track, title: "Ruby", median_wait_time: 1.year)
+    user_track = create :user_track, user: user, track: track, independent_mode: true
+
+    sign_in!(user)
+    visit my_track_path(user_track.track)
+    click_on "Switch to Mentored Mode"
+    within("#modal") do
+      refute_selector "a", text: "Switch to Mentored Mode"
+      click_on "Close"
+    end
+  end
+
+  test 'switches to independent mode' do
+    user = create(:user, :onboarded)
+    track = create(:track, title: "Ruby")
+    user_track = create :user_track, user: user, track: track, independent_mode: false
+
+    sign_in!(user)
+    visit my_track_path(user_track.track)
+    click_on "Switch to Practice Mode"
+    within("#modal") do
+      click_on "Switch to Practice Mode"
+    end
+
+    assert user_track.reload.independent_mode?
+  end
+end


### PR DESCRIPTION
We are very oversubscribed (too many students for mentors) on many tracks. We have decided to take a "tactical retreat" in order to mentors get on top of the queues. The long term solution to this is covered by the strategy doc and the Chicago project, but this should help reduce the pain for mentors a bit, and hopefully mean that everyone doesn't quit in frustration and the always-increasing queue-sizes.

This PR adds a new method to tracks for "allow new students?". It is determined by a track's median wait time raising above one week. When that is the case, no new students can join in mentored mode, and no new submissions can be posted from Independent Mode.

This PR also renames Independent Mode to Practice Mode, which is important for the explanation around this change.