### PR TITLE
omit current page from "More $LANGUAGE Resources"

### DIFF
--- a/app/views/track_pages/_links.html.haml
+++ b/app/views/track_pages/_links.html.haml
@@ -1,8 +1,9 @@
 -target ||= ""
 %ul.track-page-links
   -Git::ExercismRepo.pages.each do |page|
-    -if track.repo.send("#{page}_present?")
-      %li= link_to title_for_track_page(track, page), send("track_#{page}_page_path", track), target: target
+    -link_path = send("track_#{page}_page_path", track)
+    -if track.repo.send("#{page}_present?") && !current_page?(link_path)
+      %li= link_to title_for_track_page(track, page), link_path, target: target
 
   /%li= link_to "Getting help", "#"
   %li= link_to "Remind me how to set up the CLI", cli_walkthrough_page_path


### PR DESCRIPTION
This fixes issue #993 from the website-copy repo
(https://github.com/exercism/website-copy/issues/993), in which jj-plane
complained that the Installing Python page links back to itself.  That is not
limited to that link on that page, but _all_ the language-specific links in
that list on such pages in _all_ language tracks.

This solution _omits_ the current page's link out of the list.  Another
alternative would be to make it not a link (such as by using
`link_to_unless_current`). Even then, though, the list header stating "More
$LANGUAGE Resources" would still be misleading, as the item listed (whether
linked or not) would not be "More".