### PR TITLE
Fix grammar issue on about page

### DIFF
--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -66,7 +66,7 @@
         %h2 Supporters
         %p Exercism relies on both the generosity of individuals with their time, and the generosity of organisations to financially support us. 
         %p While much of Exercism is run by our volunteer community, the website and core infrastructure are managed by a full-time team. We also undertake specific larger projects, such as the development of our automated analyzers, which require a committed team working more intensely on something over a fixed period of time. 
-        %p In order to fund this core team and these products we rely on grant funding from companies or organisation that wish to contribute to our vision of helping providing free programming education for everyone.
+        %p In order to fund this core team and these products we rely on grant funding from companies or organisations that wish to contribute to our vision of helping providing free programming education for everyone.
         =link_to "Learn more about how you can support us ⟶", supporters_page_path, class: 'pure-button'
       .current
         %h3 Current supporters


### PR DESCRIPTION
I believe `organisation` should be `organisations`.