### PR TITLE
<MentorConversationsList /> pagination

### DIFF
--- a/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
@@ -1,5 +1,7 @@
 class Test::Components::Mentoring::MentorConversationsLists::ConversationsController < ApplicationController
   def index
+    return head :internal_server_error if params[:state] == "Error"
+
     results = [
       {
         trackTitle: "Ruby",

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
@@ -13,9 +13,27 @@ class Test::Components::Mentoring::MentorConversationsLists::ConversationsContro
         postsCount: 15,
         updatedAt: 1.year.ago.iso8601,
         url: "https://exercism.io/conversations/1"
+      },
+      {
+        trackTitle: "Go",
+        trackIconUrl: "https://assets.exercism.io/tracks/go-hex-white.png",
+        menteeAvatarUrl: "https://robohash.org/exercism_2",
+        menteeHandle: "User 2",
+        exerciseTitle: "Tournament",
+        isStarred: false,
+        haveMentoredPreviously: true,
+        isNewIteration: false,
+        postsCount: 22,
+        updatedAt: 1.week.ago.iso8601,
+        url: "https://exercism.io/conversations/2"
       }
     ]
+    page = params.fetch(:page, 1).to_i
+    per = params.fetch(:per, 1).to_i
 
-    render json: results
+    render json: {
+      results: results[page - 1, per],
+      meta: { current: page, total: results.size }
+    }
   end
 end

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
@@ -1,0 +1,21 @@
+class Test::Components::Mentoring::MentorConversationsLists::ConversationsController < ApplicationController
+  def index
+    results = [
+      {
+        trackTitle: "Ruby",
+        trackIconUrl: "https://assets.exercism.io/tracks/ruby-hex-white.png",
+        menteeAvatarUrl: "https://robohash.org/exercism",
+        menteeHandle: "mentee",
+        exerciseTitle: "Series",
+        isStarred: true,
+        haveMentoredPreviously: true,
+        isNewIteration: true,
+        postsCount: 15,
+        updatedAt: 1.year.ago.iso8601,
+        url: "https://exercism.io/conversations/1"
+      }
+    ]
+
+    render json: results
+  end
+end

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists/conversations_controller.rb
@@ -1,6 +1,6 @@
 class Test::Components::Mentoring::MentorConversationsLists::ConversationsController < ApplicationController
   def index
-    return head :internal_server_error if params[:state] == "Error"
+    return head :internal_server_error if params[:state] == "Error" || params[:state] == "Loading"
 
     results = [
       {

--- a/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
+++ b/app/controllers/test/components/mentoring/mentor_conversations_lists_controller.rb
@@ -1,24 +1,3 @@
 class Test::Components::Mentoring::MentorConversationsListsController < ApplicationController
-  def show
-    @mentor = OpenStruct.new(conversations: conversations)
-  end
-
-  private
-  def conversations
-    [
-      {
-        trackTitle: "Ruby",
-        trackIconUrl: "https://assets.exercism.io/tracks/ruby-hex-white.png",
-        menteeAvatarUrl: "https://robohash.org/exercism",
-        menteeHandle: "mentee",
-        exerciseTitle: "Series",
-        isStarred: true,
-        haveMentoredPreviously: true,
-        isNewIteration: true,
-        postsCount: 15,
-        updatedAt: 1.year.ago.iso8601,
-        url: "https://exercism.io/conversations/1"
-      }
-    ]
-  end
+  def show; end
 end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -16,8 +16,12 @@ module ComponentsHelper
     react_component("notification-icon", { count: user.notifications.count })
   end
 
-  def mentor_conversations_list(endpoint)
-    react_component("mentor-conversations-list", { endpoint: endpoint })
+  def mentor_conversations_list(endpoint, url_params, retry_params)
+    react_component("mentor-conversations-list", {
+                      endpoint: endpoint,
+                      url_params: url_params,
+                      retry_params: retry_params
+                    })
   end
 
   private

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -16,8 +16,8 @@ module ComponentsHelper
     react_component("notification-icon", { count: user.notifications.count })
   end
 
-  def mentor_conversations_list(mentor)
-    react_component("mentor-conversations-list", { conversations: mentor.conversations })
+  def mentor_conversations_list(endpoint)
+    react_component("mentor-conversations-list", { endpoint: endpoint })
   end
 
   private

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -3,6 +3,7 @@ import { usePaginatedQuery } from 'react-query'
 import dayjs from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
 import Pagination from './mentor_conversations_list/pagination'
+import { UrlParams } from '../../utils/url_params'
 dayjs.extend(RelativeTime)
 
 function MentorConversationListRow({
@@ -46,22 +47,28 @@ function MentorConversationListRow({
   )
 }
 
-async function fetchSolutions(key, url) {
+async function fetchSolutions(key, url, params) {
   const resp = await fetch(url)
 
   return resp.json()
 }
 
-export function MentorConversationsList({ endpoint }) {
+export function MentorConversationsList({ endpoint, ...props }) {
   const [page, setPage] = useState(1)
+  const urlParams = new UrlParams(
+    Object.assign({ page: page }, props.urlParams)
+  )
+  const retryParams = props.retryParams
   const { status, resolvedData, latestData } = usePaginatedQuery(
-    ['mentor-conversations-list', `${endpoint}?page=${page}`],
-    fetchSolutions
+    ['mentor-conversations-list', `${endpoint}?${urlParams.toString()}`],
+    fetchSolutions,
+    retryParams
   )
 
   return (
     <div>
       {status === 'loading' && <p>Loading</p>}
+      {status === 'error' && <p>Something went wrong</p>}
       {status === 'success' && (
         <>
           <table>

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useQuery } from 'react-query'
+import { usePaginatedQuery } from 'react-query'
 import dayjs from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
 dayjs.extend(RelativeTime)
@@ -45,6 +45,25 @@ function MentorConversationListRow({
   )
 }
 
+function Pagination({ current, total, setPage }) {
+  return (
+    <div>
+      {Array.from({ length: total }, (_, i) => i + 1).map((page) => {
+        return (
+          <button
+            key={page}
+            onClick={() => {
+              setPage(page)
+            }}
+          >
+            {page}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 async function fetchSolutions(key, url) {
   const resp = await fetch(url)
 
@@ -52,8 +71,9 @@ async function fetchSolutions(key, url) {
 }
 
 export function MentorConversationsList({ endpoint }) {
-  const { status, data } = useQuery(
-    ['mentor-conversations-list', endpoint],
+  const [page, setPage] = useState(1)
+  const { status, resolvedData, latestData } = usePaginatedQuery(
+    ['mentor-conversations-list', `${endpoint}?page=${page}`],
     fetchSolutions
   )
 
@@ -61,27 +81,36 @@ export function MentorConversationsList({ endpoint }) {
     <div>
       {status === 'loading' && <p>Loading</p>}
       {status === 'success' && (
-        <table>
-          <thead>
-            <tr>
-              <th>Track icon</th>
-              <th>Mentee avatar</th>
-              <th>Mentee handle</th>
-              <th>Exercise title</th>
-              <th>Starred?</th>
-              <th>Mentored previously?</th>
-              <th>New iteration?</th>
-              <th>Posts count</th>
-              <th>Updated at</th>
-              <th>URL</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((conversation, key) => (
-              <MentorConversationListRow key={key} {...conversation} />
-            ))}
-          </tbody>
-        </table>
+        <>
+          <table>
+            <thead>
+              <tr>
+                <th>Track icon</th>
+                <th>Mentee avatar</th>
+                <th>Mentee handle</th>
+                <th>Exercise title</th>
+                <th>Starred?</th>
+                <th>Mentored previously?</th>
+                <th>New iteration?</th>
+                <th>Posts count</th>
+                <th>Updated at</th>
+                <th>URL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {resolvedData.results.map((conversation, key) => (
+                <MentorConversationListRow key={key} {...conversation} />
+              ))}
+            </tbody>
+          </table>
+          {latestData && (
+            <Pagination
+              current={page}
+              total={latestData.meta.total}
+              setPage={setPage}
+            />
+          )}
+        </>
       )}
     </div>
   )

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useQuery } from 'react-query'
 import dayjs from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
 dayjs.extend(RelativeTime)
@@ -44,28 +45,44 @@ function MentorConversationListRow({
   )
 }
 
-export function MentorConversationsList({ conversations }) {
+async function fetchSolutions(key, url) {
+  const resp = await fetch(url)
+
+  return resp.json()
+}
+
+export function MentorConversationsList({ endpoint }) {
+  const { status, data } = useQuery(
+    ['mentor-conversations-list', endpoint],
+    fetchSolutions
+  )
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Track icon</th>
-          <th>Mentee avatar</th>
-          <th>Mentee handle</th>
-          <th>Exercise title</th>
-          <th>Starred?</th>
-          <th>Mentored previously?</th>
-          <th>New iteration?</th>
-          <th>Posts count</th>
-          <th>Updated at</th>
-          <th>URL</th>
-        </tr>
-      </thead>
-      <tbody>
-        {conversations.map((conversation, key) => (
-          <MentorConversationListRow key={key} {...conversation} />
-        ))}
-      </tbody>
-    </table>
+    <div>
+      {status === 'loading' && <p>Loading</p>}
+      {status === 'success' && (
+        <table>
+          <thead>
+            <tr>
+              <th>Track icon</th>
+              <th>Mentee avatar</th>
+              <th>Mentee handle</th>
+              <th>Exercise title</th>
+              <th>Starred?</th>
+              <th>Mentored previously?</th>
+              <th>New iteration?</th>
+              <th>Posts count</th>
+              <th>Updated at</th>
+              <th>URL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((conversation, key) => (
+              <MentorConversationListRow key={key} {...conversation} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
   )
 }

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { usePaginatedQuery } from 'react-query'
 import dayjs from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
+import Pagination from './mentor_conversations_list/pagination'
 dayjs.extend(RelativeTime)
 
 function MentorConversationListRow({
@@ -42,25 +43,6 @@ function MentorConversationListRow({
       <td>{dayjs(updatedAt).fromNow()}</td>
       <td>{url}</td>
     </tr>
-  )
-}
-
-function Pagination({ current, total, setPage }) {
-  return (
-    <div>
-      {Array.from({ length: total }, (_, i) => i + 1).map((page) => {
-        return (
-          <button
-            key={page}
-            onClick={() => {
-              setPage(page)
-            }}
-          >
-            {page}
-          </button>
-        )
-      })}
-    </div>
   )
 }
 

--- a/app/javascript/components/mentoring/mentor_conversations_list.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { usePaginatedQuery } from 'react-query'
 import dayjs from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
-import Pagination from './mentor_conversations_list/pagination'
+import { Pagination } from './mentor_conversations_list/pagination'
 import { UrlParams } from '../../utils/url_params'
 dayjs.extend(RelativeTime)
 

--- a/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function Pagination({ current, total, setPage, around = 3 }) {
+export function Pagination({ current, total, setPage, around = 3 }) {
   const range = new Range(
     Math.max(current - around, 1),
     Math.min(current + around, total)

--- a/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+export default function Pagination({ current, total, setPage, around = 3 }) {
+  const range = new Range(
+    Math.max(current - around, 1),
+    Math.min(current + around, total)
+  )
+
+  function Range(start, end) {
+    return Array(end - start + 1)
+      .fill()
+      .map((_, i) => start + i)
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setPage(1)
+        }}
+        disabled={current === 1}
+      >
+        First
+      </button>
+      {range.map((page) => {
+        return (
+          <button
+            key={page}
+            onClick={() => {
+              setPage(page)
+            }}
+            disabled={page === current}
+          >
+            {page}
+          </button>
+        )
+      })}
+      <button
+        onClick={() => {
+          setPage(total)
+        }}
+        disabled={current === total}
+      >
+        Last
+      </button>
+    </div>
+  )
+}

--- a/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
+++ b/app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx
@@ -19,6 +19,8 @@ export function Pagination({ current, total, setPage, around = 3 }) {
           setPage(1)
         }}
         disabled={current === 1}
+        aria-label="Go to first page"
+        aria-current={current === 1 ? 'page' : null}
       >
         First
       </button>
@@ -30,6 +32,8 @@ export function Pagination({ current, total, setPage, around = 3 }) {
               setPage(page)
             }}
             disabled={page === current}
+            aria-label={`Go to page ${page}`}
+            aria-current={page === current ? 'page' : null}
           >
             {page}
           </button>
@@ -40,6 +44,8 @@ export function Pagination({ current, total, setPage, around = 3 }) {
           setPage(total)
         }}
         disabled={current === total}
+        aria-label="Go to last page"
+        aria-current={current === total ? 'page' : null}
       >
         Last
       </button>

--- a/app/javascript/packs/application.jsx
+++ b/app/javascript/packs/application.jsx
@@ -31,7 +31,7 @@ initReact({
   ),
   'notification-icon': (data) => <NotificationIcon count={data.count} />,
   'mentor-conversations-list': (data) => (
-    <MentorConversationsList conversations={data.conversations} />
+    <MentorConversationsList endpoint={data.endpoint} />
   ),
 })
 

--- a/app/javascript/packs/application.jsx
+++ b/app/javascript/packs/application.jsx
@@ -31,7 +31,11 @@ initReact({
   ),
   'notification-icon': (data) => <NotificationIcon count={data.count} />,
   'mentor-conversations-list': (data) => (
-    <MentorConversationsList endpoint={data.endpoint} />
+    <MentorConversationsList
+      endpoint={data.endpoint}
+      urlParams={data.url_params}
+      retryParams={data.retry_params}
+    />
   ),
 })
 

--- a/app/javascript/utils/url_params.js
+++ b/app/javascript/utils/url_params.js
@@ -1,0 +1,11 @@
+export class UrlParams {
+  constructor(object) {
+    this.object = object
+  }
+
+  toString() {
+    return Object.keys(this.object)
+      .map((key) => key + '=' + this.object[key])
+      .join('&')
+  }
+}

--- a/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
+++ b/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
@@ -1,2 +1,7 @@
 %h1 Mentor conversations list
-= mentor_conversations_list(test_components_mentoring_mentor_conversations_list_conversations_path)
+= form_tag nil, method: :get do
+  = label_tag :state
+  = select_tag :state, options_for_select(["Success", "Error"], params[:state])
+  = submit_tag "Submit", name: nil
+%hr/
+= mentor_conversations_list(test_components_mentoring_mentor_conversations_list_conversations_path, { state: params[:state] }, { retry: false })

--- a/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
+++ b/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
@@ -1,2 +1,2 @@
 %h1 Mentor conversations list
-= mentor_conversations_list(@mentor)
+= mentor_conversations_list(test_components_mentoring_mentor_conversations_list_conversations_path)

--- a/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
+++ b/app/views/test/components/mentoring/mentor_conversations_lists/show.html.haml
@@ -1,7 +1,7 @@
 %h1 Mentor conversations list
 = form_tag nil, method: :get do
   = label_tag :state
-  = select_tag :state, options_for_select(["Success", "Error"], params[:state])
+  = select_tag :state, options_for_select(["Success", "Error", "Loading"], params[:state])
   = submit_tag "Submit", name: nil
 %hr/
-= mentor_conversations_list(test_components_mentoring_mentor_conversations_list_conversations_path, { state: params[:state] }, { retry: false })
+= mentor_conversations_list(test_components_mentoring_mentor_conversations_list_conversations_path, { state: params[:state] }, { retry: params[:state] === "Loading" })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,9 @@ Rails.application.routes.draw do
         namespace :notifications do
           resource :icon, only: %i[show update]
         namespace :mentoring do
-          resource :mentor_conversations_list, only: [:show]
+          resource :mentor_conversations_list, only: [:show] do
+            resources :conversations, only: [:index], controller: "mentor_conversations_lists/conversations"
+          end
         end
       end
     end

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@testing-library/dom": "^7.24.1",
     "@testing-library/jest-dom": "^5.11.0",
     "@testing-library/react": "^10.4.3",
-    "@testing-library/user-event": "^12.1.4",
     "husky": "^4.2.5",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "version": "0.1.0",
   "devDependencies": {
     "@prettier/plugin-ruby": "^0.18.2",
+    "@testing-library/dom": "^7.24.1",
     "@testing-library/jest-dom": "^5.11.0",
     "@testing-library/react": "^10.4.3",
+    "@testing-library/user-event": "^12.1.4",
     "husky": "^4.2.5",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-query": "^2.15.4",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
+++ b/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { Pagination } from '../../../../../app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx'
 
@@ -10,7 +9,7 @@ test('clicking on "First" sets page to 1', () => {
     <Pagination current={2} total={10} setPage={setPage} />
   )
 
-  userEvent.click(getByText('First'))
+  fireEvent.click(getByText('First'))
 
   expect(setPage.mock.calls).toEqual([[1]])
 })
@@ -55,7 +54,7 @@ test('clicking on "Last" sets page to last page', () => {
     <Pagination current={2} total={10} setPage={setPage} />
   )
 
-  userEvent.click(getByText('Last'))
+  fireEvent.click(getByText('Last'))
 
   expect(setPage.mock.calls).toEqual([[10]])
 })
@@ -100,7 +99,7 @@ test('clicking on page button sets page', () => {
     <Pagination current={2} total={10} setPage={setPage} />
   )
 
-  userEvent.click(getByText('3'))
+  fireEvent.click(getByText('3'))
 
   expect(setPage.mock.calls).toEqual([[3]])
 })

--- a/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
+++ b/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
@@ -1,0 +1,91 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/extend-expect'
+import Pagination from '../../../../../app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx'
+
+test('clicking on "First" sets page to 1', () => {
+  const setPage = jest.fn()
+  const { getByText } = render(
+    <Pagination current={2} total={10} setPage={setPage} />
+  )
+
+  userEvent.click(getByText('First'))
+
+  expect(setPage.mock.calls).toEqual([[1]])
+})
+
+test('"First" button is disabled if current is 1', () => {
+  const setPage = jest.fn()
+  const { getByText } = render(
+    <Pagination current={1} total={10} setPage={setPage} />
+  )
+
+  const button = getByText('First')
+  expect(button).toBeDisabled()
+})
+
+test('clicking on "Last" sets page to last page', () => {
+  const setPage = jest.fn()
+  const { getByText } = render(
+    <Pagination current={2} total={10} setPage={setPage} />
+  )
+
+  userEvent.click(getByText('Last'))
+
+  expect(setPage.mock.calls).toEqual([[10]])
+})
+
+test('"Last" button is disabled when current = total', () => {
+  const setPage = jest.fn()
+  const { getByText } = render(
+    <Pagination current={10} total={10} setPage={setPage} />
+  )
+
+  const button = getByText('Last')
+  expect(button).toBeDisabled()
+})
+
+test('clicking on page button sets page', () => {
+  const setPage = jest.fn()
+  const { getByText } = render(
+    <Pagination current={2} total={10} setPage={setPage} />
+  )
+
+  userEvent.click(getByText('3'))
+
+  expect(setPage.mock.calls).toEqual([[3]])
+})
+
+test('button for current page is disabled', () => {
+  const { getByText } = render(<Pagination current={2} total={10} />)
+
+  const button = getByText('2')
+  expect(button).toBeDisabled()
+})
+
+test('shows buttons around the current page', () => {
+  const { queryByText } = render(
+    <Pagination current={2} total={10} around={1} />
+  )
+
+  expect(queryByText('1')).toBeTruthy()
+  expect(queryByText('3')).toBeTruthy()
+  expect(queryByText('4')).toBeNull()
+})
+
+test('only shows counting number pages', () => {
+  const { queryByText } = render(
+    <Pagination current={1} total={10} around={1} />
+  )
+
+  expect(queryByText('0')).toBeNull()
+})
+
+test('does not show pages above the total', () => {
+  const { queryByText } = render(
+    <Pagination current={10} total={10} around={1} />
+  )
+
+  expect(queryByText('11')).toBeNull()
+})

--- a/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
+++ b/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
@@ -15,6 +15,30 @@ test('clicking on "First" sets page to 1', () => {
   expect(setPage.mock.calls).toEqual([[1]])
 })
 
+test('"First" button has correct aria-label tag', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('First')
+
+  expect(button).toHaveAttribute('aria-label', 'Go to first page')
+})
+
+test('"First" button has an aria-current tag if on the first page', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('First')
+
+  expect(button).toHaveAttribute('aria-current', 'page')
+})
+
+test('"First" button does not have an aria-current tag if not on the first page', () => {
+  const { getByText } = render(<Pagination current={2} total={2} />)
+
+  const button = getByText('First')
+
+  expect(button).not.toHaveAttribute('aria-current')
+})
+
 test('"First" button is disabled if current is 1', () => {
   const setPage = jest.fn()
   const { getByText } = render(
@@ -46,6 +70,30 @@ test('"Last" button is disabled when current = total', () => {
   expect(button).toBeDisabled()
 })
 
+test('"Last" button has correct aria-label tag', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('Last')
+
+  expect(button).toHaveAttribute('aria-label', 'Go to last page')
+})
+
+test('"Last" button has an aria-current tag if on the last page', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('Last')
+
+  expect(button).toHaveAttribute('aria-current', 'page')
+})
+
+test('"Last" button does not have an aria-current tag if not on the first page', () => {
+  const { getByText } = render(<Pagination current={1} total={2} />)
+
+  const button = getByText('Last')
+
+  expect(button).not.toHaveAttribute('aria-current')
+})
+
 test('clicking on page button sets page', () => {
   const setPage = jest.fn()
   const { getByText } = render(
@@ -55,6 +103,30 @@ test('clicking on page button sets page', () => {
   userEvent.click(getByText('3'))
 
   expect(setPage.mock.calls).toEqual([[3]])
+})
+
+test('page button has correct aria-label tag', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('1')
+
+  expect(button).toHaveAttribute('aria-label', 'Go to page 1')
+})
+
+test('page button has an aria-current tag if on the page', () => {
+  const { getByText } = render(<Pagination current={1} total={1} />)
+
+  const button = getByText('1')
+
+  expect(button).toHaveAttribute('aria-current', 'page')
+})
+
+test('page button does not have an aria-current tag if not on the page', () => {
+  const { getByText } = render(<Pagination current={1} total={2} />)
+
+  const button = getByText('2')
+
+  expect(button).not.toHaveAttribute('aria-current')
 })
 
 test('button for current page is disabled', () => {

--- a/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
+++ b/test/javascript/components/mentoring/mentor_conversations_list/pagination.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'
-import Pagination from '../../../../../app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx'
+import { Pagination } from '../../../../../app/javascript/components/mentoring/mentor_conversations_list/pagination.jsx'
 
 test('clicking on "First" sets page to 1', () => {
   const setPage = jest.fn()

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -43,6 +43,14 @@ module Components
 
         assert_text "Something went wrong"
       end
+
+      test "shows loading state" do
+        visit test_components_mentoring_mentor_conversations_list_url
+        select "Loading", from: "State"
+        click_on "Submit"
+
+        assert_text "Loading"
+      end
     end
   end
 end

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -26,6 +26,15 @@ module Components
 
         assert_table_row first("table"), row
       end
+
+      test "paginates results" do
+        visit test_components_mentoring_mentor_conversations_list_url
+        click_on "2"
+
+        within("tbody > tr:first-child") do
+          within("td:nth-child(4)") { assert_text "Tournament" }
+        end
+      end
     end
   end
 end

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -35,6 +35,14 @@ module Components
           within("td:nth-child(4)") { assert_text "Tournament" }
         end
       end
+
+      test "handles API errors" do
+        visit test_components_mentoring_mentor_conversations_list_url
+        select "Error", from: "State"
+        click_on "Submit"
+
+        assert_text "Something went wrong"
+      end
     end
   end
 end

--- a/test/system/components/mentoring/mentor_conversations_list_test.rb
+++ b/test/system/components/mentoring/mentor_conversations_list_test.rb
@@ -31,9 +31,9 @@ module Components
         visit test_components_mentoring_mentor_conversations_list_url
         click_on "2"
 
-        within("tbody > tr:first-child") do
-          within("td:nth-child(4)") { assert_text "Tournament" }
-        end
+        row = { "Exercise title" => "Tournament" }
+
+        assert_table_row first("table"), row
       end
 
       test "handles API errors" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,13 +1294,6 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
-"@testing-library/user-event@^12.1.4":
-  version "12.1.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.4.tgz#a1f257dd2ec5fc19ca5d96ef2d096f6f5888e67a"
-  integrity sha512-vd5s43lNfyq/JEr8ndQmS+An6dEVUmjW9zqtpmMHU+rrPMaHLrUIlWZ9wDE8ALS/dFMsu6U00A5X/7Dv/2tWnw==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,6 +1257,19 @@
     dom-accessibility-api "^0.5.0"
     pretty-format "^25.5.0"
 
+"@testing-library/dom@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.1.tgz#0e8acd042070f2c1b183fbfe5c0d38b3194ad3c0"
+  integrity sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
+
 "@testing-library/jest-dom@^5.11.0":
   version "5.11.2"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.2.tgz#c49de331555c70127b5d7fc97344ad5265f4c54c"
@@ -1280,6 +1293,13 @@
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
+
+"@testing-library/user-event@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.4.tgz#a1f257dd2ec5fc19ca5d96ef2d096f6f5888e67a"
+  integrity sha512-vd5s43lNfyq/JEr8ndQmS+An6dEVUmjW9zqtpmMHU+rrPMaHLrUIlWZ9wDE8ALS/dFMsu6U00A5X/7Dv/2tWnw==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"
@@ -2453,7 +2473,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -3342,6 +3362,11 @@ dom-accessibility-api@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.0.tgz#fddffd04e178796e241436c3f21be2f89c91afac"
   integrity sha512-eCVf9n4Ni5UQAFc2+fqfMPHdtiX7DA0rLakXgNBZfXNJzEbNo3MQIYd+zdYpFBqAaGYVrkd8leNSLGPrG4ODmA==
+
+dom-accessibility-api@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz#ef3cdb5d3f0d599d8f9c8b18df2fb63c9793739d"
+  integrity sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==
 
 dom-serializer@0:
   version "0.2.2"
@@ -7460,6 +7485,16 @@ pretty-format@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.3.0.tgz#d9a7b4bb2948cabc646e6a7729b12f686f3fed36"
   integrity sha512-24kRw4C2Ok8+SHquydTZZCZPF2fvANI7rChGs8sNu784+1Jkq5jVFMvNAJSLuLy6XUcP3Fnw+SscLIQag/CG8Q==
+  dependencies:
+    "@jest/types" "^26.3.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
   dependencies:
     "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7668,6 +7668,11 @@ react-is@^16.12.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-query@^2.15.4:
+  version "2.15.4"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.15.4.tgz#0447510fc30aebba5a4b99879ec4b7155d9b3f20"
+  integrity sha512-gEF2Ebe1MtiyLKEaVEIlRMl6rwvP/RVwP+Xf68vhXDfD91IeZkkW7plRjoaHa0/NeUPM1AgTHb1Z7NtqaYDXjA==
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"


### PR DESCRIPTION
## Description
This adds simple pagination for `<MentorConversationsList />`.

## Preview
![Sep-09-2020 13-04-02](https://user-images.githubusercontent.com/1901520/92556900-a0377e00-f29d-11ea-9d21-2dbfaf4bf1ab.gif)

## Questions
1. Are we fine with just passing in the endpoint rather than the initial collection of conversations? I opted to do it this way because it was easier for me to structure the code.
2. Was it a good choice to use [react-query](https://github.com/tannerlinsley/react-query)? I decided to use this as we want an external library to handle caching when loading through the pages. I'm unsure though if this was the right choice.
3. Are my JS tests correct? And is it okay to use `userEvent`?
4. Have we decided on how the pagination widget behaves? I've set it up as Google-style right now where N number of pages are shown around the page. The last N pages aren't shown, but the design on the website shows otherwise. I decided to do it this way as this is the most simple option for now. (cc @taiyab)