### PR TITLE
Don't log from react-query in tests

### DIFF
--- a/test/javascript/components/mentoring/inbox/ConversationList.test.js
+++ b/test/javascript/components/mentoring/inbox/ConversationList.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { setConsole } from 'react-query'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -10,6 +11,13 @@ const server = setupServer(
     return res(ctx.status(500, 'Internal server error'))
   })
 )
+
+// Don't output logging from react-query
+setConsole({
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+})
 
 beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())


### PR DESCRIPTION
That error is there because the API returns an erronous response, which is needed for the test actually. This hides the error output.