### PR TITLE
Add basic joining track flow

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,7 @@
+linters:
+  LineLength:
+    enabled: false
+    max: 100
+
+  ViewLength:
+    max: 200

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -16,7 +16,7 @@
       "files": ["*.css"],
       "options": {
         "tabWidth": 4,
-        "trailingComma": ""
+        "trailingComma": "none"
       }
     }
   ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,16 +88,19 @@ Naming/VariableNumber:
 Style/LambdaCall:
   EnforcedStyle: braces
 
-Rails/RefuteMethods:
-  EnforcedStyle: refute
-
-Rails/FilePath:
-  EnforcedStyle: arguments
-
-Rails/SkipsModelValidations:
-  Enabled: false
-
 Rails/HasManyOrHasOneDependent:
   Exclude:
     - "app/models/exercise/representation.rb"
     - "app/models/iteration/representation.rb"
+
+Rails/FilePath:
+  EnforcedStyle: arguments
+
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+
+Rails/RefuteMethods:
+  EnforcedStyle: refute
+
+Rails/SkipsModelValidations:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,10 @@ gem 'mandate', '0.4.0.beta.1'
 gem 'exercism-config', '>= 0.43.0'
 # gem 'exercism-config', path: '../exercism_config'
 
-gem 'bootsnap', '>= 1.4.2', require: false
-
 # Model-level dependencies
 gem 'image_processing', '~> 1.2'
 gem 'delayed_job_active_record', '~> 4.1.4'
+gem 'friendly_id', '~> 5.4.0'
 
 # View-level Dependencies
 gem 'webpacker', '~> 4.0'
@@ -45,16 +44,19 @@ group :development, :test do
   #  gem 'pry'
   #  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
+  gem 'bootsnap', '>= 1.4.2', require: false
 end
 
 group :development do
-  gem 'web-console', '>= 3.3.0'
+  gem 'haml_lint', require: false
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'solargraph'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
+  gem "spring"
+  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
     ffi (1.13.1)
+    friendly_id (5.4.0)
+      activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-protobuf (3.13.0)
@@ -174,6 +176,11 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 5.1)
+    haml_lint (0.35.0)
+      haml (>= 4.0, < 5.2)
+      rainbow
+      rubocop (>= 0.50.0)
+      sysexits (~> 1.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -303,6 +310,7 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -310,6 +318,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sysexits (1.2.0)
     temple (0.8.2)
     thor (1.0.1)
     tilt (2.0.10)
@@ -356,7 +365,9 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.4)
   exercism-config (>= 0.43.0)
   factory_bot_rails
+  friendly_id (~> 5.4.0)
   haml-rails (~> 2.0)
+  haml_lint
   image_processing (~> 1.2)
   listen (>= 3.0.5, < 3.2)
   mandate (= 0.4.0.beta.1)
@@ -375,6 +386,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov (~> 0.17.0)
   solargraph
+  spring
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/app/assets/stylesheets/tracks.css
+++ b/app/assets/stylesheets/tracks.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/commands/user_track/create.rb
+++ b/app/commands/user_track/create.rb
@@ -1,5 +1,5 @@
-class User
-  class JoinTrack
+class UserTrack
+  class Create
     include Mandate
 
     initialize_with :user, :track

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,22 @@
 class ApplicationController < ActionController::Base
   # TODO: Remove when devise is added
-  attr_reader :current_user
+  def user_logged_in?
+    !!current_user
+  end
+
+  def current_user
+    User.first
+  end
+
+  %w[index show].each do |action|
+    define_method action do
+      if user_logged_in? && respond_to?("authenticated_#{action}")
+        send("authenticated_#{action}")
+        render action: "authenticated/#{action}"
+      elsif !user_logged_in? && respond_to?("external_#{action}")
+        send("external_#{action}")
+        render action: "external/#{action}"
+      end
+    end
+  end
 end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,0 +1,21 @@
+class TracksController < ApplicationController
+  before_action :use_track, except: :index
+
+  def authenticated_index
+    @tracks = Track.all
+  end
+
+  def authenticated_show
+    @user_track = current_user.user_tracks.find_by(track: @track)
+  end
+
+  def join
+    UserTrack::Create.(current_user, @track)
+    redirect_to action: :show
+  end
+
+  private
+  def use_track
+    @track = Track.find(params[:id])
+  end
+end

--- a/app/helpers/tracks_helper.rb
+++ b/app/helpers/tracks_helper.rb
@@ -1,2 +1,0 @@
-module TracksHelper
-end

--- a/app/helpers/tracks_helper.rb
+++ b/app/helpers/tracks_helper.rb
@@ -1,0 +1,2 @@
+module TracksHelper
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,4 +1,8 @@
 class Track < ApplicationRecord
+  extend FriendlyId
+
+  friendly_id :slug, use: [:history]
+
   has_many :concepts, class_name: "Track::Concept", dependent: :destroy
   has_many :exercises, dependent: :destroy
   # has_many :concept_exercises

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
+    %meta{ content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }/
     %title Exercism
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/tracks/authenticated/index.html.haml
+++ b/app/views/tracks/authenticated/index.html.haml
@@ -1,0 +1,4 @@
+#page-tracks
+  - @tracks.each do |track|
+    = link_to track_path(track), class: "track track-#{track.slug}" do
+      = track.title

--- a/app/views/tracks/authenticated/show.html.haml
+++ b/app/views/tracks/authenticated/show.html.haml
@@ -1,0 +1,5 @@
+%h1= @track.title
+- if @user_track
+  You have joined this track
+- else
+  = button_to "Join Track", join_track_path(@track), method: :post

--- a/bin/haml-lint-quick
+++ b/bin/haml-lint-quick
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.haml$' | xargs bundle exec haml-lint app/views/layouts/application.html.haml
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.haml$' | xargs git add
+

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rubocop-quick
+++ b/bin/rubocop-quick
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion app/controllers/application_controller.rb && \
-git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs git add
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.rb$' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion Gemfile.lock && \
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.rb$' | xargs git add

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,4 +2,4 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
-# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w[new edit index session login logout users admin
+                             stylesheets assets javascripts images]
+
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  config.use :finders
+
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount ActionCable.server => '/cable'
+
   # ### #
   # API #
   # ### #
@@ -9,9 +11,7 @@ Rails.application.routes.draw do
 
       resources :tracks, only: [:show]
       resources :solutions, only: %i[show update] do
-        collection do
-          get :latest
-        end
+        get :latest, on: :collection
 
         get 'files/*filepath', to: 'files#show', format: false, as: "file"
       end
@@ -19,23 +19,36 @@ Rails.application.routes.draw do
   end
   get "api/(*url)", to: 'api/errors#render_404'
 
-  root to: "pages#index"
-
-  mount ActionCable.server => '/cable'
+  # ### #
+  # SPI #
+  # ### #
   namespace :spi do
     resources :tooling_jobs, only: :update
   end
 
+  # ############ #
+  # Normal pages #
+  # ############ #
+
   namespace :maintaining do
     resources :iterations, only: [:index]
   end
+  resources :tracks, only: %i[index show] do
+    member do
+      post :join
+    end
+  end
+
+  root to: "pages#index"
+
+  # ########################### #
+  # Temporary and testing pages #
+  # ########################### #
 
   namespace :tmp do
     resources :iterations, only: [:create]
     resources :tracks, only: [:create]
   end
-
-  resources :tracks, only: %i[index show]
 
   unless Rails.env.production?
     namespace :test do

--- a/db/migrate/20200830161328_create_friendly_id_slugs.rb
+++ b/db/migrate/20200830161328_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/migrate/20200830161328_create_friendly_id_slugs.rb
+++ b/db/migrate/20200830161328_create_friendly_id_slugs.rb
@@ -1,11 +1,4 @@
-MIGRATION_CLASS =
-  if ActiveRecord::VERSION::MAJOR >= 5
-    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
-  else
-    ActiveRecord::Migration
-  end
-
-class CreateFriendlyIdSlugs < MIGRATION_CLASS
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[6.0]
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_29_151831) do
+ActiveRecord::Schema.define(version: 2020_08_30_161328) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -61,6 +61,17 @@ ActiveRecord::Schema.define(version: 2020_08_29_151831) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["track_id"], name: "index_exercises_on_track_id"
+  end
+
+  create_table "friendly_id_slugs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, length: { slug: 70, scope: 70 }
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", length: { slug: 140 }
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
   create_table "iteration_analyses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ track_slugs.each do |track_slug|
   end
 
   p "Adding Track: #{track_slug}"
-  track = Track.create!(slug: track_slug, title: track_slug, repo_url: v3_url)
+  track = Track.create!(slug: track_slug, title: track_slug.titleize, repo_url: v3_url)
 
   begin
     #track.update(title: track.repo.config[:language])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,15 +20,15 @@ track_slugs = []
 tree = repo.send(:repo).read_tree(repo.send(:repo).head_commit, "languages/")
 tree.each_tree { |obj| track_slugs << obj[:name] }
 
-p track_slugs
+puts track_slugs
 
 track_slugs.each do |track_slug|
   if Track.find_by(slug: track_slug)
-    p "Track already added: #{track_slug}"
+    puts "Track already added: #{track_slug}"
     next
   end
 
-  p "Adding Track: #{track_slug}"
+  puts "Adding Track: #{track_slug}"
   track = Track.create!(slug: track_slug, title: track_slug.titleize, repo_url: v3_url)
 
   begin
@@ -48,16 +48,20 @@ track_slugs.each do |track_slug|
       end
     end
   rescue => e
-    p "Error creating concept exercises for Track #{track_slug}: #{e}"
+    puts "Error creating concept exercises for Track #{track_slug}: #{e}"
   end
 end
 
 
-p "Creating User iHiD"
+puts "Creating User iHiD"
 user = User.create!(handle: 'iHiD') unless User.find_by(handle: 'iHiD')
 UserTrack.create!(user: user, track: Track.find_by_slug!("ruby"))
 auth_token = user.auth_tokens.create!
-p "Run: exercism configure -a http://localhost:3020/api/v1 -t #{auth_token.token}"
+
+puts ""
+puts "To use the CLI locally, run: "
+puts "exercism configure -a http://localhost:3020/api/v1 -t #{auth_token.token}"
+puts ""
 
 =begin
 concept_exercise = ConceptExercise.create!(track: track, uuid: SecureRandom.uuid, slug: "numbers", prerequisites: [], title: "numbers")

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && bin/rubocop-quick"
+      "pre-commit": "pretty-quick --staged && bin/rubocop-quick && bin/haml-lint-quick"
     }
   }
 }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,9 +1,19 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  # Devise::Test::IntegrationHelpers
+
   # driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
   driven_by :selenium, using: :headless_chrome do |driver_option|
     # Without this argument, Chrome cannot be started in Docker
     driver_option.add_argument('no-sandbox')
+  end
+
+  def sign_in!(user = nil)
+    @current_user = user || create(:user)
+
+    # TODO: Renable when adding devise
+    # @current_user.confirm
+    # sign_in @current_user
   end
 end

--- a/test/commands/user_track/create_test.rb
+++ b/test/commands/user_track/create_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-class User::JoinTrackTest < ActiveSupport::TestCase
+class UserTrack::CreateTest < ActiveSupport::TestCase
   test "creates user_track" do
     user = create :user
     track = create :track
 
-    User::JoinTrack.(user, track)
+    UserTrack::Create.(user, track)
 
     assert_equal 1, UserTrack.count
     ut = UserTrack.last
@@ -18,6 +18,6 @@ class User::JoinTrackTest < ActiveSupport::TestCase
     user = create :user
     track = create :track
 
-    assert_idempotent_command { User::JoinTrack.(user, track) }
+    assert_idempotent_command { UserTrack::Create.(user, track) }
   end
 end

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TracksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class TracksControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -11,7 +11,7 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
 
     # User joins the track
     # Check its retrieved correctly.
-    ut = User::JoinTrack.(user, track)
+    ut = UserTrack::Create.(user, track)
     assert_equal ut, UserTrack.for!(user, track)
 
     # Check we only have basics to start with

--- a/test/system/flows/join_track_test.rb
+++ b/test/system/flows/join_track_test.rb
@@ -1,0 +1,20 @@
+require "application_system_test_case"
+
+module Flows
+  class JoinTrackTestTest < ApplicationSystemTestCase
+    test "joins track when authenticated" do
+      user = create :user
+      track = create :track, slug: "ruby", title: "Ruby"
+
+      # TODO: Add when adding devise
+      # sign_in(user)
+
+      visit tracks_url
+      click_link "Ruby"
+
+      click_on "Join Track"
+
+      assert_equal [track], user.tracks
+    end
+  end
+end


### PR DESCRIPTION
This does a few things:
- Adds haml linting (this can't autocorrect annoyingly)
- Adds friendly_id (so that urls can be `/tracks/ruby` not `/tracks/52`)
- Readds spring and bootsnap to speed up load time, especially for tests
- Adds a simple flow for starting a track
- Adds a pattern I'm trying for allowing authenticated and external views within the same controller. I might end up changing this, but I'm seeing how it goes for now (cc @kntsoriano and @SleeplessByte for thoughts on this with your Rails hats on)
- Renames `User::JoinTrack` to `UserTrack::Create`.