### PR TITLE
Change message to distinguish errors from output

### DIFF
--- a/app/views/research/submission_test_runs/_error.html.haml
+++ b/app/views/research/submission_test_runs/_error.html.haml
@@ -1,4 +1,4 @@
-%p We got the following message when we ran your code:
+%p We got the following error message when we ran your code:
 
 %pre
   %code= test_run.message


### PR DESCRIPTION
Currently the UI says "We got the following message when we ran your code:" and it looks like general output.

However, this code path is only exercised when the test-runner explicitly errored, so we should indicate this.

@iHiD - this was what we saw yesterday when I though the Rust runner wasn't writing the output file, actually it was, it was just writing it with an error message rather than test-output, but it wasn't obvious (to me, anyway) that it was an error.

e.g. 
<img width="541" alt="Screenshot 2020-01-15 at 14 36 46" src="https://user-images.githubusercontent.com/441154/72442521-960fbf00-37a4-11ea-830e-d30eb378ae71.png">
