### PR TITLE
Seed database

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,6 @@ user = User.create!(handle: 'iHiD')
 #track = Track.create!(slug: 'ruby', title: 'Ruby', repo_url: "http://github.com/exercism/v3")
 #UserTrack.create!(user: user, track: track)
 
-Solution.destroy_all
-Exercise.destroy_all
-Track.destroy_all
-
 # This is all temporary and horrible while we have a monorepo
 v3_url = "http://github.com/exercism/v3"
 repo = Git::Track.new(v3_url)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,11 @@
-user = User.create!(handle: 'iHiD')
+user = User.create!(handle: 'iHiD') unless User.find_by(handle: 'iHiD')
+
 #track = Track.create!(slug: 'ruby', title: 'Ruby', repo_url: "http://github.com/exercism/v3")
 #UserTrack.create!(user: user, track: track)
 
 # This is all temporary and horrible while we have a monorepo
 v3_url = "http://github.com/exercism/v3"
-repo = Git::Track.new(v3_url)
+repo = Git::Track.new(v3_url, :ruby)
 
 # This updates it once before we stub it below
 repo.send(:repo).send(:rugged_repo)
@@ -22,23 +23,36 @@ end
 track_slugs = []
 tree = repo.send(:repo).read_tree(repo.send(:repo).head_commit, "languages/")
 tree.each_tree { |obj| track_slugs << obj[:name] }
+
+p track_slugs
+
 track_slugs.each do |track_slug|
+  if Track.find_by(slug: track_slug)
+    p "Track already added: #{track_slug}"
+    next
+  end
+
   p "Adding Track: #{track_slug}"
   track = Track.create!(slug: track_slug, title: track_slug, repo_url: v3_url)
-  #track.update(title: track.repo.config[:language])
-  track.repo.config[:exercises][:concept].each do |exercise_config|
-    ce = ConceptExercise.create!(
-      track: track,
-      uuid: exercise_config[:uuid], 
-      slug: exercise_config[:slug],
-      title: exercise_config[:slug].titleize,
-    )
-    #exercise_config[:concepts].each do |concept|
-    #  ce.concepts << Track::Concept.find_or_create_by!(uuid: SecureRandom.uuid, name: concept, track: track)
-    #end
-    exercise_config[:prerequisites].each do |concept|
-      ce.prerequisites << Track::Concept.find_or_create_by!(uuid: SecureRandom.uuid, name: concept, track: track)
+
+  begin
+    #track.update(title: track.repo.config[:language])
+    track.repo.config[:exercises][:concept].each do |exercise_config|
+      ce = ConceptExercise.create!(
+        track: track,
+        uuid: exercise_config[:uuid], 
+        slug: exercise_config[:slug],
+        title: exercise_config[:slug].titleize,
+      )
+      #exercise_config[:concepts].each do |concept|
+      #  ce.concepts << Track::Concept.find_or_create_by!(uuid: SecureRandom.uuid, name: concept, track: track)
+      #end
+      exercise_config[:prerequisites].each do |concept|
+        ce.prerequisites << Track::Concept.find_or_create_by!(uuid: SecureRandom.uuid, name: concept, track: track)
+      end
     end
+  rescue => e
+    p "Error creating concept exercises for Track #{track_slug}: #{e}"
   end
 end
 

--- a/docker/dev/seed-db
+++ b/docker/dev/seed-db
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ./docker/dev/lib/utils.sh
+
+docker exec \
+    -e EXERCISM_DOCKER=true \
+    -e EXERCISM_ENV=test \
+    -it v3-docker-compose_website_1 \
+    /bin/sh \
+    '-c' 'bin/rails db:seed'
+
+handle_container_error


### PR DESCRIPTION
Closes #38

This is a temporary step towards proper seeding. It allows for the seed to run multiple times without creating duplicate information. The seed script will change in a future PR, which is also why I haven't yet updated the documentation.

I've considered running the seed at startup, but there is a certain cost/delay involved due to the checking out of the v3 repo, so I've opted not to at the time.