### PR TITLE
Format ANSI terminal output to HTML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'webpacker', '~> 4.0'
 
 gem 'redis'
 
+gem 'ansi-to-html', require: false
+
 group :production do
   #gem "skylight"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    ansi-to-html (0.0.3)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     ast (2.4.0)
@@ -487,6 +488,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ansi-to-html
   aws-sdk-ecr
   aws-sdk-s3
   bootsnap (>= 1.1.0)
@@ -552,4 +554,4 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/assets/stylesheets/research/experiment-solution-page.scss
+++ b/app/assets/stylesheets/research/experiment-solution-page.scss
@@ -123,10 +123,15 @@ body.namespace-research {
     }
 
     .test-run {
-      pre {
-        padding: 20px;
-        background: #eee;
-      }
+        pre {
+            padding: 20px;
+            background: #eee;
+        }
+
+        .test-output {
+            background: black;
+            color: white;
+        }
     }
 
     .passed-test {

--- a/app/models/submission_test_run_result.rb
+++ b/app/models/submission_test_run_result.rb
@@ -6,7 +6,11 @@ class SubmissionTestRunResult
     @name = params["name"]
     @status = params["status"]
     @message = params["message"]
-    @output = params["output"]
+    @output = TerminalOutput.new(params["output"])
+  end
+
+  def output_html
+    output.to_html
   end
 
   def failed?

--- a/app/models/terminal_output.rb
+++ b/app/models/terminal_output.rb
@@ -1,0 +1,14 @@
+require "ansi-to-html"
+
+class TerminalOutput
+  def initialize(output)
+    @output = output
+  end
+
+  def to_html
+    Ansi::To::Html.new(output).to_html
+  end
+
+  private
+  attr_reader :output
+end

--- a/app/views/research/submission_test_run_results/_fail.html.haml
+++ b/app/views/research/submission_test_run_results/_fail.html.haml
@@ -17,5 +17,5 @@
 - if test.output.present?
   %p Test output:
 
-  %pre
-    %code= test.output
+  %pre.test-output
+    %code= raw test.output_html


### PR DESCRIPTION
Closes https://github.com/exercism/internal-wip/issues/42.

## Description
Here is a first pass for formatting ansi terminal output to HTML. I haven't set a color palette, yet, but it is possible.

## Screenshot
<img width="677" alt="Screen Shot 2020-01-16 at 7 53 42 PM" src="https://user-images.githubusercontent.com/1901520/72523254-604d0200-389a-11ea-8930-dfaf44e181a0.png">
