### PR TITLE
<ConceptMap /> now accepts concept status from UserTrack::GenerateConceptStatusMapping

### DIFF
--- a/app/controllers/test/components/student/concept_map_controller.rb
+++ b/app/controllers/test/components/student/concept_map_controller.rb
@@ -5,44 +5,37 @@ class Test::Components::Student::ConceptMapController < ApplicationController # 
         {
           web_url: "basics-url",
           slug: "basics",
-          name: "Basics",
-          status: "completed"
+          name: "Basics"
         },
         {
           web_url: "booleans-url",
           slug: "booleans",
-          name: "Booleans",
-          status: "unlocked"
+          name: "Booleans"
         },
         {
           web_url: "numbers-url",
           slug: "floating-point-numbers",
-          name: "Floating Point Numbers",
-          status: "completed"
+          name: "Floating Point Numbers"
         },
         {
           web_url: "numbers-url",
           slug: "integers",
-          name: "Integer Numbers",
-          status: "completed"
+          name: "Integer Numbers"
         },
         {
           web_url: "anonymous-fns-url",
           slug: "bit-manipulation",
-          name: "Bit Manipulation",
-          status: "unlocked"
+          name: "Bit Manipulation"
         },
         {
           web_url: "anonymous-fns-url",
           slug: "closures",
-          name: "Closures",
-          status: "unlocked"
+          name: "Closures"
         },
         {
           web_url: "anonymous-fns-url",
           slug: "anonymous-functions",
-          name: "Anonymous Functions",
-          status: "unlocked"
+          name: "Anonymous Functions"
         }
       ],
       levels: [
@@ -52,9 +45,9 @@ class Test::Components::Student::ConceptMapController < ApplicationController # 
           integers
           floating-point-numbers
           anonymous-functions
-          closures
           bit-manipulation
-        ]
+        ],
+        ['closures']
       ],
       connections: [
         {
@@ -74,14 +67,23 @@ class Test::Components::Student::ConceptMapController < ApplicationController # 
           to: "anonymous-functions"
         },
         {
-          from: "basics",
+          from: "integers",
           to: "closures"
         },
         {
           from: "basics",
           to: "bit-manipulation"
         }
-      ]
+      ],
+      status: {
+        "basics" => :completed,
+        "booleans" => :completed,
+        "floating-point-numbers" => :unlocked,
+        "integers" => :unlocked,
+        "bit-manipulation" => :unlocked,
+        "closures" => :locked,
+        "anonymous-functions" => :unlocked
+      }
     }
   end
 end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -7,9 +7,9 @@ class Tracks::ConceptsController < ApplicationController
 
   def authenticated_index
     if current_user.joined_track?(@track)
-      layout_data = Track::DetermineConceptMapLayout.(@track)
-      layout_data[:status] = UserTrack::GenerateConceptStatusMapping.(@user_track)
-      @concept_map_data = layout_data
+      @concept_map_data = Track::DetermineConceptMapLayout.(@track).merge(
+        status: UserTrack::GenerateConceptStatusMapping.(@user_track)
+      )
       render action: "index/joined"
     else
       render action: "index/unjoined"

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -7,7 +7,9 @@ class Tracks::ConceptsController < ApplicationController
 
   def authenticated_index
     if current_user.joined_track?(@track)
-      @layout_data = Track::DetermineConceptMapLayout.(@track)
+      layout_data = Track::DetermineConceptMapLayout.(@track)
+      layout_data[:status] = UserTrack::GenerateConceptStatusMapping.(@user_track)
+      @concept_map_data = layout_data
       render action: "index/joined"
     else
       render action: "index/unjoined"

--- a/app/javascript/components/concept-map/Concept.tsx
+++ b/app/javascript/components/concept-map/Concept.tsx
@@ -7,13 +7,14 @@ export const Concept = ({
   slug,
   name,
   web_url,
-  status,
   handleEnter,
   handleLeave,
+  status,
   isActive,
   isDimmed,
   adjacentConcepts,
 }: IConcept & {
+  status: ConceptState
   isActive: boolean
   isDimmed: boolean
   adjacentConcepts: string[]

--- a/app/javascript/components/concept-map/ConceptMap.tsx
+++ b/app/javascript/components/concept-map/ConceptMap.tsx
@@ -13,7 +13,6 @@ export const ConceptMap = ({
   connections,
   status,
 }: IConceptMap) => {
-  console.info({ status })
   const [active, setActive] = useState<string | null>(null)
 
   const conceptsBySlug = indexConceptsBySlug(concepts)

--- a/app/javascript/components/concept-map/ConceptMap.tsx
+++ b/app/javascript/components/concept-map/ConceptMap.tsx
@@ -5,9 +5,15 @@ import { ConceptConnections } from './ConceptConnections'
 
 import { IConceptMap, ConceptLayer } from './concept-map-types'
 import { ConceptConnection } from './concept-connection-types'
-import { IConcept, isIConcept } from './concept-types'
+import { ConceptState, IConcept, isIConcept } from './concept-types'
 
-export const ConceptMap = ({ concepts, levels, connections }: IConceptMap) => {
+export const ConceptMap = ({
+  concepts,
+  levels,
+  connections,
+  status,
+}: IConceptMap) => {
+  console.info({ status })
   const [active, setActive] = useState<string | null>(null)
 
   const conceptsBySlug = indexConceptsBySlug(concepts)
@@ -40,9 +46,9 @@ export const ConceptMap = ({ concepts, levels, connections }: IConceptMap) => {
                     slug={slug}
                     name={concept.name}
                     web_url={concept.web_url}
-                    status={concept.status}
                     handleEnter={() => setActive(slug)}
                     handleLeave={() => setActive(null)}
+                    status={status[concept.slug] ?? ConceptState.Locked}
                     isActive={active === concept.slug}
                     isDimmed={isDimmed}
                     adjacentConcepts={adjacentBySlug.get(concept.slug) ?? []}

--- a/app/javascript/components/concept-map/concept-map-types.ts
+++ b/app/javascript/components/concept-map/concept-map-types.ts
@@ -1,10 +1,11 @@
-import { IConcept } from './concept-types'
+import { ConceptState, IConcept } from './concept-types'
 import { ConceptConnection } from './concept-connection-types'
 
 export interface IConceptMap {
   concepts: IConcept[]
   levels: ConceptLayer[]
   connections: ConceptConnection[]
+  status: { [key: string]: ConceptState }
 }
 
 export type ConceptLayer = string[]

--- a/app/javascript/components/concept-map/concept-types.ts
+++ b/app/javascript/components/concept-map/concept-types.ts
@@ -11,7 +11,6 @@ export interface IConcept {
   slug: string
   web_url: string
   name: string
-  status: ConceptState
   handleEnter?: MouseEventHandler
   handleLeave?: MouseEventHandler
 }

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -61,6 +61,7 @@ initReact({
       concepts={data.graph.concepts}
       levels={data.graph.levels}
       connections={data.graph.connections}
+      status={data.graph.status}
     />
   ),
 })

--- a/app/views/tracks/concepts/index/joined.html.haml
+++ b/app/views/tracks/concepts/index/joined.html.haml
@@ -1,3 +1,3 @@
 .md-container
   %h2 Concepts for #{@track.title}
-  = ViewComponents::Student::ConceptMap.new(@layout_data)
+  = ViewComponents::Student::ConceptMap.new(@concept_map_data)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
     namespace :test do
       namespace :components do
         namespace :student do
-          resource :concepts_map, only: [:show], controller: 'concepts_map'
+          resource :concept_map, only: [:show], controller: 'concept_map'
           resource :tracks_list, only: [:show], controller: "tracks_list" do
             member do
               get 'tracks'

--- a/test/helpers/view_components/student/concept_map_test.rb
+++ b/test/helpers/view_components/student/concept_map_test.rb
@@ -6,7 +6,8 @@ module Student
       data = {
         concepts: [],
         levels: [],
-        connections: []
+        connections: [],
+        status: []
       }
       component = ViewComponents::Student::ConceptMap.new(data).to_s
 

--- a/test/javascript/components/concept-map/ConceptMap.test.tsx
+++ b/test/javascript/components/concept-map/ConceptMap.test.tsx
@@ -22,14 +22,16 @@ import { ConceptLayer } from '../../../../app/javascript/components/concept-map/
 
 describe('<ConceptMap />', () => {
   test('renders empty component', () => {
-    const { container } = renderMap([], [], [])
+    const { container } = renderMap([], [], [], {})
     const map = container.querySelector('.c-concepts-map')
     expect(map).not.toBeNull()
   })
 
   test('renders single incomplete concept', () => {
     const testConcept = concept('test')
-    const { container } = renderMap([testConcept], [[testConcept.slug]], [])
+    const { container } = renderMap([testConcept], [[testConcept.slug]], [], {
+      test: ConceptState.Unlocked,
+    })
     const conceptEl = getByText(container, 'Test')
     const completeIconEl = queryByTitle(container, 'completed')
     expect(completeIconEl).toBeNull()
@@ -37,7 +39,9 @@ describe('<ConceptMap />', () => {
 
   test('renders single completed concept', () => {
     const testConcept = concept('test', { state: ConceptState.Completed })
-    const { container } = renderMap([testConcept], [[testConcept.slug]], [])
+    const { container } = renderMap([testConcept], [[testConcept.slug]], [], {
+      test: ConceptState.Completed,
+    })
     const conceptEl = getByText(container, 'Test')
     const completeIconEl = getByTitle(container, 'completed')
   })
@@ -51,23 +55,27 @@ const concept = (
   } = {}
 ): Concept => {
   const index = options.index ?? 0
-  const state = options.state ?? ConceptState.Locked
 
   return {
     slug: conceptName,
     name: slugToTitlecase(conceptName),
     web_url: `link-for-${conceptName}`,
-    status: state,
   }
 }
 
 const renderMap = (
   concepts: Concept[],
   levels: ConceptLayer[],
-  connections: ConceptConnection[]
+  connections: ConceptConnection[],
+  status: { [key: string]: ConceptState }
 ) => {
   return render(
-    <ConceptMap concepts={concepts} levels={levels} connections={connections} />
+    <ConceptMap
+      concepts={concepts}
+      levels={levels}
+      connections={connections}
+      status={status}
+    />
   )
 }
 


### PR DESCRIPTION
`<ConceptMap />` now takes a fourth prop `status` which represents a mapping [hash] between the concept slug and its display status in the concept map. If an empty hash is supplied, or the concept slug is absent, it is represented in the _locked state_.

 This brings together two commands in the `Tracks::ConceptsController` to create a complete set of data for the `<ConceptMap />`. Commands used to generate data:
- `Track::DetermineConceptMapLayout`
- `UserTrack::GenerateConceptStatusMapping`

This also updates the test route, `http://localhost:3020/test/components/student/concept_map`, test cases, `application.tsx`