### PR TITLE
Add tracks serializer

### DIFF
--- a/app/serializers/api/tracks_serializer.rb
+++ b/app/serializers/api/tracks_serializer.rb
@@ -1,0 +1,98 @@
+class API::TracksSerializer
+  include Rails.application.routes.url_helpers
+  include Mandate
+
+  def initialize(tracks, user = nil)
+    @tracks = tracks
+    @user = user
+  end
+
+  def to_hash
+    {
+      tracks: tracks.map do |track|
+        data_for_track(track).merge(user_data_for_track(track))
+      end
+    }
+  end
+
+  private
+  attr_reader :tracks, :user
+
+  def data_for_track(track)
+    {
+      id: track.id,
+      title: track.title,
+      num_concept_exercises: concept_exercise_counts[track.id].to_i,
+      num_practice_exercises: practice_exercise_counts[track.id].to_i,
+      web_url: routes.track_url(track),
+
+      # TODO: Set all three of these
+      icon_url: "https://assets.exercism.io/tracks/ruby-hex-white.png",
+      is_new: true,
+      tags: ["OOP", "Web Dev"]
+    }
+  end
+
+  def user_data_for_track(track)
+    return {} unless user
+
+    {
+      is_joined: joined_track_ids.include?(track.id),
+      num_completed_concept_exercises: completed_concept_exercise_counts[track.id].to_i,
+      num_completed_practice_exercises: completed_practice_exercise_counts[track.id].to_i
+    }
+  end
+
+  memoize
+  def routes
+    Rails.application.routes.url_helpers
+  end
+
+  memoize
+  def concept_exercise_counts
+    ConceptExercise.
+      where(track: tracks).
+      group(:track_id).
+      count
+  end
+
+  memoize
+  def practice_exercise_counts
+    PracticeExercise.
+      where(track: tracks).
+      group(:track_id).
+      count
+  end
+
+  memoize
+  def joined_track_ids
+    UserTrack.
+      where(user: user).
+      where(track: tracks).
+      map(&:track_id)
+  end
+
+  memoize
+  def completed_concept_exercise_counts
+    # TODO: This is currently exercises started. Once we've added
+    # the completed flags to the db we should change it to completed
+    ConceptSolution.
+      joins(:exercise).
+      where(user: user).
+      where('exercises.track_id': tracks).
+      group('exercises.track_id').
+      count
+  end
+
+  memoize
+  def completed_practice_exercise_counts
+    # TODO: This is currently exercises started. Once we've added
+    # the completed flags to the db we should change it to completed
+    PracticeSolution.
+      joins(:exercise).
+      where(user: user).
+      where('exercises.track_id': tracks).
+      group('exercises.track_id').
+      count
+  end
+end

--- a/test/serializers/api/tracks_serializer.rb
+++ b/test/serializers/api/tracks_serializer.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class API::TracksSerializerTest < ActiveSupport::TestCase
+  test "without user" do
+    track = create :track
+
+    num_concept_exercises = 3
+    num_practice_exercises = 7
+
+    num_concept_exercises.times { create :concept_exercise, track: track }
+    num_practice_exercises.times { create :practice_exercise, track: track }
+
+    serializer = API::TracksSerializer.new([track])
+    expected = {
+      tracks: [
+        {
+          id: track.id,
+          title: track.title,
+          num_concept_exercises: num_concept_exercises,
+          num_practice_exercises: num_practice_exercises,
+          web_url: "https://test.exercism.io/tracks/#{track.slug}",
+
+          # TODO: Set all three of these
+          icon_url: "https://assets.exercism.io/tracks/ruby-hex-white.png",
+          is_new: true,
+          tags: ["OOP", "Web Dev"]
+        }
+      ]
+    }
+
+    assert_equal expected, serializer.to_hash
+  end
+
+  test "with user not joined" do
+    track = create :track
+
+    serializer = API::TracksSerializer.new([track], create(:user))
+
+    track_data = serializer.to_hash[:tracks].first
+    refute track_data[:is_joined]
+    assert_equal 0, track_data[:num_completed_concept_exercises]
+    assert_equal 0, track_data[:num_completed_practice_exercises]
+  end
+
+  test "with user joined and progressed" do
+    track = create :track
+    ces = Array.new(3).map { create :concept_exercise, track: track }
+    pes = Array.new(3).map { create :practice_exercise, track: track }
+
+    user = create :user
+    create :user_track, user: user, track: track
+
+    # TODO: Change to be completed when that is in the db schema
+    # and add a case where it's not completed to check the flag is
+    # being used correctly.
+    create :concept_solution, exercise: ces[0], user: user
+    create :practice_solution, exercise: pes[0], user: user
+    create :practice_solution, exercise: pes[1], user: user
+
+    serializer = API::TracksSerializer.new([track], user)
+
+    track_data = serializer.to_hash[:tracks].first
+    assert track_data[:is_joined]
+    assert_equal 1, track_data[:num_completed_concept_exercises]
+    assert_equal 2, track_data[:num_completed_practice_exercises]
+  end
+end


### PR DESCRIPTION
This adds a serializer for the tracks data. This will power both the public tracks endpoint in the API and the JS.

## Questions
- Is the data correct? Anything missing?
- Any comments on the pattern?
- Are you both happy with the `# TODO` pattern for where the data isn't yet in the schema. Doing this allows me to do smaller PRs for these situations.

## Notes

I'm deliberately removing n+1 queries by doing memoized groups/count etc at the bottom. Any time we serialize data we should be thinking of how we can do things like this to reduce the number of DB queries.