### PR TITLE
Allow manually refetching conversations list

### DIFF
--- a/app/javascript/components/mentoring/inbox/ConversationList.jsx
+++ b/app/javascript/components/mentoring/inbox/ConversationList.jsx
@@ -11,12 +11,20 @@ export function ConversationList({ request, setPage }) {
     isFetching,
     resolvedData,
     latestData,
+    refetch,
   } = usePaginatedRequestQuery('mentor-conversations-list', request)
 
   return (
     <div className="conversations-list">
       {isFetching && <Loading />}
-      {isError && <p>Something went wrong</p>}
+      {isError && (
+        <>
+          <p>Something went wrong</p>
+          <button onClick={() => refetch()} aria-label="Retry">
+            Retry
+          </button>
+        </>
+      )}
       {isSuccess && (
         <>
           <table>

--- a/app/javascript/hooks/request-query.js
+++ b/app/javascript/hooks/request-query.js
@@ -3,7 +3,7 @@ import { UrlParams } from '../utils/url-params'
 import fetch from 'isomorphic-fetch'
 import { camelizeKeys } from 'humps'
 
-async function handleFetch(key, url, query) {
+function handleFetch(key, url, query) {
   return fetch(`${url}?${new UrlParams(query).toString()}`)
     .then((response) => response.json())
     .then((json) => camelizeKeys(json))

--- a/test/javascript/components/mentoring/inbox/ConversationList.test.js
+++ b/test/javascript/components/mentoring/inbox/ConversationList.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import '@testing-library/jest-dom/extend-expect'
+import { ConversationList } from '../../../../../app/javascript/components/mentoring/inbox/ConversationList.jsx'
+
+const server = setupServer(
+  rest.get('https://exercism.test/conversations', (req, res, ctx) => {
+    return res(ctx.status(500, 'Internal server error'))
+  })
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('allow retry after loading error', async () => {
+  const setPage = jest.fn()
+
+  render(
+    <ConversationList
+      request={{
+        endpoint: 'https://exercism.test/conversations',
+        query: { page: 2 },
+      }}
+      setPage={setPage}
+    />
+  )
+
+  await waitFor(() => expect(screen.getByText('Retry')).toBeInTheDocument())
+})

--- a/test/javascript/components/mentoring/inbox/ConversationList.test.js
+++ b/test/javascript/components/mentoring/inbox/ConversationList.test.js
@@ -23,10 +23,35 @@ test('allow retry after loading error', async () => {
       request={{
         endpoint: 'https://exercism.test/conversations',
         query: { page: 2 },
+        options: { retry: false },
       }}
       setPage={setPage}
     />
   )
 
   await waitFor(() => expect(screen.getByText('Retry')).toBeInTheDocument())
+
+  server.use(
+    rest.get('https://exercism.test/conversations', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [
+            {
+              trackTitle: 'Ruby',
+              exerciseTitle: 'Bob',
+              isStarred: false,
+              isNewIteration: false,
+              haveMentoredPreviously: false,
+            },
+          ],
+          meta: { total: 2 },
+        })
+      )
+    })
+  )
+
+  fireEvent.click(screen.getByText('Retry'))
+
+  await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument())
+  expect(screen.queryByText('Retry')).not.toBeInTheDocument()
 })


### PR DESCRIPTION
I have some questions:

Do we want to add a test if this works?
Do we want to update the test component to have this working there? At the moment, this button is shown when the state is explicitly set to the Error state, but that changes the URL which means that doing a refetch will include the error state URL and thus the same erronous data is sent back.