### PR TITLE
Remove reference/link to likely fake Feynman quote

### DIFF
--- a/app/views/mentor/registrations/landing.html.haml
+++ b/app/views/mentor/registrations/landing.html.haml
@@ -42,9 +42,7 @@
       .pure-g
         .pure-u-1-1.pure-u-md-1-2
           %ul
-            %li
-              Teaching is a powerful route to mastery. It's how the
-              %a{href: "https://twitter.com/ProfFeynman/status/996382321916895232", target: "_blank"} smartest people learn
+            %li Teaching is a powerful route to mastery.
             %li Mentoring is a great way to give back to the community that has nurtured you
             %li You can share your passion for your language with people who actively want to learn about it
         .pure-u-1-1.pure-u-md-1-2


### PR DESCRIPTION
Even though i find this quote very inspiring, and even though Feynman could have said it, searching for this quote leads to Yogi Bhajan [here](https://kundaliniresearchinstitute.org/teacher-training/) and [there](https://en.wikiquote.org/wiki/Talk:Harbhajan_Singh_Yogi). I'm not sure this is a reference you'd like to see on your website, so i just removed it. Maybe if you want to have this beautiful sentence written down, you could quote it as a Hindu proverb or something.

Sorry for being fussy about this, i was reading the `Become a mentor` page and i'm quite excited about it, then i clicked on this link and it just felt wrong.