### PR TITLE
Remove specific styling for <pre> tags nested in <li> or <p>

### DIFF
--- a/app/assets/stylesheets/code-editor.scss
+++ b/app/assets/stylesheets/code-editor.scss
@@ -69,7 +69,7 @@ body .md-editor {
     }
 
     p,li {
-        > code {
+        &> code {
             border:1px solid #fafafa;
             background:#f5f5f5;
             @include code-font;

--- a/app/assets/stylesheets/code-editor.scss
+++ b/app/assets/stylesheets/code-editor.scss
@@ -69,7 +69,7 @@ body .md-editor {
     }
 
     p,li {
-        code {
+        > code {
             border:1px solid #fafafa;
             background:#f5f5f5;
             @include code-font;


### PR DESCRIPTION
Closes https://github.com/exercism/bugs/issues/29.

I think we've deliberately included a specific style for nested `<pre>` tags, but upon inspection it doesn't make that much of a difference. When deleting this specific style, nested `<pre>` tags in the dark mode theme work well.

## Screenshots

### Without specific style
<img width="500" alt="Screen Shot 2019-09-25 at 9 30 01 AM" src="https://user-images.githubusercontent.com/1901520/65562244-3896fe80-df78-11e9-8e32-2f533c382a77.png">

### With style
<img width="502" alt="Screen Shot 2019-09-25 at 9 30 13 AM" src="https://user-images.githubusercontent.com/1901520/65562245-3896fe80-df78-11e9-907a-5b7f8006c08e.png">

The only difference is a small padding to the left and we can add that if we wanted to.