### PR TITLE
Tracks searching

### DIFF
--- a/app/commands/track/search.rb
+++ b/app/commands/track/search.rb
@@ -1,0 +1,51 @@
+class Track
+  class Search
+    STATUSES = %i[all joined unjoined].freeze
+
+    include Mandate
+
+    def initialize(criteria: nil, tags: nil, status: nil, user: nil)
+      @criteria = criteria
+      @tags = tags
+      @status = status.try(&:to_sym)
+      @user = user
+    end
+
+    def call
+      @tracks = Track.active
+      filter_criteria
+      filter_tags
+      filter_status
+      @tracks
+    end
+
+    private
+    attr_reader :criteria, :tags, :status, :user
+    attr_reader :tracks
+
+    def filter_criteria
+      return if criteria.blank?
+
+      @tracks = tracks.where(
+        "title like ?", "%#{criteria}%"
+      )
+    end
+
+    # TODO: Decide how to model tags filter
+    # and add it here.
+    def filter_tags; end
+
+    def filter_status
+      return if status.blank?
+      raise TrackSearchStatusWithoutUserError unless user
+      raise TrackSearchInvalidStatusError unless STATUSES.include?(status.to_sym)
+      return if status == :all
+
+      @tracks = if status == :joined
+                  tracks.where(id: user.tracks)
+                else
+                  tracks.where.not(id: user.tracks)
+                end
+    end
+  end
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -10,6 +10,8 @@ class Track < ApplicationRecord
 
   delegate :head_sha, to: :repo, prefix: "git"
 
+  scope :active, -> { where(active: true) }
+
   def self.for!(param)
     return param if param.is_a?(Track)
     return find_by!(id: param) if param.is_a?(Numeric)

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -4,3 +4,5 @@ class ExerciseUnavailableError < RuntimeError; end
 class IterationFileTooLargeError < RuntimeError; end
 class SolutionLockedByAnotherMentorError < RuntimeError; end
 class TooManyIterationsError < RuntimeError; end
+class TrackSearchStatusWithoutUserError < RuntimeError; end
+class TrackSearchInvalidStatusError < RuntimeError; end

--- a/db/migrate/20200504163928_create_tracks.rb
+++ b/db/migrate/20200504163928_create_tracks.rb
@@ -6,6 +6,8 @@ class CreateTracks < ActiveRecord::Migration[6.0]
 
       t.string :repo_url, null: false
 
+      t.boolean :active, default: true, null: false
+
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 2020_08_30_161328) do
     t.string "slug", null: false
     t.string "title", null: false
     t.string "repo_url", null: false
+    t.boolean "active", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/commands/track/search_test.rb
+++ b/test/commands/track/search_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Badge::CreateTest < ActiveSupport::TestCase
+  test "only include active tracks" do
+    # Create one active and one inactive track
+    track = create :track, active: true
+    create :track, active: false
+
+    assert_equal [track], Track::Search.()
+  end
+
+  test "wildcard search with criteria" do
+    # Create one track with Ruby in the title
+    track = create :track, title: "A Ruby Track"
+    create :track, title: "A JS Track"
+
+    assert_equal [track], Track::Search.(criteria: "ruby")
+  end
+
+  test "status raises without a user" do
+    assert_raises TrackSearchStatusWithoutUserError do
+      Track::Search.(status: :all)
+    end
+  end
+
+  test "status raises unless its valid" do
+    assert_raises TrackSearchInvalidStatusError do
+      Track::Search.(status: :foobar, user: create(:user))
+    end
+  end
+
+  test "status pivots correctly" do
+    user = create :user
+    joined = create :track
+    create :user_track, user: user, track: joined
+    unjoined = create :track
+
+    assert_equal [joined, unjoined],
+                 Track::Search.(status: :all, user: user)
+
+    assert_equal [joined],
+                 Track::Search.(status: :joined, user: user)
+
+    assert_equal [unjoined],
+                 Track::Search.(status: :unjoined, user: user)
+  end
+end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -16,7 +16,7 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal track, Track.for!(track.slug)
   end
 
-  test "#active scope" do
+  test ".active scope" do
     # Create one active and one inactive track
     track = create :track, active: true
     create :track, active: false

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -16,6 +16,14 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal track, Track.for!(track.slug)
   end
 
+  test "#active scope" do
+    # Create one active and one inactive track
+    track = create :track, active: true
+    create :track, active: false
+
+    assert_equal [track], Track.active
+  end
+
   %w[head_sha].each do |delegate|
     test "delegates git_#{delegate}" do
       slug = SecureRandom.uuid


### PR DESCRIPTION
This PR adds a command for searching tracks. It's pretty straight forward 🙂 

Note that I'm **not** adding new migrations for changes. I want to end up with one migration per table to make ETL easier. So you will need to reset your DB your use this. This will be a regular thing to do 🙂 You can do this with: 
```bash
bundle exec db:migrate:reset db:seed
```