### PR TITLE
Delete entry

### DIFF
--- a/app/controllers/changelog_admin/entries_controller.rb
+++ b/app/controllers/changelog_admin/entries_controller.rb
@@ -76,6 +76,14 @@ module ChangelogAdmin
       end
     end
 
+    def destroy
+      @entry = ChangelogEntry.find(params[:id])
+
+      @entry.destroy
+
+      redirect_to changelog_admin_entries_path
+    end
+
     private
 
     def check_if_entry_is_editable!

--- a/app/controllers/changelog_admin/entries_controller.rb
+++ b/app/controllers/changelog_admin/entries_controller.rb
@@ -1,5 +1,7 @@
 module ChangelogAdmin
   class EntriesController < BaseController
+    before_action :set_entry!,
+      only: [:edit, :update, :show, :publish, :unpublish, :destroy]
     before_action :check_if_entry_is_editable!, only: [:edit, :update]
 
     def index
@@ -23,13 +25,10 @@ module ChangelogAdmin
     end
 
     def show
-      @entry = ChangelogEntry.find(params[:id])
       @actions = ChangelogAdmin::ChangelogEntryAction.all
     end
 
     def publish
-      @entry = ChangelogEntry.find(params[:id])
-
       unless AllowedToPublishEntryPolicy.allowed?(
         user: current_user,
         entry: @entry
@@ -44,8 +43,6 @@ module ChangelogAdmin
     end
 
     def unpublish
-      @entry = ChangelogEntry.find(params[:id])
-
       unless AllowedToUnpublishEntryPolicy.allowed?(
         user: current_user,
         entry: @entry
@@ -77,8 +74,6 @@ module ChangelogAdmin
     end
 
     def destroy
-      @entry = ChangelogEntry.find(params[:id])
-
       @entry.destroy
 
       redirect_to changelog_admin_entries_path
@@ -86,9 +81,11 @@ module ChangelogAdmin
 
     private
 
-    def check_if_entry_is_editable!
+    def set_entry!
       @entry = ChangelogEntry.find(params[:id])
+    end
 
+    def check_if_entry_is_editable!
       return unauthorized! unless allowed_to_edit?(@entry)
     end
 

--- a/app/policies/changelog_admin/allowed_to_delete_entry_policy.rb
+++ b/app/policies/changelog_admin/allowed_to_delete_entry_policy.rb
@@ -1,0 +1,19 @@
+module ChangelogAdmin
+  class AllowedToDeleteEntryPolicy
+    def self.allowed?(*args)
+      new(*args).allowed?
+    end
+
+    def initialize(user:, entry:)
+      @user = user
+      @entry = entry
+    end
+
+    def allowed?
+      user.admin?
+    end
+
+    private
+    attr_reader :user, :entry
+  end
+end

--- a/app/policies/changelog_admin/allowed_to_delete_entry_policy.rb
+++ b/app/policies/changelog_admin/allowed_to_delete_entry_policy.rb
@@ -10,10 +10,18 @@ module ChangelogAdmin
     end
 
     def allowed?
-      user.admin?
+      admin? || own_unpublished_entry?
     end
 
     private
     attr_reader :user, :entry
+
+    def admin?
+      user.admin?
+    end
+
+    def own_unpublished_entry?
+      entry.created_by?(user) && !entry.published?
+    end
   end
 end

--- a/app/view_models/changelog_admin/changelog_entry_action.rb
+++ b/app/view_models/changelog_admin/changelog_entry_action.rb
@@ -2,16 +2,38 @@ module ChangelogAdmin
   class ChangelogEntryAction
     def self.all
       [
-        ChangelogEntryAction.new(name: :publish, confirm: true, method: :post),
-        ChangelogEntryAction.new(name: :unpublish, confirm: true, method: :post),
-        ChangelogEntryAction.new(name: :edit, confirm: false, method: :get)
+        ChangelogEntryAction.new(
+          name: :publish,
+          confirm: true,
+          method: :post,
+          action: :publish,
+        ),
+        ChangelogEntryAction.new(
+          name: :unpublish,
+          confirm: true,
+          method: :post,
+          action: :unpublish,
+        ),
+        ChangelogEntryAction.new(
+          name: :edit,
+          confirm: false,
+          method: :get,
+          action: :edit,
+        ),
+        ChangelogEntryAction.new(
+          name: :delete,
+          confirm: true,
+          method: :delete,
+          action: :destroy
+        ),
       ]
     end
 
-    def initialize(name:, confirm:, method:)
+    def initialize(name:, confirm:, method:, action: nil)
       @name = name
       @confirm = confirm
       @method = method
+      @action = action
     end
 
     def render_for(context, entry, user)
@@ -19,13 +41,13 @@ module ChangelogAdmin
 
       context.link_to(
         name.capitalize,
-        { action: name, controller: "changelog_admin/entries", id: entry.id },
+        { action: action, controller: "changelog_admin/entries", id: entry.id },
         data: { confirm: confirmation_text, method: method }
       )
     end
 
     private
-    attr_reader :name, :confirm, :method
+    attr_reader :name, :confirm, :method, :action
 
     def allowed?(entry, user)
       policy.allowed?(user: user, entry: entry)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   # ############### #
 
   namespace :changelog_admin do
-    resources :entries, only: [:new, :create, :show, :index, :edit, :update] do
+    resources :entries do
       post :publish, on: :member
       post :unpublish, on: :member
     end

--- a/test/policies/changelog_admin/allowed_to_delete_entry_policy_test.rb
+++ b/test/policies/changelog_admin/allowed_to_delete_entry_policy_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+module ChangelogAdmin
+  class AllowedToDeleteEntryPolicyTest < ActiveSupport::TestCase
+    test "allow admins to delete entries" do
+      admin = create(:user, admin: true)
+      user = create(:user)
+      entry = create(:changelog_entry,
+                     published_at: nil,
+                     created_by: user)
+
+      assert AllowedToDeleteEntryPolicy.allowed?(user: admin, entry: entry)
+    end
+
+    test "allow changelog admins to delete their own unpublished entries" do
+      user = create(:user)
+      entry = create(:changelog_entry, published_at: nil, created_by: user)
+
+      assert AllowedToDeleteEntryPolicy.allowed?(user: user, entry: entry)
+    end
+  end
+end

--- a/test/system/changelog_admin/delete_changelog_entry_test.rb
+++ b/test/system/changelog_admin/delete_changelog_entry_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+module ChangelogAdmin
+  class DeleteChangelogEntryTest < ApplicationSystemTestCase
+    test "admin deletes a changelog entry" do
+      Flipper.enable(:changelog)
+      admin = create(:user, :onboarded, admin: true)
+      entry = create(:changelog_entry)
+
+      sign_in!(admin)
+      visit changelog_admin_entry_path(entry)
+      accept_alert { click_on "Delete" }
+
+      assert_text "Entries"
+
+      Flipper.disable(:changelog)
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/exercism/wip/issues/35

Building on https://github.com/exercism/website/pull/760, this allows admins to delete entries. 

Entries are allowed to be deleted if: (1) a site admin does it or (2) a changelog admin does it provided that the entry is still unpublished.