### PR TITLE
Remove n+1s from activities

### DIFF
--- a/app/helpers/view_components/user_activity.rb
+++ b/app/helpers/view_components/user_activity.rb
@@ -5,7 +5,9 @@ module ViewComponents
     def to_s
       template = activity.class.name.split("::").last.underscore.gsub(/_activity$/, "")
       ApplicationController.render "components/user_activities/#{template}",
-        locals: { activity: activity },
+        locals: {
+          activity: activity.rendering_data
+        },
         layout: false
     end
   end

--- a/app/models/user/activities/started_exercise_activity.rb
+++ b/app/models/user/activities/started_exercise_activity.rb
@@ -1,11 +1,16 @@
 module User::Activities
   class StartedExerciseActivity < User::Activity
+    params :exercise
+
     def url
       Exercism::Routes.track_exercise_path(track, exercise)
     end
 
-    def i18n_params
-      {}
+    def cachable_rendering_data
+      super.merge(
+        exercise_title: exercise.title,
+        exercise_icon_name: exercise.icon_name
+      )
     end
 
     def guard_params
@@ -14,10 +19,6 @@ module User::Activities
 
     def grouping_params
       "Exercise##{exercise.id}"
-    end
-
-    def exercise
-      params[:exercise]
     end
   end
 end

--- a/app/models/user/activities/submitted_iteration_activity.rb
+++ b/app/models/user/activities/submitted_iteration_activity.rb
@@ -1,11 +1,22 @@
 module User::Activities
   class SubmittedIterationActivity < User::Activity
+    params :exercise, :iteration
+
     def url
       Exercism::Routes.track_exercise_iterations_path(track, exercise, idx: iteration.idx)
     end
 
-    def i18n_params
-      {}
+    def rendering_data
+      super.tap do |data|
+        data.iteration = iteration
+      end
+    end
+
+    def cachable_rendering_data
+      super.merge(
+        exercise_title: exercise.title,
+        exercise_icon_name: exercise.icon_name
+      )
     end
 
     def guard_params
@@ -14,14 +25,6 @@ module User::Activities
 
     def grouping_params
       "Exercise##{exercise.id}"
-    end
-
-    def exercise
-      params[:exercise]
-    end
-
-    def iteration
-      params[:iteration]
     end
   end
 end

--- a/app/models/user/activity.rb
+++ b/app/models/user/activity.rb
@@ -1,24 +1,62 @@
+# This class uses some caching logic to avoid n+1 lookups when
+# rendering activities in the browser.
+#
+# Each activity is expected to define a `cachable_rendering_data`
+# method, which should call super.({...}) for any data that is
+# used in rendering and cachable. For example, you might cache an
+# exercise title or icon. This should all be data that is rarely
+# changing. Where an actual object is needed to render (e.g. an
+# iteration to render the React iteration summary component) do
+# not cache it, but append it to the rendered data OpenStruct
+# (see User::Activities::SubmittedIterationActivity for an example).
+#
+# Caches can be expired by setting rendering_data_cache to {}
+# Activities will then rebuild the cache next time they load.
+#
+# Activities are also expected to define the following:
+# - url
+# - guard_params (a list of params that ensure we don't get duplicates
+# for the same object. Normally the object that this activity is about
+# surfices)
+# - grouping_params (a list of things where we would only show one
+# activity about this in a list. e.g. a single activity)
 class User::Activity < ApplicationRecord
+  extend Mandate::Memoize
+
+  # This provides a params class method to the child classes,
+  # which they can use for setting parameters.
+  # For each key passed in via params, we retrieve that
+  # key from the params on demand, and cache it.
+  def self.params(*keys)
+    keys.each do |key|
+      define_method key do
+        iv = "@params_#{key}"
+        instance_variable_get(iv) ||
+          instance_variable_set(iv, retrieve_param(key))
+      end
+    end
+  end
+
   belongs_to :user
   belongs_to :track, optional: true
 
   before_create do
-    self.version = latest_i18n_version
     self.uniqueness_key = "#{user_id}|#{type_key}|#{guard_params}"
     self.grouping_key = "#{user_id}|#{grouping_params}"
     self.occurred_at = Time.current unless self.occurred_at
+
+    self.version = latest_i18n_version
+    self.rendering_data_cache = cachable_rendering_data
   end
 
-  def text
-    I18n.t("user_activities.#{i18n_key}.#{version}", i18n_params).strip
-  end
+  def rendering_data
+    data = rendering_data_cache
+    if data.blank?
+      data = cachable_rendering_data
+      update!(rendering_data_cache: data)
+    end
 
-  def widget
-    nil
-  end
-
-  def type_key
-    type.split("::").last.underscore.split("_activity").first.to_sym
+    OpenStruct.new(data.merge(occurred_at: occurred_at))
   end
 
   # This maps
@@ -28,9 +66,26 @@ class User::Activity < ApplicationRecord
   #
   # Any non-object params are left as the were passed in.
   def params=(hash)
+    @input_params = hash
     self[:params] = hash.transform_values do |v|
       v.respond_to?(:to_global_id) ? v.to_global_id.to_s : v
     end
+  end
+
+  private
+  def cachable_rendering_data
+    {
+      text: text,
+      url: url
+    }
+  end
+
+  def text
+    I18n.t("user_activities.#{i18n_key}.#{version}", i18n_params).strip
+  end
+
+  def type_key
+    type.split("::").last.underscore.split("_activity").first.to_sym
   end
 
   # This reverses params= to explode back out
@@ -39,11 +94,11 @@ class User::Activity < ApplicationRecord
   # {discussion: Solution::MentorDiscussion.find(186)}
   #
   # Any non-object params are left as the were passed in.
-  private
-  def params
-    super.each_with_object({}) do |(k, v), h|
-      h[k.to_sym] = GlobalID::Locator.locate(v) || v
-    end
+  def retrieve_param(key)
+    return @input_params[key] if @input_params
+
+    value = self.params[key.to_s]
+    GlobalID::Locator.locate(value) || value
   end
 
   def latest_i18n_version
@@ -55,5 +110,9 @@ class User::Activity < ApplicationRecord
 
   def i18n_key
     self.class.name.underscore.split('/').last.gsub(/_activity$/, '').to_sym
+  end
+
+  def i18n_params
+    {}
   end
 end

--- a/app/views/components/user_activities/started_exercise.html.haml
+++ b/app/views/components/user_activities/started_exercise.html.haml
@@ -4,7 +4,7 @@
     .--description
       = activity.text
       .--exercise
-        = exercise_icon(activity.exercise)
-      .--exercise-name= activity.exercise.title
+        = graphical_icon(activity.exercise_icon_name)
+        .--exercise-name= activity.exercise_title
     %time{ datetime: activity.occurred_at } #{time_ago_in_words(activity.occurred_at)} ago
   = graphical_icon :"chevron-right", css_class: "--action-icon"

--- a/app/views/components/user_activities/submitted_iteration.html.haml
+++ b/app/views/components/user_activities/submitted_iteration.html.haml
@@ -4,8 +4,8 @@
     .--description
       = activity.text
       .--exercise
-        = exercise_icon(activity.exercise)
-      .--exercise-name= activity.exercise.title
+        = graphical_icon(activity.exercise_icon_name)
+        .--exercise-name= activity.exercise_title
 
     .--iteration
       = ViewComponents::Track::IterationSummary.new(activity.iteration)

--- a/db/migrate/20201109170425_create_user_activities.rb
+++ b/db/migrate/20201109170425_create_user_activities.rb
@@ -6,11 +6,13 @@ class CreateUserActivities < ActiveRecord::Migration[6.1]
       t.belongs_to :user, null: false
       t.belongs_to :track, null: true
 
-      t.integer :version, null: false
       t.json :params, null: false
       t.datetime :occurred_at, null: false
       t.string :uniqueness_key, null: false
       t.string :grouping_key, null: false
+
+      t.integer :version, null: false
+      t.json :rendering_data_cache, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,14 +243,15 @@ ActiveRecord::Schema.define(version: 2020_11_09_170425) do
   end
 
   create_table "user_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "type", null: false
     t.bigint "user_id", null: false
     t.bigint "track_id"
-    t.string "type", null: false
-    t.integer "version", null: false
     t.json "params", null: false
     t.datetime "occurred_at", null: false
     t.string "uniqueness_key", null: false
     t.string "grouping_key", null: false
+    t.integer "version", null: false
+    t.json "rendering_data_cache", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["track_id"], name: "index_user_activities_on_track_id"

--- a/test/commands/user/activity/create_test.rb
+++ b/test/commands/user/activity/create_test.rb
@@ -12,15 +12,16 @@ class User::Activity::CreateTest < ActiveSupport::TestCase
       exercise: exercise
     }
 
-    activity = User::Activity::Create.(type, user, params)
+    User::Activity::Create.(type, user, params)
 
-    assert_equal 1, User::Activity.count
+    # Reload it fresh from the db to avoid caching
+    activity = User::Activity.last
     assert_equal user, activity.user
+    assert_equal exercise, activity.exercise
     assert_equal exercise.track, activity.track
     assert_equal User::Activities::StartedExerciseActivity, activity.class
     assert_equal 1, activity.version
     assert_equal "#{user.id}|started_exercise|Exercise##{exercise.id}", activity.uniqueness_key
-    assert_equal params, activity.send(:params)
   end
 
   test "broadcasts message" do

--- a/test/factories/user/activities.rb
+++ b/test/factories/user/activities.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :started_exercise_user_activity, class: "User::Activities::StartedExerciseActivity" do
     user
+    track
+
     params do
       {
         exercise: create(:concept_exercise)
@@ -10,6 +12,8 @@ FactoryBot.define do
 
   factory :submitted_iteration_user_activity, class: "User::Activities::SubmittedIterationActivity" do
     user
+    track
+
     params do
       {
         exercise: create(:concept_exercise),

--- a/test/models/user/activities/started_exercise_activity_test.rb
+++ b/test/models/user/activities/started_exercise_activity_test.rb
@@ -17,7 +17,7 @@ class User::Activities::StartedExerciseActivityTest < ActiveSupport::TestCase
       activity.grouping_key
   end
 
-  test "text is valid" do
+  test "rendering_data is valid" do
     user = create :user
     exercise = create(:concept_exercise)
 
@@ -26,6 +26,10 @@ class User::Activities::StartedExerciseActivityTest < ActiveSupport::TestCase
       track: exercise.track,
       params: { exercise: exercise }
     )
-    assert_equal "You started a new exercise", activity.text
+    assert_equal exercise.title, activity.rendering_data.exercise_title
+    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+    assert_equal "You started a new exercise", activity.rendering_data.text
+    assert_equal Time.current, activity.rendering_data.occurred_at
   end
 end

--- a/test/models/user/activities/submitted_iteration_activity_test.rb
+++ b/test/models/user/activities/submitted_iteration_activity_test.rb
@@ -22,7 +22,7 @@ class User::Activities::SubmittedIterationActivityTest < ActiveSupport::TestCase
       activity.grouping_key
   end
 
-  test "text is valid" do
+  test "rendering_data is valid" do
     user = create :user
     exercise = create :concept_exercise
     solution = create :concept_solution, user: user, exercise: exercise
@@ -36,6 +36,11 @@ class User::Activities::SubmittedIterationActivityTest < ActiveSupport::TestCase
         exercise: exercise
       }
     )
-    assert_equal "You submitted an iteration to", activity.text
+
+    assert_equal exercise.title, activity.rendering_data.exercise_title
+    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+    assert_equal "/tracks/csharp/exercises/datetime/iterations?idx=0", activity.rendering_data.url
+    assert_equal "You submitted an iteration to", activity.rendering_data.text
+    assert_equal Time.current, activity.rendering_data.occurred_at
   end
 end

--- a/test/models/user/activity_test.rb
+++ b/test/models/user/activity_test.rb
@@ -20,4 +20,66 @@ class User::ActivityTest < ActiveSupport::TestCase
       assert_equal Time.current, activity.occurred_at
     end
   end
+
+  test "rendering data reads cache" do
+    user = create :user
+    exercise = create(:concept_exercise)
+
+    User::Activities::StartedExerciseActivity.create!(
+      user: user,
+      track: exercise.track,
+      params: {
+        exercise: exercise
+      }
+    )
+
+    # Reload it to check nothing is memoized
+    activity = User::Activity.last
+    activity.expects(:cachable_rendering_data).never
+
+    cache_data = {
+      'exercise_icon_name' => exercise.icon_name,
+      'exercise_title' => exercise.title,
+      'url' => "/tracks/csharp/exercises/datetime",
+      'text' => "You started a new exercise"
+    }
+    assert_equal cache_data, activity.rendering_data_cache
+    assert_equal exercise.title, activity.rendering_data.exercise_title
+    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+    assert_equal "You started a new exercise", activity.rendering_data.text
+    assert_equal Time.current, activity.rendering_data.occurred_at
+  end
+
+  test "rendering data rebuilds if cache is empty" do
+    user = create :user
+    exercise = create(:concept_exercise)
+
+    activity = User::Activities::StartedExerciseActivity.create!(
+      user: user,
+      track: exercise.track,
+      params: {
+        exercise: exercise
+      }
+    )
+    activity.update!(rendering_data_cache: {})
+
+    # Reload it to check nothing is memoized
+    activity = User::Activity.last
+    assert_equal({}, activity.rendering_data_cache)
+    assert_equal exercise.title, activity.rendering_data.exercise_title
+    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+    assert_equal "You started a new exercise", activity.rendering_data.text
+    assert_equal Time.current, activity.rendering_data.occurred_at
+
+    activity = User::Activity.last
+    cache_data = {
+      'exercise_icon_name' => exercise.icon_name,
+      'exercise_title' => exercise.title,
+      'url' => "/tracks/csharp/exercises/datetime",
+      'text' => "You started a new exercise"
+    }
+    assert_equal cache_data, activity.rendering_data_cache
+  end
 end


### PR DESCRIPTION
The comments in the PR hopefully explain what's going on.

Basically this removes the `n+1s` by precaching data. We'll use this same pattern for notifications. This can gracefully cope with cache being removed. The only piece is an actual cache expiry piece, which I'll do later. However, as the cached data should be long-lived stuff (e.g. exercise title and icon) it will be a real edge-case, so I'm not worrying about it for now.