### PR TITLE
Allow passing of AWS credentials to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,14 @@ services:
       - redis
     restart: always
     environment:
-      MYSQL_HOST: mysql
-      MYSQL_SOCKET:
-      MYSQL_PORT: 3306
-      MYSQL_USERNAME: root
-      MYSQL_PASSWORD: password
-      REDIS_HOST: redis
+      - MYSQL_HOST=mysql
+      - MYSQL_SOCKET=
+      - MYSQL_PORT=3306
+      - MYSQL_USERNAME=root
+      - MYSQL_PASSWORD=password
+      - REDIS_HOST=redis
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
     ports:
       - 3020:3020
     volumes:


### PR DESCRIPTION
I got AWS credential errors when running the website through Docker. This is an attempt to fix that, by allowing the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to be passed to the Docker container. Is this the right way to go about this?