### PR TITLE
Implement progress bar on concept page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,9 @@ Style/Documentation:
 Style/DocumentationMethod:
   Enabled: false
 
+Style/DoubleNegation:
+  Enabled: false
+
 Style/RedundantSelf:
   Enabled: false
 

--- a/app/commands/submission/create.rb
+++ b/app/commands/submission/create.rb
@@ -29,7 +29,6 @@ class Submission
 
       create_submission!
       create_files!
-      update_solution!
       schedule_jobs!
       submission.broadcast!
 
@@ -100,11 +99,6 @@ class Submission
           file.slice(:uuid, :filename, :digest, :content)
         )
       end
-    end
-
-    def update_solution!
-      solution.status = :submitted if solution.pending?
-      solution.save!
     end
 
     def schedule_jobs!

--- a/app/commands/user_track/generate_concept_status_mapping.rb
+++ b/app/commands/user_track/generate_concept_status_mapping.rb
@@ -5,7 +5,7 @@ class UserTrack
     initialize_with :user_track
 
     def call
-      return {} unless user_track
+      return {} unless user_track && !user_track.external?
 
       all_concepts = user_track.track.concepts.map(&:slug)
       available_concepts = user_track.available_concepts.map(&:slug)

--- a/app/commands/user_track/generate_summary.rb
+++ b/app/commands/user_track/generate_summary.rb
@@ -4,24 +4,7 @@ class UserTrack
 
     initialize_with :track, :user_track
 
-    # We want to ensure we only do this once, but we
-    # provide two access vectors, this and the
-    # user_track.summary. This slightly hacky method
-    # checks whether we've already done this work and
-    # if so returns what we already have. Otherwise
-    # it does the work and then sets it.
-    #
-    # If we don't have a user_track, then we just generate
-    # the data and don't worry about this bit.
     def call
-      return generate! unless user_track
-
-      return user_track.summary if user_track.summary_generated?
-
-      user_track.summary = generate!
-    end
-
-    def generate!
       t = Time.now.to_f
       Rails.logger.info "[BM] Starting generating user summary"
 
@@ -174,6 +157,10 @@ class UserTrack
 
       def num_completed_exercises
         num_completed_concept_exercises + num_completed_practice_exercises
+      end
+
+      def available?
+        available
       end
 
       def mastered?

--- a/app/commands/user_track/generate_summary.rb
+++ b/app/commands/user_track/generate_summary.rb
@@ -2,19 +2,46 @@ class UserTrack
   class GenerateSummary
     include Mandate
 
-    initialize_with :user_track
-    delegate :track, to: :user_track
+    initialize_with :track, :user_track
 
+    # We want to ensure we only do this once, but we
+    # provide two access vectors, this and the
+    # user_track.summary. This slightly hacky method
+    # checks whether we've already done this work and
+    # if so returns what we already have. Otherwise
+    # it does the work and then sets it.
+    #
+    # If we don't have a user_track, then we just generate
+    # the data and don't worry about this bit.
     def call
-      #####################
-      # Populate concepts #
-      #####################
-      concepts = {}
-      track.concepts.each do |concept|
-        concept_exercises = concept_exercise_data.values.
+      return generate! unless user_track
+
+      return user_track.summary if user_track.summary_generated?
+
+      user_track.summary = generate!
+    end
+
+    def generate!
+      t = Time.now.to_f
+      Rails.logger.info "[BM] Starting generating user summary"
+
+      UserTrack::Summary.new(
+        concepts.map { |k, v| [k, ConceptSummary.new(v)] }.to_h,
+        exercises.map { |k, v| [k, ExerciseSummary.new(v)] }.to_h
+      ).tap do
+        Rails.logger.info "[BM] Finished generating user summary"
+        Rails.logger.info "[BM] Generating User Summary: #{Time.now.to_f - t}"
+      end
+    end
+
+    memoize
+    def concepts
+      track.concepts.each.with_object({}) do |concept, hash|
+        concept_exercises = concept_exercises_data.values.
           select { |e| e[:taught_concepts].include?(concept.slug) }.
           map { |e| e[:slug] }
-        practice_exercises = practice_exercise_data.values.
+
+        practice_exercises = practice_exercises_data.values.
           select { |e| e[:prerequisites].include?(concept.slug) }.
           map { |e| e[:slug] }
 
@@ -22,55 +49,142 @@ class UserTrack
         concept_solutions = completed_solutions.select { |s| concept_exercises.include?(s[:slug]) }
         practice_solutions = completed_solutions.select { |s| practice_exercises.include?(s[:slug]) }
 
-        concepts[concept.slug] = UserTrack::Summary::ConceptSummary.new(
+        hash[concept.slug] = {
+          id: concept.id,
           slug: concept.slug,
           num_concept_exercises: concept_exercises.count,
           num_practice_exercises: practice_exercises.count,
           num_completed_concept_exercises: concept_solutions.count,
-          num_completed_practice_exercises: practice_solutions.count
-        )
+          num_completed_practice_exercises: practice_solutions.count,
+          available: available_concepts.include?(concept.slug)
+        }
       end
+    end
 
-      {
-        concepts: concepts
-      }
+    memoize
+    def exercises
+      track.exercises.each.with_object({}) do |exercise, hash|
+        exercise_data = exercises_data[exercise.slug]
+
+        hash[exercise.slug] = {
+          id: exercise.id,
+          slug: exercise.slug,
+          available: exercise_data[:available],
+          started: exercise_data[:started],
+          completed: exercise_data[:completed]
+        }
+      end
     end
 
     private
     memoize
-    def solutions_data
-      solutions = user_track.solutions.includes(:exercise)
+    def exercises_data
+      exercises = []
+      exercises += track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a
+      exercises += track.practice_exercises.includes(:prerequisites).to_a
 
+      exercises.each_with_object({}) do |exercise, data|
+        prerequisites = exercise.prerequisites.map(&:slug)
+
+        # Exercises are available if:
+        # - They've started
+        # - There are no outstanding prereqs
+        # - There is a user track
+        available = !!(
+          user_track && (
+            solutions_data[exercise.slug] ||
+            (prerequisites - learnt_concepts).empty?
+          )
+        )
+
+        # Exercises are started if there is solution
+        # in the database for them.
+        started = !!solutions_data[exercise.slug]
+
+        completed = started && solutions_data[exercise.slug][:completed]
+
+        exercise_data = {
+          slug: exercise.slug,
+          type: exercise.git_type.to_sym,
+          prerequisites: prerequisites,
+          available: available,
+          started: started,
+          completed: completed
+        }
+        exercise_data[:taught_concepts] = exercise.taught_concepts.map(&:slug) if exercise.concept_exercise?
+        data[exercise.slug] = exercise_data
+      end
+    end
+
+    memoize
+    def solutions_data
+      return {} unless user_track
+
+      solutions = user_track.solutions.includes(:exercise)
       solutions.each_with_object({}) do |solution, data|
         data[solution.exercise.slug] = {
           slug: solution.exercise.slug,
-          submitted: solution.submitted?,
           completed: solution.completed?
         }
       end
     end
 
     memoize
-    def concept_exercise_data
-      exercises = track.concept_exercises.includes(:taught_concepts).to_a
-      exercises.each_with_object({}) do |exercise, data|
-        data[exercise.slug] = {
-          slug: exercise.slug,
-          taught_concepts: exercise.taught_concepts.map(&:slug)
-        }
-      end
+    def concept_exercises_data
+      exercises_data.select { |_, ex| ex[:type] == :concept }
     end
 
     memoize
-    def practice_exercise_data
-      exercises = track.practice_exercises.includes(:prerequisites).to_a
+    def practice_exercises_data
+      exercises_data.select { |_, ex| ex[:type] == :practice }
+    end
 
-      exercises.each_with_object({}) do |exercise, data|
-        data[exercise.slug] = {
-          slug: exercise.slug,
-          prerequisites: exercise.prerequisites.map(&:slug)
-        }
+    memoize
+    def learnt_concepts
+      return [] unless user_track
+
+      user_track.learnt_concepts.map(&:slug)
+    end
+
+    memoize
+    def available_concepts
+      concept_ids = Exercise::TaughtConcept.
+        joins(:exercise).
+        where('exercises.slug': available_exercises).
+        select(:track_concept_id)
+
+      track.concepts.not_taught.pluck(:slug) + Track::Concept.where(id: concept_ids).pluck(:slug)
+    end
+
+    memoize
+    def available_exercises
+      exercises_data.select { |_, exercise| exercise[:available] }.keys
+    end
+
+    ConceptSummary = Struct.new(
+      :id, :slug,
+      :num_concept_exercises, :num_practice_exercises,
+      :num_completed_concept_exercises, :num_completed_practice_exercises,
+      :available,
+      keyword_init: true
+    ) do
+      def num_exercises
+        num_concept_exercises + num_practice_exercises
+      end
+
+      def num_completed_exercises
+        num_completed_concept_exercises + num_completed_practice_exercises
+      end
+
+      def mastered?
+        num_exercises.positive? && num_exercises == num_completed_exercises
       end
     end
+
+    ExerciseSummary = Struct.new(
+      :id, :slug,
+      :available, :started, :completed,
+      keyword_init: true
+    )
   end
 end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -18,7 +18,10 @@ class Tracks::ConceptsController < ApplicationController
     @num_completed = @user_track ? @user_track.learnt_concepts.count : 0
   end
 
-  def show; end
+  def show
+    @concept_exercises = @concept.concept_exercises
+    @practice_exercises = @concept.practice_exercises
+  end
 
   def tooltip
     render layout: false
@@ -28,6 +31,7 @@ class Tracks::ConceptsController < ApplicationController
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
+    @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
   end
 
   def use_concepts
@@ -36,6 +40,6 @@ class Tracks::ConceptsController < ApplicationController
 
   def use_concept
     @concept = @track.concepts.find(params[:id])
-    @concept_summary = @user_track.summary.concept(@concept.slug)
+    @concept_summary = @user_track_summary.concept(@concept.slug)
   end
 end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -30,8 +30,7 @@ class Tracks::ConceptsController < ApplicationController
   private
   def use_track
     @track = Track.find(params[:track_id])
-    @user_track = UserTrack.for(current_user, @track)
-    @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
+    @user_track = UserTrack.for(current_user, @track, external_if_missing: true)
   end
 
   def use_concepts
@@ -40,6 +39,5 @@ class Tracks::ConceptsController < ApplicationController
 
   def use_concept
     @concept = @track.concepts.find(params[:id])
-    @concept_summary = @user_track_summary.concept(@concept.slug)
   end
 end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -18,15 +18,9 @@ class Tracks::ConceptsController < ApplicationController
     @num_completed = @user_track ? @user_track.learnt_concepts.count : 0
   end
 
-  def show
-    # TODO: We don't want this here really.
-    # Move it onto the concept eventually
-    @concept_exercises = ConceptExercise.that_teach(@concept)
-    @practice_exercises = PracticeExercise.that_practice(@concept)
-  end
+  def show; end
 
   def tooltip
-    @concept_summary = @user_track.summary.concept(@concept.slug)
     render layout: false
   end
 
@@ -42,5 +36,6 @@ class Tracks::ConceptsController < ApplicationController
 
   def use_concept
     @concept = @track.concepts.find(params[:id])
+    @concept_summary = @user_track.summary.concept(@concept.slug)
   end
 end

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -7,7 +7,7 @@ class Tracks::ExercisesController < ApplicationController
 
   def index
     @exercises = @track.exercises
-    @num_completed = @user_track ? @user_track.solutions.completed.count : 0
+    @num_completed = @user_track.num_completed_exercises
   end
 
   # TODO: There is lots of logic in this view
@@ -30,8 +30,7 @@ class Tracks::ExercisesController < ApplicationController
   private
   def use_track
     @track = Track.find(params[:track_id])
-    @user_track = UserTrack.for(current_user, @track)
-    @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
+    @user_track = UserTrack.for(current_user, @track, external_if_missing: true)
   end
 
   def use_exercise

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -31,6 +31,7 @@ class Tracks::ExercisesController < ApplicationController
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
+    @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
   end
 
   def use_exercise

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -17,9 +17,7 @@ class TracksController < ApplicationController
     @user_track = UserTrack.for(current_user, @track)
 
     if @user_track
-      @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
       @activities = UserTrack::RetrieveActivities.(@user_track)
-
       render "tracks/show/joined"
     else
       render "tracks/show/unjoined"

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -15,7 +15,9 @@ class TracksController < ApplicationController
 
   def show
     @user_track = UserTrack.for(current_user, @track)
+
     if @user_track
+      @user_track_summary = UserTrack::GenerateSummary.(@track, @user_track)
       @activities = UserTrack::RetrieveActivities.(@user_track)
 
       render "tracks/show/joined"

--- a/app/css/pages/concept-show.css
+++ b/app/css/pages/concept-show.css
@@ -40,21 +40,26 @@
         & .progress {
             @apply flex-shrink-0;
 
-            & progress {
-                @apply appearance-none w-100 rounded-8 overflow-hidden mb-12;
+            & .c-concept-progress-bar {
                 height: 8px;
-
-                &::-webkit-progress-bar {
-                    @apply bg-veryLightBlue;
-                }
-                &[value] {
-                    &::-webkit-progress-value {
-                        @apply bg-lightBlue;
-                    }
-                }
+                @apply mb-8;
             }
             & .progress-text {
-                @apply text-darkGray font-medium;
+                @apply flex items-center;
+                @apply text-16 font-medium text-darkGray font-medium;
+
+                & .c-icon {
+                    height: 24px;
+                    width: 24px;
+                    @apply hidden mr-12;
+                }
+
+                &.completed {
+                    @apply text-darkGreen font-semibold;
+                    & .c-icon {
+                        @apply block;
+                    }
+                }
             }
         }
     }

--- a/app/helpers/view_components/concept.rb
+++ b/app/helpers/view_components/concept.rb
@@ -3,11 +3,11 @@ module ViewComponents
     extend Mandate::Memoize
     SIZES = %i[small medium].freeze
 
-    def initialize(concept, user_track, size)
+    def initialize(concept, user_track_summary, size)
       raise "Invalid concept icon size #{size}" unless SIZES.include?(size.to_sym)
 
       @concept = concept
-      @user_track = user_track
+      @user_track_summary = user_track_summary
       @size = size
     end
 
@@ -25,11 +25,11 @@ module ViewComponents
     end
 
     private
-    attr_reader :concept, :user_track, :size
+    attr_reader :concept, :user_track_summary, :size
 
     memoize
     def concept_summary
-      user_track.summary.concept(concept.slug)
+      user_track_summary.concept(concept.slug)
     end
   end
 end

--- a/app/helpers/view_components/concept.rb
+++ b/app/helpers/view_components/concept.rb
@@ -3,11 +3,11 @@ module ViewComponents
     extend Mandate::Memoize
     SIZES = %i[small medium].freeze
 
-    def initialize(concept, user_track_summary, size)
+    def initialize(concept, user_track, size)
       raise "Invalid concept icon size #{size}" unless SIZES.include?(size.to_sym)
 
       @concept = concept
-      @user_track_summary = user_track_summary
+      @user_track = user_track
       @size = size
     end
 
@@ -15,21 +15,18 @@ module ViewComponents
       classes = "c-concept c--#{size}"
       link_to(Exercism::Routes.track_concept_path(user_track.track, concept), class: classes) do
         tag.div(class: 'info') do
-          safe_join([
-                      ViewComponents::ConceptIcon.new(concept, :small, view_context: view_context).to_s,
-                      concept.name
-                    ])
+          safe_join(
+            [
+              ViewComponents::ConceptIcon.new(concept, :small, view_context: view_context).to_s,
+              concept.name
+            ]
+          )
         end +
           ViewComponents::ConceptProgressBar.new(concept, user_track, view_context: view_context).to_s
       end
     end
 
     private
-    attr_reader :concept, :user_track_summary, :size
-
-    memoize
-    def concept_summary
-      user_track_summary.concept(concept.slug)
-    end
+    attr_reader :concept, :user_track, :size
   end
 end

--- a/app/helpers/view_components/concept_progress_bar.rb
+++ b/app/helpers/view_components/concept_progress_bar.rb
@@ -1,29 +1,24 @@
 module ViewComponents
   class ConceptProgressBar < ViewComponent
     extend Mandate::Memoize
-    def initialize(concept, user_track_summary, view_context: nil)
+    def initialize(concept, user_track, view_context: nil)
       @concept = concept
-      @user_track_summary = user_track_summary
+      @user_track = user_track
       @view_context = view_context
     end
 
     def to_s
       classes = ["c-concept-progress-bar"]
-      classes << "--completed" if concept_summary&.mastered?
+      classes << "--completed" if user_track.concept_mastered?(concept)
 
       tag.progress(
         class: classes.join(" "),
-        value: concept_summary.num_completed_exercises,
-        max: concept_summary.num_exercises
+        value: user_track.num_completed_exercises_for_concept(concept),
+        max: user_track.num_exercises_for_concept(concept)
       )
     end
 
     private
-    attr_reader :concept, :user_track_summary, :size
-
-    memoize
-    def concept_summary
-      user_track_summary.concept(concept.slug)
-    end
+    attr_reader :concept, :user_track, :size
   end
 end

--- a/app/helpers/view_components/concept_progress_bar.rb
+++ b/app/helpers/view_components/concept_progress_bar.rb
@@ -1,15 +1,15 @@
 module ViewComponents
   class ConceptProgressBar < ViewComponent
     extend Mandate::Memoize
-    def initialize(concept, user_track, view_context: nil)
+    def initialize(concept, user_track_summary, view_context: nil)
       @concept = concept
-      @user_track = user_track
+      @user_track_summary = user_track_summary
       @view_context = view_context
     end
 
     def to_s
       classes = ["c-concept-progress-bar"]
-      classes << "--completed" if concept_summary.mastered?
+      classes << "--completed" if concept_summary&.mastered?
 
       tag.progress(
         class: classes.join(" "),
@@ -19,11 +19,11 @@ module ViewComponents
     end
 
     private
-    attr_reader :concept, :user_track, :size
+    attr_reader :concept, :user_track_summary, :size
 
     memoize
     def concept_summary
-      user_track.summary.concept(concept.slug)
+      user_track_summary.concept(concept.slug)
     end
   end
 end

--- a/app/helpers/view_components/widgets/exercise.rb
+++ b/app/helpers/view_components/widgets/exercise.rb
@@ -3,9 +3,9 @@ module ViewComponents
     class Exercise < ViewComponent
       extend Mandate::Memoize
 
-      def initialize(exercise, user_track_summary, large: true, desc: true)
+      def initialize(exercise, user_track, large: true, desc: true)
         @exercise = exercise
-        @user_track_summary = user_track_summary
+        @user_track = user_track
         @large = large
         @desc = desc
       end
@@ -30,14 +30,14 @@ module ViewComponents
       end
 
       private
-      attr_reader :exercise, :user_track_summary, :large, :desc
+      attr_reader :exercise, :user_track, :large, :desc
 
       def available?
-        user_track_summary.exercise_available?(exercise)
+        user_track.exercise_available?(exercise)
       end
 
       def completed?
-        user_track_summary.exercise_completed?(exercise)
+        user_track.exercise_completed?(exercise)
       end
 
       def ex_icon

--- a/app/helpers/view_components/widgets/exercise.rb
+++ b/app/helpers/view_components/widgets/exercise.rb
@@ -3,8 +3,9 @@ module ViewComponents
     class Exercise < ViewComponent
       extend Mandate::Memoize
 
-      def initialize(exercise, large: true, desc: true)
+      def initialize(exercise, user_track_summary, large: true, desc: true)
         @exercise = exercise
+        @user_track_summary = user_track_summary
         @large = large
         @desc = desc
       end
@@ -28,33 +29,15 @@ module ViewComponents
         end
       end
 
-      # TODO: We want to have a solutions list that
-      # pre-fetches all the relevant solutions for a
-      # user, which we then pass into this. This whole
-      # method should then be replaces and the solution
-      # should be passed in directly.
-      memoize
-      def solution
-        # TODO: This will break once devise is added
-        Solution.for(User.first, exercise)
-      end
-
       private
-      attr_reader :exercise, :large, :desc
+      attr_reader :exercise, :user_track_summary, :large, :desc
 
       def available?
-        return true if solution
-
-        # TODO: This is another example of something that should
-        # be precached somewhere. What's the right way of doing this?!
-        #
-        # TODO: This will break once devise is added
-        user_track = UserTrack.for(User.first, exercise.track)
-        user_track&.exercise_available?(exercise)
+        user_track_summary.exercise_available?(exercise)
       end
 
       def completed?
-        solution&.completed?
+        user_track_summary.exercise_completed?(exercise)
       end
 
       def ex_icon

--- a/app/models/concept_solution.rb
+++ b/app/models/concept_solution.rb
@@ -1,3 +1,2 @@
 class ConceptSolution < Solution
-  enum status: { pending: 0, submitted: 1 }
 end

--- a/app/models/practice_solution.rb
+++ b/app/models/practice_solution.rb
@@ -1,3 +1,2 @@
 class PracticeSolution < Solution
-  enum status: { pending: 0, submitted: 1 }
 end

--- a/app/models/track/concept.rb
+++ b/app/models/track/concept.rb
@@ -17,9 +17,14 @@ class Track::Concept < ApplicationRecord
     "C# structs are closely related to classes. They have state and behavior. They have constructors that take arguments, instances can be assigned, tested for equality and stored in collections." # rubocop:disable Layout/LineLength
   end
 
-  # Cache this
-  def num_exercises
-    3
+  memoize
+  def concept_exercises
+    ConceptExercise.that_teach(self)
+  end
+
+  memoize
+  def practice_exercises
+    PracticeExercise.that_practice(self)
   end
 
   memoize

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -19,18 +19,25 @@ class UserTrack < ApplicationRecord
     nil
   end
 
-  def summary
-    @summary ||= UserTrack::Summary.new(self)
-  end
-
   def solutions
     user.solutions.joins(:exercise).where("exercises.track_id": track)
   end
 
-  # TODO: Cache this in the db?
-  def num_concepts_mastered
-    2
+  # A track's summary is a effeciently created summary of all
+  # of a user_track's data. It's cached across requests, allowing
+  # us to quickly retrieve data without requiring lots of complex
+  # SQL queries. There is a little bit of a dance here, which is
+  # documented in the UserTrack::GenerateSummary class.
+  attr_writer :summary
+  def summary
+    @summary ||= UserTrack::GenerateSummary.(track, self)
   end
+
+  def summary_generated?
+    !!@summary
+  end
+
+  delegate :exercise_available?, :concept_available?, to: :summary
 
   def learnt_concept?(concept)
     learnt_concepts.include?(concept)
@@ -50,65 +57,13 @@ class UserTrack < ApplicationRecord
     available_exercises.select { |e| e.is_a?(PracticeExercise) }
   end
 
-  def exercise_available?(exercise)
-    (exercise.prerequisites - learnt_concepts).empty?
-  end
-
   memoize
   def available_concepts
-    available_exercise_ids = available_exercises.map(&:id)
-    concept_ids = Exercise::TaughtConcept.where(exercise_id: available_exercise_ids).
-      select(:track_concept_id)
-
-    track.concepts.not_taught + Track::Concept.where(id: concept_ids)
+    Track::Concept.where(id: summary.available_concept_ids)
   end
 
   memoize
   def available_exercises
-    without_prereqs = track.exercises.without_prerequisites
-
-    return without_prereqs if learnt_concepts.blank?
-
-    ids = DetermineAvailableExercisesIds.(id)
-    without_prereqs + Exercise.where(id: ids)
+    Exercise.where(id: summary.available_exercise_ids)
   end
-
-  ###
-  # Inline helper for available exercises
-  ###
-  class DetermineAvailableExercisesIds
-    include Mandate
-
-    initialize_with :user_track_id
-
-    # Get two datasets.
-    # The second is the exercises with the count of all their prereq concepts
-    # The second is the exercises with the count of all their prereq concepts
-    # If the number is the same in both, then we have a match.
-    #
-    # Taken from https://stackoverflow.com/questions/48290118/sql-join-on-a-table-that-matches-multiple-rows-and-put-into-multiple-columns
-    def call
-      ActiveRecord::Base.connection.select_values(%{
-        SELECT
-          a.exercise_id
-        FROM
-          (
-            SELECT prereqs.exercise_id, COUNT(*) AS num_concepts
-            FROM user_track_learnt_concepts utc
-            INNER JOIN exercise_prerequisites prereqs
-              ON utc.track_concept_id = prereqs.track_concept_id
-            INNER JOIN exercises on exercises.id = prereqs.exercise_id
-            WHERE utc.user_track_id = #{user_track_id}
-            GROUP BY prereqs.exercise_id
-          ) a
-        INNER JOIN
-          (
-            SELECT exercise_id, COUNT(*) AS num_concepts
-            FROM exercise_prerequisites
-            GROUP BY exercise_id
-          ) b ON a.exercise_id = b.exercise_id AND a.num_concepts = b.num_concepts
-      })
-    end
-  end
-  private_constant :DetermineAvailableExercisesIds
 end

--- a/app/models/user_track/external.rb
+++ b/app/models/user_track/external.rb
@@ -1,0 +1,105 @@
+# This is a version of the user track for when we
+# don't have a logged in user but we still want to
+# have the functionality of a user track
+class UserTrack
+  class External
+    extend Mandate::Memoize
+    attr_reader :track
+
+    def initialize(track)
+      @track = track
+    end
+
+    #######################
+    # Non-summary methods #
+    #######################
+    def external?
+      true
+    end
+
+    def learnt_concepts
+      []
+    end
+
+    ####################
+    # Exercise methods #
+    ####################
+    def exercise_available?(_)
+      false
+    end
+
+    def exercise_completed?(_)
+      false
+    end
+
+    ###############################
+    # Exercises aggregate methods #
+    ###############################
+    def num_completed_exercises
+      0
+    end
+
+    def available_exercise_ids
+      []
+    end
+
+    ###################
+    # Concept methods #
+    ###################
+    def concept_available?(_)
+      false
+    end
+
+    def concept_mastered?(_)
+      false
+    end
+
+    def num_exercises_for_concept(obj)
+      slug = obj.is_a?(Track::Concept) ? obj.slug : obj.to_s
+      concept_exercises_counts[slug]
+    end
+
+    def num_completed_exercises_for_concept(_)
+      0
+    end
+
+    #############################
+    # Concept aggregate methods #
+    #############################
+    def available_concept_ids
+      []
+    end
+
+    memoize
+    def num_concepts
+      track.concepts.size
+    end
+
+    def num_concepts_mastered
+      0
+    end
+
+    ###################
+    # Private methods #
+    ###################
+
+    memoize
+    def concept_exercises_counts
+      taught_counts = Exercise::TaughtConcept.
+        joins(:exercise, :concept).
+        where('exercises.track_id': track.id).
+        group('track_concepts.slug').
+        count
+
+      practice_counts = Exercise::Prerequisite.
+        joins(:exercise, :concept).
+        where('exercises.track_id': track.id).
+        where('exercises.type': "PracticeExercise").
+        group('track_concepts.slug').
+        count
+
+      # Sum the counts
+      taught_counts.merge(practice_counts) { |_, t, p| t + p }
+    end
+  end
+end

--- a/app/models/user_track/summary.rb
+++ b/app/models/user_track/summary.rb
@@ -7,16 +7,9 @@ class UserTrack
       @mapped_exercises = exercises
     end
 
-    def exercise(obj)
-      slug = obj.is_a?(Exercise) ? obj.slug : obj.to_s
-      mapped_exercises[slug]
-    end
-
-    def concept(obj)
-      slug = obj.is_a?(Track::Concept) ? obj.slug : obj.to_s
-      mapped_concepts[slug]
-    end
-
+    ####################
+    # Exercise methods #
+    ####################
     def exercise_available?(obj)
       exercise(obj).available
     end
@@ -25,21 +18,65 @@ class UserTrack
       exercise(obj).completed
     end
 
-    def concept_available?(obj)
-      concept(obj).available
+    ###############################
+    # Exercises aggregate methods #
+    ###############################
+    def num_completed_exercises
+      mapped_exercises.values.count(&:completed)
     end
 
     def available_exercise_ids
       mapped_exercises.values.select(&:available).map(&:id)
     end
 
+    ###################
+    # Concept methods #
+    ###################
+    def concept_available?(obj)
+      concept(obj).available?
+    end
+
+    def concept_mastered?(obj)
+      concept(obj).mastered?
+    end
+
+    def num_exercises_for_concept(concept)
+      concept(concept).num_exercises
+    end
+
+    def num_completed_exercises_for_concept(concept)
+      concept(concept).num_completed_exercises
+    end
+
+    #############################
+    # Concept aggregate methods #
+    #############################
     def available_concept_ids
       mapped_concepts.values.select(&:available).map(&:id)
     end
 
     memoize
+    def num_concepts
+      mapped_concepts.size
+    end
+
+    memoize
     def num_concepts_mastered
       mapped_concepts.values.count(&:mastered?)
+    end
+
+    #################
+    # Private stuff #
+    #################
+
+    def exercise(obj)
+      slug = obj.is_a?(Exercise) ? obj.slug : obj.to_s
+      mapped_exercises[slug]
+    end
+
+    def concept(obj)
+      slug = obj.is_a?(Track::Concept) ? obj.slug : obj.to_s
+      mapped_concepts[slug]
     end
 
     private

--- a/app/models/user_track/summary.rb
+++ b/app/models/user_track/summary.rb
@@ -1,39 +1,48 @@
 class UserTrack
   class Summary
-    def initialize(user_track)
-      @user_track = user_track
-      populate!
+    extend Mandate::Memoize
+
+    def initialize(concepts, exercises)
+      @mapped_concepts = concepts
+      @mapped_exercises = exercises
     end
 
-    def concept(slug)
-      concepts[slug]
+    def exercise(obj)
+      slug = obj.is_a?(Exercise) ? obj.slug : obj.to_s
+      mapped_exercises[slug]
+    end
+
+    def concept(obj)
+      slug = obj.is_a?(Track::Concept) ? obj.slug : obj.to_s
+      mapped_concepts[slug]
+    end
+
+    def exercise_available?(obj)
+      exercise(obj).available
+    end
+
+    def exercise_completed?(obj)
+      exercise(obj).completed
+    end
+
+    def concept_available?(obj)
+      concept(obj).available
+    end
+
+    def available_exercise_ids
+      mapped_exercises.values.select(&:available).map(&:id)
+    end
+
+    def available_concept_ids
+      mapped_concepts.values.select(&:available).map(&:id)
+    end
+
+    memoize
+    def num_concepts_mastered
+      mapped_concepts.values.count(&:mastered?)
     end
 
     private
-    attr_accessor :user_track, :concepts
-
-    def populate!
-      data = UserTrack::GenerateSummary.(user_track)
-      @concepts = data[:concepts]
-    end
-
-    ConceptSummary = Struct.new(
-      :slug,
-      :num_concept_exercises, :num_practice_exercises,
-      :num_completed_concept_exercises, :num_completed_practice_exercises,
-      keyword_init: true
-    ) do
-      def num_exercises
-        num_concept_exercises + num_practice_exercises
-      end
-
-      def num_completed_exercises
-        num_completed_concept_exercises + num_completed_practice_exercises
-      end
-
-      def mastered?
-        num_exercises.positive? && num_exercises == num_completed_exercises
-      end
-    end
+    attr_accessor :track, :user_track, :mapped_concepts, :mapped_exercises
   end
 end

--- a/app/views/tracks/concepts/show.html.haml
+++ b/app/views/tracks/concepts/show.html.haml
@@ -13,11 +13,14 @@
           = graphical_icon(:exercises)
           5 exercises
       .progress.tw-w-5-7
-        %progress
-        .progress-text
-          0 of
-          = pluralize(@practice_exercises.size + @concept_exercises.size, "exercise")
-          complete
+
+        = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
+        .progress-text{ class: @concept_summary.mastered? ? 'completed' : '' }
+          = graphical_icon "completed-check-circle"
+          #{@concept_summary.num_completed_exercises}/#{@concept_summary.num_exercises}
+          = 'exercise'.pluralize(@concept_summary.num_exercises)
+          completed
+
 
   %section.lg-container.tw-flex
     .tw-flex-grow.tw-w-arbitary

--- a/app/views/tracks/concepts/show.html.haml
+++ b/app/views/tracks/concepts/show.html.haml
@@ -13,12 +13,11 @@
           = graphical_icon(:exercises)
           5 exercises
       .progress.tw-w-5-7
-
-        = render ViewComponents::ConceptProgressBar.new(@concept, @user_track_summary)
-        .progress-text{ class: @concept_summary.mastered? ? 'completed' : '' }
+        = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
+        .progress-text{ class: @user_track.concept_mastered?(@concept) ? 'completed' : '' }
           = graphical_icon "completed-check-circle"
-          #{@concept_summary.num_completed_exercises}/#{@concept_summary.num_exercises}
-          = 'exercise'.pluralize(@concept_summary.num_exercises)
+          #{@user_track.num_completed_exercises_for_concept(@concept)}/#{@user_track.num_exercises_for_concept(@concept)}
+          = 'exercise'.pluralize(@user_track.num_exercises_for_concept(@concept))
           completed
 
   %section.lg-container.tw-flex
@@ -51,7 +50,7 @@
 
           .exercises
             - @concept_exercises.each do |concept_exercise|
-              = render ViewComponents::Widgets::Exercise.new(concept_exercise, @user_track_summary)
+              = render ViewComponents::Widgets::Exercise.new(concept_exercise, @user_track)
 
       - if @practice_exercises.present?
         .practice
@@ -59,4 +58,4 @@
 
           .exercises
             - @practice_exercises.each do |practice_exercise|
-              = render ViewComponents::Widgets::Exercise.new(practice_exercise, @user_track_summary)
+              = render ViewComponents::Widgets::Exercise.new(practice_exercise, @user_track)

--- a/app/views/tracks/concepts/show.html.haml
+++ b/app/views/tracks/concepts/show.html.haml
@@ -14,13 +14,12 @@
           5 exercises
       .progress.tw-w-5-7
 
-        = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
+        = render ViewComponents::ConceptProgressBar.new(@concept, @user_track_summary)
         .progress-text{ class: @concept_summary.mastered? ? 'completed' : '' }
           = graphical_icon "completed-check-circle"
           #{@concept_summary.num_completed_exercises}/#{@concept_summary.num_exercises}
           = 'exercise'.pluralize(@concept_summary.num_exercises)
           completed
-
 
   %section.lg-container.tw-flex
     .tw-flex-grow.tw-w-arbitary
@@ -52,7 +51,7 @@
 
           .exercises
             - @concept_exercises.each do |concept_exercise|
-              = render ViewComponents::Widgets::Exercise.new(concept_exercise)
+              = render ViewComponents::Widgets::Exercise.new(concept_exercise, @user_track_summary)
 
       - if @practice_exercises.present?
         .practice
@@ -60,4 +59,4 @@
 
           .exercises
             - @practice_exercises.each do |practice_exercise|
-              = render ViewComponents::Widgets::Exercise.new(practice_exercise)
+              = render ViewComponents::Widgets::Exercise.new(practice_exercise, @user_track_summary)

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -6,7 +6,7 @@
         .name= @concept.name
         .in in
         = track_icon(@track)
-      .num-exercises= pluralize(@concept.num_exercises, "exercise")
+      .num-exercises= pluralize(@concept_summary.num_exercises, "exercise")
 
   .blurb= @concept.blurb
 
@@ -15,8 +15,7 @@
     .mastered
       .summary
         = graphical_icon "completed-check-circle"
-        #{num_exercises}/#{num_exercises}
-        = pluralize(num_exercises, "exercise")
+        #{num_exercises}/#{num_exercises} #{'exercise'.pluralize(num_exercises)}
         completed
       = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
       .info You’ve mastered #{@concept.name}. Well done!

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -1,3 +1,5 @@
+- num_exercises = @user_track.num_exercises_for_concept(@concept)
+
 .c-concept-tooltip
   .heading
     = render ViewComponents::ConceptIcon.new(@concept, :large)
@@ -6,16 +8,15 @@
         .name= @concept.name
         .in in
         = track_icon(@track)
-      .num-exercises= pluralize(@concept_summary.num_exercises, "exercise")
+      .num-exercises= pluralize(num_exercises, "exercise")
 
   .blurb= @concept.blurb
 
-  - if @concept_summary.mastered?
-    - num_exercises = @concept_summary.num_exercises
+  - if @user_track.concept_mastered?(@concept)
     .mastered
       .summary
         = graphical_icon "completed-check-circle"
         #{num_exercises}/#{num_exercises} #{'exercise'.pluralize(num_exercises)}
         completed
-      = render ViewComponents::ConceptProgressBar.new(@concept, @user_track_summary)
+      = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
       .info You’ve mastered #{@concept.name}. Well done!

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -17,5 +17,5 @@
         = graphical_icon "completed-check-circle"
         #{num_exercises}/#{num_exercises} #{'exercise'.pluralize(num_exercises)}
         completed
-      = render ViewComponents::ConceptProgressBar.new(@concept, @user_track)
+      = render ViewComponents::ConceptProgressBar.new(@concept, @user_track_summary)
       .info You’ve mastered #{@concept.name}. Well done!

--- a/app/views/tracks/exercises/index.html.haml
+++ b/app/views/tracks/exercises/index.html.haml
@@ -16,5 +16,5 @@
   .exercises
     .lg-container.container
       - @exercises.each do |exercise|
-        = render ViewComponents::Widgets::Exercise.new(exercise, @user_track_summary)
+        = render ViewComponents::Widgets::Exercise.new(exercise, @user_track)
 

--- a/app/views/tracks/exercises/index.html.haml
+++ b/app/views/tracks/exercises/index.html.haml
@@ -16,5 +16,5 @@
   .exercises
     .lg-container.container
       - @exercises.each do |exercise|
-        = render ViewComponents::Widgets::Exercise.new(exercise)
+        = render ViewComponents::Widgets::Exercise.new(exercise, @user_track_summary)
 

--- a/app/views/tracks/exercises/show.html.haml
+++ b/app/views/tracks/exercises/show.html.haml
@@ -74,7 +74,7 @@
 
           .prereqs
             - @exercise.prerequisite_exercises.each do |prereq|
-              = render ViewComponents::Widgets::Exercise.new(prereq, @user_track_summary, large: false)
+              = render ViewComponents::Widgets::Exercise.new(prereq, @user_track, large: false)
 
       - else
         / TODO: External state

--- a/app/views/tracks/exercises/show.html.haml
+++ b/app/views/tracks/exercises/show.html.haml
@@ -74,7 +74,7 @@
 
           .prereqs
             - @exercise.prerequisite_exercises.each do |prereq|
-              = render ViewComponents::Widgets::Exercise.new(prereq, large: false)
+              = render ViewComponents::Widgets::Exercise.new(prereq, @user_track_summary, large: false)
 
       - else
         / TODO: External state

--- a/app/views/tracks/exercises/show/_completed_sections.html.haml
+++ b/app/views/tracks/exercises/show/_completed_sections.html.haml
@@ -8,7 +8,7 @@
     %h3 You’ve learnt #{pluralize exercise.taught_concepts.size, 'concept'} by completing this exercise.
     .concepts
       - exercise.taught_concepts.each do |concept|
-        = render ViewComponents::Concept.new(concept, user_track_summary, :small)
+        = render ViewComponents::Concept.new(concept, user_track, :small)
 
     = render ViewComponents::ProminentLink.new("See how your concept map has changed", track_concepts_path(track))
     .explanation

--- a/app/views/tracks/exercises/show/_completed_sections.html.haml
+++ b/app/views/tracks/exercises/show/_completed_sections.html.haml
@@ -8,7 +8,7 @@
     %h3 You’ve learnt #{pluralize exercise.taught_concepts.size, 'concept'} by completing this exercise.
     .concepts
       - exercise.taught_concepts.each do |concept|
-        = render ViewComponents::Concept.new(concept, user_track, :small)
+        = render ViewComponents::Concept.new(concept, user_track_summary, :small)
 
     = render ViewComponents::ProminentLink.new("See how your concept map has changed", track_concepts_path(track))
     .explanation

--- a/app/views/tracks/show/joined.html.haml
+++ b/app/views/tracks/show/joined.html.haml
@@ -16,7 +16,7 @@
     .lg-container.container
       .lhs
         = render "tracks/show/joined/activities_section", activities: @activities
-        = render "tracks/show/joined/concepts_section", track: @track, user_track: @user_track
+        = render "tracks/show/joined/concepts_section", track: @track, user_track_summary: @user_track_summary
       .rhs
         %section.contributors
           %header

--- a/app/views/tracks/show/joined.html.haml
+++ b/app/views/tracks/show/joined.html.haml
@@ -16,7 +16,7 @@
     .lg-container.container
       .lhs
         = render "tracks/show/joined/activities_section", activities: @activities
-        = render "tracks/show/joined/concepts_section", track: @track, user_track_summary: @user_track_summary
+        = render "tracks/show/joined/concepts_section", track: @track, user_track: @user_track
       .rhs
         %section.contributors
           %header

--- a/app/views/tracks/show/joined/_concepts_section.html.haml
+++ b/app/views/tracks/show/joined/_concepts_section.html.haml
@@ -3,23 +3,24 @@
     = graphical_icon :concepts
     %h2 Concept Mastery
     .progress
-      #{user_track_summary.num_concepts_mastered}/#{track.concepts.size}
+      #{user_track.num_concepts_mastered}/#{user_track.num_concepts}
       mastered
 
   .concepts
     - track.concepts[0, 6].each do |concept|
-      - concept_summary = user_track_summary.concept(concept.slug)
+      - mastered = user_track.concept_mastered?(concept)
 
-      - completed_class = concept_summary.mastered? ? 'completed' : ''
-      = link_to track_concept_path(track, concept), class: "concept #{completed_class}" do
+      = link_to track_concept_path(track, concept), class: "concept #{mastered ? 'completed' : ''}" do
         = render ViewComponents::ConceptIcon.new(concept, :medium)
         .info
           .name
             = concept.name
-            - if concept_summary.mastered?
+            - if mastered
               = icon "completed-check-circle", "Concept Completed"
-          .completion #{concept_summary.num_completed_exercises}/#{concept_summary.num_exercises} exercises completed
+          .completion
+            #{user_track.num_completed_exercises_for_concept(concept)}/#{user_track.num_exercises_for_concept(concept)}
+            exercises completed
 
-        = render ViewComponents::ConceptProgressBar.new(concept, user_track_summary)
+        = render ViewComponents::ConceptProgressBar.new(concept, user_track)
         = graphical_icon 'chevron-right', css_class: 'action-icon'
 

--- a/app/views/tracks/show/joined/_concepts_section.html.haml
+++ b/app/views/tracks/show/joined/_concepts_section.html.haml
@@ -11,7 +11,7 @@
       - concept_summary = user_track.summary.concept(concept.slug)
 
       - completed_class = concept_summary.mastered? ? 'completed' : ''
-      = link_to track_concept_path(concept), class: "concept #{completed_class}" do
+      = link_to track_concept_path(track, concept), class: "concept #{completed_class}" do
         = render ViewComponents::ConceptIcon.new(concept, :medium)
         .info
           .name

--- a/app/views/tracks/show/joined/_concepts_section.html.haml
+++ b/app/views/tracks/show/joined/_concepts_section.html.haml
@@ -3,12 +3,12 @@
     = graphical_icon :concepts
     %h2 Concept Mastery
     .progress
-      #{user_track.num_concepts_mastered}/#{track.concepts.size}
+      #{user_track_summary.num_concepts_mastered}/#{track.concepts.size}
       mastered
 
   .concepts
     - track.concepts[0, 6].each do |concept|
-      - concept_summary = user_track.summary.concept(concept.slug)
+      - concept_summary = user_track_summary.concept(concept.slug)
 
       - completed_class = concept_summary.mastered? ? 'completed' : ''
       = link_to track_concept_path(track, concept), class: "concept #{completed_class}" do
@@ -20,6 +20,6 @@
               = icon "completed-check-circle", "Concept Completed"
           .completion #{concept_summary.num_completed_exercises}/#{concept_summary.num_exercises} exercises completed
 
-        = render ViewComponents::ConceptProgressBar.new(concept, user_track)
+        = render ViewComponents::ConceptProgressBar.new(concept, user_track_summary)
         = graphical_icon 'chevron-right', css_class: 'action-icon'
 

--- a/db/migrate/20200506152426_create_solutions.rb
+++ b/db/migrate/20200506152426_create_solutions.rb
@@ -7,7 +7,6 @@ class CreateSolutions < ActiveRecord::Migration[6.0]
       t.belongs_to :exercise, foreign_key: true, null: false
 
       t.string :uuid, null: false, unique: true
-      t.integer :status, null: false, default: 0
 
       t.string :git_slug, null: false
       t.string :git_sha, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,7 +137,6 @@ ActiveRecord::Schema.define(version: 2020_11_09_170425) do
     t.bigint "user_id", null: false
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
-    t.integer "status", default: 0, null: false
     t.string "git_slug", null: false
     t.string "git_sha", null: false
     t.datetime "downloaded_at"

--- a/test/commands/submission/create_test.rb
+++ b/test/commands/submission/create_test.rb
@@ -78,19 +78,6 @@ class Submission::CreateTest < ActiveSupport::TestCase
     Submission::Create.(solution, files, :cli)
   end
 
-  test "updates solution status" do
-    files = [{ filename: 'foo.bar', content: "foobar" }]
-
-    solution = create :concept_solution
-    assert_equal 'pending', solution.status
-    assert solution.pending?
-
-    Submission::UploadWithExercise.stubs(:call)
-    ToolingJob::Create.stubs(:call)
-    Submission::Create.(solution, [files.first], :cli)
-    assert_equal 'submitted', solution.reload.status
-  end
-
   test "award rookie badge job is enqueued" do
     # Generic setup
     files = [{ filename: 'foo.bar', content: "foobar" }]

--- a/test/commands/user_track/generate_summary/concept_test.rb
+++ b/test/commands/user_track/generate_summary/concept_test.rb
@@ -1,20 +1,35 @@
 require "test_helper"
 
-class UserTrack::Summary::ConceptTest < ActiveSupport::TestCase
+class UserTrack::GenerateSummary::ConceptTest < ActiveSupport::TestCase
+  test "with multi-type accessing" do
+    track = create :track
+    concept = create :track_concept, track: track
+    ut = create :user_track, track: track
+
+    summary = UserTrack::GenerateSummary.(track, ut)
+
+    # Test we can access by object or slug
+    assert_equal concept.slug, summary.concept(concept).slug
+    assert_equal concept.slug, summary.concept(concept.slug).slug
+  end
+
   test "with no exercises" do
     track = create :track
     concept = create :track_concept, track: track
     ut = create :user_track, track: track
 
-    summary = UserTrack::Summary.new(ut)
+    summary = UserTrack::GenerateSummary.(track, ut)
 
-    expected = UserTrack::Summary::ConceptSummary.new(
+    expected = UserTrack::GenerateSummary::ConceptSummary.new(
+      id: concept.id,
       slug: concept.slug,
       num_concept_exercises: 0,
       num_practice_exercises: 0,
       num_completed_concept_exercises: 0,
-      num_completed_practice_exercises: 0
+      num_completed_practice_exercises: 0,
+      available: true
     )
+
     assert_equal expected, summary.concept(concept.slug)
   end
 
@@ -35,14 +50,16 @@ class UserTrack::Summary::ConceptTest < ActiveSupport::TestCase
     pe_3 = create :practice_exercise, :random_slug, track: track
     pe_3.prerequisites << create(:track_concept, track: track)
 
-    summary = UserTrack::Summary.new(ut)
+    summary = UserTrack::GenerateSummary.(track, ut)
 
-    expected = UserTrack::Summary::ConceptSummary.new(
+    expected = UserTrack::GenerateSummary::ConceptSummary.new(
+      id: concept.id,
       slug: concept.slug,
       num_concept_exercises: 1,
       num_practice_exercises: 2,
       num_completed_concept_exercises: 0,
-      num_completed_practice_exercises: 0
+      num_completed_practice_exercises: 0,
+      available: true
     )
     assert_equal expected, summary.concept(concept.slug)
   end
@@ -73,14 +90,46 @@ class UserTrack::Summary::ConceptTest < ActiveSupport::TestCase
     pe_3.prerequisites << concept
     create :practice_solution, user: user, exercise: pe_3, completed_at: Time.current
 
-    summary = UserTrack::Summary.new(ut)
+    summary = UserTrack::GenerateSummary.(track, ut)
 
-    expected = UserTrack::Summary::ConceptSummary.new(
+    expected = UserTrack::GenerateSummary::ConceptSummary.new(
+      id: concept.id,
       slug: concept.slug,
       num_concept_exercises: 2,
       num_practice_exercises: 3,
       num_completed_concept_exercises: 1,
-      num_completed_practice_exercises: 2
+      num_completed_practice_exercises: 2,
+      available: true
+    )
+    assert_equal expected, summary.concept(concept.slug)
+  end
+
+  test "no user_track" do
+    track = create :track
+    concept = create :track_concept, track: track
+
+    ce_1 = create :concept_exercise, :random_slug, track: track
+    ce_1.taught_concepts << concept
+    ce_2 = create :concept_exercise, :random_slug, track: track
+    ce_2.taught_concepts << create(:track_concept, track: track)
+
+    pe_1 = create :practice_exercise, :random_slug, track: track
+    pe_1.prerequisites << concept
+    pe_2 = create :practice_exercise, :random_slug, track: track
+    pe_2.prerequisites << concept
+    pe_3 = create :practice_exercise, :random_slug, track: track
+    pe_3.prerequisites << create(:track_concept, track: track)
+
+    summary = UserTrack::GenerateSummary.(track, nil)
+
+    expected = UserTrack::GenerateSummary::ConceptSummary.new(
+      id: concept.id,
+      slug: concept.slug,
+      num_concept_exercises: 1,
+      num_practice_exercises: 2,
+      num_completed_concept_exercises: 0,
+      num_completed_practice_exercises: 0,
+      available: false
     )
     assert_equal expected, summary.concept(concept.slug)
   end

--- a/test/commands/user_track/generate_summary/exercises_available_test.rb
+++ b/test/commands/user_track/generate_summary/exercises_available_test.rb
@@ -1,0 +1,134 @@
+require "test_helper"
+
+class UserTrack::Summary::ExercisesAvailableTest < ActiveSupport::TestCase
+  test "exercise_available? with no prerequisites" do
+    track = create :track
+    exercise = create :concept_exercise, :random_slug, track: track
+    user_track = create :user_track, track: track
+    assert summary_for(user_track).exercise_available?(exercise)
+  end
+
+  test "exercise_available? with prerequisites" do
+    track = create :track
+    user_track = create :user_track, track: track
+    exercise = create :concept_exercise, :random_slug, track: track
+
+    prereq_1 = create :track_concept, track: track
+    create(:exercise_prerequisite, exercise: exercise, concept: prereq_1)
+
+    prereq_2 = create :track_concept, track: track
+    create(:exercise_prerequisite, exercise: exercise, concept: prereq_2)
+
+    refute summary_for(user_track).exercise_available?(exercise)
+
+    create :user_track_learnt_concept, concept: prereq_1, user_track: user_track
+    refute summary_for(user_track).exercise_available?(exercise)
+
+    create :user_track_learnt_concept, concept: prereq_2, user_track: user_track
+    assert summary_for(user_track).exercise_available?(exercise)
+  end
+
+  test "available concepts" do
+    track = create :track
+    basics = create :track_concept, track: track, slug: "co_basics"
+    enums = create :track_concept, track: track, slug: "co_enums"
+    strings = create :track_concept, track: track, slug: "co_strings"
+
+    # Nothing teaches recursion
+    recursion = create :track_concept, track: track, slug: "co_recursion"
+
+    basics_exercise = create :concept_exercise, slug: "ex_basics", track: track
+    basics_exercise.taught_concepts << basics
+
+    enums_exercise = create :concept_exercise, slug: "ex_enums", track: track
+    enums_exercise.prerequisites << basics
+    enums_exercise.taught_concepts << enums
+
+    strings_exercise = create :concept_exercise, slug: "ex_strings", track: track
+    strings_exercise.prerequisites << enums
+    strings_exercise.prerequisites << basics
+    strings_exercise.taught_concepts << strings
+
+    user = create :user
+    user_track = create :user_track, track: track, user: user
+
+    summary = summary_for(user_track)
+    assert_equal [basics, recursion].map(&:id), summary.available_concept_ids
+    assert summary.concept_available?(recursion)
+    assert summary.concept_available?(basics)
+    refute summary.concept_available?(enums)
+    refute summary.concept_available?(strings)
+
+    create :user_track_learnt_concept, user_track: user_track, concept: basics
+
+    summary = summary_for(user_track)
+    assert_equal [basics, enums, recursion].map(&:id), summary.available_concept_ids
+    assert summary.concept_available?(recursion)
+    assert summary.concept_available?(basics)
+    assert summary.concept_available?(enums)
+    refute summary.concept_available?(strings)
+
+    create :user_track_learnt_concept, user_track: user_track, concept: enums
+
+    summary = summary_for(user_track)
+    assert_equal [basics, enums, strings, recursion].map(&:id), summary.available_concept_ids
+    assert summary.concept_available?(recursion)
+    assert summary.concept_available?(basics)
+    assert summary.concept_available?(enums)
+    assert summary.concept_available?(strings)
+  end
+
+  test "available exercises" do
+    track = create :track
+    concept_exercise_1 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_2 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_3 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_4 = create :concept_exercise, :random_slug, track: track
+
+    practice_exercise_1 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_2 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_3 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_4 = create :practice_exercise, :random_slug, track: track
+
+    prereq_1 = create :track_concept, track: track
+    prereq_2 = create :track_concept, track: track
+
+    create(:exercise_prerequisite, exercise: concept_exercise_2, concept: prereq_1)
+    create(:exercise_prerequisite, exercise: practice_exercise_2, concept: prereq_1)
+    create(:exercise_prerequisite, exercise: concept_exercise_3, concept: prereq_1)
+    create(:exercise_prerequisite, exercise: practice_exercise_3, concept: prereq_1)
+    create(:exercise_prerequisite, exercise: concept_exercise_3, concept: prereq_2)
+    create(:exercise_prerequisite, exercise: practice_exercise_3, concept: prereq_2)
+    create(:exercise_prerequisite, exercise: concept_exercise_4, concept: prereq_2)
+    create(:exercise_prerequisite, exercise: practice_exercise_4, concept: prereq_2)
+    user_track = create :user_track, track: track
+
+    summary = summary_for(user_track)
+    assert_equal [
+      concept_exercise_1, practice_exercise_1
+    ].map(&:id).sort, summary.available_exercise_ids.sort
+
+    create :user_track_learnt_concept, concept: prereq_1, user_track: user_track
+    summary = summary_for(user_track)
+    assert_equal [
+      concept_exercise_1,
+      practice_exercise_1,
+      concept_exercise_2,
+      practice_exercise_2
+    ].map(&:id).sort, summary.available_exercise_ids.sort
+
+    create :user_track_learnt_concept, concept: prereq_2, user_track: user_track
+    summary = summary_for(user_track)
+    assert_equal [
+      concept_exercise_1, practice_exercise_1,
+      concept_exercise_2, concept_exercise_3, concept_exercise_4,
+      practice_exercise_2, practice_exercise_3, practice_exercise_4
+    ].map(&:id).sort, summary.available_exercise_ids.sort
+  end
+
+  private
+  def summary_for(user_track)
+    user_track = UserTrack.find(user_track.id)
+    UserTrack::GenerateSummary.(user_track.track, user_track)
+  end
+end

--- a/test/helpers/view_components/widgets/exercise_test.rb
+++ b/test/helpers/view_components/widgets/exercise_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 # rubocop:disable Layout/LineLength
 class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   test "external" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -15,7 +15,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "external no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary, desc: false)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -27,7 +27,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "external small" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary, large: false)
     expected = %(
       <div class="c-exercise-widget --small --locked">
         #{exercise_icon}
@@ -39,7 +39,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -51,7 +51,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary, desc: false)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -63,7 +63,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked small" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary, large: false)
     expected = %(
       <div class="c-exercise-widget --small --locked">
         #{exercise_icon}
@@ -75,7 +75,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -86,7 +86,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available no desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -97,7 +97,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available small" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -107,7 +107,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -118,7 +118,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress no desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -129,7 +129,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress small" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -139,7 +139,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -150,7 +150,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -161,13 +161,17 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed small" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
         #{info_div completed: true, desc: false}
       </a>)
     assert_html_equal expected, comp.to_s
+  end
+
+  def user_track_summary
+    UserTrack::GenerateSummary.(Track.last, UserTrack.last)
   end
 
   def assert_html_equal(expected, actual)
@@ -182,8 +186,9 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   def locked_exercise
-    create(:practice_exercise).tap do |exercise|
-      create :exercise_prerequisite, exercise: exercise
+    track = create :track
+    create(:practice_exercise, track: track).tap do |exercise|
+      create :exercise_prerequisite, exercise: exercise, concept: create(:track_concept, track: track)
       create :user_track, track: exercise.track # TODO: Will break with devise added
     end
   end

--- a/test/helpers/view_components/widgets/exercise_test.rb
+++ b/test/helpers/view_components/widgets/exercise_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 # rubocop:disable Layout/LineLength
 class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   test "external" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -15,7 +15,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "external no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track, desc: false)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -27,7 +27,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "external small" do
-    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track_summary, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(external_exercise, user_track, large: false)
     expected = %(
       <div class="c-exercise-widget --small --locked">
         #{exercise_icon}
@@ -39,7 +39,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -51,7 +51,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track, desc: false)
     expected = %(
       <div class="c-exercise-widget --large --locked">
         #{exercise_icon}
@@ -63,7 +63,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "locked small" do
-    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track_summary, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(locked_exercise, user_track, large: false)
     expected = %(
       <div class="c-exercise-widget --small --locked">
         #{exercise_icon}
@@ -75,7 +75,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -86,7 +86,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available no desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -97,7 +97,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "available small" do
-    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track_summary, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(available_exercise, user_track, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -107,7 +107,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -118,7 +118,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress no desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -129,7 +129,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "in-progress small" do
-    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track_summary, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(in_progress_exercise, user_track, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -139,7 +139,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -150,7 +150,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed no-desc" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary, desc: false)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track, desc: false)
     expected = %(
       <a class="c-exercise-widget --large" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -161,7 +161,7 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
   end
 
   test "completed small" do
-    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track_summary, large: false)
+    comp = render ViewComponents::Widgets::Exercise.new(completed_exercise, user_track, large: false)
     expected = %(
       <a class="c-exercise-widget --small" href="/tracks/ruby/exercises/bob">
         #{exercise_icon}
@@ -170,8 +170,8 @@ class ViewComponents::Widgets::ExerciseTest < ActionView::TestCase
     assert_html_equal expected, comp.to_s
   end
 
-  def user_track_summary
-    UserTrack::GenerateSummary.(Track.last, UserTrack.last)
+  def user_track
+    UserTrack.last || UserTrack::External.new(Track.last)
   end
 
   def assert_html_equal(expected, actual)

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Git
   class ExerciseTest < Minitest::Test
     def test_editor_solution_files
-      exercise = Exercise.new(:ruby, :bob, "HEAD", "practice")
+      exercise = Git::Exercise.new(:ruby, :bob, "HEAD", "practice")
 
       expected_files = ["bob.rb"]
       assert_equal expected_files, exercise.editor_solution_files.keys
@@ -11,20 +11,20 @@ module Git
     end
 
     def test_read_file_blob
-      exercise = Exercise.new(:ruby, :bob, "HEAD", "practice")
+      exercise = Git::Exercise.new(:ruby, :bob, "HEAD", "practice")
 
       assert_equal "stub content\n", exercise.read_file_blob('bob.rb')
     end
 
     def test_non_ignored_files
-      exercise = Exercise.new(:csharp, :datetime, "HEAD", "concept")
+      exercise = Git::Exercise.new(:csharp, :datetime, "HEAD", "concept")
 
       assert_equal exercise.non_ignored_filepaths, exercise.non_ignored_files.keys
       assert exercise.non_ignored_files[".docs/hints.md"].start_with?("## General")
     end
 
     def test_non_ignored_filepaths
-      exercise = Exercise.new(:csharp, :datetime, "HEAD", "concept")
+      exercise = Git::Exercise.new(:csharp, :datetime, "HEAD", "concept")
 
       expected_filepaths = [
         ".docs/hints.md",

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -17,11 +17,6 @@ class SolutionTest < ActiveSupport::TestCase
       assert_equal uuid, solution.uuid
     end
 
-    test "#{solution_type}: status defaults to 0" do
-      solution = create solution_type
-      assert_equal 'pending', solution.status
-    end
-
     test "#{solution_type}: git_slug and git_sha are set correctly" do
       solution = create solution_type
       assert_equal solution.track.git_head_sha, solution.git_sha

--- a/test/models/track/concept_test.rb
+++ b/test/models/track/concept_test.rb
@@ -24,4 +24,24 @@ class Track::ConceptTest < ActiveSupport::TestCase
     assert_equal "https://docs.microsoft.com/en-us/dotnet/api/system.datetime?view=netcore-3.1", links.first["url"]  # rubocop:disable Layout/LineLength
     assert_equal "DateTime class", links.first["description"]
   end
+
+  test "concept_exercises" do
+    track = create :track
+    concept = create :track_concept, track: track
+
+    ce_1 = create :concept_exercise, :random_slug, track: track
+    ce_1.taught_concepts << concept
+    ce_2 = create :concept_exercise, :random_slug, track: track
+    ce_2.taught_concepts << create(:track_concept, track: track)
+
+    pe_1 = create :practice_exercise, :random_slug, track: track
+    pe_1.prerequisites << concept
+    pe_2 = create :practice_exercise, :random_slug, track: track
+    pe_2.prerequisites << concept
+    pe_3 = create :practice_exercise, :random_slug, track: track
+    pe_3.prerequisites << create(:track_concept, track: track)
+
+    assert_equal [ce_1], concept.concept_exercises
+    assert_equal [pe_1, pe_2], concept.practice_exercises
+  end
 end

--- a/test/models/user/activities/started_exercise_activity_test.rb
+++ b/test/models/user/activities/started_exercise_activity_test.rb
@@ -18,18 +18,20 @@ class User::Activities::StartedExerciseActivityTest < ActiveSupport::TestCase
   end
 
   test "rendering_data is valid" do
-    user = create :user
-    exercise = create(:concept_exercise)
+    freeze_time do
+      user = create :user
+      exercise = create(:concept_exercise)
 
-    activity = User::Activities::StartedExerciseActivity.create!(
-      user: user,
-      track: exercise.track,
-      params: { exercise: exercise }
-    )
-    assert_equal exercise.title, activity.rendering_data.exercise_title
-    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
-    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
-    assert_equal "You started a new exercise", activity.rendering_data.text
-    assert_equal Time.current, activity.rendering_data.occurred_at
+      activity = User::Activities::StartedExerciseActivity.create!(
+        user: user,
+        track: exercise.track,
+        params: { exercise: exercise }
+      )
+      assert_equal exercise.title, activity.rendering_data.exercise_title
+      assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+      assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+      assert_equal "You started a new exercise", activity.rendering_data.text
+      assert_equal Time.current, activity.rendering_data.occurred_at
+    end
   end
 end

--- a/test/models/user_track/external_test.rb
+++ b/test/models/user_track/external_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class UserTrack::ExternalTest < ActiveSupport::TestCase
+  test "hard-coded methods" do
+    ut = UserTrack::External.new(mock)
+    assert ut.external?
+    assert_equal [], ut.learnt_concepts
+
+    refute ut.exercise_available?(mock)
+    refute ut.exercise_completed?(mock)
+
+    assert_equal 0, ut.num_completed_exercises
+    assert_equal [], ut.available_exercise_ids
+
+    refute ut.concept_available?(mock)
+    refute ut.concept_mastered?(mock)
+    assert_equal 0, ut.num_completed_exercises_for_concept(mock)
+
+    assert_equal [], ut.available_concept_ids
+    assert_equal 0, ut.num_concepts_mastered
+  end
+
+  test "num_concepts" do
+    track = create :track
+    create :track_concept, track: track
+    create :track_concept, track: track
+
+    ut = UserTrack::External.new(track)
+    assert_equal 2, ut.num_concepts
+  end
+
+  test "num_exercises_for_concept" do
+    track = create :track
+    concept_1 = create :track_concept, track: track
+    concept_2 = create :track_concept, track: track
+
+    ce_1 = create :concept_exercise, :random_slug, track: track
+    ce_1.taught_concepts << concept_1
+
+    ce_2 = create :concept_exercise, :random_slug, track: track
+    ce_2.prerequisites << concept_1 # This should not be counted
+    ce_1.taught_concepts << concept_2
+
+    pe_1 = create :practice_exercise, :random_slug, track: track
+    pe_1.prerequisites << concept_1
+    pe_1.prerequisites << concept_2
+
+    pe_2 = create :practice_exercise, :random_slug, track: track
+    pe_2.prerequisites << concept_1
+
+    ut = UserTrack::External.new(track)
+    assert_equal 3, ut.num_exercises_for_concept(concept_1)
+    assert_equal 2, ut.num_exercises_for_concept(concept_2)
+  end
+end

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -39,42 +39,47 @@ class UserTrackTest < ActiveSupport::TestCase
 
   test "exercise_available? with no prerequisites" do
     exercise = create :concept_exercise
-    user_track = create :user_track
+    user_track = create :user_track, track: exercise.track
     assert user_track.exercise_available?(exercise)
   end
 
   test "exercise_available? with prerequisites" do
-    exercise = create :concept_exercise
-    prereq_1 = create(:exercise_prerequisite, exercise: exercise).concept
-    prereq_2 = create(:exercise_prerequisite, exercise: exercise).concept
-    user_track = create :user_track
+    track = create :track
+    exercise = create :concept_exercise, :random_slug, track: track
 
+    prereq_1 = create :track_concept, track: track
+    create(:exercise_prerequisite, exercise: exercise, concept: prereq_1)
+
+    prereq_2 = create :track_concept, track: track
+    create(:exercise_prerequisite, exercise: exercise, concept: prereq_2)
+
+    user_track = create :user_track, track: track
     refute user_track.exercise_available?(exercise)
 
     create :user_track_learnt_concept, concept: prereq_1, user_track: user_track
-    refute user_track.reload.exercise_available?(exercise)
+    refute UserTrack.find(user_track.id).exercise_available?(exercise)
 
     create :user_track_learnt_concept, concept: prereq_2, user_track: user_track
-    assert user_track.reload.exercise_available?(exercise)
+    assert UserTrack.find(user_track.id).exercise_available?(exercise)
   end
 
   test "available concepts" do
     track = create :track
-    basics = create :track_concept, track: track
-    enums = create :track_concept, track: track
-    strings = create :track_concept, track: track
+    basics = create :track_concept, track: track, slug: "co_basics"
+    enums = create :track_concept, track: track, slug: "co_enums"
+    strings = create :track_concept, track: track, slug: "co_strings"
 
     # Nothing teaches recursion
-    recursion = create :track_concept, track: track
+    recursion = create :track_concept, track: track, slug: "co_recursion"
 
-    basics_exercise = create :concept_exercise, track: track
+    basics_exercise = create :concept_exercise, slug: "ex_basics", track: track
     basics_exercise.taught_concepts << basics
 
-    enums_exercise = create :concept_exercise, track: track
+    enums_exercise = create :concept_exercise, slug: "ex_enums", track: track
     enums_exercise.prerequisites << basics
     enums_exercise.taught_concepts << enums
 
-    strings_exercise = create :concept_exercise, track: track
+    strings_exercise = create :concept_exercise, slug: "ex_strings", track: track
     strings_exercise.prerequisites << enums
     strings_exercise.prerequisites << basics
     strings_exercise.taught_concepts << strings
@@ -82,7 +87,7 @@ class UserTrackTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, track: track, user: user
 
-    assert_equal [recursion, basics], user_track.available_concepts
+    assert_equal [basics, recursion], user_track.available_concepts
     assert user_track.concept_available?(recursion)
     assert user_track.concept_available?(basics)
     refute user_track.concept_available?(enums)
@@ -93,7 +98,7 @@ class UserTrackTest < ActiveSupport::TestCase
 
     create :user_track_learnt_concept, user_track: user_track, concept: basics
 
-    assert_equal [recursion, basics, enums], user_track.available_concepts
+    assert_equal [basics, enums, recursion], user_track.available_concepts
     assert user_track.concept_available?(recursion)
     assert user_track.concept_available?(basics)
     assert user_track.concept_available?(enums)
@@ -104,24 +109,24 @@ class UserTrackTest < ActiveSupport::TestCase
 
     create :user_track_learnt_concept, user_track: user_track, concept: enums
 
-    assert_equal [recursion, basics, enums, strings], user_track.available_concepts
+    assert_equal [basics, enums, strings, recursion], user_track.available_concepts
     assert user_track.concept_available?(recursion)
     assert user_track.concept_available?(basics)
     assert user_track.concept_available?(enums)
     assert user_track.concept_available?(strings)
   end
 
-  test "available exercises and concepts" do
+  test "available exercises" do
     track = create :track
-    concept_exercise_1 = create :concept_exercise, track: track
-    concept_exercise_2 = create :concept_exercise, track: track
-    concept_exercise_3 = create :concept_exercise, track: track
-    concept_exercise_4 = create :concept_exercise, track: track
+    concept_exercise_1 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_2 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_3 = create :concept_exercise, :random_slug, track: track
+    concept_exercise_4 = create :concept_exercise, :random_slug, track: track
 
-    practice_exercise_1 = create :practice_exercise, track: track
-    practice_exercise_2 = create :practice_exercise, track: track
-    practice_exercise_3 = create :practice_exercise, track: track
-    practice_exercise_4 = create :practice_exercise, track: track
+    practice_exercise_1 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_2 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_3 = create :practice_exercise, :random_slug, track: track
+    practice_exercise_4 = create :practice_exercise, :random_slug, track: track
 
     prereq_1 = create :track_concept, track: track
     prereq_2 = create :track_concept, track: track
@@ -146,10 +151,10 @@ class UserTrackTest < ActiveSupport::TestCase
     create :user_track_learnt_concept, concept: prereq_1, user_track: user_track
     assert_equal [
       concept_exercise_1,
-      practice_exercise_1,
       concept_exercise_2,
+      practice_exercise_1,
       practice_exercise_2
-    ], user_track.reload.available_exercises
+    ], user_track.available_exercises
 
     assert_equal [concept_exercise_1, concept_exercise_2], user_track.available_concept_exercises
     assert_equal [practice_exercise_1, practice_exercise_2], user_track.available_practice_exercises
@@ -159,10 +164,9 @@ class UserTrackTest < ActiveSupport::TestCase
 
     create :user_track_learnt_concept, concept: prereq_2, user_track: user_track
     assert_equal [
-      concept_exercise_1, practice_exercise_1,
-      concept_exercise_2, concept_exercise_3, concept_exercise_4,
-      practice_exercise_2, practice_exercise_3, practice_exercise_4
-    ], user_track.reload.available_exercises
+      concept_exercise_1, concept_exercise_2, concept_exercise_3, concept_exercise_4,
+      practice_exercise_1, practice_exercise_2, practice_exercise_3, practice_exercise_4
+    ], user_track.available_exercises
 
     assert_equal [
       concept_exercise_1,
@@ -189,7 +193,7 @@ class UserTrackTest < ActiveSupport::TestCase
 
   test "summary is memoized" do
     ut = create :user_track
-    UserTrack::Summary.expects(:new).with(ut).returns(mock).once
+    UserTrack::GenerateSummary.expects(:call).with(ut.track, ut).returns(mock).once
     2.times { ut.summary }
   end
 end


### PR DESCRIPTION
The first commit implements the progress bar at the RHS.

<img width="1440" alt="Screenshot 2020-11-11 at 22 38 12" src="https://user-images.githubusercontent.com/286476/98872526-9c2b0680-246e-11eb-95f1-8cfc3418e520.png">

---

The second commit is a more comprehensive implementation of the user_track methods onto the new summary class, which builds on my work in https://github.com/exercism/v3-website/pull/270