### PR TITLE
Don't use complex objects for streaming

### DIFF
--- a/app/channels/iteration_channel.rb
+++ b/app/channels/iteration_channel.rb
@@ -1,8 +1,10 @@
 class IterationChannel < ApplicationCable::Channel
   def subscribed
+    # Assert that the user owns this iteration
     iteration = current_user.iterations.find_by!(uuid: params[:uuid])
 
-    stream_for iteration
+    # Don't use persisted objects for stream_for
+    stream_for iteration.id
   end
 
   def unsubscribed
@@ -10,6 +12,6 @@ class IterationChannel < ApplicationCable::Channel
   end
 
   def self.broadcast!(iteration)
-    broadcast_to iteration, iteration: SerializeIteration.(iteration)
+    broadcast_to iteration.id, iteration: SerializeIteration.(iteration)
   end
 end

--- a/app/channels/submission/test_runs_channel.rb
+++ b/app/channels/submission/test_runs_channel.rb
@@ -1,7 +1,10 @@
 class Submission::TestRunsChannel < ApplicationCable::Channel
   def subscribed
+    # Assert that the user owns this submission
     submission = current_user.submissions.find_by!(uuid: params[:submission_uuid])
-    stream_for submission
+
+    # Don't use persisted objects for stream_for
+    stream_for submission.id
   end
 
   def unsubscribed
@@ -9,7 +12,7 @@ class Submission::TestRunsChannel < ApplicationCable::Channel
   end
 
   def self.broadcast!(test_run)
-    broadcast_to test_run.submission,
+    broadcast_to test_run.submission_id,
       test_run: SerializeSubmissionTestRun.(test_run)
   end
 end

--- a/app/channels/submissions_channel.rb
+++ b/app/channels/submissions_channel.rb
@@ -1,7 +1,10 @@
 class SubmissionsChannel < ApplicationCable::Channel
   def subscribed
+    # Assert that the user owns this solution
     solution = current_user.solutions.find(params[:solution_id])
-    stream_for solution
+
+    # Don't use persisted objects for stream_for
+    stream_for solution.id
   end
 
   def unsubscribed
@@ -9,6 +12,6 @@ class SubmissionsChannel < ApplicationCable::Channel
   end
 
   def self.broadcast!(solution)
-    broadcast_to solution, submissions: solution.serialized_submissions
+    broadcast_to solution.id, submissions: solution.serialized_submissions
   end
 end

--- a/test/channels/submission/test_runs_channel_test.rb
+++ b/test/channels/submission/test_runs_channel_test.rb
@@ -9,7 +9,7 @@ class Submission::TestRunsChannelTest < ActionCable::Channel::TestCase
       raw_results: { message: nil }
 
     assert_broadcast_on(
-      submission,
+      submission.id,
       test_run: {
         id: test_run.id,
         submission_uuid: test_run.submission.uuid,

--- a/test/channels/submissions_channel_test.rb
+++ b/test/channels/submissions_channel_test.rb
@@ -7,7 +7,7 @@ class SubmissionsChannelTest < ActionCable::Channel::TestCase
     submission_2 = create :submission, solution: solution, tests_status: :passed
 
     assert_broadcast_on(
-      SubmissionsChannel.broadcasting_for(solution),
+      SubmissionsChannel.broadcasting_for(solution.id),
       submissions: [{ id: submission_1.id, testsStatus: "queued" }, { id: submission_2.id, testsStatus: "passed" }]
     ) do
       SubmissionsChannel.broadcast!(solution)


### PR DESCRIPTION
It's more efficient in anycable to use ids, not complex objects with websockets. This PR changes to us using that: More details:
- https://docs.anycable.io/#/v1/rails/channels_state
- https://docs.anycable.io/#/v1/architecture?id=restoring-state-objects