### PR TITLE
Language Server Protocol POC

### DIFF
--- a/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import MonacoEditor from 'react-monaco-editor'
+import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
+import { listen, MessageConnection } from 'vscode-ws-jsonrpc'
+import {
+  MonacoLanguageClient,
+  CloseAction,
+  ErrorAction,
+  MonacoServices,
+  createConnection,
+} from 'monaco-languageclient'
+import normalizeUrl from 'normalize-url'
+import ReconnectingWebsocket from 'reconnecting-websocket'
+
+export type FileEditorHandle = {
+  getFile: () => File
+}
+
+type FileEditorProps = {
+  file: File
+  language: string
+  onRunTests: () => void
+}
+
+const SAVE_INTERVAL = 500
+
+export function ExercismMonacoEditor({
+  width,
+  height,
+  language,
+  editorDidMount,
+  onRunTests,
+  options,
+  value,
+  theme,
+}: {
+  width: string
+  height: string
+  language: string
+  editorDidMount: (editor: monacoEditor.editor.IStandaloneCodeEditor) => void
+  onRunTests: () => void
+  options: monacoEditor.editor.IStandaloneEditorConstructionOptions
+  value: string
+  theme: string
+}) {
+  const handleEditorDidMount = (editor) => {
+    editor.addAction({
+      id: 'runTests',
+      label: 'Run tests',
+      keybindings: [monacoEditor.KeyCode.F2],
+      run: onRunTests,
+    })
+
+    MonacoServices.install(editor)
+    const url = normalizeUrl(`ws://localhost:3000/${language}`)
+    const webSocket = new ReconnectingWebsocket(url, [], {
+      maxReconnectionDelay: 10000,
+      minReconnectionDelay: 1000,
+      reconnectionDelayGrowFactor: 1.3,
+      connectionTimeout: 10000,
+      maxRetries: Infinity,
+      debug: false,
+    })
+    listen({
+      webSocket,
+      onConnection: (connection) => {
+        const languageClient = new MonacoLanguageClient({
+          name: 'Language Client',
+          clientOptions: {
+            documentSelector: [language],
+            errorHandler: {
+              error: () => ErrorAction.Continue,
+              closed: () => CloseAction.DoNotRestart,
+            },
+          },
+          connectionProvider: {
+            get: (errorHandler, closeHandler) => {
+              return Promise.resolve(
+                createConnection(connection, errorHandler, closeHandler)
+              )
+            },
+          },
+        })
+        const disposable = languageClient.start()
+        connection.onClose(() => disposable.dispose())
+      },
+    })
+    editorDidMount(editor)
+  }
+
+  return (
+    <MonacoEditor
+      width="800"
+      height="600"
+      language={language}
+      editorDidMount={handleEditorDidMount}
+      options={options}
+      value={value}
+      theme={theme}
+    />
+  )
+}

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -7,19 +7,9 @@ import React, {
   useState,
 } from 'react'
 import { File } from '../Editor'
-import MonacoEditor from 'react-monaco-editor'
+import { ExercismMonacoEditor } from './ExercismMonacoEditor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 import { useStorage } from '../../../utils/use-storage'
-import { listen, MessageConnection } from 'vscode-ws-jsonrpc'
-import {
-  MonacoLanguageClient,
-  CloseAction,
-  ErrorAction,
-  MonacoServices,
-  createConnection,
-} from 'monaco-languageclient'
-import normalizeUrl from 'normalize-url'
-import ReconnectingWebsocket from 'reconnecting-websocket'
 
 export type FileEditorHandle = {
   getFile: () => File
@@ -51,47 +41,6 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
     const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor>()
     const editorDidMount = useCallback(
       (editor) => {
-        editor.addAction({
-          id: 'runTests',
-          label: 'Run tests',
-          keybindings: [monacoEditor.KeyCode.F2],
-          run: onRunTests,
-        })
-
-        MonacoServices.install(editor)
-        const url = normalizeUrl(`ws://localhost:3000/${language}`)
-        const webSocket = new ReconnectingWebsocket(url, [], {
-          maxReconnectionDelay: 10000,
-          minReconnectionDelay: 1000,
-          reconnectionDelayGrowFactor: 1.3,
-          connectionTimeout: 10000,
-          maxRetries: Infinity,
-          debug: false,
-        })
-        listen({
-          webSocket,
-          onConnection: (connection) => {
-            const languageClient = new MonacoLanguageClient({
-              name: 'Language Client',
-              clientOptions: {
-                documentSelector: [language],
-                errorHandler: {
-                  error: () => ErrorAction.Continue,
-                  closed: () => CloseAction.DoNotRestart,
-                },
-              },
-              connectionProvider: {
-                get: (errorHandler, closeHandler) => {
-                  return Promise.resolve(
-                    createConnection(connection, errorHandler, closeHandler)
-                  )
-                },
-              },
-            })
-            const disposable = languageClient.start()
-            connection.onClose(() => disposable.dispose())
-          },
-        })
         editorRef.current = editor
       },
       [editorRef]
@@ -157,12 +106,13 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
             Revert to last run code
           </button>
         )}
-        <MonacoEditor
+        <ExercismMonacoEditor
           key={file.filename}
           width="800"
           height="600"
           language={language}
           editorDidMount={editorDidMount}
+          onRunTests={onRunTests}
           options={options}
           value={content}
           theme={theme}

--- a/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
-export default function MonacoEditor({
-  value,
-  editorDidMount,
-  theme,
-  options,
+export function ExercismMonacoEditor({
+  width,
+  height,
   language,
-  onChange,
+  editorDidMount,
+  onRunTests,
+  options,
+  value,
+  theme,
 }) {
+  const textareaRef = useRef<HTMLTextArea | undefined>()
   const editor = {
     getValue: () => {
-      return value
+      return textareaRef.current?.value
     },
-  }
-
-  const handleChange = (e) => {
-    onChange(e.target.value, e)
   }
 
   useEffect(() => {
@@ -29,9 +28,9 @@ export default function MonacoEditor({
       <p>Wrap: {options.wordWrap}</p>
       <p>Value: {value}</p>
       <textarea
+        ref={textareaRef}
         data-testid="editor-value"
-        onChange={handleChange}
-        value={value}
+        defaultValue={value}
       ></textarea>
     </div>
   )

--- a/app/javascript/declarations.d.ts
+++ b/app/javascript/declarations.d.ts
@@ -1,0 +1,30 @@
+declare module 'reconnecting-websocket' {
+  interface ReconnectingWebsocket extends WebSocket {
+    [key: string]: any
+    new (
+      url: string | (() => string),
+      protocols?: string | Array<string>,
+      options?: {
+        maxReconnectionDelay?: number
+        minReconnectionDelay?: number
+        reconnectionDelayGrowFactor?: number
+        connectionTimeout?: number
+        maxRetries?: number
+        debug?: boolean
+      }
+    ): ReconnectingWebsocket
+
+    close(
+      code?: number,
+      reason?: string,
+      options?: {
+        keepClosed?: boolean
+        fastClosed?: boolean
+        delay?: number
+      }
+    ): void
+  }
+
+  const ReconnectingWebsocket: ReconnectingWebsocket
+  export = ReconnectingWebsocket
+}

--- a/app/javascript/utils/use-storage.ts
+++ b/app/javascript/utils/use-storage.ts
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react'
 import { StoredMemoryValue, useMutableMemoryValue } from 'use-memory-value'
 
-export function useStorage(key, initialValue) {
-  const memoryValue = new StoredMemoryValue(key, true, initialValue)
+export function useStorage<T>(key: string, initialValue: T) {
+  const memoryValue = new StoredMemoryValue<T>(key, true, initialValue)
 
   return useMutableMemoryValue(memoryValue)
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,6 +16,7 @@ module.exports = function (api) {
   }
 
   return {
+    sourceType: 'unambiguous',
     presets: [
       isTestEnv && [
         '@babel/preset-env',

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,10 @@
 const { environment } = require('@rails/webpacker')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
+const aliases = {
+  vscode: require.resolve('monaco-languageclient/lib/vscode-compatibility'),
+}
 
+environment.config.merge({ resolve: { alias: aliases } })
 environment.plugins.append('MonacoWebpackPlugin', new MonacoWebpackPlugin())
 
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@types/actioncable": "^5.2.3",
     "@types/humps": "^2.0.0",
+    "@types/normalize-url": "^4.2.0",
     "actioncable": "^5.2.4-3",
     "core-js": "^3.6.5",
     "dayjs": "^1.8.35",
@@ -16,6 +17,7 @@
     "humps": "^2.0.1",
     "localforage": "^1.9.0",
     "monaco-editor-webpack-plugin": "^2.0.0",
+    "monaco-languageclient": "^0.13.0",
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
@@ -24,11 +26,13 @@
     "react-monaco-editor": "^0.40.0",
     "react-popper": "^2.2.3",
     "react-query": "^2.15.4",
+    "reconnecting-websocket": "3.2.2",
     "regenerator-runtime": "^0.13.7",
     "tailwindcss": "^1.8.10",
     "turbolinks": "^5.2.0",
+    "use-is-mounted": "^1.0.0",
     "use-memory-value": "^1.2.0",
-    "use-is-mounted": "^1.0.0"
+    "vscode-ws-jsonrpc": "^0.2.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/test/javascript/components/student/Editor.test.js
+++ b/test/javascript/components/student/Editor.test.js
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
@@ -162,27 +166,12 @@ test('disables submit button unless tests passed', async () => {
     />
   )
 
-  expect(getByText('Submit')).toBeDisabled()
+  await waitFor(() => {
+    expect(getByText('Submit')).toBeDisabled()
+  })
 })
 
 test('populates files', async () => {
-  const server = setupServer(
-    rest.get('https://exercism.test/test_run', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          test_run: {
-            id: null,
-            submission_uuid: '123',
-            status: 'queued',
-            message: '',
-            tests: [],
-          },
-        })
-      )
-    })
-  )
-  server.listen()
-
   const { getByText } = render(
     <Editor
       endpoint="https://exercism.test/submissions"
@@ -198,7 +187,7 @@ test('populates files', async () => {
     />
   )
 
-  expect(getByText('class Lasagna')).toBeInTheDocument()
-
-  server.close()
+  await waitFor(() => {
+    expect(getByText('class Lasagna')).toBeInTheDocument()
+  })
 })

--- a/test/javascript/components/student/Editor/FileEditor.test.js
+++ b/test/javascript/components/student/Editor/FileEditor.test.js
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
@@ -50,11 +54,15 @@ test('loads data from storage', async () => {
 })
 
 test('saves data to storage when data changed', async () => {
+  jest.useFakeTimers()
   const { getByTestId } = render(
     <FileEditor file={{ filename: 'file', content: '' }} language="go" />
   )
 
   fireEvent.change(getByTestId('editor-value'), { target: { value: 'code' } })
+  await waitFor(() => {
+    jest.runOnlyPendingTimers()
+  })
 
   expect(await localForage.getItem('file-editor-content')).toEqual('code')
 

--- a/test/javascript/components/student/Editor/TestRunSummary.test.js
+++ b/test/javascript/components/student/Editor/TestRunSummary.test.js
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/test/javascript/components/student/Editor/TestSummary.test.ts
+++ b/test/javascript/components/student/Editor/TestSummary.test.ts
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/test/javascript/components/student/Editor/TestsList.test.ts
+++ b/test/javascript/components/student/Editor/TestsList.test.ts
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/test/javascript/components/track/IterationSummary.test.ts
+++ b/test/javascript/components/track/IterationSummary.test.ts
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/test/javascript/components/track/iteration-summary/AnalysisStatusSummary.test.ts
+++ b/test/javascript/components/track/iteration-summary/AnalysisStatusSummary.test.ts
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/test/javascript/components/track/iteration-summary/TestsStatusSummary.test.ts
+++ b/test/javascript/components/track/iteration-summary/TestsStatusSummary.test.ts
@@ -1,3 +1,7 @@
+jest.mock(
+  '../../../../../app/javascript/components/student/editor/ExercismMonacoEditor'
+)
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["webpack-env"]
+    "types": ["webpack-env", "app/javascript/declarations"]
   },
   "exclude": ["**/*.spec.ts", "node_modules", "vendor", "public"],
   "compileOnSave": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,6 +1610,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/normalize-url@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-url/-/normalize-url-4.2.0.tgz#b72486d1d87e70b2b94bd34d9300fe41c736f788"
+  integrity sha512-lMD7+DEzeaAWiJzVzlFJHWCRi/SConK0T/dMxIUYw+r0Et0xNo5yN9b0wa8NUgqECJfAbPYneecqDxQNyhTHnA==
+  dependencies:
+    normalize-url "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -4885,6 +4892,11 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -7002,6 +7014,16 @@ monaco-editor@*:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.2.tgz#37054e63e480d51a2dd17d609dcfb192304d5605"
   integrity sha512-jS51RLuzMaoJpYbu7F6TPuWpnWTLD4kjRW0+AZzcryvbxrTwhNy1KC9yboyKpgMTahpUbDUsuQULoo0GV1EPqg==
 
+monaco-languageclient@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.13.0.tgz#59b68b42fb7633171502d6557f597c2752f6c266"
+  integrity sha512-aCwd33dTitwV5QwY56rpYHwzEGXei8TZ+yvZcvP3gEMd6Mizr8m3pOuoknDi2SUfLuNAHS6+ulvLgZlNQB5awg==
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    vscode-jsonrpc "^5.0.0"
+    vscode-languageclient "^6.0.0"
+    vscode-uri "^2.1.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7279,6 +7301,11 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
+normalize-url@*:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-5.3.0.tgz#8959b3cdaa295b61592c1f245dded34b117618dd"
+  integrity sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==
 
 normalize-url@1.9.1:
   version "1.9.1"
@@ -8964,6 +8991,11 @@ readdirp@~3.4.0:
   integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
   dependencies:
     picomatch "^2.2.1"
+
+reconnecting-websocket@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz#8097514e926e9855e03c39e76efa2e3d1f371bee"
+  integrity sha512-SWSfoXiaHVOqXuPWFgGWeUxKnb5HIY7I/Fh5C/hy4wUOgeOh7YIMXEiv5/eHBlNs4tNzCrO5YDR9AH62NWle0Q==
 
 redent@^1.0.0:
   version "1.0.0"
@@ -10690,6 +10722,44 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
+  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
+
+vscode-languageclient@^6.0.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz#c979c5bb5855714a0307e998c18ca827c1b3953a"
+  integrity sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==
+  dependencies:
+    semver "^6.3.0"
+    vscode-languageserver-protocol "^3.15.3"
+
+vscode-languageserver-protocol@^3.15.3:
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
+  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+  dependencies:
+    vscode-jsonrpc "^5.0.1"
+    vscode-languageserver-types "3.15.1"
+
+vscode-languageserver-types@3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
+  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+
+vscode-uri@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
+  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
+
+vscode-ws-jsonrpc@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.2.0.tgz#5e9c26e10da54a1a235da7d59e74508bbcb8edd9"
+  integrity sha512-NE9HNRgPjCaPyTJvIudcpyIWPImxwRDtuTX16yks7SAiZgSXigxAiZOvSvVBGmD1G/OMfrFo6BblOtjVR9DdVA==
+  dependencies:
+    vscode-jsonrpc "^5.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
*Opening this PR to demonstrate a simple implementation of connecting to a Language Server via Monaco*

## Screenshot
![Nov-08-2020 11-20-03](https://user-images.githubusercontent.com/1901520/98456172-23e5ec00-21b5-11eb-91f2-56fbc9c776b6.gif)

## How it works
In this example, we use the `solargraph` language server for Ruby. We'd need to have this running separately, behind this websocket proxy (https://github.com/wylieconlon/jsonrpc-ws-proxy). Browsers don't support direct TCP connections that's why we need to hide it behind a websocket proxy. I imagine that we'd do the same for the other language servers.

We then use https://github.com/TypeFox/monaco-languageclient as the language client to interpret the data from the language server.