### PR TITLE
Only focus button if dialog has every been expanded

### DIFF
--- a/app/javascript/components/student/tracks-list/TagsFilter.jsx
+++ b/app/javascript/components/student/tracks-list/TagsFilter.jsx
@@ -4,13 +4,18 @@ import { TagOptionList } from './TagOptionList'
 export function TagsFilter({ options, dispatch }) {
   const [expanded, setExpanded] = useState(false)
   const [selectedTags, setSelectedTags] = useState([])
+  const [hasExpandedEver, markAsExpanded] = useState(false)
 
   const dialogRef = useRef(null)
   const filterButtonRef = useRef(null)
 
   useEffect(() => {
-    const elemToFocus = expanded ? dialogRef : filterButtonRef
-    elemToFocus.current.focus()
+    if (expanded) {
+      dialogRef.current.focus()
+      markAsExpanded(true)
+    } else if (hasExpandedEver) {
+      filterButtonRef.current.focus()
+    }
   }, [expanded])
 
   useEffect(() => {

--- a/test/javascript/components/student/TracksList/TagsFilter.test.js
+++ b/test/javascript/components/student/TracksList/TagsFilter.test.js
@@ -17,3 +17,44 @@ test('hides option list when clicking "Close"', () => {
 
   expect(queryByText('OOP')).not.toBeVisible()
 })
+
+test('focuses on dialog when expanded', () => {
+  const { getByText, getByRole } = render(
+    <TagsFilter
+      options={[
+        { category: 'Paradigm', options: [{ value: 'oop', label: 'OOP' }] },
+      ]}
+    />
+  )
+
+  fireEvent.click(getByText('Filter by'))
+
+  expect(getByRole('dialog')).toHaveFocus()
+})
+
+test('focuses on filter only after expanding and closing', () => {
+  const { getByText, getByRole } = render(
+    <TagsFilter
+      options={[
+        { category: 'Paradigm', options: [{ value: 'oop', label: 'OOP' }] },
+      ]}
+    />
+  )
+
+  fireEvent.click(getByText('Filter by'))
+  fireEvent.click(getByText('Close'))
+
+  expect(getByText('Filter by')).toHaveFocus()
+})
+
+test('does not focus on filter by default', () => {
+  const { getByText, getByRole } = render(
+    <TagsFilter
+      options={[
+        { category: 'Paradigm', options: [{ value: 'oop', label: 'OOP' }] },
+      ]}
+    />
+  )
+
+  expect(getByText('Filter by')).not.toHaveFocus()
+})


### PR DESCRIPTION
Currently the Filters button gets focus when the page loads.

This changes that so the Filters button only gets focus when the dialog has been expanded and is now being closed.