### PR TITLE
Use flipper to toggle mentor commentary

### DIFF
--- a/app/views/mentor/solutions/analysis/_javascript_resistor_color_duo_experiment.html.haml
+++ b/app/views/mentor/solutions/analysis/_javascript_resistor_color_duo_experiment.html.haml
@@ -1,4 +1,4 @@
--return unless [6, 1530, 38366].include?(current_user.id)
+-return unless Flipper[:mentor_commentary].enabled?(current_user)
 
 .javascript-resistor-color-duo-experiment-analysis-section
   %h3


### PR DESCRIPTION
I've created a feature named `mentor_commentary` in `exercism.io/flipper`.

In that page, under actors, simply put in the user's ID. For clarity, `flipper_id` == `user_id`.