### PR TITLE
Remove obsolete Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,6 @@ The website can be run natively, through Docker, or as part of a wider Docker-co
 
 If you are looking to create a full Exercism setup locally, with tooling such as test-runners and other services, please check out our [development environment instructions](./DEV_ENVIRONMENT.md).
 
-### Using Docker
-
-To build the Dockerfile, run:
-
-```
-docker build -f Dockerfile.dev -t exercism-website .
-```
-
-To execute the Dockerfile, run the following with your AWS keys:
-
-```
-./bin/run-docker
-```
-
 ### Using Docker Compose
 
 You'll need to fetch the [v3-docker-compose](https://github.com/exercism/v3-docker-compose) repository.

--- a/README.md
+++ b/README.md
@@ -12,23 +12,9 @@ This is the website component of Exercism. It is Ruby on Rails app, backed by My
 
 The website can be run natively, through Docker, or as part of a wider Docker-compose with mysql, redis etc. All options have tradeoffs and the Core Team make use of all three approaches. The various options are outlined below.
 
-If you are looking to create a full Exercism setup locally, with tooling such as test-runners and other services, please check out our [development environment instructions](./DEV_ENVIRONMENT.md).
+If you are looking to create a full Exercism setup locally, with tooling such as test-runners and other services, please check out our [development environment](https://github.com/exercism/development-environment) repo.
 
-### Using Docker Compose
-
-You'll need to fetch the [v3-docker-compose](https://github.com/exercism/v3-docker-compose) repository.
-
-To fire up the Exercism stack using Docker Compose:
-
-```sh
-# edit stack.yml
-./bin/build_stack
-./bin/start
-```
-
-Please check the repository README for additional help.
-
-#### Running tests in the scope of Docker Compose
+### Running tests in the scope of Docker Compose
 
 Assuming your docker-compose is already "up". All these are run "inside" the existing `website` container that needs to already have been started.
 


### PR DESCRIPTION
The script that is being referred to (`./bin/run-docker`) does not exist and is superseded by the `docker-compose` instructions below that I think.