### PR TITLE
Add message when user doesn't have a browser with websockets

### DIFF
--- a/app/assets/stylesheets/research/websocket-compatibility-message.scss
+++ b/app/assets/stylesheets/research/websocket-compatibility-message.scss
@@ -1,0 +1,20 @@
+@import 'variables';
+
+body.namespace-research {
+    .websocket-compatibility-message {
+      background-color: white;
+      padding: 30px;
+      color: #333;
+      width: 500px;
+
+      > h1 {
+          font-size: 22px;
+          margin-bottom: 20px;
+          font-weight: $fw-bold;
+      }
+
+      > p {
+          margin-bottom: 0;
+      }
+    }
+}

--- a/app/javascript/src/experiment-solution.js
+++ b/app/javascript/src/experiment-solution.js
@@ -6,6 +6,7 @@ import InfoPanel from './info_panel';
 import SubmitButton from './submit_button';
 import Submission from './submission';
 import PageThemeSelect from './page_theme_select';
+import WebsocketsCompatibilityMessage from './websockets_compatibility_message';
 
 class ExperimentSolution {
   constructor(element) {
@@ -16,6 +17,7 @@ class ExperimentSolution {
   }
 
   _setup() {
+    this._checkWebsocketsCompatibility();
     this._setupSubmitButton();
     this._setupShortcuts();
     this._setupInfoPanel();
@@ -24,6 +26,13 @@ class ExperimentSolution {
     this._setupThemeSelector();
     this._setupChannel();
     this._setupSplit();
+  }
+
+  _checkWebsocketsCompatibility() {
+    if(!('WebSocket' in window) && !('MozWebSocket' in window)) {
+      const modal = new WebsocketsCompatibilityMessage();
+      modal.render();
+    }
   }
 
   _setupSubmitButton() {

--- a/app/javascript/src/websockets_compatibility_message.js
+++ b/app/javascript/src/websockets_compatibility_message.js
@@ -1,0 +1,17 @@
+class WebsocketsCompatibilityMessage {
+  render() {
+    this.container = $(`
+      <div class="overlay">
+        <div class="websocket-compatibility-message">
+          <h1>Incompatible browser</h1>
+          <p>
+            In order to participate in this experiment, you must use a browser
+            that supports WebSockets.
+          </p>
+        </div>
+      </div>
+    `).appendTo('body');
+  }
+}
+
+export default WebsocketsCompatibilityMessage;


### PR DESCRIPTION
Closes https://github.com/exercism/internal-wip/issues/22.

As previously discussed, as a temporary solution, we just inform the user that they need to use websockets when doing the research experiment. I think we should change the copy on this modal to be better, but can't think of anything right now.

## Screenshots
<img width="1440" alt="Screen Shot 2020-02-26 at 4 41 34 PM" src="https://user-images.githubusercontent.com/1901520/75327326-2c142a80-58b7-11ea-95f7-2fc1e7106b03.png">
