### PR TITLE
Add support for creating solutions not via CLI

### DIFF
--- a/app/commands/iteration/prepare_http_files.rb
+++ b/app/commands/iteration/prepare_http_files.rb
@@ -1,5 +1,5 @@
-module CLI
-  class PrepareUploadedFiles
+class Iteration
+  class PrepareHttpFiles
     include Mandate
 
     initialize_with :http_files

--- a/app/commands/iteration/prepare_mapped_files.rb
+++ b/app/commands/iteration/prepare_mapped_files.rb
@@ -1,0 +1,18 @@
+class Iteration
+  class PrepareMappedFiles
+    include Mandate
+
+    initialize_with :files
+
+    def call
+      files.map do |filename, content|
+        raise IterationFileTooLargeError if content.size > 1.megabyte
+
+        {
+          filename: filename,
+          content: content
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -60,7 +60,7 @@ module API
       end
 
       begin
-        Iteration::Create.(solution, files, :cli)
+        Iteration::Create.(solution, files, :cli, true)
       rescue DuplicateIterationError
         return render_error(400, :duplicate_iteration)
       end

--- a/app/controllers/tmp/iterations_controller.rb
+++ b/app/controllers/tmp/iterations_controller.rb
@@ -18,7 +18,7 @@ class Tmp::IterationsController < ApplicationController
       }
     ]
 
-    Iteration::Create.(solution, files, submitted_via: "script")
+    Iteration::Create.(solution, files, "script", true)
 
     head 200
   end

--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -9,13 +9,13 @@ class Iteration < ApplicationRecord
   has_many :representations, class_name: "Iteration::Representation", dependent: :destroy
   has_many :discussion_posts, class_name: "Iteration::DiscussionPost", dependent: :destroy
 
-  enum tests_status: { pending: 0, passed: 1, failed: 2, errored: 3, exceptioned: 4 },
+  enum tests_status: { pending: 0, passed: 1, failed: 2, errored: 3, exceptioned: 4, cancelled: 5 }, # rubocop:disable Layout/LineLength
        _prefix: "tests"
 
-  enum representation_status: { pending: 0, approved: 1, disapproved: 2, inconclusive: 3, exceptioned: 4 },
+  enum representation_status: { pending: 0, approved: 1, disapproved: 2, inconclusive: 3, exceptioned: 4, cancelled: 5 }, # rubocop:disable Layout/LineLength
        _prefix: "representation"
 
-  enum analysis_status: { pending: 0, approved: 1, disapproved: 2, inconclusive: 3, exceptioned: 4 },
+  enum analysis_status: { pending: 0, approved: 1, disapproved: 2, inconclusive: 3, exceptioned: 4, cancelled: 5 }, # rubocop:disable Layout/LineLength
        _prefix: "analysis"
 
   before_create do

--- a/db/migrate/20200510141523_create_iterations.rb
+++ b/db/migrate/20200510141523_create_iterations.rb
@@ -4,6 +4,8 @@ class CreateIterations < ActiveRecord::Migration[6.0]
       t.belongs_to :solution, foreign_key: true, null: false
       t.string :uuid, null: false
 
+      t.boolean :major, null: false
+
       t.integer :tests_status, null: false, default: 0
       t.integer :representation_status, null: false, default: 0
       t.integer :analysis_status, null: false, default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2020_08_30_161328) do
   create_table "iterations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "solution_id", null: false
     t.string "uuid", null: false
+    t.boolean "major", null: false
     t.integer "tests_status", default: 0, null: false
     t.integer "representation_status", default: 0, null: false
     t.integer "analysis_status", default: 0, null: false

--- a/scripts/submit_iteration.rb
+++ b/scripts/submit_iteration.rb
@@ -41,7 +41,8 @@ loop do
     Iteration::Create.(
       solution,
       files,
-      submitted_via: "script"
+      "script",
+      true
     )
     puts "Done"
   rescue StandardError => e

--- a/test/commands/iteration/create_test.rb
+++ b/test/commands/iteration/create_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Iteration::CreateTest < ActiveSupport::TestCase
-  test "creates iteration in the database" do
+  test "creates major iteration" do
     filename_1 = "subdir/foobar.rb"
     content_1 = "'I think' = 'I am'"
     digest_1 = Digest::SHA1.hexdigest(content_1)
@@ -21,10 +21,16 @@ class Iteration::CreateTest < ActiveSupport::TestCase
     Iteration::Representation::Init.expects(:call)
 
     solution = create :concept_solution
-    iteration = Iteration::Create.(solution, files, :cli)
+    iteration = Iteration::Create.(solution, files, :cli, true)
 
+    # Check db record is setup correctly
     assert iteration.persisted?
     assert_equal iteration.solution, solution
+    assert :pending, iteration.tests_status
+    assert :pending, iteration.representation_status
+    assert :pending, iteration.analysis_status
+
+    # Check files are set up correctly
     assert_equal 2, iteration.files.count
 
     first_file = iteration.files.first
@@ -36,6 +42,25 @@ class Iteration::CreateTest < ActiveSupport::TestCase
     assert_equal filename_2, second_file.filename
     assert_equal digest_2, second_file.digest
     assert_equal content_2, second_file.content
+  end
+
+  test "does not use analysis or representation for minor iteration" do
+    solution = create :concept_solution
+    files = [
+      { filename: "subdir/foobar.rb", content: "'I think' = 'I am'" }
+    ]
+
+    Iteration::UploadWithExercise.expects(:call)
+    Iteration::TestRun::Init.expects(:call)
+    Iteration::Analysis::Init.expects(:call).never
+    Iteration::Representation::Init.expects(:call).never
+
+    iteration = Iteration::Create.(solution, files, :cli, false)
+
+    # Check they are correctly marked as cancelled
+    assert :pending, iteration.tests_status
+    assert :cancelled, iteration.representation_status
+    assert :cancelled, iteration.analysis_status
   end
 
   test "guards against duplicates" do
@@ -56,18 +81,18 @@ class Iteration::CreateTest < ActiveSupport::TestCase
     ToolingJob::Create.stubs(:call)
 
     # Do it once successfully
-    Iteration::Create.(solution, files, :cli)
+    Iteration::Create.(solution, files, :cli, true)
 
     # The second time *in a row* it should fail
     assert_raises DuplicateIterationError do
-      Iteration::Create.(solution, files, :cli)
+      Iteration::Create.(solution, files, :cli, true)
     end
 
     # Submit something different
-    Iteration::Create.(solution, [files.first], :cli)
+    Iteration::Create.(solution, [files.first], :cli, true)
 
     # The duplicate should now succeed
-    Iteration::Create.(solution, files, :cli)
+    Iteration::Create.(solution, files, :cli, true)
   end
 
   test "updates solution status" do
@@ -79,7 +104,7 @@ class Iteration::CreateTest < ActiveSupport::TestCase
 
     Iteration::UploadWithExercise.stubs(:call)
     ToolingJob::Create.stubs(:call)
-    Iteration::Create.(solution, [files.first], :cli)
+    Iteration::Create.(solution, [files.first], :cli, true)
     assert_equal 'submitted', solution.reload.status
   end
 
@@ -94,7 +119,7 @@ class Iteration::CreateTest < ActiveSupport::TestCase
     solution = create :concept_solution, user: user
 
     assert_enqueued_with(job: AwardBadgeJob, args: [user, :rookie]) do
-      Iteration::Create.(solution, [files.first], :cli)
+      Iteration::Create.(solution, [files.first], :cli, true)
     end
   end
 end

--- a/test/commands/iteration/prepare_http_files_test.rb
+++ b/test/commands/iteration/prepare_http_files_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-class CLI::PrepareUploadedFilesTest < ActiveSupport::TestCase
-  test "creates iteration correctly" do
+class Iteration::PrepareHttpFilesTest < ActiveSupport::TestCase
+  test "extracts contents correctly" do
     filename_1 = "subdir/foobar.rb"
     content_1 = "'I think' = 'I am'"
     headers_1 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_1}\"\r\nContent-Type: application/octet-stream\r\n" # rubocop:disable Layout/LineLength
@@ -12,7 +12,7 @@ class CLI::PrepareUploadedFilesTest < ActiveSupport::TestCase
     headers_2 = "Content-Disposition: form-data; name=\"files[]\"; filename=\"#{filename_2}\"\r\nContent-Type: application/octet-stream\r\n" # rubocop:disable Layout/LineLength
     file_2 = mock(read: content_2, headers: headers_2)
 
-    files = CLI::PrepareUploadedFiles.([file_1, file_2])
+    files = Iteration::PrepareHttpFiles.([file_1, file_2])
 
     assert_equal 2, files.count
 
@@ -32,7 +32,7 @@ class CLI::PrepareUploadedFilesTest < ActiveSupport::TestCase
     file = mock(read: content, headers: headers)
 
     assert_raises IterationFileTooLargeError do
-      CLI::PrepareUploadedFiles.([file])
+      Iteration::PrepareHttpFiles.([file])
     end
   end
 end

--- a/test/commands/iteration/prepare_mapped_files_test.rb
+++ b/test/commands/iteration/prepare_mapped_files_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class Iteration::PrepareMappedFilesTest < ActiveSupport::TestCase
+  test "remaps correctly" do
+    filename_1 = "subdir/foobar.rb"
+    content_1 = "'I think' = 'I am'"
+
+    filename_2 = "barfood.rb"
+    content_2 = "something = :else"
+
+    files = Iteration::PrepareMappedFiles.({
+                                             filename_1 => content_1,
+                                             filename_2 => content_2
+                                           })
+
+    assert_equal 2, files.count
+
+    first_file = files.first
+    assert_equal filename_1, first_file[:filename]
+    assert_equal content_1, first_file[:content]
+
+    second_file = files.last
+    assert_equal filename_2, second_file[:filename]
+    assert_equal content_2, second_file[:content]
+  end
+
+  test "raises if file is too large" do
+    filename = "subdir/foobar.rb"
+    content = Array.new(1.megabyte + 1, 'x')
+
+    assert_raises IterationFileTooLargeError do
+      Iteration::PrepareMappedFiles.({ filename => content })
+    end
+  end
+end

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -285,7 +285,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     http_files = [SecureRandom.uuid, SecureRandom.uuid]
     files = mock
     CLI::PrepareUploadedFiles.expects(:call).with(http_files).returns(files)
-    Iteration::Create.expects(:call).with(solution, files, :cli)
+    Iteration::Create.expects(:call).with(solution, files, :cli, true)
 
     patch api_solution_path(solution.uuid),
       params: { files: http_files },

--- a/test/factories/iterations.rb
+++ b/test/factories/iterations.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     uuid { SecureRandom.compact_uuid }
     solution { create :concept_solution }
     submitted_via { "cli" }
+    major { true }
   end
 end

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -27,7 +27,8 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
       Iteration::Create.(
         basics_solution,
         [{ filename: 'basics.rb', content: 'my code' }],
-        :cli
+        :cli,
+        true
       )
 
     # Simulate a test run being returned


### PR DESCRIPTION
This adds two things:
1. Support for uploading files via a mapped files has (`(filename: contents}`) which is how I presume the editor should work.
2. A major flag for iterations. 

I don't particularly like this approach or solution. I suspect a better other option is that we have a model for submitted code (a `submission`) and then an iteration is more like a pointer to a specific submission. I still think I might end up doing this, but it's a chunky rewrite to do it and I don't want to go into that rabbit hole right now, else we'll just get behind.

I'm trying to insulate the public API from knowing about this, and the downstream of tooling jobs is already insulated, so if I do  change it, it shouldn't affect the React side much. 