### PR TITLE
Use location.assign to preserve back button

### DIFF
--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -215,7 +215,7 @@ export function Editor({
         body: JSON.stringify({}),
       }).then((json: any) => {
         const iteration = typecheck<Iteration>(json, 'iteration')
-        location.replace(iteration.links.self)
+        location.assign(iteration.links.self)
       })
     },
     [submission]


### PR DESCRIPTION
Closes https://github.com/exercism/v3-website/issues/238.

I was a bit confused about using `pushState` as it does not create a request to the server but we want to do that. I think what was wrong was that I did `location.replace` instead of `location.assign`.