### PR TITLE
Add basic styling to changelog admin

### DIFF
--- a/app/assets/stylesheets/changelog_admin/edit-entry.scss
+++ b/app/assets/stylesheets/changelog_admin/edit-entry.scss
@@ -1,0 +1,16 @@
+@import 'variables';
+@import 'mixins';
+
+#changelog-admin-edit-entry {
+    table {
+        margin-bottom:10px;
+        th, td {
+            border:1px solid #ddd;
+            padding:10px;
+        }
+    }
+    a {
+        color:$color-2;
+    }
+}
+

--- a/app/assets/stylesheets/changelog_admin/entries.scss
+++ b/app/assets/stylesheets/changelog_admin/entries.scss
@@ -1,0 +1,16 @@
+@import 'variables';
+@import 'mixins';
+
+#changelog-admin-entries {
+    table {
+        margin-bottom:10px;
+        th, td {
+            border:1px solid #ddd;
+            padding:10px;
+        }
+    }
+    a {
+        color:$color-2;
+    }
+}
+

--- a/app/assets/stylesheets/changelog_admin/entry.scss
+++ b/app/assets/stylesheets/changelog_admin/entry.scss
@@ -1,0 +1,22 @@
+@import 'variables';
+@import 'mixins';
+
+#changelog-admin-entry {
+    h2 {
+        @include font-size(16, 16);
+        margin-bottom:10px;
+    }
+    dt {
+        font-weight:$fw-semibold;
+    }
+    dd {
+        margin-bottom:10px;
+    }
+    .pure-button {
+        background:$color-2;
+    }
+    .entries-link {
+        margin-top:10px;
+        display:block;
+    }
+}

--- a/app/assets/stylesheets/changelog_admin/form.scss
+++ b/app/assets/stylesheets/changelog_admin/form.scss
@@ -1,0 +1,30 @@
+@import 'variables';
+@import 'mixins';
+
+.lo-changelog-admin-form {
+    input {
+        padding:10px;
+    }
+    label {
+        margin-top:20px;
+        margin-bottom:5px;
+    }
+    #changelog_entry_form_title {
+        width:100%;
+    }
+    #changelog_entry_form_details_markdown {
+        width:100%;
+        height:300px;
+    }
+    #changelog_entry_form_info_url {
+        width:400px;
+    }
+    #changelog_entry_form_tweet_copy {
+        width:400px;
+        height:100px;
+    }
+    .pure-button {
+        margin-top:20px;
+    }
+}
+

--- a/app/assets/stylesheets/changelog_admin/new-entry.scss
+++ b/app/assets/stylesheets/changelog_admin/new-entry.scss
@@ -1,0 +1,15 @@
+@import 'variables';
+@import 'mixins';
+
+#changelog-admin-new-entry {
+    table {
+        margin-bottom:10px;
+        th, td {
+            border:1px solid #ddd;
+            padding:10px;
+        }
+    }
+    a {
+        color:$color-2;
+    }
+}

--- a/app/assets/stylesheets/changelog_admin/page.scss
+++ b/app/assets/stylesheets/changelog_admin/page.scss
@@ -1,0 +1,14 @@
+@import 'variables';
+@import 'mixins';
+
+.lo-changelog-admin-page {
+    padding:20px 0;
+    h1 {
+        @include font-size(20, 20);
+        margin-bottom:10px;
+    }
+    p {
+        @include font-size(15, 21);
+        margin-bottom:10px;
+    }
+}

--- a/app/views/changelog_admin/entries/_actions.html.haml
+++ b/app/views/changelog_admin/entries/_actions.html.haml
@@ -1,3 +1,4 @@
-%ul
-  - actions.each do |action|
-    %li= action.render_for(self, entry, current_user)
+- actions.each do |action|
+  = action.render_for(self, entry, current_user)
+
+= link_to "Back to Changelog Admin", changelog_admin_root_path, class: 'entries-link'

--- a/app/views/changelog_admin/entries/_form.html.haml
+++ b/app/views/changelog_admin/entries/_form.html.haml
@@ -8,14 +8,14 @@
 = form_for form,
   url: url,
   method: method,
-  html: { class: "pure-form pure-form-stacked" } do |f|
-  = f.label :title
-  = f.text_field :title, required: true
+  html: { class: "pure-form pure-form-stacked lo-changelog-admin-form" } do |f|
+  = f.label :title, "Short (10 word?) title explaining what's changed"
+  = f.text_field :title, required: true, placeholder: "e.g. New exercise! Bob has arrived on the Ruby track"
 
-  = f.label :details_markdown, "Details"
+  = f.label :details_markdown, "Details - As much or as little as you like about what you did. What's the reason? What changes will the user see? Is this part of a set of changes?"
   = f.text_area :details_markdown
 
-  = f.label :referenceable_gid, "About"
+  = f.label :referenceable_gid, "What track/exercise does this apply to (if appropriate)"
   = f.grouped_collection_select :referenceable_gid,
     form.referenceable_types,
     :all,
@@ -24,10 +24,10 @@
     :title,
     { prompt: "General" }
 
-  = f.label :info_url
-  = f.text_field :info_url
+  = f.label :info_url, "More info URL. Is there a PR, issue, or commit you can link to?"
+  = f.text_field :info_url, placeholder: "e.g. https://github.com/exercism/wip/issues/35"
 
-  = f.label :tweet_copy
-  = f.text_area :tweet_copy
+  = f.label :tweet_copy, "Tweet copy (max 250 chars)"
+  = f.text_area :tweet_copy, max_length: 250
 
   = f.submit "Save", class: "pure-button pure-button-primary"

--- a/app/views/changelog_admin/entries/edit.html.haml
+++ b/app/views/changelog_admin/entries/edit.html.haml
@@ -1,7 +1,8 @@
-.lo-container
-  %h1 Edit Entry
+#changelog-admin-edit-entry.lo-changelog-admin-page
+  .lo-container
+    %h1 Edit Entry
 
-  = render "form",
-    form: @form,
-    url: changelog_admin_entry_path(@entry),
-    method: :patch
+    = render "form",
+      form: @form,
+      url: changelog_admin_entry_path(@entry),
+      method: :patch

--- a/app/views/changelog_admin/entries/index.html.haml
+++ b/app/views/changelog_admin/entries/index.html.haml
@@ -1,15 +1,19 @@
-.lo-container
-  %h1 Entries
+#changelog-admin-entries.lo-changelog-admin-page
+  .lo-container
+    %h1 Changelog - Admin
+    %p This section allows maintainers to write updates to the exercise userbase about changes to their tracks.
+    %p All posts are checked and published by admins.
+    %p= link_to "Add a new changelog entry", new_changelog_admin_entry_path
 
-  %table
-    %tr
-      %th Title
-      %th Created by
-      %th Actions
-    - @entries.each do |entry|
+    %table
       %tr
-        %td= entry.title
-        %td= entry.created_by_name
-        %th= link_to "View", changelog_admin_entry_path(entry)
-
-  = link_to "Create new entry", new_changelog_admin_entry_path
+        %th Title
+        %th Created by
+        %th Published?
+        %th Actions
+      - @entries.each do |entry|
+        %tr
+          %td= entry.title
+          %td= entry.created_by_name
+          %td= entry.published?? "Yes" : "No"
+          %th= link_to "View", changelog_admin_entry_path(entry)

--- a/app/views/changelog_admin/entries/new.html.haml
+++ b/app/views/changelog_admin/entries/new.html.haml
@@ -1,4 +1,6 @@
-.lo-container
-  %h1 New Entry
+#changelog-admin-new-entry.lo-changelog-admin-page
+  .lo-container
+    %h1 New Entry
+    %p Use this form to create a new entry in the Changelog
 
-  = render "form", form: @form, url: changelog_admin_entries_path
+    = render "form", form: @form, url: changelog_admin_entries_path

--- a/app/views/changelog_admin/entries/show.html.haml
+++ b/app/views/changelog_admin/entries/show.html.haml
@@ -1,21 +1,20 @@
-%h1 Changelog Entry
+#changelog-admin-entry.lo-changelog-admin-page
+  .lo-container
+    %h1 Changelog Entry
 
-%h2 Info
+    %dl
+      %dt Title:
+      %dd= @entry.title
+      %dt Details:
+      %dd= @entry.details_markdown
+      %dt About:
+      %dd= @entry.referenceable_title
+      %dt Info url:
+      %dd= @entry.info_url
+      %dt Published at:
+      %dd= @entry.published_at
+      %dt Tweet copy:
+      %dd= @entry.tweet_copy
 
-%dl
-  %dt Title
-  %dd= @entry.title
-  %dt Details
-  %dd= @entry.details_markdown
-  %dt About
-  %dd= @entry.referenceable_title
-  %dt Info url
-  %dd= @entry.info_url
-  %dt Published at
-  %dd= @entry.published_at
-  %dt Tweet copy
-  %dd= @entry.tweet_copy
-
-%h2 Actions
-
-= render "actions", actions: @actions, entry: @entry
+    %h2 Actions
+    = render "actions", actions: @actions, entry: @entry

--- a/test/system/changelog_admin/create_changelog_entry_test.rb
+++ b/test/system/changelog_admin/create_changelog_entry_test.rb
@@ -13,11 +13,11 @@ module ChangelogAdmin
 
       sign_in!(admin)
       visit new_changelog_admin_entry_path
-      fill_in "Title", with: "New Exercise"
+      fill_in "Short", with: "New Exercise"
       fill_in "Details", with: "# We've added a new exercise!"
       select_option "Ruby - Hello world",
         selector: "#changelog_entry_form_referenceable_gid"
-      fill_in "Info url", with: "https://github.com/exercism"
+      fill_in "More info URL", with: "https://github.com/exercism"
       fill_in "Tweet copy", with: "Hello, world!"
       click_on "Save"
 
@@ -41,11 +41,11 @@ module ChangelogAdmin
 
       sign_in!(admin)
       visit new_changelog_admin_entry_path
-      fill_in "Title", with: "   "
+      fill_in "Short", with: "   "
       fill_in "Details", with: "# We've added a new exercise!"
       select_option "Ruby - Hello world",
         selector: "#changelog_entry_form_referenceable_gid"
-      fill_in "Info url", with: "https://github.com/exercism"
+      fill_in "More info URL", with: "https://github.com/exercism"
       click_on "Save"
 
       assert_text "Title can't be blank"
@@ -55,7 +55,7 @@ module ChangelogAdmin
         visible: false
       )
       assert_field "Details", with: "# We've added a new exercise!"
-      assert_field "Info url", with: "https://github.com/exercism"
+      assert_field "More info URL", with: "https://github.com/exercism"
 
       Flipper.disable(:changelog)
     end

--- a/test/system/changelog_admin/delete_changelog_entry_test.rb
+++ b/test/system/changelog_admin/delete_changelog_entry_test.rb
@@ -12,7 +12,7 @@ module ChangelogAdmin
       visit changelog_admin_entry_path(entry)
       accept_alert { click_on "Delete" }
 
-      assert_text "Entries"
+      assert_text "Changelog - Admin"
 
       Flipper.disable(:changelog)
       Flipper.disable(:changelog_destructive)

--- a/test/system/changelog_admin/edit_changelog_entry_test.rb
+++ b/test/system/changelog_admin/edit_changelog_entry_test.rb
@@ -16,11 +16,11 @@ module ChangelogAdmin
       sign_in!(admin)
       visit edit_changelog_admin_entry_path(entry)
 
-      fill_in "Title", with: "New Exercise - Hello world"
+      fill_in "Short", with: "New Exercise - Hello world"
       fill_in "Details", with: "# We've added a new exercise named Hello world!"
       select_option "Ruby - Hello world",
         selector: "#changelog_entry_form_referenceable_gid"
-      fill_in "Info url", with: "https://github.com/exercism/hello-world"
+      fill_in "More info URL", with: "https://github.com/exercism/hello-world"
       click_on "Save"
 
       assert_text "New Exercise - Hello world"
@@ -38,7 +38,7 @@ module ChangelogAdmin
 
       sign_in!(admin)
       visit edit_changelog_admin_entry_path(entry)
-      fill_in "Title", with: "  "
+      fill_in "Short", with: "  "
       click_on "Save"
 
       assert_text "Title can't be blank"
@@ -59,11 +59,11 @@ module ChangelogAdmin
       sign_in!(site_admin)
       visit edit_changelog_admin_entry_path(entry)
 
-      fill_in "Title", with: "New Exercise - Hello world"
+      fill_in "Short", with: "New Exercise - Hello world"
       fill_in "Details", with: "# We've added a new exercise named Hello world!"
       select_option "Ruby - Hello world",
         selector: "#changelog_entry_form_referenceable_gid"
-      fill_in "Info url", with: "https://github.com/exercism/hello-world"
+      fill_in "More info URL", with: "https://github.com/exercism/hello-world"
       click_on "Save"
 
       assert_text "New Exercise - Hello world"

--- a/test/system/changelog_admin/publish_changelog_entry_test.rb
+++ b/test/system/changelog_admin/publish_changelog_entry_test.rb
@@ -12,7 +12,7 @@ module ChangelogAdmin
       visit changelog_admin_entry_path(entry)
       accept_alert { click_on "Publish" }
 
-      assert_text "Published at\n2016-12-25 00:00:00 UTC"
+      assert_text "Published at:\n2016-12-25 00:00:00 UTC"
 
       Flipper.disable(:changelog)
       travel_back

--- a/test/system/changelog_admin/view_all_changelog_entries_test.rb
+++ b/test/system/changelog_admin/view_all_changelog_entries_test.rb
@@ -15,8 +15,9 @@ module ChangelogAdmin
 
       assert_text "First entry"
       assert_text "Changelog Admin"
+      assert_text "No"
       assert_link "View", href: changelog_admin_entry_path(entry)
-      assert_link "Create new entry", href: new_changelog_admin_entry_path
+      assert_link "Add a new changelog entry", href: new_changelog_admin_entry_path
 
       Flipper.disable(:changelog)
     end


### PR DESCRIPTION
I've added some basic styling. We'll style it more properly when we have some more time but this gets it to a point where it's not blocked :)

<img width="1177" alt="Screenshot 2019-10-08 at 15 48 56" src="https://user-images.githubusercontent.com/286476/66401258-2b035f00-e9e3-11e9-9d3b-11c9f2147a52.png">
