### PR TITLE
simplify bezier curve control point math

### DIFF
--- a/app/javascript/components/concepts-map/helpers/draw-helpers.ts
+++ b/app/javascript/components/concepts-map/helpers/draw-helpers.ts
@@ -25,10 +25,7 @@ export function drawPath(
   path = scalePath(path, options.scale)
   const { start, end } = path
 
-  const pageWidth = document.documentElement.clientWidth
-  const normalize =
-    ((end.y - start.y) * Math.abs(start.x - end.x)) / (pageWidth / 2)
-  const adjust = 6
+  const halfDeltaY = (end.y - start.y) / 2
 
   if (options.dim) {
     ctx.globalAlpha = Number(
@@ -44,9 +41,9 @@ export function drawPath(
   ctx.moveTo(start.x, start.y)
   ctx.bezierCurveTo(
     start.x,
-    start.y + normalize + adjust,
+    start.y + halfDeltaY,
     end.x,
-    end.y - normalize - adjust,
+    end.y - halfDeltaY,
     end.x,
     end.y
   )


### PR DESCRIPTION
Issue: when zoomed or even with varying computers there was notable difference in the apperance of the bezier curves used to draw each path. The mathematical determination of control points is simplified to remove variable inputs and create a consistent appearance.

New appearance:
![new-curve](https://user-images.githubusercontent.com/8953691/96023430-a88c5700-0e0f-11eb-9578-667d99d2158c.png)

Old (problematic) appearance:
![chrome-125-ubuntu](https://user-images.githubusercontent.com/8953691/96023470-ba6dfa00-0e0f-11eb-874a-fda74dcb11d2.png)
