### PR TITLE
Fix code samples in dark theme mode

### DIFF
--- a/app/assets/stylesheets/pages/solution-page.scss
+++ b/app/assets/stylesheets/pages/solution-page.scss
@@ -61,7 +61,6 @@
 
     .test-suite,
     .solution.multi-file {
-        background:#f9f9f9;
         h3 {
             padding:10px 50px 10px 27px;
             font-weight:$bold;
@@ -79,9 +78,6 @@
             margin-right: 10px;
         }
     }
-    .test-suite pre {
-        background:#f9f9f9;
-    }
     .solution pre {
         background:#fff;
     }
@@ -90,6 +86,7 @@
         pre {
             padding-top:0;
             padding-bottom:0;
+            border-radius: 0;
         }
     }
     .lhs-content {
@@ -362,6 +359,23 @@ body:not(.prism-dark) #teams-my-solution-page {
     }
 }
 
+body:not(.prism-dark) {
+    #solution-page,
+    #mentor-solution-page,
+    #my-solution-page,
+    #teams-solution-page,
+    #teams-my-solution-page,
+    #my-track-not-joined-page {
+        .test-suite,
+        .solution.multi-file,
+        .test-suite pre,
+        .solution pre,
+        .code-sample pre,
+        .code-sample code {
+            background:#f9f9f9;
+        }
+    }
+}
 body.prism-dark {
     #solution-page,
     #mentor-solution-page,

--- a/app/assets/stylesheets/pages/solution-page.scss
+++ b/app/assets/stylesheets/pages/solution-page.scss
@@ -367,15 +367,14 @@ body.prism-dark {
     #mentor-solution-page,
     #my-solution-page,
     #teams-solution-page,
-    #teams-my-solution-page {
+    #teams-my-solution-page,
+    #my-track-not-joined-page {
         .test-suite,
-        .solution.multi-file {
-            background:#272822;
-        }
-        .test-suite pre {
-            background:#272822;
-        }
-        .solution pre {
+        .solution.multi-file,
+        .test-suite pre,
+        .solution pre,
+        .code-sample pre,
+        .code-sample code {
             background:#272822;
         }
     }

--- a/app/assets/stylesheets/pages/track-page.scss
+++ b/app/assets/stylesheets/pages/track-page.scss
@@ -146,35 +146,7 @@ body.controller-my-tracks.action-show {
         .about {
             text-align:justify;
         }
-        .code-sample {
-            @include width-medium() {
-                display:block;
-                float:right;
-                margin:0 0 20px 50px;
-            }
-            display:none;
-            margin-top:35px;
-            background-image:image-url("code-sample-frame.png");
-            background-size:contain;
-            background-repeat:no-repeat;
-            padding:30px 10px;
-            height:200px;
-            width: 258px;
 
-            pre {
-                background:#fafafa;
-                @include font-size(10, 13);
-                padding:2px 5px;
-                height:144px;
-                code {
-                    background:#f8f8f8;
-                }
-            }
-            img {
-                display:block;
-                width:100%;
-            }
-        }
         h2 {
             @include font-size(22, 22);
             font-weight:$regular;
@@ -204,6 +176,37 @@ body.controller-my-tracks.action-show {
             }
         }
     }
+
+    .code-sample {
+        @include width-medium() {
+            display:block;
+            float:right;
+            margin:0 0 20px 50px;
+        }
+        display:none;
+        margin-top:35px;
+        background-image:image-url("code-sample-frame.png");
+        background-size:contain;
+        background-repeat:no-repeat;
+        padding:30px 10px;
+        height:200px;
+        width: 258px;
+
+        pre {
+            background:#fafafa;
+            @include font-size(10, 13);
+            padding:2px 5px;
+            height:144px;
+            code {
+                background:#f8f8f8;
+            }
+        }
+        img {
+            display:block;
+            width:100%;
+        }
+    }
+
     .testimonal-section {
         padding:70px 0;
         border:solid #eee;

--- a/app/assets/stylesheets/pages/track-page.scss
+++ b/app/assets/stylesheets/pages/track-page.scss
@@ -147,6 +147,34 @@ body.controller-my-tracks.action-show {
             text-align:justify;
         }
 
+        .code-sample {
+            @include width-medium() {
+                display:block;
+                float:right;
+                margin:0 0 20px 50px;
+            }
+            display:none;
+            margin-top:35px;
+            background-image:image-url("code-sample-frame.png");
+            background-size:contain;
+            background-repeat:no-repeat;
+            padding:28px 6px;
+            height:200px;
+            width: 258px;
+
+            pre {
+                @include font-size(10, 13);
+                padding:10px 10px;
+                height:151px;
+                margin:0;
+                border-radius: 0 0 9px 9px;
+            }
+            img {
+                display:block;
+                width:100%;
+            }
+        }
+
         h2 {
             @include font-size(22, 22);
             font-weight:$regular;
@@ -174,36 +202,6 @@ body.controller-my-tracks.action-show {
             font-weight:$regular;
             &:hover {
             }
-        }
-    }
-
-    .code-sample {
-        @include width-medium() {
-            display:block;
-            float:right;
-            margin:0 0 20px 50px;
-        }
-        display:none;
-        margin-top:35px;
-        background-image:image-url("code-sample-frame.png");
-        background-size:contain;
-        background-repeat:no-repeat;
-        padding:30px 10px;
-        height:200px;
-        width: 258px;
-
-        pre {
-            background:#fafafa;
-            @include font-size(10, 13);
-            padding:2px 5px;
-            height:144px;
-            code {
-                background:#f8f8f8;
-            }
-        }
-        img {
-            display:block;
-            width:100%;
         }
     }
 

--- a/app/assets/stylesheets/prism-modifications.scss
+++ b/app/assets/stylesheets/prism-modifications.scss
@@ -35,7 +35,3 @@ pre.line-numbers {
         }
     }
 }
-
-pre[class*="language-"] {
-  border-radius: 0 !important;
-}


### PR DESCRIPTION
This builds on #567 to improve the way we render dark theme throughout the site. it DRYs up the code further and ensures that the dark-theme box fits neatly into the graphic.

Closes exercism/exercism#4690

<img width="624" alt="Screenshot 2019-10-22 at 17 59 22" src="https://user-images.githubusercontent.com/286476/67310493-c3c2d000-f4f5-11e9-904d-7266d3da5a33.png">
<img width="636" alt="Screenshot 2019-10-22 at 17 59 40" src="https://user-images.githubusercontent.com/286476/67310495-c3c2d000-f4f5-11e9-9ded-885937eb0601.png">
