### PR TITLE
Don't store iteration file content in the db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.6.6'
 
 # Service/framework dependencies
-gem 'rails', git: 'http://github.com/rails/rails.git', ref: "b39ea7cc3662345ad8efbe496db5ae594449f85f"
+gem 'rails', git: 'http://github.com/rails/rails.git', ref: "7101489293ece071013417aeed2da3aa1b0927c9"
 # gem 'rails', '~> 6.1.0.alpha'
 gem 'mysql2', '>= 0.4.4'
 gem 'puma', '~> 4.1'
@@ -22,7 +22,7 @@ gem 'mandate', '0.4.0.beta.1'
 gem 'exercism-config', '>= 0.36.0'
 # gem 'exercism-config', path: '../exercism_config'
 
-# gem 'bootsnap', '>= 1.4.2', require: false
+gem 'bootsnap', '>= 1.4.2', require: false
 
 # Model-level dependencies
 gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: http://github.com/rails/rails.git
-  revision: b39ea7cc3662345ad8efbe496db5ae594449f85f
-  ref: b39ea7cc3662345ad8efbe496db5ae594449f85f
+  revision: 7101489293ece071013417aeed2da3aa1b0927c9
+  ref: 7101489293ece071013417aeed2da3aa1b0927c9
   specs:
     actioncable (6.1.0.alpha)
       actionpack (= 6.1.0.alpha)
@@ -73,7 +73,7 @@ GIT
       activerecord (= 6.1.0.alpha)
       activestorage (= 6.1.0.alpha)
       activesupport (= 6.1.0.alpha)
-      bundler (>= 1.3.0)
+      bundler (>= 1.15.0)
       railties (= 6.1.0.alpha)
       sprockets-rails (>= 2.0.0)
     railties (6.1.0.alpha)
@@ -120,6 +120,8 @@ GEM
     backport (1.1.2)
     benchmark (0.1.0)
     bindex (0.8.1)
+    bootsnap (1.4.8)
+      msgpack (~> 1.0)
     builder (3.2.4)
     capybara (3.33.0)
       addressable
@@ -192,7 +194,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -211,6 +213,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     mocha (1.11.2)
+    msgpack (1.3.3)
     mysql2 (0.5.3)
     netrc (0.11.0)
     nio4r (2.5.2)
@@ -347,6 +350,7 @@ DEPENDENCIES
   ansi-to-html
   anycable-rails (~> 0.6)
   aws-sdk-s3 (~> 1)
+  bootsnap (>= 1.4.2)
   capybara (>= 2.15)
   commonmarker
   delayed_job_active_record (~> 4.1.4)

--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -83,7 +83,7 @@ class Iteration
         submitted_via: submitted_via
       ).tap do |iteration|
         files.each do |file|
-          iteration.files.create!(file.slice(:uuid, :filename, :content, :digest))
+          iteration.files.create!(file.slice(:uuid, :filename, :digest))
         end
       end
     end

--- a/app/commands/iteration/file/download.rb
+++ b/app/commands/iteration/file/download.rb
@@ -1,0 +1,23 @@
+class Iteration
+  class File
+    class Download
+      include Mandate
+
+      initialize_with :iteration_uuid, :filename
+
+      def initialize(iteration_uuid, filename)
+        @iteration_uuid = iteration_uuid
+        @filename = filename
+      end
+
+      def call
+        key = GenerateS3Key.(iteration_uuid, filename)
+
+        s3_client = ExercismConfig::SetupS3Client.()
+        obj = s3_client.get_object(bucket: Exercism.config.aws_iterations_bucket,
+                                   key: key)
+        obj.body.read
+      end
+    end
+  end
+end

--- a/app/commands/iteration/file/generate_s3_key.rb
+++ b/app/commands/iteration/file/generate_s3_key.rb
@@ -1,0 +1,18 @@
+class Iteration
+  class File
+    class GenerateS3Key
+      include Mandate
+
+      initialize_with :iteration_uuid, :filename
+
+      def call
+        [
+          Rails.env,
+          "storage",
+          iteration_uuid,
+          Digest::SHA1.hexdigest(filename)
+        ].join('/')
+      end
+    end
+  end
+end

--- a/app/commands/iteration/representation/process.rb
+++ b/app/commands/iteration/representation/process.rb
@@ -29,7 +29,9 @@ class Iteration
           exercise_version: exercise_version,
           ast_digest: iteration_representation.ast_digest
         ) do |rep|
+          # rep.source_iteration = iteration
           rep.ast = ast
+          # rep.mapping = mapping
         end
 
         # Then all of the submethods here should

--- a/app/models/iteration/file.rb
+++ b/app/models/iteration/file.rb
@@ -1,3 +1,7 @@
 class Iteration::File < ApplicationRecord
   belongs_to :iteration
+
+  def content
+    Iteration::File::Download.(uuid, filename)
+  end
 end

--- a/db/migrate/20200510163215_create_iteration_files.rb
+++ b/db/migrate/20200510163215_create_iteration_files.rb
@@ -7,12 +7,9 @@ class CreateIterationFiles < ActiveRecord::Migration[6.0]
       t.string :filename, null: false
       t.string :digest, null: false
 
-      # We're going to save content for now
-      # to make local development easier and
-      # to keep old content inline for now.
-      # Once we're happy everything is in S3,
-      # we can delete this column
-      t.binary :content, null: false
+      # The contents of this column needs moving to 
+      # S3 as part of this migration.
+      # t.binary :content, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,7 +89,6 @@ ActiveRecord::Schema.define(version: 2020_06_08_143333) do
     t.string "uuid", null: false
     t.string "filename", null: false
     t.string "digest", null: false
-    t.binary "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["iteration_id"], name: "index_iteration_files_on_iteration_id"

--- a/test/commands/iteration/file/download_test.rb
+++ b/test/commands/iteration/file/download_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Iteration::File::DownloadTest < ActiveSupport::TestCase
+  test "downloads correctly" do
+    iteration_uuid = SecureRandom.uuid
+
+    filename = "subdir/original_file_1.rb"
+    file_contents = "file 1 contents"
+    key = Iteration::File::GenerateS3Key.(iteration_uuid, filename)
+
+    s3_object = mock
+    s3_object.expects(body: mock(read: file_contents))
+    s3_client = mock
+    s3_client.expects(:get_object).with(
+      bucket: Exercism.config.aws_iterations_bucket,
+      key: key
+    ).returns(s3_object)
+    ExercismConfig::SetupS3Client.stubs(call: s3_client)
+
+    assert_equal file_contents,
+                 Iteration::File::Download.(iteration_uuid, filename)
+  end
+end

--- a/test/commands/iteration/file/generate_s3_key_test.rb
+++ b/test/commands/iteration/file/generate_s3_key_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class Iteration::File::GenerateS3KeyTest < ActiveSupport::TestCase
+  test "generates correctly" do
+    iteration_uuid = SecureRandom.uuid
+    filename = "two_fer.rb"
+    filename_hash = Digest::SHA1.hexdigest(filename)
+
+    expected = "test/storage/#{iteration_uuid}/#{filename_hash}"
+    assert_equal expected, Iteration::File::GenerateS3Key.(iteration_uuid, filename)
+  end
+end

--- a/test/commands/iteration/upload_for_storage_test.rb
+++ b/test/commands/iteration/upload_for_storage_test.rb
@@ -22,21 +22,21 @@ class Iteration::UploadForStorageTest < ActiveSupport::TestCase
     s3_client.expects(:put_object).with(
       body: file_1_contents,
       bucket: Exercism.config.aws_iterations_bucket,
-      key: "test/storage/#{iteration_uuid}/#{file_1_name}",
+      key: Iteration::File::GenerateS3Key.(iteration_uuid, file_1_name),
       acl: 'private'
     )
 
     s3_client.expects(:put_object).with(
       body: file_2_contents,
       bucket: Exercism.config.aws_iterations_bucket,
-      key: "test/storage/#{iteration_uuid}/#{file_2_name}",
+      key: Iteration::File::GenerateS3Key.(iteration_uuid, file_2_name),
       acl: 'private'
     )
 
     s3_client.expects(:put_object).with(
       body: file_3_contents,
       bucket: Exercism.config.aws_iterations_bucket,
-      key: "test/storage/#{iteration_uuid}/#{file_3_name}",
+      key: Iteration::File::GenerateS3Key.(iteration_uuid, file_3_name),
       acl: 'private'
     )
 

--- a/test/factories/iteration/files.rb
+++ b/test/factories/iteration/files.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     uuid { SecureRandom.compact_uuid }
     iteration
     filename { "foobar.rb" }
-    content { "foobar content" }
     digest { SecureRandom.compact_uuid }
   end
 end


### PR DESCRIPTION
- Retrieve files from s3 when rather than storing them locally.
- Use a hash of the filename for security (cc @SleeplessByte - we discussed this ages ago).