### PR TITLE
Use correct labels and state in Git tracks API

### DIFF
--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -36,7 +36,7 @@ module GitAPI
           }
         end
         .select { |issue| filter_labels.all? { |filter_label| issue[:labels].include?(filter_label) } }
-        .sort { |a, b| a[:title] <=> b[:title] } 
+        .sort_by{|a|a[:title]}
     end
 
     def query(states)

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -6,20 +6,25 @@ module GitAPI
     layout false
 
     def creation_issues
-      issues = fetch_issues('type/new-exercise')
+      issues = fetch_issues(%w(type/new-exercise status/help-wanted), %w(OPEN))
       render json: issues
     end
 
+    def creation_issues_count
+      issues = fetch_issues(%w(type/new-exercise), %w(OPEN CLOSED))
+      render json: issues.length
+    end
+
     def improve_issues
-      issues = fetch_issues('type/improve-exercise')
+      issues = fetch_issues(%w(type/improve-exercise status/help-wanted), %w(OPEN))
       render json: issues
     end
 
     private
 
-    def fetch_issues(filter_label)
+    def fetch_issues(filter_labels, states)
       client = Octokit::Client.new(access_token: Rails.application.secrets.exercism_bot_token)
-      response = client.post '/graphql', { query: query }.to_json
+      response = client.post '/graphql', { query: query(states) }.to_json
       response.data.repository.issues.edges.map do |issue|
           {
             number: issue.node.number,
@@ -30,17 +35,17 @@ module GitAPI
             labels: issue.node.labels.edges.map { |label| label.node.name }
           }
         end
-        .select { |issue| issue[:labels].include?(filter_label) }
+        .select { |issue| filter_labels.all? { |filter_label| issue[:labels].include?(filter_label) } }
     end
 
-    def query
+    def query(states)
       %Q{
         { 
           repository(name: "v3", owner: "exercism") {
             id
             issues(
               first: 100
-              states: [#{state}]
+              states: [#{states.join(',')}]
               filterBy: { labels: ["track/#{@track.slug}"] }
             ) {
               edges {

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -36,6 +36,7 @@ module GitAPI
           }
         end
         .select { |issue| filter_labels.all? { |filter_label| issue[:labels].include?(filter_label) } }
+        .sort { |a, b| a[:title] <=> b[:title] } 
     end
 
     def query(states)

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -84,18 +84,5 @@ module GitAPI
         error: { type: type }
       }, status: 400
     end
-
-    def state
-      case params[:state]
-      when "open"
-        "OPEN"
-      when "closed"
-        "CLOSED"
-      when "all"
-        "OPEN,CLOSED"
-      else
-        "OPEN"
-      end
-    end
   end
 end

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -5,17 +5,17 @@ module GitAPI
 
     layout false
 
-    def creation_issues
+    def open_creation_issues
       issues = fetch_issues(%w(type/new-exercise status/help-wanted), %w(OPEN))
       render json: issues
     end
 
-    def creation_issues_count
+    def num_creation_issues
       issues = fetch_issues(%w(type/new-exercise), %w(OPEN CLOSED))
       render json: issues.length
     end
 
-    def improve_issues
+    def open_improve_issues
       issues = fetch_issues(%w(type/improve-exercise status/help-wanted), %w(OPEN))
       render json: issues
     end
@@ -32,11 +32,11 @@ module GitAPI
             body: issue.node.body,
             url: issue.node.url,
             updatedAt: issue.node.updatedAt,
-            labels: issue.node.labels.edges.map { |label| label.node.name }
+            labels: issue.node.labels.edges.map{|label| label.node.name }
           }
         end
-        .select { |issue| filter_labels.all? { |filter_label| issue[:labels].include?(filter_label) } }
-        .sort_by{|a|a[:title]}
+        .select{|issue| filter_labels.all?{|filter_label| issue[:labels].include?(filter_label)}}
+        .sort_by{|issue|issue[:title]}
     end
 
     def query(states)

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -40,7 +40,7 @@ module GitAPI
             id
             issues(
               first: 100
-              states: [OPEN]
+              states: [#{state}]
               filterBy: { labels: ["track/#{@track.slug}"] }
             ) {
               edges {
@@ -66,6 +66,7 @@ module GitAPI
     end
 
     private
+
     def set_track
       @track = Track.find_by_slug(params[:id])
       render_error(:track_not_found) unless @track
@@ -76,6 +77,18 @@ module GitAPI
       render json: {
         error: { type: type }
       }, status: 400
+
+    def state
+      case params[:state]
+      when "open"
+        "OPEN"
+      when "closed"
+        "CLOSED"
+      when "all"
+        "OPEN,CLOSED"
+      else
+        "OPEN"
+      end
     end
   end
 end

--- a/app/controllers/git_api/tracks_controller.rb
+++ b/app/controllers/git_api/tracks_controller.rb
@@ -83,6 +83,7 @@ module GitAPI
       render json: {
         error: { type: type }
       }, status: 400
+    end
 
     def state
       case params[:state]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     resources :tracks, only: [] do
       member do
         get :creation_issues
+        get :creation_issues_count
         get :improve_issues
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,9 +43,9 @@ Rails.application.routes.draw do
     resources :concept_exercises, only: [:create]
     resources :tracks, only: [] do
       member do
-        get :creation_issues
-        get :creation_issues_count
-        get :improve_issues
+        get :open_creation_issues
+        get :num_creation_issues
+        get :open_improve_issues
       end
     end
   end


### PR DESCRIPTION
The current API did not account for the fact that some issues could already be in progress. We probably don't want to show them as they are already being worked on. This PR adds support for that and also adds a dedicated API method to retrieve the number of new Concept Exercise issues. Previously, this was done client-side which meant that we ran the risk of users getting a rate limit error.