### PR TITLE
Add h3 styling for research experiment

### DIFF
--- a/app/assets/stylesheets/research/experiment-solution-page.scss.erb
+++ b/app/assets/stylesheets/research/experiment-solution-page.scss.erb
@@ -328,7 +328,13 @@ body.namespace-research.controller-experiment_solutions.action-show {
                     border-top:0;
                 }
             }
-
+            h3 {
+                font-weight: 600;
+                font-size: 18px;
+                line-height: 20px;
+                margin-top: 20px;
+                margin-bottom: 5px;
+            }
             p, li {
                 @include font-size(15, 21);
                 margin-bottom: 10px;


### PR DESCRIPTION
(cc @TheLostLambda - This fixes your "Making Pokémon" headings)