### PR TITLE
Fix "users in countries" stat

### DIFF
--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -44,7 +44,7 @@
           .label conversations
         .hex
           .value 330k
-          .label users in 220 countries
+          .label users in 221 countries and territories
         .hex
           .value 50
           .label programming languages


### PR DESCRIPTION
"Users in 221 countries" is wrong and somewhat confusing because there are only ~206 countries (depending on who you ask).

According to @iHiD on Slack, this number is based on Google Analytics data (and just grew to 221).

Google Analytics regions/countries are based on ISO 3166-1 alpha-2 country codes, so the number corresponds to "countries, dependent territories, and special areas of geographical interest." [1] and not countries. One country may have multiple country codes (e.g. France and French Guyana are counted separately). The phrase "countries and territories" appears to be widely used in this context.

It looks a bit long on the website, though:

![grafik](https://user-images.githubusercontent.com/20866761/66440778-83af1800-ea34-11e9-9248-ae0757847ebb.png)

[1] https://en.wikipedia.org/w/index.php?oldid=918488418