### PR TITLE
Add iteration creation endpoints

### DIFF
--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -1,0 +1,18 @@
+class Iteration
+  class Create
+    include Mandate
+
+    initialize_with :solution, :submission
+
+    def call
+      id = Iteration.connection.insert(%{
+        INSERT INTO iterations (solution_id, submission_id, idx, created_at, updated_at)
+        SELECT #{solution.id}, #{submission.id}, (COUNT(*) + 1), NOW(), NOW()
+        FROM iterations where solution_id = #{solution.id}
+      })
+      Iteration.find(id)
+    rescue ActiveRecord::RecordNotUnique
+      Iteration.find_by!(solution: solution, submission: submission)
+    end
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -51,6 +51,10 @@ module API
       render_404(:solution_not_found)
     end
 
+    def render_submission_not_found
+      render_404(:submission_not_found)
+    end
+
     def render_solution_not_accessible
       render_403(:solution_not_accessible)
     end

--- a/app/controllers/api/iterations_controller.rb
+++ b/app/controllers/api/iterations_controller.rb
@@ -1,0 +1,27 @@
+module API
+  class IterationsController < BaseController
+    def create
+      begin
+        solution = Solution.find_by!(uuid: params[:solution_id])
+      rescue ActiveRecord::RecordNotFound
+        return render_solution_not_found
+      end
+
+      return render_solution_not_accessible unless solution.user_id == current_user.id
+
+      begin
+        submission = solution.submissions.find_by!(uuid: params[:submission_id])
+      rescue ActiveRecord::RecordNotFound
+        return render_submission_not_found
+      end
+
+      iteration = Iteration::Create.(solution, submission)
+
+      render json: {
+        iteration: {
+          idx: iteration.idx
+        }
+      }, status: :created
+    end
+  end
+end

--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -1,0 +1,4 @@
+class Iteration < ApplicationRecord
+  belongs_to :solution
+  belongs_to :submission
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -25,6 +25,10 @@ class Submission < ApplicationRecord
     self.git_sha = solution.git_sha
   end
 
+  def to_param
+    uuid
+  end
+
   def broadcast!
     SubmissionsChannel.broadcast!(solution)
     SubmissionChannel.broadcast!(self)

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -8,6 +8,7 @@ en:
       solution_not_found: "This solution could not be found"
       solution_not_accessible: "You do not have permission to view this solution"
       solution_not_unlocked: "You have not unlocked this exercise"
+      submission_not_found: "This submission could not be found"
       team_not_found: "The team could not be found"
       track_ambiguous: "Please specify a track ID"
       track_not_found: "The track you specified does not exist"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
         get 'files/*filepath', to: 'files#show', format: false, as: "file"
         resources :submissions, only: %i[create]
+        resources :iterations, only: %i[create]
       end
       resources :submission, only: [] do
         resources :cancellations, only: %i[create], controller: "submissions/cancellations"

--- a/db/migrate/20201027144915_create_iterations.rb
+++ b/db/migrate/20201027144915_create_iterations.rb
@@ -1,0 +1,12 @@
+class CreateIterations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :iterations do |t|
+      t.belongs_to :solution, foreign_key: true, null: false
+      t.belongs_to :submission, foreign_key: true, null: false, index: {unique: true}
+      
+      t.integer :idx, null: false, limit: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_30_161328) do
+ActiveRecord::Schema.define(version: 2020_10_27_144915) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -82,6 +82,16 @@ ActiveRecord::Schema.define(version: 2020_08_30_161328) do
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, length: { slug: 70, scope: 70 }
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", length: { slug: 140 }
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
+  create_table "iterations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.bigint "submission_id", null: false
+    t.integer "idx", limit: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["solution_id"], name: "index_iterations_on_solution_id"
+    t.index ["submission_id"], name: "index_iterations_on_submission_id", unique: true
   end
 
   create_table "notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -225,6 +235,9 @@ ActiveRecord::Schema.define(version: 2020_08_30_161328) do
     t.string "slug", null: false
     t.string "title", null: false
     t.string "repo_url", null: false
+    t.string "test_pattern"
+    t.string "ignore_pattern"
+    t.string "git_head_sha", default: "HEAD", null: false
     t.json "tags"
     t.boolean "active", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -291,6 +304,8 @@ ActiveRecord::Schema.define(version: 2020_08_30_161328) do
   add_foreign_key "exercise_taught_concepts", "exercises"
   add_foreign_key "exercise_taught_concepts", "track_concepts"
   add_foreign_key "exercises", "tracks"
+  add_foreign_key "iterations", "solutions"
+  add_foreign_key "iterations", "submissions"
   add_foreign_key "notifications", "users"
   add_foreign_key "solution_mentor_discussions", "solution_mentor_requests", column: "request_id"
   add_foreign_key "solution_mentor_discussions", "solutions"

--- a/test/commands/iteration/create_test.rb
+++ b/test/commands/iteration/create_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Iteration::CreateTest < ActiveSupport::TestCase
+  test "increments iteration" do
+    solution = create :concept_solution
+
+    it_1 = Iteration::Create.(solution, create(:submission, solution: solution))
+    assert_equal 1, it_1.idx
+
+    it_2 = Iteration::Create.(solution, create(:submission, solution: solution))
+    assert_equal 2, it_2.idx
+
+    it_3 = Iteration::Create.(solution, create(:submission, solution: solution))
+    assert_equal 3, it_3.idx
+
+    # Check different count for different solution
+    other_solution = create :concept_solution
+    it_4 = Iteration::Create.(other_solution, create(:submission, solution: other_solution))
+    assert_equal 1, it_4.idx
+  end
+
+  test "returns existing in case of duplicate" do
+    solution = create :concept_solution
+    submission = create :submission, solution: solution
+
+    first = Iteration::Create.(solution, submission)
+    second = Iteration::Create.(solution, submission)
+    assert_equal first, second
+  end
+end

--- a/test/controllers/api/iterations_controller_test.rb
+++ b/test/controllers/api/iterations_controller_test.rb
@@ -1,0 +1,84 @@
+require_relative './base_test_case'
+
+class API::IterationsControllerTest < API::BaseTestCase
+  ###
+  # CREATE
+  ###
+  test "create should return 401 with incorrect token" do
+    post api_solution_iterations_path(1, submission_id: 1), headers: @headers, as: :json
+    assert_response 401
+  end
+
+  test "create should 404 if the solution doesn't exist" do
+    setup_user
+    post api_solution_iterations_path(999, submission_id: create(:submission)), headers: @headers, as: :json
+    assert_response 404
+  end
+
+  test "create should 404 if the submission doesn't exist" do
+    setup_user
+    post api_solution_iterations_path(create(:concept_solution).uuid, submission_id: 999), headers: @headers, as: :json
+    assert_response 403
+  end
+
+  test "create should 404 if the solution belongs to someone else" do
+    setup_user
+    solution = create :concept_solution
+    submission = create :submission, solution: solution
+    post api_solution_iterations_path(solution.uuid, submission_id: submission.uuid), headers: @headers, as: :json
+    assert_response 403
+    expected = { error: {
+      type: "solution_not_accessible",
+      message: I18n.t('api.errors.solution_not_accessible')
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  test "create should 404 if the submission doesn't belong to the solution" do
+    setup_user
+    solution = create :concept_solution, user: @current_user
+    submission = create :submission
+    post api_solution_iterations_path(solution.uuid, submission_id: submission.uuid), headers: @headers, as: :json
+    assert_response 404
+    expected = { error: {
+      type: "submission_not_found",
+      message: I18n.t('api.errors.submission_not_found')
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  test "create should return serialized iteration" do
+    setup_user
+    solution = create :concept_solution, user: @current_user
+    submission = create :submission, solution: solution
+
+    post api_solution_iterations_path(solution.uuid, submission_id: submission.uuid),
+      headers: @headers,
+      as: :json
+
+    assert_response :success
+    expected = {
+      iteration: {
+        idx: 1
+      }
+    }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  test "create should create submission" do
+    setup_user
+    solution = create :concept_solution, user: @current_user
+    submission = create :submission, solution: solution
+
+    Iteration::Create.expects(:call).with(solution, submission).returns(create(:iteration))
+
+    post api_solution_iterations_path(solution.uuid, submission_id: submission.uuid),
+      headers: @headers,
+      as: :json
+
+    assert_response :success
+  end
+end

--- a/test/factories/iterations.rb
+++ b/test/factories/iterations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :iteration do
+    solution { submission.solution }
+    submission
+    idx { 0 }
+  end
+end

--- a/test/models/iteration_test.rb
+++ b/test/models/iteration_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class IterationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
@kntsoriano This gives you the endpoints in the API for the editor.

### Create submission

This is what you call with the files to create the submission. It returns a serialized solution

```POST api/solutions/:solution_uuid/submissions```


### Create iteration

This is what you call when the user clicks the Submit button once their tests have passed. Note that the key is `submission_id` but the value should be the UUID we're using everywhere.

Returns `{iteration: {idx: 123}}`

```POST api/solutions/:solution_uuid/iterations?submission_id=:submission_uuid```


