### PR TITLE
Fixes a typo in the Unpause Track modal

### DIFF
--- a/app/views/my/tracks/_paused_modal.html.haml
+++ b/app/views/my/tracks/_paused_modal.html.haml
@@ -1,7 +1,7 @@
 =hex_green_track_icon(@track)
 .main-section
   %h2 Unpause the #{@track.title} Track
-  %p This track is currently paused. If you would like to continue this track and view your solutuions, please unpause the track.
+  %p This track is currently paused. If you would like to continue this track and view your solutions, please unpause the track.
   .buttons
     = link_to "Unpause the #{@track.title} Track", unpause_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
     = link_to "Cancel", tracks_path, class: "pure-button cancel-button"


### PR DESCRIPTION
Just another skirmish in the ceaseless war against the [👹 typo demon](https://en.wikipedia.org/wiki/Titivillus)!