### PR TITLE
Add copy to clipboard button

### DIFF
--- a/app/controllers/test/components/common/copy_to_clipboard_button_controller.rb
+++ b/app/controllers/test/components/common/copy_to_clipboard_button_controller.rb
@@ -1,0 +1,5 @@
+class Test::Components::Common::CopyToClipboardButtonController < Test::BaseController
+  def show
+    @text_to_copy = "exercism download --track=csharp --exercise=anagram"
+  end
+end

--- a/app/helpers/view_components/common/copy_to_clipboard_button.rb
+++ b/app/helpers/view_components/common/copy_to_clipboard_button.rb
@@ -1,0 +1,11 @@
+module ViewComponents
+  module Common
+    class CopyToClipboardButton < ViewComponent
+      initialize_with :text_to_copy
+
+      def to_s
+        react_component("common-copy-to-clipboard-button", { text_to_copy: text_to_copy })
+      end
+    end
+  end
+end

--- a/app/javascript/components/common/CopyToClipboardButton.tsx
+++ b/app/javascript/components/common/CopyToClipboardButton.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+
+export function CopyToClipboardButton({ textToCopy }: { textToCopy: string }) {
+  const [justCopied, setJustCopied] = useState(false)
+
+  const onClick = async () => {
+    await navigator.clipboard.writeText(textToCopy)
+    setJustCopied(true)
+  }
+
+  useEffect(() => {
+    if (!justCopied) {
+      return
+    }
+
+    const justCopiedTimeout = 2000
+    const timer = setTimeout(() => setJustCopied(false), justCopiedTimeout)
+    return () => clearTimeout(timer)
+  }, [justCopied, setJustCopied])
+
+  return (
+    <button
+      onClick={onClick}
+      className={`c-copy-to-clipboard-button ${justCopied ? 'copied' : ''}`}
+    >
+      {justCopied ? 'Copied' : 'Copy'}
+    </button>
+  )
+}

--- a/app/javascript/components/common/index.ts
+++ b/app/javascript/components/common/index.ts
@@ -1,0 +1,1 @@
+export { CopyToClipboardButton } from './CopyToClipboardButton'

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -43,6 +43,7 @@ import 'components/concept-map/ConceptMap.css'
 
 import React from 'react'
 import { initReact } from './react-bootloader.jsx'
+import * as Common from '../components/common'
 import * as Example from '../components/example'
 import * as Maintaining from '../components/maintaining'
 import * as Notifications from '../components/notifications'
@@ -97,6 +98,9 @@ initReact({
   ),
   'user-summary-tooltip': (data: any) => (
     <Tooltips.UserSummary endpoint={data.endpoint} />
+  ),
+  'common-copy-to-clipboard-button': (data: any) => (
+    <Common.CopyToClipboardButton textToCopy={data.text_to_copy} />
   ),
 })
 

--- a/app/views/test/components/common/copy_to_clipboard_button/show.html.haml
+++ b/app/views/test/components/common/copy_to_clipboard_button/show.html.haml
@@ -1,0 +1,1 @@
+= ViewComponents::Common::CopyToClipboardButton.new(@text_to_copy)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,9 @@ Rails.application.routes.draw do
             get 'user_summary/:id', to: 'tooltip#user_summary', as: 'user_summary'
           end
         end
+        namespace :common do
+          resource :copy_to_clipboard_button, controller: "copy_to_clipboard_button", only: [:show]
+        end
       end
     end
   end

--- a/test/javascript/components/common/CopyToClipboardButton.test.js
+++ b/test/javascript/components/common/CopyToClipboardButton.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, waitFor, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { CopyToClipboardButton } from '../../../../app/javascript/components/common/CopyToClipboardButton'
+
+test('copies text to clipboard when clicking', async () => {
+  // The clipboard API is not supported so we have to mock it
+  navigator.clipboard = { writeText: () => {} }
+  jest.spyOn(navigator.clipboard, 'writeText')
+
+  const { getByText } = render(
+    <CopyToClipboardButton textToCopy="exercism download --track=ruby --exercise=bob" />
+  )
+
+  fireEvent.click(getByText('Copy'))
+
+  await waitFor(() =>
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'exercism download --track=ruby --exercise=bob'
+    )
+  )
+})
+
+test('changes text to copied temporarily', async () => {
+  const { getByText, queryByText } = render(
+    <CopyToClipboardButton textToCopy="exercism download --track=ruby --exercise=bob" />
+  )
+
+  fireEvent.click(getByText('Copy'))
+
+  await waitFor(() => expect(queryByText('Copied')).toBeInTheDocument())
+  await waitFor(() => expect(queryByText('Copy')).toBeInTheDocument(), {
+    timeout: 2500,
+  })
+})


### PR DESCRIPTION
I've considered several options on how to implement this. The old code used `document.execCommand('copy')`, which is nice because it works in all browsers. The main disadvantage is that it requires the text to copy to be selected first. This would mean passing in either a reference to the HTML element that contains the text (don't know if this is possible from HAML) or a selector to allow the element to be found.

An alternative is the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), which allows one to just specify the text to copy to the clipboard. This makes the component a lot easier to use, also from HAML. There are two caveats to this approach:

1. The API is not supported by IE (see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#Browser_compatibility)
1. The element text is not automatically selected by the component. I'm not sure if this actually a disadvantage or not, but it is worth noting.

Let me know if you feel that the current approach is valid.