### PR TITLE
Loosen Codeowners restrictions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,18 @@
-* @iHiD
+# JS files
+*.js      @iHiD @kntsoriano @erikschierboom
+
+# Ruby files
+*.rb      @iHiD
+*.ru      @iHiD
+Gemfile*  @iHiD
+config/   @iHiD
+db/       @iHiD
+lib/      @iHiD
+
+# Docker and deployment files
+docker/   @iHiD
+Procfile* @iHiD
+
+# Bin files
+bin/     @iHiD
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@ Gemfile*  @iHiD
 config/   @iHiD
 db/       @iHiD
 lib/      @iHiD
+Rakefile  @iHiD
 
 # Docker and deployment files
 docker/   @iHiD
@@ -15,4 +16,3 @@ Procfile* @iHiD
 
 # Bin files
 bin/     @iHiD
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # JS files
-*.js      @iHiD @kntsoriano @erikschierboom
+*.js      @erikschierboom @iHiD @kntsoriano 
 
 # Ruby files
 *.rb      @iHiD
@@ -11,8 +11,10 @@ lib/      @iHiD
 Rakefile  @iHiD
 
 # Docker and deployment files
-docker/   @iHiD
-Procfile* @iHiD
+docker/          @iHiD
+dev.Dockerfile   @erikschierboom @iHiD @kntsoriano
+Procfile*        @iHiD
+.github          @iHiD
 
 # Bin files
 bin/     @iHiD


### PR DESCRIPTION
PRs require one CodeOwner reviewer to approve. This loosens the existing requirements somewhat by allowing Erik/Karlo to be autonomous on reviewing/merging any JS PRs, and removes codeowner restrictions from other non-critical files.