### PR TITLE
Add commentary to mentor comments and restrict to single exercise

### DIFF
--- a/app/assets/stylesheets/pages/mentor-solution.scss
+++ b/app/assets/stylesheets/pages/mentor-solution.scss
@@ -146,6 +146,92 @@
             }
         }
     }
+    .javascript-resistor-color-duo-experiment-analysis-section {
+        margin-bottom:20px;
+        h3 {
+            background:$color-1;
+            border:solid $color-1;
+            border-width: 0 1px;
+            color:#fff;
+            padding:15px;
+            i {
+                color:#fff;
+                margin-left:5px;
+            }
+        }
+        .recommendation {
+            padding:10px 15px;
+            border-bottom:1px solid #aaa;
+            font-weight:$fw-semibold;
+            border:solid $color-1;
+            border-width: 0 1px 1px 1px;
+            margin-bottom:10px;
+        }
+
+        .comments {
+            .beta {
+                text-color:#666;
+                font-style:italic;
+                padding:10px 15px;
+                background:$color-1-opaque;
+                border:1px solid $color-1;
+            }
+            h4 {
+                font-weight:$fw-bold;
+                padding:15px;
+            }
+            .comment-with-commentary {
+                margin-top:10px;
+                border:1px solid $color-1;
+            }
+            .commentary {
+                padding: 10px 15px;
+                background:$color-1-opaque;
+                margin-bottom:0;
+               * {
+                    @include font-size(14, 19);
+                }
+                code { &, * { font-size:13px; } }
+            }
+            .commentary-and-comment {
+                padding:0 15px 10px 15px;
+                margin:0px 0 0 0;
+                border-bottom: 1px solid $color-1;
+                background:$color-1-opaque;
+                //font-weight:$fw-bold;
+            }
+
+            .comment.widget-code-snippet {
+                position: relative;
+                overflow: hidden;
+                background:#fcfcfc;
+                padding: 10px 15px;
+                textarea {
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                    width: 5px;
+                    height:5px;
+                    z-index:5
+                }
+                .copy-button {
+                    z-index:10;
+                }
+                .editable-text-html {
+                    padding-right:65px;
+                    margin-bottom:0;
+                   * {
+                        @include font-size(14, 19);
+                    }
+                    code { &, * { font-size:12px; } }
+                }
+                &:last-child {
+                    border-width:0;
+                }
+            }
+        }
+    }
+
     .discussion,
     .new-editable-text {
         h3 {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,5 +1,6 @@
 $color-1: #3ab292;
 $color-2: #009cab;
+$color-1-opaque: rgba($color-1, 0.1);
 $color-2-opaque: #f3fdfd;
 $color-3: #45027b;
 

--- a/app/models/git/website_content.rb
+++ b/app/models/git/website_content.rb
@@ -57,6 +57,21 @@ class Git::WebsiteContent < Git::RepoBase
     nil
   end
 
+  def automated_comment_commentary_for(code)
+    ptr = head_commit.tree["automated-comments"]
+    tree = repo.lookup(ptr[:oid])
+    path = "#{code.split(".")[0...-1].join("/")}/commentary/"
+    filename = "#{code.split(".").last}.md"
+
+    tree.walk_blobs do |root, file|
+      next unless root == path
+      next unless file[:name] == filename
+      file_blob = repo.lookup(file[:oid])
+      return file_blob.text
+    end
+
+    nil
+  end
 
   def mentors
     ptr = head_commit.tree["mentors"]

--- a/app/models/iteration_analysis.rb
+++ b/app/models/iteration_analysis.rb
@@ -26,6 +26,17 @@ class IterationAnalysis < ApplicationRecord
     }.compact
   end
 
+  def built_comments_with_commentary
+    return [] unless analysis_comments_data.present?
+
+    analysis_comments_data.map { |comment_data|
+      [
+        begin AnalysisServices::BuildCommentCommentary.(comment_data) rescue nil end,
+        begin AnalysisServices::BuildComment.(comment_data) rescue nil end
+      ]
+    }.compact
+  end
+
   def analysis
     (super || {}).symbolize_keys
   end

--- a/app/services/analysis_services/build_comment_commentary.rb
+++ b/app/services/analysis_services/build_comment_commentary.rb
@@ -1,0 +1,23 @@
+module AnalysisServices
+  class BuildCommentCommentary
+    include Mandate
+
+    initialize_with :comment_data
+
+    def call
+      template, params =
+        if comment_data.is_a?(Hash)
+          [ comment_data['comment'], (comment_data['params'] || {}).symbolize_keys ]
+        else
+          [comment_data, {}]
+        end
+
+        repo.automated_comment_commentary_for(template) % params
+    end
+
+    def repo
+      Git::WebsiteContent.head
+    end
+  end
+end
+

--- a/app/views/mentor/solutions/_analysis.html.haml
+++ b/app/views/mentor/solutions/_analysis.html.haml
@@ -1,26 +1,27 @@
-/-return unless current_user.admin?
 -return unless @iteration.analyses.present?
 
 -analysis = @iteration.analyses.last
 -return unless analysis.handled?
 
-.analysis-section
-  %h3
-    Automatic Analysis
-    =link_to "https://github.com/exercism/automated-mentoring-support" do
-      %i.fa.fa-info-circle
-  .recommendation
-    %strong Recommendation:
-    =analysis.analysis_status.to_s.titleize
-    -if analysis.built_comments.size > 0
-      with comments
+-if @solution.exercise.track.slug == "javascript" && @solution.exercise.slug == "resistor-color-duo"
+  = render "mentor/solutions/analysis/javascript_resistor_color_duo_experiment", analysis: analysis
+-else
+  .analysis-section
+    %h3
+      Automatic Analysis
+      =link_to "https://github.com/exercism/automated-mentoring-support" do
+        %i.fa.fa-info-circle
+    .recommendation
+      %strong Recommendation:
+      =analysis.analysis_status.to_s.titleize
+      -if analysis.built_comments.size > 0
+        with comments
 
-  .comments
-    /%h4 Suggested comments
-    -analysis.built_comments.each.with_index do |comment, idx|
-      .comment.widget-code-snippet
-        =button_tag "copy", class: 'pure-button copy-button'
-        =text_area_tag "analysis-comment-#{idx}", comment, class: 'download-code', readonly: true
-        .editable-text
-          .editable-text-viewer
-            .editable-text-html= raw ParseMarkdown.(comment)
+    .comments
+      -analysis.built_comments.each.with_index do |comment, idx|
+        .comment.widget-code-snippet
+          =button_tag "copy", class: 'pure-button copy-button'
+          =text_area_tag "analysis-comment-#{idx}", comment, class: 'download-code', readonly: true
+          .editable-text
+            .editable-text-viewer
+              .editable-text-html= raw ParseMarkdown.(comment)

--- a/app/views/mentor/solutions/analysis/_javascript_resistor_color_duo_experiment.html.haml
+++ b/app/views/mentor/solutions/analysis/_javascript_resistor_color_duo_experiment.html.haml
@@ -1,0 +1,36 @@
+-return unless [1530, 38366].include?(current_user.id)
+
+.javascript-resistor-color-duo-experiment-analysis-section
+  %h3
+    Automatic Analysis
+    =link_to "https://github.com/exercism/automated-mentoring-support" do
+      %i.fa.fa-info-circle
+  .recommendation
+    %strong Recommendation:
+    =analysis.analysis_status.to_s.titleize
+    -if analysis.built_comments_with_commentary.size > 0
+      with comments
+
+  .comments
+    .beta
+      %strong Note:
+      This exercise is using an experimental analyzer, which provides a mixture of commentary for mentors and/or pastable comments. Please help us by adding your thoughts and ideas to #{link_to "this GitHub issue", "https://github.com/exercism/javascript-analyzer/issues/49"}.
+
+    -analysis.built_comments_with_commentary.each.with_index do |(commentary, comment), idx|
+      .comment-with-commentary
+        -if commentary.present?
+          .commentary
+            =raw ParseMarkdown.(commentary)
+
+        -if commentary.present? && comment.present?
+          %h5.commentary-and-comment Try suggesting the following:
+          /Suggested comment for student:
+
+        -if comment.present?
+          .comment.widget-code-snippet
+            =button_tag "copy", class: 'pure-button copy-button'
+            =text_area_tag "analysis-comment-#{idx}", comment, class: 'download-code', readonly: true
+            .editable-text
+              .editable-text-viewer
+                .editable-text-html= raw ParseMarkdown.(comment)
+

--- a/test/services/analysis_services/build_comment_commentary_test.rb
+++ b/test/services/analysis_services/build_comment_commentary_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+module AnalysisServices
+  class BuildCommentCommentaryTest < ActiveSupport::TestCase
+    test "generates comment correctly" do
+      system_user = create :user, :system
+      iteration = create :iteration
+
+      templates = {"tests.comment" => "the comment"}
+
+      website_copy = mock
+      website_copy.expects(:automated_comment_commentary_for).with("tests.comment").returns(templates["tests.comment"])
+      Git::WebsiteContent.stubs(head: website_copy)
+
+      comment_data = { 'comment' => "tests.comment" }
+      expected = "the comment"
+      assert_equal expected, BuildCommentCommentary.(comment_data)
+    end
+  end
+end


### PR DESCRIPTION
This is an experiment I am trying with @sleeplessbyte.

I've isolated everything as much as feels sensible for now. Depending on how this goes, this PR will either be reverted, or I will add another PR incorporating things more properly.