### PR TITLE
User cancels submission before API accepts it

### DIFF
--- a/app/javascript/components/student/editor/CodeEditor.tsx
+++ b/app/javascript/components/student/editor/CodeEditor.tsx
@@ -1,6 +1,11 @@
 import React, { useRef } from 'react'
+import { Action } from '../Editor'
 
-export function CodeEditor({ onSubmit }: { onSubmit: (code: string) => void }) {
+export function CodeEditor({
+  dispatch,
+}: {
+  dispatch: (action: Action) => void
+}) {
   const editor = useRef<HTMLTextAreaElement>(null)
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -10,7 +15,7 @@ export function CodeEditor({ onSubmit }: { onSubmit: (code: string) => void }) {
       return
     }
 
-    onSubmit(editor.current.value)
+    dispatch({ type: 'submitting', payload: { code: editor.current.value } })
   }
 
   return (

--- a/app/javascript/components/student/editor/Submitting.tsx
+++ b/app/javascript/components/student/editor/Submitting.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Action } from '../Editor'
+
+export function Submitting({
+  dispatch,
+}: {
+  dispatch: (action: Action) => void
+}) {
+  return (
+    <div>
+      <p>Submitting...</p>
+      <button
+        onClick={() => {
+          dispatch({ type: 'cancelled' })
+        }}
+      >
+        Cancel
+      </button>
+    </div>
+  )
+}

--- a/app/javascript/components/student/editor/TestRunSummary.tsx
+++ b/app/javascript/components/student/editor/TestRunSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from 'react'
+import React, { useReducer, useEffect, useRef } from 'react'
 import { Submission, TestRunStatus } from '../Editor'
 import { TestRunChannel } from '../../../channels/testRunChannel'
 
@@ -70,6 +70,7 @@ export function TestRunSummary({
     tests: [],
   })
   const haveTestsResolved = RESOLVED_TEST_STATUSES.includes(testRun.status)
+  const timer = useRef<number>()
 
   useEffect(() => {
     const channel = new TestRunChannel(submission, (testRun: TestRun) => {
@@ -86,8 +87,17 @@ export function TestRunSummary({
       return
     }
 
-    setTimeout(() => dispatch({ type: 'testRun.timeout' }), timeout)
+    timer.current = window.setTimeout(
+      () => dispatch({ type: 'testRun.timeout' }),
+      timeout
+    )
   }, [testRun.status])
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timer.current)
+    }
+  }, [])
 
   return (
     <div>

--- a/app/javascript/utils/fetch-json.ts
+++ b/app/javascript/utils/fetch-json.ts
@@ -5,23 +5,28 @@ export async function fetchJSON(endpoint: string, options: any) {
     'content-type': 'application/json',
     accept: 'application/json',
   }
-  const response = await fetch(
-    endpoint,
-    Object.assign(options, { headers: headers })
-  )
 
-  if (!response.ok) {
-    throw response
+  try {
+    const response = await fetch(
+      endpoint,
+      Object.assign(options, { headers: headers })
+    )
+
+    if (!response.ok) {
+      throw response
+    }
+
+    const contentType = response.headers.get('Content-Type')
+    if (
+      !contentType ||
+      (!contentType.includes('+json') &&
+        !contentType.includes('application/json'))
+    ) {
+      throw response
+    }
+
+    return camelizeKeys(await response.json())
+  } catch (responseOrError) {
+    return Promise.reject(responseOrError)
   }
-
-  const contentType = response.headers.get('Content-Type')
-  if (
-    !contentType ||
-    (!contentType.includes('+json') &&
-      !contentType.includes('application/json'))
-  ) {
-    throw response
-  }
-
-  return camelizeKeys(await response.json())
 }

--- a/test/javascript/components/student/Editor.test.js
+++ b/test/javascript/components/student/Editor.test.js
@@ -5,73 +5,100 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Editor } from '../../../../app/javascript/components/student/Editor'
 
-const server = setupServer(
-  rest.post('https://exercism.test/submissions', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        submission: {
-          id: 2,
-          tests_status: 'pending',
-          test_runs: [],
-          message: '',
-        },
-      })
-    )
-  }),
-  rest.post('https://exercism.test/submissions/pass', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        submission: { id: 2, tests_status: 'pass', test_runs: [], message: '' },
-      })
-    )
-  })
-)
-
-beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 test('clears current submission when resubmitting', async () => {
+  const server = setupServer(
+    rest.post('https://exercism.test/submissions', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          submission: {
+            id: 2,
+            tests_status: 'pending',
+            test_runs: [],
+            message: '',
+          },
+        })
+      )
+    })
+  )
+  server.listen()
+
   const { getByText, queryByText } = render(
     <Editor endpoint="https://exercism.test/submissions" />
   )
-
   fireEvent.click(getByText('Submit'))
   await waitFor(() =>
     expect(queryByText('Status: pending')).toBeInTheDocument()
   )
-
   fireEvent.click(getByText('Submit'))
+
   await waitFor(() =>
     expect(queryByText('Status: pending')).not.toBeInTheDocument()
   )
   await waitFor(() =>
     expect(queryByText('Status: pending')).toBeInTheDocument()
   )
+
+  server.close()
 })
 
 test('shows message when test times out', async () => {
+  const server = setupServer(
+    rest.post('https://exercism.test/submissions', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          submission: {
+            id: 2,
+            tests_status: 'pending',
+            test_runs: [],
+            message: '',
+          },
+        })
+      )
+    })
+  )
+  server.listen()
+
   const { getByText, queryByText } = render(
     <Editor endpoint="https://exercism.test/submissions" timeout={0} />
   )
-
   fireEvent.click(getByText('Submit'))
   await waitFor(() =>
     expect(queryByText('Status: pending')).toBeInTheDocument()
   )
+
   await waitFor(() =>
     expect(queryByText('Status: timeout')).toBeInTheDocument()
   )
+
+  server.close()
 })
 
 test('does not time out when tests have resolved', async () => {
-  const { getByText, queryByText } = render(
-    <Editor endpoint="https://exercism.test/submissions/pass" timeout={0} />
+  const server = setupServer(
+    rest.post('https://exercism.test/submissions', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          submission: {
+            id: 2,
+            tests_status: 'pass',
+            test_runs: [],
+            message: '',
+          },
+        })
+      )
+    })
   )
+  server.listen()
 
+  const { getByText, queryByText } = render(
+    <Editor endpoint="https://exercism.test/submissions" timeout={0} />
+  )
   fireEvent.click(getByText('Submit'))
   await waitFor(() => expect(queryByText('Status: pass')).toBeInTheDocument())
+
   await waitFor(() =>
     expect(queryByText('Status: timeout')).not.toBeInTheDocument()
   )
+
+  server.close()
 })


### PR DESCRIPTION
https://github.com/exercism/v3-project-management/issues/53

## Description
This PR adds a "Cancel" button to allow the user to cancel their submission while a response from the submissions API isn't received.

## Questions
1. @iHiD How does this look like from the backend? Is it safe to assume that we can just cancel the request if the API hasn't responded in time? I'm probably thinking that it isn't, so we might need to change the API call to not take too long, and just acknowledge that it has received the request and respond right away? The current API is already queueing jobs and other things before it responds. I decided to push through with this, though, as this solves the instance where the user might have internet problems.
