### PR TITLE
Update octokit to fix deprecation errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.1)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     flipper (0.17.1)
@@ -294,7 +294,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    octokit (4.14.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
@@ -319,7 +320,7 @@ GEM
     propono (2.2.0)
       aws-sdk-sns
       aws-sdk-sqs
-    public_suffix (4.0.1)
+    public_suffix (4.0.4)
     puma (3.12.4)
     rack (2.0.8)
     rack-protection (2.0.7)


### PR DESCRIPTION
Relevant issue: https://github.com/octokit/octokit.rb/issues/1191

This issue is completely separate to the register issue we have on the Slack channel as this gem only works with pulling data from GitHub. We have a different gem for OAuth authentication for GitHub.