### PR TITLE
Clear ace editor selection when setting its value

### DIFF
--- a/app/javascript/src/ace-editor.js
+++ b/app/javascript/src/ace-editor.js
@@ -75,7 +75,7 @@ class AceEditor {
   }
 
   setValue(value) {
-    this.editor.setValue(value);
+    this.editor.setValue(value, -1);
   }
 
   _setup() {


### PR DESCRIPTION
Closes https://github.com/exercism/research_experiment_1/issues/116.

When you call `setValue` on Ace Editor, it automatically selects all the text in the editor. This PR clears the selection whenever that value is set on the editor.

Reference: https://stackoverflow.com/questions/18614169/set-value-for-ace-editor-without-selecting-the-whole-editor