### PR TITLE
Add <MentorConversationsList />

### DIFF
--- a/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
@@ -15,7 +15,7 @@ class Test::Components::Mentoring::MentorConversationsListsController < Applicat
         haveMentoredPreviously: true,
         isNewIteration: true,
         postsCount: 15,
-        updatedAt: 1.year.ago,
+        updatedAt: 1.year.ago.iso8601,
         url: "https://exercism.io/conversations/1"
       }
     ]

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
@@ -1,0 +1,23 @@
+class Test::Components::Mentoring::MentorConversationsListsController < ApplicationController
+  def show
+    @mentor = OpenStruct.new(conversations: conversations)
+  end
+
+  private
+  def conversations
+    [
+      {
+        trackIconUrl: "https://assets.exercism.io/tracks/ruby-hex-white.png",
+        menteeAvatarUrl: "https://robohash.org/exercism",
+        menteeHandle: "mentee",
+        exerciseTitle: "Series",
+        isStarred: true,
+        haveMentoredPreviously: true,
+        isNewIteration: true,
+        postsCount: 15,
+        updatedAt: 1.year.ago,
+        url: "https://exercism.io/conversations/1"
+      }
+    ]
+  end
+end

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
@@ -7,6 +7,7 @@ class Test::Components::Mentoring::MentorConversationsListsController < Applicat
   def conversations
     [
       {
+        trackTitle: "Ruby",
         trackIconUrl: "https://assets.exercism.io/tracks/ruby-hex-white.png",
         menteeAvatarUrl: "https://robohash.org/exercism",
         menteeHandle: "mentee",

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -14,6 +14,9 @@ module ComponentsHelper
 
   def notification_icon(user)
     react_component("notification-icon", { count: user.notifications.count })
+
+  def mentor_conversations_list(mentor)
+    react_component("mentor-conversations-list", { conversations: mentor.conversations })
   end
 
   private

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -14,6 +14,7 @@ module ComponentsHelper
 
   def notification_icon(user)
     react_component("notification-icon", { count: user.notifications.count })
+  end
 
   def mentor_conversations_list(mentor)
     react_component("mentor-conversations-list", { conversations: mentor.conversations })

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import dayjs from 'dayjs'
+import RelativeTime from 'dayjs/plugin/relativeTime'
+dayjs.extend(RelativeTime)
+
+function MentorConversationListRow({
+  trackIconUrl,
+  menteeAvatarUrl,
+  menteeHandle,
+  exerciseTitle,
+  isStarred,
+  haveMentoredPreviously,
+  isNewIteration,
+  postsCount,
+  updatedAt,
+  url,
+}) {
+  return (
+    <tr>
+      <td>
+        <img style={{ width: 100 }} src={trackIconUrl} />
+      </td>
+      <td>
+        <img style={{ width: 100 }} src={menteeAvatarUrl} />
+      </td>
+      <td>{menteeHandle}</td>
+      <td>{exerciseTitle}</td>
+      <td>{isStarred.toString()}</td>
+      <td>{haveMentoredPreviously.toString()}</td>
+      <td>{isNewIteration.toString()}</td>
+      <td>{postsCount}</td>
+      <td>{dayjs(updatedAt).from(dayjs())}</td>
+      <td>{url}</td>
+    </tr>
+  )
+}
+
+export function MentorConversationsList({ conversations }) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Track icon</th>
+          <th>Mentee avatar</th>
+          <th>Mentee handle</th>
+          <th>Exercise title</th>
+          <th>Starred?</th>
+          <th>Mentored previously?</th>
+          <th>New iteration?</th>
+          <th>Posts count</th>
+          <th>Updated at</th>
+          <th>URL</th>
+        </tr>
+      </thead>
+      <tbody>
+        {conversations.map((conversation, key) => (
+          <MentorConversationListRow key={key} {...conversation} />
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -4,6 +4,7 @@ import RelativeTime from 'dayjs/plugin/relativeTime'
 dayjs.extend(RelativeTime)
 
 function MentorConversationListRow({
+  trackTitle,
   trackIconUrl,
   menteeAvatarUrl,
   menteeHandle,
@@ -18,10 +19,18 @@ function MentorConversationListRow({
   return (
     <tr>
       <td>
-        <img style={{ width: 100 }} src={trackIconUrl} />
+        <img
+          style={{ width: 100 }}
+          src={trackIconUrl}
+          alt={`icon indicating ${trackTitle}`}
+        />
       </td>
       <td>
-        <img style={{ width: 100 }} src={menteeAvatarUrl} />
+        <img
+          style={{ width: 100 }}
+          src={menteeAvatarUrl}
+          alt={`avatar for ${menteeHandle}`}
+        />
       </td>
       <td>{menteeHandle}</td>
       <td>{exerciseTitle}</td>

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -29,7 +29,7 @@ function MentorConversationListRow({
       <td>{haveMentoredPreviously.toString()}</td>
       <td>{isNewIteration.toString()}</td>
       <td>{postsCount}</td>
-      <td>{dayjs(updatedAt).from(dayjs())}</td>
+      <td>{dayjs(updatedAt).fromNow()}</td>
       <td>{url}</td>
     </tr>
   )

--- a/app/javascript/packs/application.jsx
+++ b/app/javascript/packs/application.jsx
@@ -15,6 +15,7 @@ import { initReact } from './react_bootloader.jsx'
 import { ExampleIterationsSummaryTable } from '../components/example/iterations_summary_table.jsx'
 import { MaintainingIterationsSummaryTable } from '../components/maintaining/iterations_summary_table.jsx'
 import { NotificationIcon } from '../components/notifications/icon.jsx'
+import { MentorConversationsList } from '../components/mentoring/mentor_conversations_list.jsx'
 
 // Add all react components here.
 // Each should map 1-1 to a component in app/helpers/components
@@ -29,6 +30,9 @@ initReact({
     <MaintainingIterationsSummaryTable iterations={data.iterations} />
   ),
   'notification-icon': (data) => <NotificationIcon count={data.count} />,
+  'mentor-conversations-list': (data) => (
+    <MentorConversationsList conversations={data.conversations} />
+  ),
 })
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
+++ b/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
@@ -1,0 +1,2 @@
+%h1 Mentor conversations list
+= mentor_conversations_list(@mentor)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
         end
         namespace :notifications do
           resource :icon, only: %i[show update]
+        namespace :mentoring do
+          resource :mentor_conversations_list, only: [:show]
         end
       end
     end

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/webpacker": "4.2.2",
     "actioncable": "^5.2.4-3",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "dayjs": "^1.8.35",
     "global": "^4.4.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/test/support/table_matchers.rb
+++ b/test/support/table_matchers.rb
@@ -1,0 +1,19 @@
+module TableMatchers
+  def assert_table_row(table, fields)
+    within(table) do
+      headers = all("th").map(&:text)
+
+      fields.each do |header, assertion|
+        position = headers.index(header)
+
+        within("td:nth-child(#{position + 1})") do
+          if assertion.respond_to?(:call)
+            assertion.()
+          elsif assertion.is_a?(String)
+            assert_text assertion
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -7,8 +7,10 @@ module Components
         visit test_components_mentoring_mentor_conversations_list_url
 
         within("tbody > tr:first-child") do
-          within("td:nth-child(1)") { assert_css "img[src='https://assets.exercism.io/tracks/ruby-hex-white.png']" }
-          within("td:nth-child(2)") { assert_css "img[src='https://robohash.org/exercism']" }
+          within("td:nth-child(1)") do
+            assert_css "img[src='https://assets.exercism.io/tracks/ruby-hex-white.png'][alt='icon indicating Ruby']"
+          end
+          within("td:nth-child(2)") { assert_css "img[src='https://robohash.org/exercism'][alt='avatar for mentee']" }
           within("td:nth-child(3)") { assert_text "mentee" }
           within("td:nth-child(4)") { assert_text "Series" }
           within("td:nth-child(5)") { assert_text "true" }

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+module Components
+  module Mentoring
+    class MentorConversationsListTest < ApplicationSystemTestCase
+      test "shows correct information" do
+        visit test_components_mentoring_mentor_conversations_list_url
+
+        within("tbody > tr:first-child") do
+          within("td:nth-child(1)") { assert_css "img[src='https://assets.exercism.io/tracks/ruby-hex-white.png']" }
+          within("td:nth-child(2)") { assert_css "img[src='https://robohash.org/exercism']" }
+          within("td:nth-child(3)") { assert_text "mentee" }
+          within("td:nth-child(4)") { assert_text "Series" }
+          within("td:nth-child(5)") { assert_text "true" }
+          within("td:nth-child(6)") { assert_text "true" }
+          within("td:nth-child(7)") { assert_text "true" }
+          within("td:nth-child(8)") { assert_text "15" }
+          within("td:nth-child(9)") { assert_text "a year ago" }
+          within("td:nth-child(10)") { assert_text "https://exercism.io/conversations/1" }
+        end
+      end
+    end
+  end
+end

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -1,25 +1,30 @@
 require "application_system_test_case"
+require_relative "../../../support/table_matchers"
 
 module Components
   module Mentoring
     class MentorConversationsListTest < ApplicationSystemTestCase
+      include TableMatchers
+
       test "shows correct information" do
         visit test_components_mentoring_mentor_conversations_list_url
 
-        within("tbody > tr:first-child") do
-          within("td:nth-child(1)") do
+        row = {
+          "Track icon" => lambda {
             assert_css "img[src='https://assets.exercism.io/tracks/ruby-hex-white.png'][alt='icon indicating Ruby']"
-          end
-          within("td:nth-child(2)") { assert_css "img[src='https://robohash.org/exercism'][alt='avatar for mentee']" }
-          within("td:nth-child(3)") { assert_text "mentee" }
-          within("td:nth-child(4)") { assert_text "Series" }
-          within("td:nth-child(5)") { assert_text "true" }
-          within("td:nth-child(6)") { assert_text "true" }
-          within("td:nth-child(7)") { assert_text "true" }
-          within("td:nth-child(8)") { assert_text "15" }
-          within("td:nth-child(9)") { assert_text "a year ago" }
-          within("td:nth-child(10)") { assert_text "https://exercism.io/conversations/1" }
-        end
+          },
+          "Mentee avatar" => -> { assert_css "img[src='https://robohash.org/exercism'][alt='avatar for mentee']" },
+          "Mentee handle" => "mentee",
+          "Exercise title" => "Series",
+          "Starred?" => "true",
+          "Mentored previously?" => "true",
+          "New iteration?" => "true",
+          "Posts count" => "15",
+          "Updated at" => "a year ago",
+          "URL" => "https://exercism.io/conversations/1"
+        }
+
+        assert_table_row first("table"), row
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,6 +3143,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.8.35:
+  version "1.8.35"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.35.tgz#67118378f15d31623f3ee2992f5244b887606888"
+  integrity sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Description
This adds the skeleton for the `<MentorConversationsList />` component. We can now work on the pagination, filtering, and sorting separately. We might encounter some merge issues, but it should be relatively easy to fix.

I chose to keep it simple and not think about the API response for now. I don't have enough expertise on this to make a decision.

*EDIT: The failed rubocop run isn't in any way related to the changes here. `master` is broken and I've added a fix in https://github.com/exercism/v3-website/pull/56.*

## Screenshot
![Screen Shot 2020-09-09 at 10 32 30 AM](https://user-images.githubusercontent.com/1901520/92547786-45dff280-f288-11ea-9dd0-92a2a2789ec4.png)

## Questions
1. For the relative time display, I chose to use [dayjs](https://github.com/iamkun/dayjs). I'm pretty out of touch with the JS ecosystem so I'm unsure whether this was a good decision. (cc @SleeplessByte)
2. Did I miss any fields?