### PR TITLE
Loosen Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.6'
+ruby '~> 2.6.0'
 
 # Service/framework dependencies
 gem 'rails', git: 'http://github.com/rails/rails.git', ref: "7101489293ece071013417aeed2da3aa1b0927c9"


### PR DESCRIPTION
This allows patch level differences for the Ruby version, so that systems that _require_ certain patches can apply them, without having to pin a specific patch level on their system (rbenv, uru, etc.)