### PR TITLE
Guard submitting a solution when tests haven't passed

### DIFF
--- a/app/models/research/experiment_solution.rb
+++ b/app/models/research/experiment_solution.rb
@@ -1,5 +1,8 @@
 module Research
   class ExperimentSolution < ApplicationRecord
+    class NotAllowedToSubmitError < StandardError
+    end
+
     include SolutionBase
 
     belongs_to :user
@@ -56,6 +59,8 @@ module Research
     end
 
     def submit!(time: Time.current)
+      raise NotAllowedToSubmitError unless submissions.last.pass?
+
       update!(finished_at: time)
     end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -3,6 +3,7 @@ class Submission < ApplicationRecord
   has_one :test_run, class_name: "SubmissionTestRun"
 
   delegate :tests_info, to: :solution
+  delegate :pass?, to: :test_run
 
   scope :tested, -> { where(tested: true) }
   scope :successfully_tested, -> {

--- a/test/models/research/experiment_solution_test.rb
+++ b/test/models/research/experiment_solution_test.rb
@@ -50,5 +50,28 @@ module Research
 
       assert_equal({ "subdir/ruby_1_a.rb" => "TODO\n" }, solution.latest_files)
     end
+
+    test "#submit! records submission time" do
+      solution = build(:research_experiment_solution)
+      submission = build(:submission)
+      submission.stubs(:pass?).returns(true)
+      solution.submissions = [submission]
+
+      solution.submit!(time: Date.new(2016, 12, 25))
+
+      solution.reload
+      assert_equal Date.new(2016, 12, 25), solution.finished_at
+    end
+
+    test "#submit! raises an error when last submission hasn't passed" do
+      solution = build(:research_experiment_solution)
+      submission = build(:submission)
+      submission.stubs(:pass?).returns(false)
+      solution.submissions = [submission]
+
+      assert_raises ExperimentSolution::NotAllowedToSubmitError do
+        solution.submit!
+      end
+    end
   end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class SubmissionTest < ActiveSupport::TestCase
+  test "#pass? delegates to test run" do
+    submission = build(:submission)
+    test_run = build(:submission_test_run)
+    test_run.stubs(:pass?).returns(true)
+    submission.test_run = test_run
+
+    assert submission.pass?
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/internal-wip/issues/26.