### PR TITLE
Don't escape tags in blog rss

### DIFF
--- a/app/views/blog_posts/index.rss.haml
+++ b/app/views/blog_posts/index.rss.haml
@@ -23,4 +23,4 @@
         %pubDate= post.published_at.rfc822
         %guid{isPermaLink: 'true'}= blog_post_url(post)
         %comments= blog_post_url(post, anchor: 'comments')
-        %content:encoded <![CDATA[#{post.content}]]>
+        %content:encoded <![CDATA[#{raw post.content}]]>


### PR DESCRIPTION
Don't escape content in RSS of blog posts.