### PR TITLE
Add markdown preview

### DIFF
--- a/app/views/changelog_admin/entries/_form.html.haml
+++ b/app/views/changelog_admin/entries/_form.html.haml
@@ -13,7 +13,7 @@
   = f.text_field :title, required: true, placeholder: "e.g. New exercise! Bob has arrived on the Ruby track"
 
   = f.label :details_markdown, "Details - As much or as little as you like about what you did. What's the reason? What changes will the user see? Is this part of a set of changes?"
-  = f.text_area :details_markdown
+  = render "markdown_field", f: f, field: :details_markdown
 
   = f.label :referenceable_gid, "What track/exercise does this apply to (if appropriate)"
   = f.grouped_collection_select :referenceable_gid,

--- a/app/views/changelog_admin/entries/_markdown_field.html.haml
+++ b/app/views/changelog_admin/entries/_markdown_field.html.haml
@@ -1,0 +1,15 @@
+.new-editable-text
+  .tabs-and-panes.selected-1
+    .tabs
+      .tab.tab-1.write-tab{data: {tab: "markdown"}} Write
+      .tab.tab-2.preview-tab{data: {tab: "preview"}} Preview
+    .panes
+      .pane.pane-1.markdown
+        = f.text_area field
+      .pane.pane-2.preview
+        .preview-area
+
+- content_for :js do
+  :javascript
+    setupTabs()
+    setupNewEditableText(#{f.object.id})

--- a/app/views/layouts/changelog_admin.html.haml
+++ b/app/views/layouts/changelog_admin.html.haml
@@ -5,6 +5,7 @@
     =async_stylesheet_link_tag '//fonts.googleapis.com/css?family=Dosis:600,700,800'
     =async_stylesheet_link_tag '//pro.fontawesome.com/releases/v5.6.3/css/all.css', integrity: 'sha384-LRlmVvLKVApDVGuspQFnRQJjkv0P7/YFrw84YYQtmYG4nK8c+M+NlmYDCv0rKWpG', crossorigin: 'anonymous'
     =async_stylesheet_link_tag '//pro.fontawesome.com/releases/v5.6.3/css/v4-shims.css'
+    = render "layouts/prismjs"
 
     =csrf_meta_tags
     =yield(:head)


### PR DESCRIPTION
Closes https://github.com/exercism/wip/issues/44.

I decided to repurpose our markdown preview in discussion posts as it seems to be easily pluggable.

The only problem I've noticed are that header tags aren't rendered properly as the CSS was maybe written to accommodate the comments use case. If this is okay with us, we can merge this, otherwise, I'll be injecting a different CSS to render the header tags correctly.

## Markdown
<img width="1127" alt="Screen Shot 2019-10-09 at 1 52 59 PM" src="https://user-images.githubusercontent.com/1901520/66455024-22bb2a80-ea9c-11e9-9fc0-0b8d25bf0872.png">
## Rendered
<img width="1153" alt="Screen Shot 2019-10-09 at 1 53 03 PM" src="https://user-images.githubusercontent.com/1901520/66455025-22bb2a80-ea9c-11e9-9788-10e1f878e0a7.png">
