### PR TITLE
Add concept tooltip rendered server-side

### DIFF
--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -1,7 +1,7 @@
 class Tracks::ConceptsController < ApplicationController
   before_action :use_track
   before_action :use_concepts, only: :index
-  before_action :use_concept, only: %i[show start complete]
+  before_action :use_concept, only: %i[show tooltip start complete]
 
   skip_before_action :authenticate_user!, only: %i[index show]
 
@@ -23,6 +23,10 @@ class Tracks::ConceptsController < ApplicationController
     # Move it onto the concept eventually
     @concept_exercises = ConceptExercise.that_teach(@concept)
     @practice_exercises = PracticeExercise.that_practice(@concept)
+  end
+
+  def tooltip
+    render layout: false
   end
 
   private

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -26,6 +26,7 @@ class Tracks::ConceptsController < ApplicationController
   end
 
   def tooltip
+    @concept_summary = @user_track.summary.concept(@concept.slug)
     render layout: false
   end
 

--- a/app/css/components/concept-icon.css
+++ b/app/css/components/concept-icon.css
@@ -23,12 +23,20 @@
         @apply text-14 font-semibold;
     }
 
+    &.c--large {
+        width: 48px;
+        height: 48px;
+        padding: 6px;
+
+        border: 2px solid black;
+        @apply text-16 font-semibold;
+    }
+
     &.c--huge {
         width: 96px;
         height: 96px;
-        padding-left: 3px;
         border: 4px solid black;
         font-size: 42px;
-        @apply font-bold flex items-end p-8;
+        @apply font-bold flex p-8;
     }
 }

--- a/app/css/components/concept-progress-bar.css
+++ b/app/css/components/concept-progress-bar.css
@@ -14,7 +14,7 @@ progress.c-concept-progress-bar {
     &.--completed {
         &[value] {
             &::-webkit-progress-value {
-                @apply bg-darkGreen;
+                @apply bg-tooManyGreens;
             }
         }
     }

--- a/app/css/components/tooltips/concept.css
+++ b/app/css/components/tooltips/concept.css
@@ -1,0 +1,36 @@
+@import "../../styles";
+
+.c-concept-tooltip {
+    max-width: 460px;
+
+    @apply shadow-lg rounded-8 py-20 px-24 bg-white;
+
+    & .c-concept-icon {
+        @apply mr-16;
+    }
+
+    & .heading {
+        @apply flex mb-12;
+
+        & .title {
+            @apply flex items-center;
+
+            & .name {
+                @apply text-h5 mr-8;
+            }
+            & .in {
+                @apply mr-8;
+            }
+            & .c-icon {
+                height: 32px;
+                width: 32px;
+            }
+        }
+        & .num-exercises {
+            @apply text-15 font-medium text-textLight;
+        }
+    }
+    & .blurb {
+        @apply text-15 leading-paragraph;
+    }
+}

--- a/app/css/components/tooltips/concept.css
+++ b/app/css/components/tooltips/concept.css
@@ -33,4 +33,24 @@
     & .blurb {
         @apply text-15 leading-paragraph;
     }
+
+    & .mastered {
+        @apply mt-16;
+        & .summary {
+            @apply flex font-semibold mb-8 text-darkGreen;
+
+            & .c-icon {
+                height: 16px;
+                width: 16px;
+                @apply mr-12;
+            }
+        }
+        & .c-concept-progress-bar {
+            @apply mb-12;
+            height: 6px;
+        }
+        & .info {
+            @apply text-darkGray leading-paragraph font-medium;
+        }
+    }
 }

--- a/app/helpers/view_components/concept_icon.rb
+++ b/app/helpers/view_components/concept_icon.rb
@@ -1,6 +1,6 @@
 module ViewComponents
   class ConceptIcon < ViewComponent
-    SIZES = %i[small medium huge].freeze
+    SIZES = %i[small medium large huge].freeze
 
     def initialize(concept, size, view_context: nil)
       raise "Invalid concept icon size #{size}" unless SIZES.include?(size.to_sym)

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -24,7 +24,7 @@ import '../../css/components/reputation.css'
 import '../../css/components/tab.css'
 import '../../css/components/textual-content.css'
 import '../../css/components/tracks-list.css'
-import '../../css/components/tooltips/tooltip.css'
+import '../../css/components/tooltips/concept.css'
 import '../../css/components/tooltips/user-summary.css'
 import '../../css/components/user_activity.css'
 

--- a/app/models/track/concept.rb
+++ b/app/models/track/concept.rb
@@ -12,6 +12,16 @@ class Track::Concept < ApplicationRecord
 
   delegate :about, :links, to: :git
 
+  # TODO: Read from git
+  def blurb
+    "C# structs are closely related to classes. They have state and behavior. They have constructors that take arguments, instances can be assigned, tested for equality and stored in collections." # rubocop:disable Layout/LineLength
+  end
+
+  # Cache this
+  def num_exercises
+    3
+  end
+
   memoize
   def git
     Git::Concept.new(track.slug, slug, "HEAD")

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -9,3 +9,14 @@
       .num-exercises= pluralize(@concept.num_exercises, "exercise")
 
   .blurb= @concept.blurb
+
+  - if @concept_summary.mastered?
+    - num_exercises = @concept_summary.num_exercises
+    .mastered
+      .summary
+        = graphical_icon "completed-check-circle"
+        #{num_exercises}/#{num_exercises}
+        = pluralize(num_exercises, "exercise")
+        completed
+      = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
+      .info You’ve mastered #{@concept.name}. Well done!

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -1,0 +1,11 @@
+.c-concept-tooltip
+  .heading
+    = render ViewComponents::ConceptIcon.new(@concept, :large)
+    .summary
+      .title
+        .name= @concept.name
+        .in in
+        = track_icon(@track)
+      .num-exercises= pluralize(@concept.num_exercises, "exercise")
+
+  .blurb= @concept.blurb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,9 @@ Rails.application.routes.draw do
     resources :submissions, only: [:index]
   end
   resources :tracks, only: %i[index show] do
-    resources :concepts, only: %i[index show], controller: "tracks/concepts"
+    resources :concepts, only: %i[index show], controller: "tracks/concepts" do
+      get :tooltip, on: :member
+    end
 
     resources :exercises, only: %i[index show], controller: "tracks/exercises" do
       member do

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
       darkGreen: '#43B593',
       mediumGreen: '#B8EADB',
       lightGreen: '#ABDBCC',
+      tooManyGreens: '#59D2AE',
 
       orange: '#F69605',
       red: '#EB5757',


### PR DESCRIPTION
Adds a ~tooltip~ (thing that's a bit like a tooltip but this is the wrong thing to call it) component for concepts.

Accessible via `/tracks/ruby/concepts/booleans/tooltip` or `tooltip_track_concept_path(:ruby, :booleans)`

<img width="467" alt="Screenshot 2020-11-11 at 21 55 49" src="https://user-images.githubusercontent.com/286476/98868863-b82ba980-2468-11eb-8f0d-1890f97e051e.png">
