### PR TITLE
Add default request values to view components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,3 +108,7 @@ Rails/RefuteMethods:
 
 Rails/SkipsModelValidations:
   Enabled: false
+
+Rails/HelperInstanceVariable:
+  Exclude:
+    - "app/helpers/view_components/**/*"

--- a/app/helpers/view_components/mentoring/inbox.rb
+++ b/app/helpers/view_components/mentoring/inbox.rb
@@ -28,10 +28,12 @@ module ViewComponents
 
       private
       def default_conversations_request
+        # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.conversations_test_components_mentoring_inbox_path }
       end
 
       def default_tracks_request
+        # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.tracks_test_components_mentoring_inbox_path }
       end
     end

--- a/app/helpers/view_components/mentoring/inbox.rb
+++ b/app/helpers/view_components/mentoring/inbox.rb
@@ -1,8 +1,6 @@
 module ViewComponents
   module Mentoring
     class Inbox < ViewComponent
-      attr_reader :conversations_request, :tracks_request
-
       def initialize(conversations_request = default_conversations_request, tracks_request = default_tracks_request)
         @conversations_request = conversations_request
         @tracks_request = tracks_request
@@ -27,6 +25,8 @@ module ViewComponents
       private_constant :SORT_OPTIONS
 
       private
+      attr_reader :conversations_request, :tracks_request
+
       def default_conversations_request
         # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.conversations_test_components_mentoring_inbox_path }

--- a/app/helpers/view_components/mentoring/inbox.rb
+++ b/app/helpers/view_components/mentoring/inbox.rb
@@ -1,7 +1,12 @@
 module ViewComponents
   module Mentoring
     class Inbox < ViewComponent
-      initialize_with :conversations_request, :tracks_request
+      attr_reader :conversations_request, :tracks_request
+
+      def initialize(conversations_request = default_conversations_request, tracks_request = default_tracks_request)
+        @conversations_request = conversations_request
+        @tracks_request = tracks_request
+      end
 
       def to_s
         react_component(
@@ -20,6 +25,15 @@ module ViewComponents
         { value: 'student', label: 'Sort by Student' }
       ].freeze
       private_constant :SORT_OPTIONS
+
+      private
+      def default_conversations_request
+        { endpoint: Exercism::Routes.conversations_test_components_mentoring_inbox_path }
+      end
+
+      def default_tracks_request
+        { endpoint: Exercism::Routes.tracks_test_components_mentoring_inbox_path }
+      end
     end
   end
 end

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -1,8 +1,6 @@
 module ViewComponents
   module Mentoring
     class Queue < ViewComponent
-      attr_reader :request
-
       def initialize(request = default_request)
         @request = request
       end
@@ -25,6 +23,8 @@ module ViewComponents
       private_constant :SORT_OPTIONS
 
       private
+      attr_reader :request
+
       def default_request
         # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.solutions_test_components_mentoring_queue_path }

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -2,6 +2,7 @@ module ViewComponents
   module Mentoring
     class Queue < ViewComponent
       attr_reader :request
+
       def initialize(request = default_request)
         @request = request
       end

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -1,7 +1,10 @@
 module ViewComponents
   module Mentoring
     class Queue < ViewComponent
-      initialize_with :request
+      attr_reader :request
+      def initialize(request = default_request)
+        @request = request
+      end
 
       def to_s
         react_component(
@@ -19,6 +22,11 @@ module ViewComponents
         { value: "student", label: "Sort by Student" }
       ].freeze
       private_constant :SORT_OPTIONS
+
+      private
+      def default_request
+        { endpoint: Exercism::Routes.solutions_test_components_mentoring_queue_path }
+      end
     end
   end
 end

--- a/app/helpers/view_components/mentoring/queue.rb
+++ b/app/helpers/view_components/mentoring/queue.rb
@@ -25,6 +25,7 @@ module ViewComponents
 
       private
       def default_request
+        # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.solutions_test_components_mentoring_queue_path }
       end
     end

--- a/app/helpers/view_components/student/tracks_list.rb
+++ b/app/helpers/view_components/student/tracks_list.rb
@@ -24,6 +24,7 @@ module ViewComponents
 
       private
       def default_request
+        # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.tracks_test_components_student_tracks_list_path }
       end
     end

--- a/app/helpers/view_components/student/tracks_list.rb
+++ b/app/helpers/view_components/student/tracks_list.rb
@@ -1,7 +1,12 @@
 module ViewComponents
   module Student
     class TracksList < ViewComponent
-      initialize_with :data, :request
+      attr_reader :data, :request
+
+      def initialize(data, request = default_request)
+        @data = data
+        @request = request
+      end
 
       def to_s
         react_component("student-tracks-list", {
@@ -16,6 +21,11 @@ module ViewComponents
         { value: "unjoined", label: "Unjoined" }
       ].freeze
       private_constant :STATUS_OPTIONS
+
+      private
+      def default_request
+        { endpoint: Exercism::Routes.tracks_test_components_student_tracks_list_path }
+      end
     end
   end
 end

--- a/app/helpers/view_components/student/tracks_list.rb
+++ b/app/helpers/view_components/student/tracks_list.rb
@@ -1,8 +1,6 @@
 module ViewComponents
   module Student
     class TracksList < ViewComponent
-      attr_reader :data, :request
-
       def initialize(data, request = default_request)
         @data = data
         @request = request
@@ -23,6 +21,8 @@ module ViewComponents
       private_constant :STATUS_OPTIONS
 
       private
+      attr_reader :data, :request
+
       def default_request
         # TODO: Change this to the actual endpoint, not the test endpoint
         { endpoint: Exercism::Routes.tracks_test_components_student_tracks_list_path }


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/37.

Our test files are verbose as we need to pass in extra parameters in order to easily stub errors, etc. When this PR is merged, a view component can simply be rendered by `ViewComponents::Mentoring::Queue.new`. This view component already has the corrects defaults inside it.