### PR TITLE
Allow passing class name to Icon and GraphicalIcon components

### DIFF
--- a/app/javascript/components/common/GraphicalIcon.tsx
+++ b/app/javascript/components/common/GraphicalIcon.tsx
@@ -7,8 +7,13 @@ export function GraphicalIcon({
   icon: string
   className?: string
 }) {
+  let classNames = ['c-icon']
+  if (className !== undefined) {
+    classNames.push(className)
+  }
+
   return (
-    <svg className={`c-icon ${className ? className : ''}`} role="presentation">
+    <svg className={classNames.join(' ')} role="presentation">
       <use xlinkHref={`#${icon}`} />
     </svg>
   )

--- a/app/javascript/components/common/GraphicalIcon.tsx
+++ b/app/javascript/components/common/GraphicalIcon.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 
-export function GraphicalIcon({ icon }: { icon: string }) {
+export function GraphicalIcon({
+  icon,
+  className,
+}: {
+  icon: string
+  className?: string
+}) {
   return (
-    <svg className="c-icon" role="presentation">
+    <svg className={`c-icon ${className ? className : ''}`} role="presentation">
       <use xlinkHref={`#${icon}`} />
     </svg>
   )

--- a/app/javascript/components/common/Icon.tsx
+++ b/app/javascript/components/common/Icon.tsx
@@ -1,8 +1,16 @@
 import React from 'react'
 
-export function Icon({ icon, alt }: { icon: string; alt: string }) {
+export function Icon({
+  icon,
+  alt,
+  className,
+}: {
+  icon: string
+  alt: string
+  className?: string
+}) {
   return (
-    <svg className="c-icon" role="img">
+    <svg className={`c-icon ${className ? className : ''}`} role="img">
       <title>{alt}</title>
       <use xlinkHref={`#${icon}`} />
     </svg>

--- a/app/javascript/components/common/Icon.tsx
+++ b/app/javascript/components/common/Icon.tsx
@@ -9,8 +9,13 @@ export function Icon({
   alt: string
   className?: string
 }) {
+  let classNames = ['c-icon']
+  if (className !== undefined) {
+    classNames.push(className)
+  }
+
   return (
-    <svg className={`c-icon ${className ? className : ''}`} role="img">
+    <svg className={classNames.join(' ')} role="img">
       <title>{alt}</title>
       <use xlinkHref={`#${icon}`} />
     </svg>


### PR DESCRIPTION
@iHiD Note that I've used `className`, not `classNames` as the former is the default react naming convention.