### PR TITLE
Use rubocop comments for long lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,6 @@ Layout/LineLength:
   Exclude:
     - "config/**/*"
     - "test/models/notifications/*"
-    - "test/commands/cli/prepare_uploaded_files_test.rb"
     - "test/helpers/view_components/example/iterations_summary_table_test.rb"
     - "test/helpers/view_components/maintaining/iterations_summary_table_test.rb"
 

--- a/test/commands/cli/prepare_uploaded_files_test.rb
+++ b/test/commands/cli/prepare_uploaded_files_test.rb
@@ -4,12 +4,12 @@ class CLI::PrepareUploadedFilesTest < ActiveSupport::TestCase
   test "creates iteration correctly" do
     filename_1 = "subdir/foobar.rb"
     content_1 = "'I think' = 'I am'"
-    headers_1 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_1}\"\r\nContent-Type: application/octet-stream\r\n"
+    headers_1 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_1}\"\r\nContent-Type: application/octet-stream\r\n" # rubocop:disable Layout/LineLength
     file_1 = mock(read: content_1, headers: headers_1)
 
     filename_2 = "barfood.rb"
     content_2 = "something = :else"
-    headers_2 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_2}\"\r\nContent-Type: application/octet-stream\r\n"
+    headers_2 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_2}\"\r\nContent-Type: application/octet-stream\r\n" # rubocop:disable Layout/LineLength
     file_2 = mock(read: content_2, headers: headers_2)
 
     files = CLI::PrepareUploadedFiles.([file_1, file_2])
@@ -28,7 +28,7 @@ class CLI::PrepareUploadedFilesTest < ActiveSupport::TestCase
   test "raises if file is too large" do
     filename = "subdir/foobar.rb"
     content = Array.new(1.megabyte + 1, 'x')
-    headers = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename}\"\r\nContent-Type: application/octet-stream\r\n"
+    headers = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename}\"\r\nContent-Type: application/octet-stream\r\n" # rubocop:disable Layout/LineLength
     file = mock(read: content, headers: headers)
 
     assert_raises IterationFileTooLargeError do


### PR DESCRIPTION
Let's add line-comments rather than full-file exclusions as a rule moving forward. (I don't mind that they make the lines even longer - as we're accepting here that the line is effectively infinitely long)