### PR TITLE
Add track mastery section

### DIFF
--- a/app/css/components/concept-icon.css
+++ b/app/css/components/concept-icon.css
@@ -1,0 +1,24 @@
+.c-concept-icon {
+    width: 24px;
+    height: 24px;
+
+    @apply border-1 border-black;
+    vertical-align: bottom;
+
+    &.c--small {
+        width: 24px;
+        height: 24px;
+        font-size: 11px;
+        line-height: 29px;
+        padding-left: 3px;
+    }
+
+    &.c--medium {
+        width: 32px;
+        height: 32px;
+        line-height: 38px;
+        padding-left: 3px;
+
+        @apply text-14 font-semibold;
+    }
+}

--- a/app/css/pages/exercise-show.css
+++ b/app/css/pages/exercise-show.css
@@ -77,8 +77,7 @@
             @apply mr-16;
         }
         & .text {
-            @apply text-18 leading-paragraph font-semibold;
-            @apply flex-grow;
+            @apply text-h5 flex-grow;
         }
     }
     & section.completed-info {
@@ -94,16 +93,8 @@
                 @apply flex items-center border-1 border-unnamed15;
                 @apply py-8 px-16 mr-8 bg-white rounded-8 shadow-base;
                 @apply text-14 font-semibold;
-                & .concept-icon {
+                & .c-concept-icon {
                     @apply mr-8;
-                    width: 24px;
-                    height: 24px;
-
-                    @apply border-1 border-black;
-                    font-size: 11px;
-                    vertical-align: bottom;
-                    line-height: 29px;
-                    padding-left: 3px;
                 }
             }
         }
@@ -135,16 +126,8 @@
                 @apply flex items-center border-1 border-unnamed15;
                 @apply py-8 px-16 mr-8 bg-white rounded-8 shadow-base;
                 @apply text-14 font-semibold;
-                & .concept-icon {
+                & .c-concept-icon {
                     @apply mr-8;
-                    width: 24px;
-                    height: 24px;
-
-                    @apply border-1 border-black;
-                    font-size: 11px;
-                    vertical-align: bottom;
-                    line-height: 29px;
-                    padding-left: 3px;
                 }
             }
         }

--- a/app/css/pages/track-show-joined.css
+++ b/app/css/pages/track-show-joined.css
@@ -109,6 +109,8 @@
         }
     }
     & section.activities {
+        @apply mb-64;
+
         & .start-track-cta,
         & .placeholder-activity {
             @apply shadow-lg bg-white rounded-8;
@@ -171,6 +173,71 @@
                     height: 16px;
                     top: -16px;
                     left: 36px;
+                }
+            }
+        }
+    }
+    & section.concepts {
+        @apply mb-64;
+
+        & .header {
+            @apply flex items-center mb-28;
+
+            & .c-icon {
+                width: 32px;
+                height: 32px;
+                @apply mr-16;
+            }
+            & h2 {
+                @apply text-h3;
+                @apply mr-16;
+            }
+            & .progress {
+                @apply py-8 px-12 text-textLight font-medium;
+                @apply border-1 border-textLight rounded-100;
+            }
+        }
+
+        & .concepts {
+            @apply grid gap-12;
+            grid-template-columns: repeat(1, auto);
+
+            & .concept {
+                @apply flex items-center py-24 px-32;
+                @apply bg-white rounded-8 shadow-lg;
+
+                & .c-concept-icon {
+                    @apply mr-24;
+                }
+                & .info {
+                    @apply flex-grow;
+
+                    & .name {
+                        @apply text-h5 mb-6;
+                    }
+                    & .completion {
+                        @apply text-textLight font-medium;
+                    }
+                }
+                & progress {
+                    max-width: 320px;
+                    @apply ml-64 flex-grow;
+                    @apply appearance-none w-100 rounded-8 overflow-hidden mb-12;
+                    height: 6px;
+
+                    &::-webkit-progress-bar {
+                        @apply bg-veryLightBlue;
+                    }
+                    &[value] {
+                        &::-webkit-progress-value {
+                            @apply bg-lightBlue;
+                        }
+                    }
+                }
+                & .action-icon {
+                    height: 16px;
+                    width: 16px;
+                    @apply ml-64;
                 }
             }
         }

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -21,6 +21,10 @@
     line-height: 1.25;
     @apply font-semibold text-black;
 }
+.text-h5 {
+    line-height: 1.38;
+    @apply text-18 font-semibold text-black;
+}
 .text-prose {
     @apply text-18 leading-paragraph;
 }

--- a/app/helpers/view_components/concept_icon.rb
+++ b/app/helpers/view_components/concept_icon.rb
@@ -1,0 +1,15 @@
+module ViewComponents
+  class ConceptIcon < ViewComponent
+    SIZES = %i[small medium].freeze
+
+    initialize_with :concept, :size
+
+    def to_s
+      raise "Invalid concept icon size #{size}" unless SIZES.include?(size.to_sym)
+
+      text = concept.name[0, 2]
+      classes = "c-concept-icon c--#{size}"
+      tag.div(text, class: classes)
+    end
+  end
+end

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -15,6 +15,7 @@ import '../../css/layout.css'
 import '../../css/site-header.css'
 
 import '../../css/components/bg-img.css'
+import '../../css/components/concept-icon.css'
 import '../../css/components/iteration-summary.css'
 import '../../css/components/prominent-link'
 import '../../css/components/reputation.css'

--- a/app/models/track/concept.rb
+++ b/app/models/track/concept.rb
@@ -10,9 +10,7 @@ class Track::Concept < ApplicationRecord
     where.not(id: Exercise::TaughtConcept.select(:track_concept_id))
   }
 
-  delegate :about,
-    :links,
-    to: :git
+  delegate :about, :links, to: :git
 
   memoize
   def git

--- a/app/models/user/activities/completed_exercise_activity.rb
+++ b/app/models/user/activities/completed_exercise_activity.rb
@@ -1,0 +1,24 @@
+module User::Activities
+  class CompletedExerciseActivity < User::Activity
+    params :exercise
+
+    def url
+      Exercism::Routes.track_exercise_path(track, exercise)
+    end
+
+    def cachable_rendering_data
+      super.merge(
+        exercise_title: exercise.title,
+        exercise_icon_name: exercise.icon_name
+      )
+    end
+
+    def guard_params
+      "Exercise##{exercise.id}"
+    end
+
+    def grouping_params
+      "Exercise##{exercise.id}"
+    end
+  end
+end

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -23,6 +23,11 @@ class UserTrack < ApplicationRecord
     user.solutions.joins(:exercise).where("exercises.track_id": track)
   end
 
+  # TODO: Cache this in the db?
+  def num_concepts_mastered
+    2
+  end
+
   def learnt_concept?(concept)
     learnt_concepts.include?(concept)
   end
@@ -98,7 +103,7 @@ class UserTrack < ApplicationRecord
             FROM exercise_prerequisites
             GROUP BY exercise_id
           ) b ON a.exercise_id = b.exercise_id AND a.num_concepts = b.num_concepts
-     })
+      })
     end
   end
   private_constant :DetermineAvailableExercisesIds

--- a/app/views/components/user_activities/completed_exercise.html.haml
+++ b/app/views/components/user_activities/completed_exercise.html.haml
@@ -1,0 +1,11 @@
+= link_to activity.url, class: 'c-user-activity c-user-activity-completed-exercise' do
+  = graphical_icon :"check-circle", css_class: "--descriptive-icon"
+  .--info
+    .--description
+      = activity.text
+      .--exercise
+        = graphical_icon(activity.exercise_icon_name)
+        .--exercise-name= activity.exercise_title
+    %time{ datetime: activity.occurred_at } #{time_ago_in_words(activity.occurred_at)} ago
+  = graphical_icon :"chevron-right", css_class: "--action-icon"
+

--- a/app/views/components/user_activities/submitted_iteration.html.haml
+++ b/app/views/components/user_activities/submitted_iteration.html.haml
@@ -1,5 +1,5 @@
 = link_to activity.url, class: 'c-user-activity c-user-activity-submitted-iteration' do
-  = graphical_icon :"check-circle", css_class: "--descriptive-icon"
+  = graphical_icon :iteration, css_class: "--descriptive-icon"
   .--info
     .--description
       = activity.text

--- a/app/views/icons/_iteration.html.haml
+++ b/app/views/icons/_iteration.html.haml
@@ -1,0 +1,6 @@
+<symbol id="iteration" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.5 10.7469V17.4999C4.5 19.1568 5.84315 20.4999 7.5 20.4999H16.5C18.1569 20.4999 19.5 19.1568 19.5 17.4999V16.7499" stroke="#6D6986" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.5 13.747V7C19.5 5.34315 18.1569 4 16.5 4H7.5C5.84315 4 4.5 5.34315 4.5 7V7.75" stroke="#6D6986" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.25 14.4969L4.5 10.7469L0.75 14.4969" stroke="#6D6986" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.75 9.99695L19.5 13.7469L23.25 9.99695" stroke="#6D6986" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</symbol>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -51,5 +51,6 @@
       = render("icons/features")
       = render("icons/pulse")
       = render("icons/exercism_face")
+      = render("icons/iteration")
       </svg>
 

--- a/app/views/tracks/exercises/show/_completed_sections.html.haml
+++ b/app/views/tracks/exercises/show/_completed_sections.html.haml
@@ -9,7 +9,7 @@
     .concepts
       - exercise.taught_concepts.each do |concept|
         = link_to track_concept_path(track, concept), class: 'concept' do
-          .concept-icon= concept.name[0, 2]
+          = ViewComponents::ConceptIcon.new(concept, :small)
           = concept.name
 
     = ViewComponents::ProminentLink.new("See how your concept map has changed", track_concepts_path(track))

--- a/app/views/tracks/show/joined.html.haml
+++ b/app/views/tracks/show/joined.html.haml
@@ -15,22 +15,8 @@
   %article
     .lg-container.container
       .lhs
-        %section.activities
-          - if @activities.present?
-            - @activities.each do |activity|
-              = ViewComponents::UserActivity.new(activity)
-          - else
-            .start-track-cta
-              = graphical_icon "exercism-face"
-              .content
-                %h3 Start the track with "Hello, World!"
-                %p Complete the "Hello, World!" tutorial to submit your first bit of code on the track and familiarise yourself with how Exercism works.
-                .actions
-                  .btn-cta Start in editor
-                  .info Completing this will unlock more exercises for you on the track.
-            .placeholder-activity
-              = graphical_icon :pulse
-              %p This is where your activity and progress on the track is displayed once you begin completing execises.
+        = render "tracks/show/joined/activities_section", activities: @activities
+        = render "tracks/show/joined/concepts_section", track: @track, user_track: @user_track
       .rhs
         %section.contributors
           %header

--- a/app/views/tracks/show/joined/_activities_section.html.haml
+++ b/app/views/tracks/show/joined/_activities_section.html.haml
@@ -1,0 +1,17 @@
+%section.activities
+  - if activities.present?
+    - activities.each do |activity|
+      = ViewComponents::UserActivity.new(activity)
+  - else
+    .start-track-cta
+      = graphical_icon "exercism-face"
+      .content
+        %h3 Start the track with "Hello, World!"
+        %p Complete the "Hello, World!" tutorial to submit your first bit of code on the track and familiarise yourself with how Exercism works.
+        .actions
+          .btn-cta Start in editor
+          .info Completing this will unlock more exercises for you on the track.
+    .placeholder-activity
+      = graphical_icon :pulse
+      %p This is where your activity and progress on the track is displayed once you begin completing exercises.
+

--- a/app/views/tracks/show/joined/_concepts_section.html.haml
+++ b/app/views/tracks/show/joined/_concepts_section.html.haml
@@ -1,0 +1,19 @@
+%section.concepts
+  .header
+    = graphical_icon :concepts
+    %h2 Concept Mastery
+    .progress
+      #{user_track.num_concepts_mastered}/#{track.concepts.size}
+      mastered
+
+  .concepts
+    - track.concepts[0, 6].each do |concept|
+      = link_to track_concept_path(concept), class: 'concept' do
+        = ViewComponents::ConceptIcon.new(concept, :medium)
+        .info
+          .name= concept.name
+          .completion 1/3 exercises completed
+
+        %progress{ value: 1, max: 3 }
+        = graphical_icon 'chevron-right', css_class: 'action-icon'
+

--- a/config/locales/user_activities/en.yml
+++ b/config/locales/user_activities/en.yml
@@ -1,11 +1,13 @@
 en:
   user_activities:
-    # Mentoring
     started_exercise:
       1: >
         You started a new exercise
 
-    # Mentoring
     submitted_iteration:
       1: >
         You submitted an iteration to
+
+    completed_exercise:
+      1: >
+        You completed an exercise

--- a/db/migrate/20201109170425_create_user_activities.rb
+++ b/db/migrate/20201109170425_create_user_activities.rb
@@ -8,7 +8,7 @@ class CreateUserActivities < ActiveRecord::Migration[6.1]
 
       t.json :params, null: false
       t.datetime :occurred_at, null: false
-      t.string :uniqueness_key, null: false
+      t.string :uniqueness_key, null: false, unique: true
       t.string :grouping_key, null: false
 
       t.integer :version, null: false

--- a/test/models/user/activities/completed_exercise_activity_test.rb
+++ b/test/models/user/activities/completed_exercise_activity_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class User::Activities::CompletedExerciseActivityTest < ActiveSupport::TestCase
+  test "keys" do
+    user = create :user
+    exercise = create(:concept_exercise)
+
+    activity = User::Activities::CompletedExerciseActivity.create!(
+      user: user,
+      track: exercise.track,
+      params: { exercise: exercise }
+    )
+    assert_equal "#{user.id}|completed_exercise|Exercise##{exercise.id}",
+      activity.uniqueness_key
+
+    assert_equal "#{user.id}|Exercise##{exercise.id}",
+      activity.grouping_key
+  end
+
+  test "rendering_data is valid" do
+    user = create :user
+    exercise = create(:concept_exercise)
+
+    activity = User::Activities::CompletedExerciseActivity.create!(
+      user: user,
+      track: exercise.track,
+      params: { exercise: exercise }
+    )
+    assert_equal exercise.title, activity.rendering_data.exercise_title
+    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+    assert_equal "You completed an exercise", activity.rendering_data.text
+    assert_equal Time.current, activity.rendering_data.occurred_at
+  end
+end


### PR DESCRIPTION
Also:
- Extracts concept-icon into its own component.
- Adds extra user activity.

Because I'm bad at separating things into atomic commits when I'm in the zone 🙂 

<img width="911" alt="Screenshot 2020-11-11 at 00 53 15" src="https://user-images.githubusercontent.com/286476/98751621-5ad81f80-23b8-11eb-9c87-1c864987641b.png">
