### PR TITLE
Download submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'omniauth-github'
 gem 'kaminari'
 gem 'friendly_id', github: 'norman/friendly_id', branch: 'master', ref: 'cdd5971f91c40e0c05e5afb498d2ec1b452ffb44'
 gem 'mandate'
+gem 'concurrent-ruby'
 
 gem 'haml-rails'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,6 +499,7 @@ DEPENDENCIES
   capybara (~> 3.0)
   chromedriver-helper
   commonmarker
+  concurrent-ruby
   daemons
   dalli
   delayed_job_active_record

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -11,4 +11,8 @@ class Submission < ApplicationRecord
   def broadcast!
     BroadcastSubmissionJob.perform_now(self)
   end
+
+  def files
+    SubmissionServices::DownloadFiles.(uuid, filenames)
+  end
 end

--- a/app/services/submission_services/download_files.rb
+++ b/app/services/submission_services/download_files.rb
@@ -1,0 +1,45 @@
+module SubmissionServices
+  class DownloadFiles
+    include Mandate
+    def initialize(submission_uuid, filenames)
+      @filenames = filenames
+      @files = Concurrent::Map.new
+      @path = "#{Rails.env}/storage/#{submission_uuid}"
+    end
+
+    def call
+      threads = []
+      filenames.each do |original_filename, stored_filename|
+        threads << Thread.new { download_file(original_filename, stored_filename) }
+      end
+      threads.each(&:join)
+
+      # Convert to a normal hash for the return.
+      # There's probably a nicer way to do this but
+      # RubyDoc is down for me so :shrug:
+      files.keys.zip(files.values).to_h
+    end
+
+    private
+    attr_reader :filenames, :files, :path
+
+    def download_file(original_filename, stored_filename)
+      resp = s3_client.get_object(bucket: submissions_bucket,
+                                  key: "#{path}/#{stored_filename}")
+      files[original_filename] = resp.body.read
+    end
+
+    memoize
+    def s3_client
+      @client ||= Aws::S3::Client.new(
+        access_key_id: Rails.application.secrets.aws_access_key_id,
+        secret_access_key: Rails.application.secrets.aws_secret_access_key,
+        region: Rails.application.secrets.aws_region
+      )
+    end
+
+    def submissions_bucket
+      Rails.application.secrets.aws_submissions_bucket
+    end
+  end
+end

--- a/app/services/submission_services/upload_to_s3_for_storage.rb
+++ b/app/services/submission_services/upload_to_s3_for_storage.rb
@@ -1,4 +1,3 @@
-# t = Time.now.to_f; UploadSubmissionToS3ForStorage.(submission, files); Time.now.to_f - t
 module SubmissionServices
   class UploadToS3ForStorage
     include Mandate

--- a/app/services/submission_services/upload_to_s3_for_storage.rb
+++ b/app/services/submission_services/upload_to_s3_for_storage.rb
@@ -11,9 +11,9 @@ module SubmissionServices
 
     def call
       threads = []
-      files.each { |filename, code|
+      files.each do |filename, code|
         threads << Thread.new { upload_file(filename, code) }
-      }
+      end
       threads.each(&:join)
     end
 

--- a/test/services/submission_services/create_test.rb
+++ b/test/services/submission_services/create_test.rb
@@ -3,29 +3,34 @@ require 'test_helper'
 module SubmissionServices
   class CreateTest < ActiveSupport::TestCase
     test "creates for submission user" do
+      uuid = SecureRandom.uuid
+      mapped_uuid1 = "uuid-1"
+      mapped_uuid2 = "uuid-2"
+
       solution = create :solution
       code = "foobar"
       filename1 = "foobar"
       filename2 = "barfoo"
       file_contents1 = "foobar123"
       file_contents2 = "barfoo123"
-      uuid = SecureRandom.uuid
 
       files = {filename1 => file_contents1, filename2 => file_contents2}
+      mapped_files = {mapped_uuid1 => file_contents1, mapped_uuid2 => file_contents2}
+
+      SecureRandom.expects(:uuid).twice.returns(mapped_uuid1, mapped_uuid2)
+      BroadcastSubmissionJob.expects(:perform_now).with do |submission|
+        assert_equal Submission, submission.class 
+      end
 
       UploadToS3ForTesting.expects(:call).with(uuid, solution, solution.track, files)
-      UploadToS3ForStorage.expects(:call).with(uuid, files)
+      UploadToS3ForStorage.expects(:call).with(uuid, mapped_files)
       RunTests.expects(:call).with(uuid, solution)
 
       Create.(uuid, solution, files)
 
       submission = Submission.find_by_uuid!(uuid)
       assert_equal submission.solution, solution
-      assert_equal [filename1, filename2], submission.filenames
-
-      #file = submission.files.first
-      #assert_equal filename1, file.filename.with_slashes
-      #assert_equal file_contents1, file.download
+      assert_equal({filename1 => mapped_uuid1, filename2 => mapped_uuid2}, submission.filenames)
     end
   end
 end

--- a/test/services/submission_services/download_files_test.rb
+++ b/test/services/submission_services/download_files_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require 'webmock/minitest'
+
+module SubmissionServices
+  class DownloadFilesTest < ActiveSupport::TestCase
+    test "uploads correct files" do
+      submission_uuid = SecureRandom.uuid
+
+      mapped_name_1 = SecureRandom.uuid
+      mapped_name_2 = SecureRandom.uuid
+
+      file_1_name = "original_file_1.rb"
+      file_2_name = "original_file_2.rb"
+
+      file_1_contents = "file 1 contents"
+      file_2_contents = "file 2 contents"
+
+      mapped_filenames = {
+        file_1_name => mapped_name_1,
+        file_2_name => mapped_name_2
+      }
+
+      bucket = mock
+      s3_client = mock
+      resp1 = mock
+      s3_client.expects(:get_object).with(
+        bucket: bucket,
+        key: "test/storage/#{submission_uuid}/#{mapped_name_1}",
+      ).returns(resp1)
+      resp1.expects(:body).returns(mock(read: file_1_contents))
+
+      resp2 = mock
+      s3_client.expects(:get_object).with(
+        bucket: bucket,
+        key: "test/storage/#{submission_uuid}/#{mapped_name_2}",
+      ).returns(resp2)
+      resp2.expects(:body).returns(mock(read: file_2_contents))
+
+      Aws::S3::Client.expects(:new).returns(s3_client)
+      s = DownloadFiles.new(submission_uuid, mapped_filenames)
+      s.stubs(submissions_bucket: bucket)
+
+      expected = {file_1_name => file_1_contents, file_2_name => file_2_contents}
+      assert_equal expected, s.()
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/internal-wip/issues/17

This does two things:
1) It stores the filenames as uuids for security, so we don't allow arbitary paths in our s3.
2) It downloads the files on demand in a multithreaded way.