### PR TITLE
Add serialization for test run

### DIFF
--- a/app/serializers/serialize_iteration_test_run.rb
+++ b/app/serializers/serialize_iteration_test_run.rb
@@ -1,0 +1,41 @@
+class SerializeIterationTestRun
+  include Mandate
+
+  initialize_with :test_run
+
+  def call
+    {
+      id: test_run.id,
+      status: status,
+      message: message,
+      tests: tests
+    }
+  end
+
+  private
+  def status
+    return OPS_ERROR_STATUS unless test_run.ops_success?
+    return :error unless VALID_STATUSES.include?(test_run.status)
+
+    test_run.status
+  end
+
+  def message
+    return test_run.message if test_run.message.present?
+    return nil if test_run.ops_success?
+
+    # TODO: Decide how this is corrolated with the
+    # errors upstream and move into i18n.
+    "Some error occurred"
+  end
+
+  def tests
+    test_run.tests
+  end
+
+  OPS_ERROR_STATUS = "ops_error".freeze
+  private_constant :OPS_ERROR_STATUS
+
+  VALID_STATUSES = %i[pass fail error].freeze
+  private_constant :VALID_STATUSES
+end

--- a/test/serializers/serialize_iteration_test_run.rb
+++ b/test/serializers/serialize_iteration_test_run.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class SerializeIterationTestRunTest < ActiveSupport::TestCase
+  test "test successful run" do
+    test = {
+      'name' => 'test_a_name_given',
+      'status' => 'pass',
+      'output' => 'foobar'
+    }
+    test_run = create :iteration_test_run,
+                      ops_status: 200,
+                      status: "pass",
+                      tests: [test]
+
+    actual = SerializeIterationTestRun.(test_run)
+
+    expected = {
+      id: test_run.id,
+      status: :pass,
+      message: test_run.message,
+      tests: [test]
+    }
+    assert_equal expected, actual
+  end
+
+  test "status: proxies fail" do
+    test_run = create :iteration_test_run,
+                      ops_status: 200,
+                      status: 'fail'
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_equal :fail, output[:status]
+  end
+
+  test "status: proxies error" do
+    test_run = create :iteration_test_run,
+                      ops_status: 200,
+                      status: 'error'
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_equal :error, output[:status]
+  end
+
+  test "status: returns error if unexpected" do
+    test_run = create :iteration_test_run,
+                      ops_status: 200,
+                      status: 'foobar'
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_equal :error, output[:status]
+  end
+
+  test "message: returns message if there is one" do
+    message = "foobar"
+    test_run = create :iteration_test_run, message: message
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_equal message, output[:message]
+  end
+
+  test "message: returns nil if there is no message" do
+    test_run = create :iteration_test_run,
+                      ops_status: 200,
+                      raw_results: { message: nil }
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_nil output[:message]
+  end
+
+  test "ops_error returns status and message" do
+    test_run = create :iteration_test_run,
+                      ops_status: 403,
+                      raw_results: { message: nil } # Override the factory
+
+    output = SerializeIterationTestRun.(test_run)
+
+    assert_equal "ops_error", output[:status]
+    assert_equal "Some error occurred", output[:message]
+  end
+end


### PR DESCRIPTION
This adds the serialization for the test run, which the in-browser coding components will use.