### PR TITLE
Delete stale notifications for solutions and iterations

### DIFF
--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -7,7 +7,7 @@ class Iteration < ApplicationRecord
 
   has_many :files, class_name: "IterationFile", dependent: :destroy
   has_many :discussion_posts, dependent: :destroy
-  has_many :notifications, as: :about
+  has_many :notifications, as: :about, dependent: :destroy
 
   has_many :analyses, class_name: "IterationAnalysis", dependent: :destroy
 

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -14,6 +14,8 @@ class Solution < ApplicationRecord
   has_many :stars, class_name: "SolutionStar", dependent: :destroy
   has_many :comments, class_name: "SolutionComment", dependent: :destroy
 
+  has_many :notifications, as: :about, dependent: :destroy
+
   delegate :auto_approve?, to: :exercise
 
   scope :core, -> { joins(:exercise).merge(Exercise.core) }

--- a/app/tasks/temporary/delete_stale_notifications_task.rb
+++ b/app/tasks/temporary/delete_stale_notifications_task.rb
@@ -1,0 +1,41 @@
+module Temporary
+  class DeleteStaleNotificationsTask
+    include Mandate
+
+    def initialize(stream: $stdout)
+      @stream = stream
+    end
+
+    def call
+      delete_solution_notifications!
+      delete_iteration_notifications!
+    end
+
+    private
+    attr_reader :stream
+
+    def delete_solution_notifications!
+      solution_ids = Solution.select(:id)
+
+      notifications = Notification.
+        where(about_type: "Solution").
+        where.not(about_id: solution_ids)
+
+      stream.puts "Deleting #{notifications.count} stale notifications about solutions"
+
+      notifications.destroy_all
+    end
+
+    def delete_iteration_notifications!
+      iteration_ids = Iteration.select(:id)
+
+      notifications = Notification.
+        where(about_type: "Iteration").
+        where.not(about_id: iteration_ids)
+
+      stream.puts "Deleting #{notifications.count} stale notifications about iterations"
+
+      notifications.destroy_all
+    end
+  end
+end

--- a/lib/tasks/temporary/delete_stale_notifications.rake
+++ b/lib/tasks/temporary/delete_stale_notifications.rake
@@ -1,0 +1,10 @@
+namespace :temporary do
+  desc "Delete stale notifications about solutions and iterations"
+  task :delete_stale_notifications => :environment do
+    puts "Deleting notifications...."
+
+    Temporary::DeleteStaleNotificationsTask.()
+
+    puts "Done"
+  end
+end

--- a/test/models/iteration_test.rb
+++ b/test/models/iteration_test.rb
@@ -19,4 +19,13 @@ class IterationTest < ActiveSupport::TestCase
     assert_equal [mentor_dp, user_dp].sort, iteration.discussion_posts.sort
     assert_equal [mentor_dp], iteration.mentor_discussion_posts
   end
+
+  test "notifications are deleted when iteration is deleted" do
+    iteration = create(:iteration)
+    notification = create(:notification, about: iteration)
+
+    iteration.destroy
+
+    refute Notification.exists?(notification.id)
+  end
 end

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -224,4 +224,13 @@ class SolutionTest < ActiveSupport::TestCase
     assert track.accepting_new_students?
     assert solution.reload.track_accepting_new_students?
   end
+
+  test "notifications are deleted when solution is deleted" do
+    solution = create(:solution)
+    notification = create(:notification, about: solution)
+
+    solution.destroy
+
+    refute Notification.exists?(notification.id)
+  end
 end

--- a/test/tasks/temporary/delete_stale_notifications_task_test.rb
+++ b/test/tasks/temporary/delete_stale_notifications_task_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+module Temporary
+  class DeleteStaleNotificationsTaskTest < ActiveSupport::TestCase
+    test "deletes notifications about deleted solutions" do
+      stale = create(:notification,
+                     about_type: "Solution",
+                     about_id: 123)
+      solution = create(:solution)
+      active = create(:notification, about: solution)
+
+      null_stream = File.open(File::NULL, "w")
+      DeleteStaleNotificationsTask.(stream: null_stream)
+
+      refute Notification.exists?(stale.id)
+      assert Notification.exists?(active.id)
+    end
+
+    test "deletes notifications about deleted iterations" do
+      stale = create(:notification,
+                     about_type: "Iteration",
+                     about_id: 123)
+      iteration = create(:solution)
+      active = create(:notification, about: iteration)
+
+      null_stream = File.open(File::NULL, "w")
+      DeleteStaleNotificationsTask.(stream: null_stream)
+
+      refute Notification.exists?(stale.id)
+      assert Notification.exists?(active.id)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/bugs/issues/33.

On a tangent, upon diving into the code, we might want to consider making the several notifications as first-class citizens of our codebase by creating a class for each. It took me a bit of time to navigate the code and search around to view the different types of notifications.