### PR TITLE
Use language_track, not research_track, when submitting for test-running

### DIFF
--- a/app/controllers/research/base_controller.rb
+++ b/app/controllers/research/base_controller.rb
@@ -1,8 +1,10 @@
-class Research::BaseController < ApplicationController
-  before_action :authenticate_user!
-  before_action :check_user_joined_research!
+module Research
+  class BaseController < ApplicationController
+    before_action :authenticate_user!
+    before_action :check_user_joined_research!
 
-  def check_user_joined_research!
-    redirect_to research_join_path unless current_user.joined_research?
+    def check_user_joined_research!
+      redirect_to research_join_path unless current_user.joined_research?
+    end
   end
 end

--- a/app/controllers/research/experiment_solutions_controller.rb
+++ b/app/controllers/research/experiment_solutions_controller.rb
@@ -3,12 +3,12 @@ module Research
     def create
       experiment = Experiment.find(params[:experiment_id])
 
-      # TODO - Remove this placeholder
-      exercise = Exercise.find_by(slug: "two-fer", track: Track.find_by_slug("ruby"))
+      exercise_slug = "#{params[:language]}-#{params[:part]}-#{%w{a b}.sample}"
+      exercise = Exercise.find_by_slug!(exercise_slug)
 
-      # TODO - Check this is on the experiment track etc
-      #exercise_slug = "#{params[:language]}_#{%w{a b}.sample}_#{part}"
-      #exercise = Exercise.find_by_slug!(exercise_slug)
+      # Guard to ensure that someone doesn't try and access
+      # a non-research solution through this method.
+      raise "Incorrect exercise" unless exercise.track.research_track?
 
       solution = Research::CreateSolution.(
         current_user,

--- a/app/controllers/research/user_experiments_controller.rb
+++ b/app/controllers/research/user_experiments_controller.rb
@@ -17,7 +17,6 @@ module Research
       @language_track = Track.find_by_slug!(params[:language])
       @part1_solution = @user_experiment.language_part(@language_track.slug, 1)
       @part2_solution = @user_experiment.language_part(@language_track.slug, 2)
-
     end
 
     private

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -29,6 +29,13 @@ class Exercise < ApplicationRecord
     where.not(id: user.solutions.completed.select(:exercise_id))
   }
 
+  def language_track
+    return track unless track.research_track?
+
+    track_slug = Research::ExerciseSlug.deconstruct(slug)[:language]
+    Track.find_by_slug!(track_slug)
+  end
+
   def download_command(team: nil)
     cmd = "exercism download --exercise=#{slug} --track=#{track.slug}"
     cmd += " --team=#{team.slug}" if team

--- a/app/models/research/experiment.rb
+++ b/app/models/research/experiment.rb
@@ -1,8 +1,10 @@
-class Research::Experiment < ApplicationRecord
-  extend  FriendlyId
-  friendly_id :title, use: [:slugged, :history]
+module Research
+  class Experiment < ApplicationRecord
+    extend FriendlyId
+    friendly_id :title, use: [:slugged, :history]
 
-  def to_param
-    slug
+    def to_param
+      slug
+    end
   end
 end

--- a/app/models/research/experiment_solution.rb
+++ b/app/models/research/experiment_solution.rb
@@ -11,13 +11,9 @@ module Research
     # Don't pass query params language into this, only pass
     # things that have been pre-parsed via Track.find_by_slu
     scope :by_language_part, -> (language_slug:, part:) {
-
-      # Guard against unsafe parts.
-      return [] unless %w{a b}.include?(part)
-
       slug = Research::ExerciseSlug.construct(
         language: language_slug,
-        part: part,
+        part: part.to_i,
         exercise: "%"
       )
 
@@ -26,6 +22,10 @@ module Research
 
     def research_experiment_solution?
       true
+    end
+
+    def finished?
+      finished_at.present?
     end
 
     def language_slug

--- a/app/models/research/experiment_solution.rb
+++ b/app/models/research/experiment_solution.rb
@@ -1,33 +1,35 @@
-class Research::ExperimentSolution < ApplicationRecord
-  include SolutionBase
+module Research
+  class ExperimentSolution < ApplicationRecord
+    include SolutionBase
 
-  belongs_to :user
-  belongs_to :exercise
-  belongs_to :experiment
+    belongs_to :user
+    belongs_to :exercise
+    belongs_to :experiment
 
-  has_many :submissions, as: :solution
+    has_many :submissions, as: :solution
 
-  # Don't pass query params language into this, only pass
-  # things that have been pre-parsed via Track.find_by_slu
-  scope :by_language_part, -> (language_slug:, part:) {
+    # Don't pass query params language into this, only pass
+    # things that have been pre-parsed via Track.find_by_slu
+    scope :by_language_part, -> (language_slug:, part:) {
 
-    # Guard against unsafe parts.
-    return [] unless %w{a b}.include?(part)
+      # Guard against unsafe parts.
+      return [] unless %w{a b}.include?(part)
 
-    slug = Research::ExerciseSlug.construct(
-      language: language_slug,
-      part: part,
-      exercise: "%"
-    )
+      slug = Research::ExerciseSlug.construct(
+        language: language_slug,
+        part: part,
+        exercise: "%"
+      )
 
-    joins(:exercise).where("exercises.slug LIKE ?", slug)
-  }
+      joins(:exercise).where("exercises.slug LIKE ?", slug)
+    }
 
-  def research_experiment_solution?
-    true
-  end
+    def research_experiment_solution?
+      true
+    end
 
-  def language_slug
-    Research::ExerciseSlug.deconstruct(exercise.slug)[:language]
+    def language_slug
+      Research::ExerciseSlug.deconstruct(exercise.slug)[:language]
+    end
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -42,6 +42,10 @@ class Track < ApplicationRecord
     Git::ExercismRepo.new(repo_url)
   end
 
+  def research_track?
+    slug.starts_with?("research")
+  end
+
   def accepting_new_students?
     median_wait_time &&
     median_wait_time < 1.week

--- a/app/services/submission_services/run_tests.rb
+++ b/app/services/submission_services/run_tests.rb
@@ -6,7 +6,7 @@ module SubmissionServices
 
     def call
       RestClient.post "#{orchestrator_url}/submissions", {
-        track_slug: solution.exercise.track.slug,
+        track_slug: solution.exercise.language_track.slug,
         exercise_slug: solution.exercise.slug,
         submission_uuid: uuid
       }

--- a/app/views/research/user_experiments/_language_part.html.haml
+++ b/app/views/research/user_experiments/_language_part.html.haml
@@ -1,8 +1,7 @@
 -if solution
-  -if solution.submitted?
+  -if solution.finished?
     Done
   -else
-    =button_to "Continue Part #{part}", research_experiment_solution(solution), class: 'pure-b Iutton'
+    =link_to "Continue Part #{part}", research_experiment_solution_path(solution), class: 'pure-button'
 -else
-  / TODO - This won't work until we're using current slugs
   =button_to "Start Part #{part}", research_experiment_solutions_path(experiment_id: @experiment.id, language: @language_track.slug, part: part), method: :post, form_class: 'pure-button'

--- a/app/views/research/user_experiments/language.html.haml
+++ b/app/views/research/user_experiments/language.html.haml
@@ -13,7 +13,7 @@
         %p In part 1 you will lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
         =render "language_part", part: 1, solution: @part1_solution, enabled: true
 
-      -part2_enabled = @part1_solution.try(&:submitted?)
+      -part2_enabled = @part1_solution.try(&:finished?)
       .part-2.part{class: part2_enabled ? "" : "disabled"}
         %h2 #{@language_track.title}: Part 2
         %p In part 2 you will lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -54,4 +54,15 @@ class ExerciseTest < ActiveSupport::TestCase
     expected = "exercism download --exercise=#{exercise.slug} --track=#{exercise.track.slug} --team=#{team.slug}"
     assert_equal expected, exercise.download_command(team: team)
   end
+
+  test "language_track" do
+    ruby_track = create :track, slug: "ruby"
+    javascript_track = create :track, slug: "javascript"
+    research_track = create :track, slug: "research_123"
+
+    assert_equal ruby_track, create(:exercise, track: ruby_track).language_track
+    assert_equal javascript_track, create(:exercise, track: javascript_track).language_track
+    assert_equal ruby_track, create(:exercise, track: research_track, slug: "ruby-1-a").language_track
+    assert_equal javascript_track, create(:exercise, track: research_track, slug: "javascript-1-a").language_track
+  end
 end

--- a/test/models/research/experiment_solution_test.rb
+++ b/test/models/research/experiment_solution_test.rb
@@ -3,23 +3,23 @@ require 'test_helper'
 module Research
   class ExperimentSolutionTest < ActiveSupport::TestCase
     test "the truth" do
-      ruby_a_1 = create :exercise, slug: "ruby-a-1"
-      ruby_a_2 = create :exercise, slug: "ruby-a-2"
-      ruby_b_1 = create :exercise, slug: "ruby-b-1"
-      ruby_b_2 = create :exercise, slug: "ruby-b-2"
-      common_lisp_1_a = create :exercise, slug: "common-lisp-a-1"
-      csharp_a_1 = create :exercise, slug: "csharp-a-1"
+      ruby_1_a = create :exercise, slug: "ruby-1-a"
+      ruby_1_b = create :exercise, slug: "ruby-1-b"
+      ruby_2_a = create :exercise, slug: "ruby-2-a"
+      ruby_2_b = create :exercise, slug: "ruby-2-b"
+      common_lisp_1_a = create :exercise, slug: "common-lisp-1-a"
+      csharp_1_a = create :exercise, slug: "csharp-1-a"
 
-      s_ruby_a_1 = create :research_experiment_solution, exercise: ruby_a_1
-      s_ruby_a_2 = create :research_experiment_solution, exercise: ruby_a_2
-      s_ruby_b_1 = create :research_experiment_solution, exercise: ruby_b_1
-      s_ruby_b_2 = create :research_experiment_solution, exercise: ruby_b_2
+      s_ruby_1_a = create :research_experiment_solution, exercise: ruby_1_a
+      s_ruby_1_b = create :research_experiment_solution, exercise: ruby_1_b
+      s_ruby_2_a = create :research_experiment_solution, exercise: ruby_2_a
+      s_ruby_2_b = create :research_experiment_solution, exercise: ruby_2_b
       s_common_lisp_1_a = create :research_experiment_solution, exercise: common_lisp_1_a
-      s_csharp_a_1 = create :research_experiment_solution, exercise: csharp_a_1
+      s_csharp_1_a = create :research_experiment_solution, exercise: csharp_1_a
 
-      assert_equal [s_ruby_a_1, s_ruby_a_2].map(&:id), Research::ExperimentSolution.by_language_part(language_slug: :ruby, part: 'a').map(&:id)
-      assert_equal [s_csharp_a_1], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'a')
-      assert_equal [], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'b')
+      assert_equal [s_ruby_1_a, s_ruby_1_b].map(&:id), Research::ExperimentSolution.by_language_part(language_slug: :ruby, part: 1).map(&:id)
+      assert_equal [s_csharp_1_a], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 1)
+      assert_equal [], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 2)
     end
 
     test "solution pivots" do

--- a/test/models/research/experiment_solution_test.rb
+++ b/test/models/research/experiment_solution_test.rb
@@ -1,37 +1,39 @@
 require 'test_helper'
 
-class Research::ExperimentSolutionTest < ActiveSupport::TestCase
-  test "the truth" do
-    ruby_a_1 = create :exercise, slug: "ruby-a-1"
-    ruby_a_2 = create :exercise, slug: "ruby-a-2"
-    ruby_b_1 = create :exercise, slug: "ruby-b-1"
-    ruby_b_2 = create :exercise, slug: "ruby-b-2"
-    common_lisp_1_a = create :exercise, slug: "common-lisp-a-1"
-    csharp_a_1 = create :exercise, slug: "csharp-a-1"
+module Research
+  class ExperimentSolutionTest < ActiveSupport::TestCase
+    test "the truth" do
+      ruby_a_1 = create :exercise, slug: "ruby-a-1"
+      ruby_a_2 = create :exercise, slug: "ruby-a-2"
+      ruby_b_1 = create :exercise, slug: "ruby-b-1"
+      ruby_b_2 = create :exercise, slug: "ruby-b-2"
+      common_lisp_1_a = create :exercise, slug: "common-lisp-a-1"
+      csharp_a_1 = create :exercise, slug: "csharp-a-1"
 
-    s_ruby_a_1 = create :research_experiment_solution, exercise: ruby_a_1
-    s_ruby_a_2 = create :research_experiment_solution, exercise: ruby_a_2
-    s_ruby_b_1 = create :research_experiment_solution, exercise: ruby_b_1
-    s_ruby_b_2 = create :research_experiment_solution, exercise: ruby_b_2
-    s_common_lisp_1_a = create :research_experiment_solution, exercise: common_lisp_1_a
-    s_csharp_a_1 = create :research_experiment_solution, exercise: csharp_a_1
+      s_ruby_a_1 = create :research_experiment_solution, exercise: ruby_a_1
+      s_ruby_a_2 = create :research_experiment_solution, exercise: ruby_a_2
+      s_ruby_b_1 = create :research_experiment_solution, exercise: ruby_b_1
+      s_ruby_b_2 = create :research_experiment_solution, exercise: ruby_b_2
+      s_common_lisp_1_a = create :research_experiment_solution, exercise: common_lisp_1_a
+      s_csharp_a_1 = create :research_experiment_solution, exercise: csharp_a_1
 
-    assert_equal [s_ruby_a_1, s_ruby_a_2].map(&:id), Research::ExperimentSolution.by_language_part(language_slug: :ruby, part: 'a').map(&:id)
-    assert_equal [s_csharp_a_1], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'a')
-    assert_equal [], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'b')
-  end
+      assert_equal [s_ruby_a_1, s_ruby_a_2].map(&:id), Research::ExperimentSolution.by_language_part(language_slug: :ruby, part: 'a').map(&:id)
+      assert_equal [s_csharp_a_1], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'a')
+      assert_equal [], Research::ExperimentSolution.by_language_part(language_slug: :csharp, part: 'b')
+    end
 
-  test "solution pivots" do
-    solution = create :research_experiment_solution
-    assert solution.research_experiment_solution?
-    refute solution.team_solution?
-    refute solution.use_auto_analysis?
-  end
+    test "solution pivots" do
+      solution = create :research_experiment_solution
+      assert solution.research_experiment_solution?
+      refute solution.team_solution?
+      refute solution.use_auto_analysis?
+    end
 
-  test "language_slug" do
-    ruby_solution = create(:research_experiment_solution, exercise: create(:exercise, slug: "ruby-b-2"))
-    lisp_solution = create(:research_experiment_solution, exercise: create(:exercise, slug: "common-lisp-a-1"))
-    assert_equal :ruby, ruby_solution.language_slug
-    assert_equal :"common-lisp", lisp_solution.language_slug
+    test "language_slug" do
+      ruby_solution = create(:research_experiment_solution, exercise: create(:exercise, slug: "ruby-b-2"))
+      lisp_solution = create(:research_experiment_solution, exercise: create(:exercise, slug: "common-lisp-a-1"))
+      assert_equal :ruby, ruby_solution.language_slug
+      assert_equal :"common-lisp", lisp_solution.language_slug
+    end
   end
 end

--- a/test/models/research/experiment_test.rb
+++ b/test/models/research/experiment_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class Research::ExperimentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/research/user_experiment_test.rb
+++ b/test/models/research/user_experiment_test.rb
@@ -1,26 +1,28 @@
 require 'test_helper'
 
-class Research::UserExperimentTest < ActiveSupport::TestCase
-  test "solutions and lang_started" do
-    user = create :user
-    experiment = create :research_experiment
-    user_experiment = create :research_user_experiment, experiment: experiment, user: user
+module Research
+  class UserExperimentTest < ActiveSupport::TestCase
+    test "solutions and lang_started" do
+      user = create :user
+      experiment = create :research_experiment
+      user_experiment = create :research_user_experiment, experiment: experiment, user: user
 
-    ruby_exercise_1 = create :exercise, slug: "ruby-a-1"
-    ruby_exercise_2 = create :exercise, slug: "ruby-a-2"
-    common_lisp_exercise = create :exercise, slug: "common-lisp-a-1"
-    csharp_exercise = create :exercise, slug: "csharp-a-1"
+      ruby_exercise_1 = create :exercise, slug: "ruby-a-1"
+      ruby_exercise_2 = create :exercise, slug: "ruby-a-2"
+      common_lisp_exercise = create :exercise, slug: "common-lisp-a-1"
+      csharp_exercise = create :exercise, slug: "csharp-a-1"
 
-    solution1 = create :research_experiment_solution, user: user, experiment: experiment, exercise: ruby_exercise_1
-    solution2 = create :research_experiment_solution, user: user, experiment: experiment, exercise: ruby_exercise_2
-    solution3 = create :research_experiment_solution, user: user, experiment: experiment, exercise: common_lisp_exercise
+      solution1 = create :research_experiment_solution, user: user, experiment: experiment, exercise: ruby_exercise_1
+      solution2 = create :research_experiment_solution, user: user, experiment: experiment, exercise: ruby_exercise_2
+      solution3 = create :research_experiment_solution, user: user, experiment: experiment, exercise: common_lisp_exercise
 
-    assert_equal [solution1, solution2, solution3], user_experiment.solutions
-    assert_equal [:ruby, :'common-lisp'], user_experiment.languages_started
-    assert user_experiment.language_started?(:ruby)
-    assert user_experiment.language_started?("ruby")
-    assert user_experiment.language_started?(:'common-lisp')
-    refute user_experiment.language_started?(:csharp)
-    refute user_experiment.language_started?(:prolog)
+      assert_equal [solution1, solution2, solution3], user_experiment.solutions
+      assert_equal [:ruby, :'common-lisp'], user_experiment.languages_started
+      assert user_experiment.language_started?(:ruby)
+      assert user_experiment.language_started?("ruby")
+      assert user_experiment.language_started?(:'common-lisp')
+      refute user_experiment.language_started?(:csharp)
+      refute user_experiment.language_started?(:prolog)
+    end
   end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -15,4 +15,9 @@ class TrackTest < ActiveSupport::TestCase
     track.median_wait_time = 604801
     refute track.accepting_new_students?
   end
+
+  test "research_track?" do
+    refute create(:track, slug: "ruby").research_track?
+    assert create(:track, slug: "research_123").research_track?
+  end
 end

--- a/test/services/submission_services/run_tests_test.rb
+++ b/test/services/submission_services/run_tests_test.rb
@@ -12,5 +12,20 @@ module SubmissionServices
       )
       RunTests.(submission.uuid, submission.solution)
     end
+
+    test "uses language_track" do
+      research_track = create :track, slug: "research_123"
+      ruby_track = create :track, slug: "ruby"
+      exercise = create :exercise, track: research_track, slug: "ruby-1-b"
+
+      submission = create :submission, solution: create(:research_experiment_solution, exercise: exercise)
+
+      RestClient.expects(:post).with('http://test-runner.example.com/submissions',
+        track_slug: ruby_track.slug,
+        exercise_slug: exercise.slug,
+        submission_uuid: submission.uuid
+      )
+      RunTests.(submission.uuid, submission.solution)
+    end
   end
 end

--- a/test/system/research/user_logs_in_to_join_test.rb
+++ b/test/system/research/user_logs_in_to_join_test.rb
@@ -3,7 +3,6 @@ require_relative "./test_case"
 module Research
   class UserLogsInToJoinTest < TestCase
     test "user logs in" do
-      skip
       user = create(:user,
                     :onboarded,
                     email: "test@example.com",

--- a/test/system/research/user_signs_up_to_join_test.rb
+++ b/test/system/research/user_signs_up_to_join_test.rb
@@ -5,7 +5,6 @@ module Research
     include ActiveJob::TestHelper
 
     test "user signs up" do
-      skip
       perform_enqueued_jobs do
         visit new_user_registration_path
         sign_up
@@ -13,7 +12,7 @@ module Research
         log_in
         onboard
 
-        assert_text "Current Research"
+        assert_text "Experiments"
       end
     end
 

--- a/test/system/research/user_signs_up_to_join_test.rb
+++ b/test/system/research/user_signs_up_to_join_test.rb
@@ -5,6 +5,7 @@ module Research
     include ActiveJob::TestHelper
 
     test "user signs up" do
+      skip
       perform_enqueued_jobs do
         visit new_user_registration_path
         sign_up


### PR DESCRIPTION
When we pass the track slug to the test runners we should use the language track slug (e.g. `csharp`) not the "fake" research tracks where the research exercises actually live.

Note: The extraction of `Research` into modules was done because ruby defined `Research` as a class if it came across it in the context of `class Research::Foo` before `module Research`