### PR TITLE
Refactor sort options into the relevant view component class

### DIFF
--- a/app/controllers/test/components/mentoring/inbox_controller.rb
+++ b/app/controllers/test/components/mentoring/inbox_controller.rb
@@ -1,11 +1,5 @@
 class Test::Components::Mentoring::InboxController < ApplicationController
-  def show
-    @sort_options = [
-      { value: 'recent', label: 'Sort by Most Recent' },
-      { value: 'exercise', label: 'Sort by Exercise' },
-      { value: 'student', label: 'Sort by Student' }
-    ]
-  end
+  def show; end
 
   def tracks
     # By passing a state param, we can mock our controller's response.

--- a/app/controllers/test/components/mentoring/queue_controller.rb
+++ b/app/controllers/test/components/mentoring/queue_controller.rb
@@ -1,11 +1,5 @@
 class Test::Components::Mentoring::QueueController < ApplicationController
-  def show
-    @sort_options = [
-      { value: "recent", label: "Sort by Most Recent" },
-      { value: "exercise", label: "Sort by Exercise" },
-      { value: "student", label: "Sort by Student" }
-    ]
-  end
+  def show; end
 
   def solutions
     return head :internal_server_error if params[:state] == "Error" || params[:state] == "Loading"

--- a/app/helpers/view_components/mentoring/inbox.rb
+++ b/app/helpers/view_components/mentoring/inbox.rb
@@ -1,15 +1,24 @@
 module ViewComponents
   module Mentoring
     class Inbox < ViewComponent
-      initialize_with :conversations_request, :tracks_request, :sort_options
+      initialize_with :conversations_request, :tracks_request
 
       def to_s
-        react_component("mentoring-inbox", {
-                          conversations_request: conversations_request,
-                          tracks_request: tracks_request,
-                          sort_options: sort_options
-                        })
+        react_component(
+          "mentoring-inbox",
+          {
+            conversations_request: conversations_request,
+            tracks_request: tracks_request,
+            sort_options: SORT_OPTIONS
+          }
+        )
       end
+
+      SORT_OPTIONS = [
+        { value: 'recent', label: 'Sort by Most Recent' },
+        { value: 'exercise', label: 'Sort by Exercise' },
+        { value: 'student', label: 'Sort by Student' }
+      ].freeze
     end
   end
 end

--- a/app/helpers/view_components/mentoring/inbox.rb
+++ b/app/helpers/view_components/mentoring/inbox.rb
@@ -19,6 +19,7 @@ module ViewComponents
         { value: 'exercise', label: 'Sort by Exercise' },
         { value: 'student', label: 'Sort by Student' }
       ].freeze
+      private_constant :SORT_OPTIONS
     end
   end
 end

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -1,11 +1,23 @@
 module ViewComponents
   module Mentoring
     class Queue < ViewComponent
-      initialize_with :request, :sort_options
+      initialize_with :request
 
       def to_s
-        react_component("mentoring-queue", { request: request, sort_options: sort_options })
+        react_component(
+          "mentoring-queue",
+          {
+            request: request,
+            sort_options: SORT_OPTIONS
+          }
+        )
       end
+
+      SORT_OPTIONS = [
+        { value: "recent", label: "Sort by Most Recent" },
+        { value: "exercise", label: "Sort by Exercise" },
+        { value: "student", label: "Sort by Student" }
+      ].freeze
     end
   end
 end

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -18,6 +18,7 @@ module ViewComponents
         { value: "exercise", label: "Sort by Exercise" },
         { value: "student", label: "Sort by Student" }
       ].freeze
+      private_constant :SORT_OPTIONS
     end
   end
 end

--- a/app/views/test/components/mentoring/inbox/show.html.haml
+++ b/app/views/test/components/mentoring/inbox/show.html.haml
@@ -7,4 +7,4 @@
   = select_tag :tracks_endpoint_state, options_for_select(%w[Success Error Loading], params[:tracks_endpoint_state])
   = submit_tag "Submit", name: nil
 %hr/
-= ViewComponents::Mentoring::Inbox.new({ endpoint: conversations_test_components_mentoring_inbox_path, query: { state: params[:conversations_endpoint_state], sort: :exercise }, retry: { retry: params[:conversations_endpoint_state] == "Loading" } }, { endpoint: tracks_test_components_mentoring_inbox_path, query: { state: params[:tracks_endpoint_state] }, retry: { retry: params[:tracks_endpoint_state] == "Loading" } }, @sort_options)
+= ViewComponents::Mentoring::Inbox.new({ endpoint: conversations_test_components_mentoring_inbox_path, query: { state: params[:conversations_endpoint_state], sort: :exercise }, retry: { retry: params[:conversations_endpoint_state] == "Loading" } }, { endpoint: tracks_test_components_mentoring_inbox_path, query: { state: params[:tracks_endpoint_state] }, retry: { retry: params[:tracks_endpoint_state] == "Loading" } })

--- a/app/views/test/components/mentoring/queue/show.html.haml
+++ b/app/views/test/components/mentoring/queue/show.html.haml
@@ -5,4 +5,4 @@
   = select_tag :state, options_for_select(%w[Success Error Loading], params[:state])
   = submit_tag "Submit", name: nil
 %hr/
-= ViewComponents::Mentoring::Queue.new({ endpoint: solutions_test_components_mentoring_queue_path, query: { state: params[:state] }, retry: { retry: params[:state] == "Loading" } }, @sort_options)
+= ViewComponents::Mentoring::Queue.new({ endpoint: solutions_test_components_mentoring_queue_path, query: { state: params[:state] }, retry: { retry: params[:state] == "Loading" } })

--- a/test/helpers/view_components/mentoring/inbox_test.rb
+++ b/test/helpers/view_components/mentoring/inbox_test.rb
@@ -4,23 +4,21 @@ class MentoringInboxTest < ViewComponentTestCase
   test "mentoring inbox rendered correctly" do
     conversations_request = { endpoint: "conversations-endpoint" }
     tracks_request = { endpoint: "tracks-endpoint" }
-    sort_options = [
-      { value: 'recent', label: 'Sort by Most Recent' },
-      { value: 'exercise', label: 'Sort by Exercise' },
-      { value: 'student', label: 'Sort by Student' }
-    ]
 
-    assert_component_equal ViewComponents::Mentoring::Inbox.new(
-      conversations_request, tracks_request, sort_options
-    ).to_s,
-                           { id: "mentoring-inbox", props: {
-                             conversations_request: { endpoint: "conversations-endpoint" },
-                             tracks_request: { endpoint: "tracks-endpoint" },
-                             sort_options: [
-                               { value: 'recent', label: 'Sort by Most Recent' },
-                               { value: 'exercise', label: 'Sort by Exercise' },
-                               { value: 'student', label: 'Sort by Student' }
-                             ]
-                           } }
+    component = ViewComponents::Mentoring::Inbox.new(
+      conversations_request, tracks_request
+    ).to_s
+
+    assert_component_equal(
+      component,
+      {
+        id: "mentoring-inbox",
+        props: {
+          conversations_request: { endpoint: "conversations-endpoint" },
+          tracks_request: { endpoint: "tracks-endpoint" },
+          sort_options: ViewComponents::Mentoring::Inbox::SORT_OPTIONS
+        }
+      }
+    )
   end
 end

--- a/test/helpers/view_components/mentoring/inbox_test.rb
+++ b/test/helpers/view_components/mentoring/inbox_test.rb
@@ -16,7 +16,11 @@ class MentoringInboxTest < ViewComponentTestCase
         props: {
           conversations_request: { endpoint: "conversations-endpoint" },
           tracks_request: { endpoint: "tracks-endpoint" },
-          sort_options: ViewComponents::Mentoring::Inbox::SORT_OPTIONS
+          sort_options: [
+            { value: 'recent', label: 'Sort by Most Recent' },
+            { value: 'exercise', label: 'Sort by Exercise' },
+            { value: 'student', label: 'Sort by Student' }
+          ]
         }
       }
     )


### PR DESCRIPTION
As I commented [here](https://github.com/exercism/v3-website/pull/93#discussion_r493896871), I think sort_options are a property of the component, not the controller. So I've moved them in here. This still keeps everything serverside, but removes the duplication between identical data in app and test that could cause out-of-sync-bugs.