### PR TITLE
Install dependencies on container startup

### DIFF
--- a/docker/dev/init.dev.sh
+++ b/docker/dev/init.dev.sh
@@ -3,6 +3,9 @@ while ! mysqladmin ping -h"$DB_HOST" --silent; do
     sleep 2
 done
 
+echo "Install dependencies"
+bundle install
+
 echo "Create and migrate DBs"
 # init.sql creates initial MySQL USER and databases
 mysql -u root -ppassword -h "$DB_HOST" < docker/dev/init.sql


### PR DESCRIPTION
*Disclaimer: I'm not really sure if this is the right solution, but this fixed the issue.*

## Background
In the development environment, my `stack.yml`, particularly the website section, is configured to be the following:

```yml
  website:
    source: true
    # change these (and ports below) to remap outside service ports
    environment:
      WEBPACKER_DEV_SERVER_PUBLIC: "localhost:9999"
      CABLE_URL: "ws://localhost:9998/cable"
    # reconfigure the external ports to avoid conflicts
    ports:
      - 3020:3020 # rails, 3020 internal
      - 9999:3035 # webpack, 3035 internal
      - 9998:3334 # cable, 3334 internal
```

## Issue
Since I'm using my local copy of `v3-website` as the container's source, it doesn't start up when I upgrade a gem. The container doesn't start up since the gem's new version isn't in the container.

## Solution
When starting up the container, run `bundle install` in order to install the dependencies. This was a crude solution by me just to progress, and I'm not sure whether it's in the right place.