### PR TITLE
Fix terminal breaking with nil string

### DIFF
--- a/app/models/terminal_output.rb
+++ b/app/models/terminal_output.rb
@@ -6,6 +6,7 @@ class TerminalOutput
   end
 
   def to_html
+    return nil unless output
     Ansi::To::Html.new(output).to_html
   end
 

--- a/test/models/terminal_output_test.rb
+++ b/test/models/terminal_output_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class TerminalOutputTest < ActiveSupport::TestCase
+  test "to_html parses normal text" do
+    assert_equal "ran@xub", TerminalOutput.new("ran@xub").to_html
+  end
+
+  test "to_html copes with nil" do
+    assert_nil TerminalOutput.new(nil).to_html
+  end
+end
+
+

--- a/test/models/terminal_output_test.rb
+++ b/test/models/terminal_output_test.rb
@@ -5,6 +5,13 @@ class TerminalOutputTest < ActiveSupport::TestCase
     assert_equal "ran@xub", TerminalOutput.new("ran@xub").to_html
   end
 
+<<<<<<< Updated upstream
+=======
+  test "to_html parses ansi" do
+    assert_equal "<span style='color:#A00;'>Hello</span><span style='color:#00A;'>World</span>", TerminalOutput.new("\e[31mHello\e[0m\e[34mWorld\e[0").to_html
+  end
+
+>>>>>>> Stashed changes
   test "to_html copes with nil" do
     assert_nil TerminalOutput.new(nil).to_html
   end


### PR DESCRIPTION
@kntsoriano It would be worth adding a unit test here that checks that it actually converts ANSI to HTML correctly.