### PR TITLE
Publish entry

### DIFF
--- a/app/controllers/changelog_admin/entries_controller.rb
+++ b/app/controllers/changelog_admin/entries_controller.rb
@@ -24,6 +24,14 @@ module ChangelogAdmin
       @entry = ChangelogEntry.find(params[:id])
     end
 
+    def publish
+      @entry = ChangelogEntry.find(params[:id])
+
+      @entry.publish!
+
+      redirect_to changelog_admin_entry_path(@entry)
+    end
+
     private
 
     def form_params

--- a/app/models/changelog_entry.rb
+++ b/app/models/changelog_entry.rb
@@ -16,4 +16,8 @@ class ChangelogEntry < ApplicationRecord
   def publish!(time = Time.current)
     update!(published_at: time)
   end
+
+  def published?
+    published_at.present?
+  end
 end

--- a/app/models/changelog_entry.rb
+++ b/app/models/changelog_entry.rb
@@ -1,4 +1,6 @@
 class ChangelogEntry < ApplicationRecord
+  class EntryAlreadyPublishedError < StandardError; end;
+
   belongs_to :referenceable, polymorphic: true, optional: true
   belongs_to :created_by, class_name: "User"
 
@@ -14,6 +16,8 @@ class ChangelogEntry < ApplicationRecord
   end
 
   def publish!(time = Time.current)
+    raise EntryAlreadyPublishedError if published?
+
     update!(published_at: time)
   end
 

--- a/app/models/changelog_entry.rb
+++ b/app/models/changelog_entry.rb
@@ -12,4 +12,8 @@ class ChangelogEntry < ApplicationRecord
   def referenceable
     ChangelogAdmin::Referenceable.for(super)
   end
+
+  def publish!(time = Time.current)
+    update!(published_at: time)
+  end
 end

--- a/app/views/changelog_admin/entries/_actions.html.haml
+++ b/app/views/changelog_admin/entries/_actions.html.haml
@@ -1,0 +1,6 @@
+%ul
+  - unless entry.published?
+    %li= link_to "Publish",
+        publish_changelog_admin_entry_path(entry),
+        data: { method: :post,
+        confirm: "Are you sure you want to publish this entry?" }

--- a/app/views/changelog_admin/entries/show.html.haml
+++ b/app/views/changelog_admin/entries/show.html.haml
@@ -11,3 +11,12 @@
   %dd= @entry.referenceable_title
   %dt Info url
   %dd= @entry.info_url
+  %dt Published at
+  %dd= @entry.published_at
+
+%h2 Actions
+
+%ul
+  %li= link_to "Publish",
+    publish_changelog_admin_entry_path(@entry),
+    data: { method: :post, confirm: "Are you sure you want to publish this entry?" }

--- a/app/views/changelog_admin/entries/show.html.haml
+++ b/app/views/changelog_admin/entries/show.html.haml
@@ -16,7 +16,4 @@
 
 %h2 Actions
 
-%ul
-  %li= link_to "Publish",
-    publish_changelog_admin_entry_path(@entry),
-    data: { method: :post, confirm: "Are you sure you want to publish this entry?" }
+= render "actions", entry: @entry

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,9 @@ Rails.application.routes.draw do
   # ############### #
 
   namespace :changelog_admin do
-    resources :entries, only: [:new, :create, :show, :index]
+    resources :entries, only: [:new, :create, :show, :index] do
+      post :publish, on: :member
+    end
 
     root to: "entries#index"
   end

--- a/db/migrate/20190923102032_add_published_at_to_changelog_entries.rb
+++ b/db/migrate/20190923102032_add_published_at_to_changelog_entries.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToChangelogEntries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :changelog_entries, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_044907) do
+ActiveRecord::Schema.define(version: 2019_09_23_102032) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_09_23_044907) do
     t.string "info_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "published_at"
     t.index ["created_by_id"], name: "index_changelog_entries_on_created_by_id"
     t.index ["referenceable_type", "referenceable_id"], name: "index_changelog_entries_on_referenceable"
   end

--- a/test/models/changelog_entry_test.rb
+++ b/test/models/changelog_entry_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class ChangelogEntryTest < ActiveSupport::TestCase
+  test "#publish! sets the published_at time" do
+    time = Time.utc(2016, 12, 25)
+    entry = create(:changelog_entry)
+
+    entry.publish!(time)
+
+    assert_equal time, entry.published_at
+  end
+end

--- a/test/models/changelog_entry_test.rb
+++ b/test/models/changelog_entry_test.rb
@@ -10,6 +10,15 @@ class ChangelogEntryTest < ActiveSupport::TestCase
     assert_equal time, entry.published_at
   end
 
+  test "#publish! raises an error when publishing an already published entry" do
+    time = Time.utc(2016, 12, 25)
+    entry = create(:changelog_entry, published_at: time)
+
+    assert_raises ChangelogEntry::EntryAlreadyPublishedError do
+      entry.publish!
+    end
+  end
+
   test "published? returns true if published_at is set" do
     entry = create(:changelog_entry, published_at: Time.new(2016, 12, 25))
 

--- a/test/models/changelog_entry_test.rb
+++ b/test/models/changelog_entry_test.rb
@@ -9,4 +9,16 @@ class ChangelogEntryTest < ActiveSupport::TestCase
 
     assert_equal time, entry.published_at
   end
+
+  test "published? returns true if published_at is set" do
+    entry = create(:changelog_entry, published_at: Time.new(2016, 12, 25))
+
+    assert entry.published?
+  end
+
+  test "published? returns false if published_at isn't set" do
+    entry = create(:changelog_entry, published_at: nil)
+
+    refute entry.published?
+  end
 end

--- a/test/system/changelog_admin/publish_changelog_entry_test.rb
+++ b/test/system/changelog_admin/publish_changelog_entry_test.rb
@@ -1,0 +1,21 @@
+require "application_system_test_case"
+
+module ChangelogAdmin
+  class PublishChangelogEntryTest < ApplicationSystemTestCase
+    test "admin publishes a changelog entry" do
+      travel_to(Time.utc(2016, 12, 25))
+      Flipper.enable(:changelog)
+      admin = create(:user, :onboarded, may_edit_changelog: true)
+      entry = create(:changelog_entry)
+
+      sign_in!(admin)
+      visit changelog_admin_entry_path(entry)
+      accept_alert { click_on "Publish" }
+
+      assert_text "Published at\n2016-12-25 00:00:00 UTC"
+
+      Flipper.disable(:changelog)
+      travel_back
+    end
+  end
+end

--- a/test/views/changelog_admin/entries/actions_test.rb
+++ b/test/views/changelog_admin/entries/actions_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module ChangelogAdmin
+  class ActionsTest < ActionView::TestCase
+    test "show publish button if entry is unpublished" do
+      entry = create(:changelog_entry, published_at: nil)
+
+      render "changelog_admin/entries/actions", entry: entry
+
+      assert_select "a", exact_text: "Publish"
+    end
+
+    test "hide publish button if entry is published" do
+      entry = create(:changelog_entry, published_at: Time.new(2016, 12, 25))
+
+      render "changelog_admin/entries/actions", entry: entry
+
+      assert_select "a", 0, exact_text: "Publish"
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/exercism/wip/issues/35.

## Questions
1. Who is allowed to publish the entry? Should it only be the one who created the entry? With editing, in the spec, it's specified that users can only edit their own articles, should it be the same for publishing?
2. In the spec, there isn't anything about unpublishing an entry. I think we should include it as well. But it might get complicated quickly when we've already tweeted the links, and we might need to delete tweets as well.