### PR TITLE
Install yarn dependencies at runtime

### DIFF
--- a/docker/dev/init.dev.sh
+++ b/docker/dev/init.dev.sh
@@ -5,6 +5,7 @@ done
 
 echo "Install dependencies"
 bundle check || bundle install
+yarn install
 
 echo "Create and migrate DBs"
 # init.sql creates initial MySQL USER and databases


### PR DESCRIPTION
This is similar to how we install the Ruby bundles at runtime. In practice this addition means that new NPM packages can be installed and used with just a restart of the container, instead of having to do a full rebuild.﻿
