### PR TITLE
Improve logic around accepting solutions

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -51,10 +51,11 @@ class Track < ApplicationRecord
   end
 
   def accepting_new_students?
-    # Some exceptions
-    return true if %w{mips delphi}.include?(slug)
+    # Always return true if there are < 10 solutions in the queue
+    return true if SolutionsToBeMentored.new(nil, [id], []).mentored_core_solutions.count < 10
 
-    # Then check we have a median time and it's reasonable
+    # If we have a median time then use it as the guage
+    # If there's a queue and we're over the median then the track is out of order
     median_wait_time && median_wait_time < 1.week
   end
 end

--- a/app/services/solutions_to_be_mentored.rb
+++ b/app/services/solutions_to_be_mentored.rb
@@ -78,6 +78,8 @@ class SolutionsToBeMentored
   end
 
   def base_user_query
+    return base_query unless user
+
     base_query.
 
       # Not things you already mentor

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -2,17 +2,26 @@ require 'test_helper'
 
 class TrackTest < ActiveSupport::TestCase
   test "accepting_new_students?" do
-    track = build :track
+    create_solution = ->(track) do
+      s = create :solution,
+        user: create(:user, current_sign_in_at: Time.now),
+        exercise: create(:exercise, track: track, core: true),
+        mentoring_requested_at: Time.now - 1.week
+      create :iteration, solution: s
+    end
 
-    track.median_wait_time = nil
-    refute track.accepting_new_students?
+    # If a track has <10 solutions, always return true
+    track = create :track, median_wait_time: 2.years
+    9.times { create_solution.call(track) }
 
     # Under 1 week
-    track.median_wait_time = 604799
+    track = create :track, median_wait_time: 604799
+    10.times { create_solution.call(track) }
     assert track.accepting_new_students?
 
     # Over 1 week
-    track.median_wait_time = 604801
+    track = create :track, median_wait_time: 604801
+    10.times { create_solution.call(track) }
     refute track.accepting_new_students?
   end
 


### PR DESCRIPTION
We now use median wait time, or if its not set (no solutions recently mentored) then we use the volume of solutions in the queue as the gauge.