### PR TITLE
Discourage pronouns in mentor testimonials

### DIFF
--- a/app/views/my/solutions/mentor_ratings.html.haml
+++ b/app/views/my/solutions/mentor_ratings.html.haml
@@ -25,7 +25,7 @@
           =label_tag "mentor_reviews_#{mentor.id}_rating_#{i}", ""
 
       .feedback
-        %p Leave a public testimonial for this mentor (optional):
+        %p Leave a public testimonial for this mentor (optional). Avoid pronouns (she/he his/her).
         =text_area_tag "mentor_reviews[#{mentor.id}][feedback]"
 
   =button_tag "Continue", class: 'pure-button'#, disabled: true


### PR DESCRIPTION
Some mentors are accidentally misgendered by students in testimonials, this small change might stop that.

Later, we will hopefully record and display mentors preferred pronouns somewhere.

Feel free to suggest other language to do this.