### PR TITLE
Fixes median wait times

### DIFF
--- a/app/services/track_services/update_median_wait_time.rb
+++ b/app/services/track_services/update_median_wait_time.rb
@@ -3,59 +3,11 @@ module TrackServices
     include Mandate
 
     def call
-      ActiveRecord::Base.connection.execute(
-        <<~SQL
-          UPDATE `tracks`
-          INNER JOIN (#{track_wait_times.to_sql}) wait_times
-          ON wait_times.track_id = tracks.id
-          SET tracks.median_wait_time = wait_times.median_wait_time
-        SQL
-      )
-    end
-
-    private
-
-    def track_wait_times
-      Track.
-        select("track_id, AVG(wait_time) as median_wait_time").
-        from(mentored_solutions_grouped_by_track).
-        where("group_position BETWEEN group_total_count / 2.0 AND (group_total_count / 2.0 + 1)").
-        group(:track_id)
-    end
-
-    def mentored_solutions_grouped_by_track
-      Solution.
-        select(
-          <<~SQL
-            mentored_solutions.track_id,
-            wait_time,
-            @group_position := CASE
-              WHEN @current_group = mentored_solutions.track_id THEN @group_position + 1
-              ELSE (@current_group := mentored_solutions.track_id) AND 1
-            END AS group_position,
-            group_total_count
-          SQL
-        ).
-        from(
-          <<~SQL
-            (SELECT @group_position := 0, @current_group := 0) s,
-            (#{mentored_solutions.to_sql}) mentored_solutions
-          SQL
-        ).
-        joins(
-          <<~SQL
-            INNER JOIN (#{mentored_solutions_count.to_sql}) mentored_solutions_count
-            ON mentored_solutions_count.track_id = mentored_solutions.track_id
-          SQL
-        ).
-        order("mentored_solutions.track_id, mentored_solutions.wait_time")
-    end
-
-    def mentored_solutions_count
-      Solution.
-        select("track_id, COUNT(*) as group_total_count").
-        from(mentored_solutions).
-        group(:track_id)
+      mentored_solutions.group_by(&:track_id).each do |track_id, solutions|
+        Track.where(id: track_id).update(
+          median_wait_time: calculate_median(solutions.map(&:wait_time))
+        )
+      end
     end
 
     def mentored_solutions
@@ -65,6 +17,12 @@ module TrackServices
         joins(:exercise).
         merge(Exercise.core).
         having("first_mentored_at >= ?", 4.weeks.ago)
+    end
+
+    def calculate_median(vals)
+      vals.sort!
+      len = vals.length
+      median = (vals[(len - 1) / 2] + vals[len / 2]) / 2.0
     end
   end
 end

--- a/app/services/track_services/update_median_wait_time.rb
+++ b/app/services/track_services/update_median_wait_time.rb
@@ -3,11 +3,14 @@ module TrackServices
     include Mandate
 
     def call
+      unprocessed_ids = Track.pluck(:id)
       mentored_solutions.group_by(&:track_id).each do |track_id, solutions|
-        Track.where(id: track_id).update(
+        Track.where(id: track_id).update_all(
           median_wait_time: calculate_median(solutions.map(&:wait_time))
         )
+        unprocessed_ids.delete(track_id)
       end
+      Track.where(id: unprocessed_ids).update_all(median_wait_time: nil)
     end
 
     def mentored_solutions

--- a/test/services/track_services/update_median_wait_time_test.rb
+++ b/test/services/track_services/update_median_wait_time_test.rb
@@ -13,13 +13,17 @@ module TrackServices
       create_solution_with_wait_time(wait_time: 3.days, track: track2)
       create_solution_with_wait_time(wait_time: 4.days, track: track2)
       create_solution_with_wait_time(wait_time: 5.days, track: track2)
+      track3 = create(:track, median_wait_time: 100)
 
       TrackServices::UpdateMedianWaitTime.()
 
       track1.reload
-      assert_equal 3.days, track1.median_wait_time
+      assert_equal 3.days, track1.reload.median_wait_time
       track2.reload
-      assert_equal 3.5.days, track2.median_wait_time
+      assert_equal 3.5.days, track2.reload.median_wait_time
+
+      # sets median wait time to nil if there are no solutions
+      assert_nil track3.reload.median_wait_time
     end
 
     private


### PR DESCRIPTION
@kntsoriano There was a bug in the median wait time calculations. I've refactored by removing a load of the SQL and just calculating the medians in Ruby. It simplifies the code and fixes the bug.

Annoyingly, I don't know what caused the bug and can't get a failing test for it, but it was very much wrong in production. 

I'm self-merging/deploying this as it has the side effect of marking the wrong tracks as oversubscribed.

---

Update: I've also added another commit to reset the wait time if there are no solutions that match.