### PR TITLE
Fix <Student.TracksList /> caching problem

### DIFF
--- a/app/javascript/components/student/TracksList.jsx
+++ b/app/javascript/components/student/TracksList.jsx
@@ -11,11 +11,13 @@ function reducer(state, action) {
       return {
         ...state,
         query: { ...state.query, criteria: action.payload.criteria },
+        options: { ...state.options, initialData: undefined },
       }
     case 'status.changed':
       return {
         ...state,
         query: { ...state.query, status: action.payload.status },
+        options: { ...state.options, initialData: undefined },
       }
   }
 }


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/39.

This one was tricky. Since we pass the `initialData` parameter in, each change to the query will still have the `initialData` parameter set to what we first passed in. I decided to solve this by setting the `initialData` to undefined whenever we change the query. This might not be the best solution, but I hope to find a better pattern once I work on more components.