### PR TITLE
Refactor tooling jobs

### DIFF
--- a/app/commands/submission/analysis/process.rb
+++ b/app/commands/submission/analysis/process.rb
@@ -3,10 +3,9 @@ class Submission
     class Process
       include Mandate
 
-      def initialize(submission_uuid, ops_status, ops_message, data)
+      def initialize(submission_uuid, ops_status, data)
         @submission = Submission.find_by!(uuid: submission_uuid)
         @ops_status = ops_status.to_i
-        @ops_message = ops_message
         @data = data.is_a?(Hash) ? data.symbolize_keys : {}
       end
 
@@ -15,7 +14,6 @@ class Submission
         # us some basis of the next set of decisions etc.
         analysis = submission.analyses.create!(
           ops_status: ops_status,
-          ops_message: ops_message,
           data: data
         )
 
@@ -42,7 +40,7 @@ class Submission
       end
 
       private
-      attr_reader :submission, :ops_status, :ops_message, :data
+      attr_reader :submission, :ops_status, :data
 
       def handle_ops_error!
         submission.analysis_exceptioned!

--- a/app/commands/submission/representation/process.rb
+++ b/app/commands/submission/representation/process.rb
@@ -3,10 +3,9 @@ class Submission
     class Process
       include Mandate
 
-      def initialize(submission_uuid, ops_status, ops_message, ast, mapping)
+      def initialize(submission_uuid, ops_status, ast, mapping)
         @submission = Submission.find_by!(uuid: submission_uuid)
         @ops_status = ops_status.to_i
-        @ops_message = ops_message
         @ast = ast
         @mapping = mapping
       end
@@ -17,7 +16,6 @@ class Submission
         @submission_representation = Submission::Representation.create!(
           submission: submission,
           ops_status: ops_status,
-          ops_message: ops_message,
           ast: ast
         )
 
@@ -52,7 +50,7 @@ class Submission
 
         submission.broadcast!
       end
-      attr_reader :submission, :ops_status, :ops_message, :ast, :mapping
+      attr_reader :submission, :ops_status, :ast, :mapping
       attr_reader :submission_representation, :exercise_representation
 
       private

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -3,10 +3,9 @@ class Submission
     class Process
       include Mandate
 
-      def initialize(submission_uuid, ops_status, ops_message, results)
+      def initialize(submission_uuid, ops_status, results)
         @submission = Submission.find_by!(uuid: submission_uuid)
         @ops_status = ops_status.to_i
-        @ops_message = ops_message
         @results = results.is_a?(Hash) ? results.symbolize_keys : {}
       end
 
@@ -15,7 +14,6 @@ class Submission
         # to record this whatever happens.
         test_run = submission.test_runs.create!(
           ops_status: ops_status,
-          ops_message: ops_message,
           raw_results: results
         )
 
@@ -43,7 +41,7 @@ class Submission
       end
 
       private
-      attr_reader :submission, :ops_status, :ops_message, :results
+      attr_reader :submission, :ops_status, :results
 
       def handle_ops_error!
         submission.tests_exceptioned!

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -3,17 +3,16 @@ class Submission
     class Process
       include Mandate
 
-      def initialize(submission_uuid, ops_status, results)
-        @submission = Submission.find_by!(uuid: submission_uuid)
-        @ops_status = ops_status.to_i
-        @results = results.is_a?(Hash) ? results.symbolize_keys : {}
+      def initialize(tooling_job)
+        @tooling_job = tooling_job
       end
 
       def call
         # This goes in its own transaction. We want
         # to record this whatever happens.
         test_run = submission.test_runs.create!(
-          ops_status: ops_status,
+          tooling_job_id: tooling_job.id,
+          ops_status: tooling_job.execution_status.to_i,
           raw_results: results
         )
 
@@ -41,7 +40,7 @@ class Submission
       end
 
       private
-      attr_reader :submission, :ops_status, :results
+      attr_reader :tooling_job
 
       def handle_ops_error!
         submission.tests_exceptioned!
@@ -64,6 +63,19 @@ class Submission
       def cancel_other_services!
         ToolingJob::Cancel.(submission.uuid, :analyzer)
         ToolingJob::Cancel.(submission.uuid, :representer)
+      end
+
+      memoize
+      def submission
+        Submission.find_by!(uuid: tooling_job.submission_uuid)
+      end
+
+      memoize
+      def results
+        res = JSON.parse(tooling_job.execution_output['results.json'])
+        res.is_a?(Hash) ? res.symbolize_keys : {}
+      rescue StandardError
+        {}
       end
     end
   end

--- a/app/commands/tooling_job/cancel.rb
+++ b/app/commands/tooling_job/cancel.rb
@@ -1,4 +1,4 @@
-module ToolingJob
+class ToolingJob
   class Cancel
     include Mandate
 

--- a/app/commands/tooling_job/cancel.rb
+++ b/app/commands/tooling_job/cancel.rb
@@ -5,54 +5,15 @@ class ToolingJob
     initialize_with :submission_uuid, :type
 
     def call
-      return unless queued_dynamodb_job
+      return unless job
 
-      update_dynamodb
-      update_submission
+      job.cancelled!
+      update_submission!
     end
 
     private
     memoize
-    def queued_dynamodb_job
-      client.query(
-        {
-          table_name: Exercism.config.dynamodb_tooling_jobs_table,
-          index_name: "submission_type",
-          expression_attribute_values: {
-            ":SU" => submission_uuid,
-            ":TP" => type,
-            ":JS" => :queued
-          },
-          expression_attribute_names: {
-            "#SU": "submission_uuid",
-            "#TP": "type",
-            "#ID": "id",
-            "#JS": "job_status"
-          },
-          key_condition_expression: "#SU = :SU AND #TP = :TP",
-          filter_expression: "#JS = :JS",
-          projection_expression: "#ID"
-        }
-      ).items.first
-    end
-
-    def update_dynamodb
-      client.update_item(
-        table_name: Exercism.config.dynamodb_tooling_jobs_table,
-        key: {
-          id: queued_dynamodb_job["id"]
-        },
-        expression_attribute_names: {
-          "#JS": "job_status"
-        },
-        expression_attribute_values: {
-          ":js": "cancelled"
-        },
-        update_expression: "SET #JS = :js"
-      )
-    end
-
-    def update_submission
+    def update_submission!
       submission = Submission.find_by!(uuid: submission_uuid)
 
       case type
@@ -65,9 +26,8 @@ class ToolingJob
       end
     end
 
-    memoize
-    def client
-      ExercismConfig::SetupDynamoDBClient.()
+    def job
+      ToolingJob.find_queued(submission_uuid, type)
     end
   end
 end

--- a/app/commands/tooling_job/create.rb
+++ b/app/commands/tooling_job/create.rb
@@ -1,4 +1,4 @@
-module ToolingJob
+class ToolingJob
   class Create
     include Mandate
 

--- a/app/commands/tooling_job/process.rb
+++ b/app/commands/tooling_job/process.rb
@@ -11,13 +11,10 @@ class ToolingJob
 
     private
     def process_test_runner_job!
-      Submission::TestRun::Process.(
-        job.submission_uuid,
-        job.execution_status,
-        safe_json_parse("results.json")
-      )
+      Submission::TestRun::Process.(job)
     end
 
+    # TODO: Refactor this to be like test runner
     def process_representer_job!
       Submission::Representation::Process.(
         job.submission_uuid,
@@ -27,6 +24,7 @@ class ToolingJob
       )
     end
 
+    # TODO: Refactor this to be like test runner
     def process_analyzer_job!
       Submission::Analysis::Process.(
         job.submission_uuid,

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -41,6 +41,36 @@ class Submission < ApplicationRecord
   end
 
   def serialized
+    # tests_data = tests_status
+    # if tests_exceptioned?
+    #   client = ExercismConfig::SetupDynamoDBClient.()
+    #   tests_data += client.query(
+    #     table_name: Exercism.config.dynamodb_tooling_jobs_table,
+    #     index_name: "submission_type",
+    #     expression_attribute_values: {
+    #       ":SU" => submission_uuid,
+    #       ":TP" => type,
+    #       ":JS" => :exceptioned
+    #     },
+    #     expression_attribute_names: {
+    #       "#SU": "submission_uuid",
+    #       "#TP": "type",
+    #       "#ID": "id",
+    #       "#JS": "job_status"
+    #     },
+    #     key_condition_expression: "#SU = :SU AND #TP = :TP",
+    #     filter_expression: "#JS = :JS",
+    #     projection_expression: "#ID"
+    #     key: {
+    #       submission_uuid: uuid,
+    #       type: :test_runner
+    #     },
+    #     attributes_to_get: %i[
+    #       execution_metadata
+    #     ]
+    #   ).item['execution_metadata']
+    # end
+
     {
       id: id,
       track: track.title,

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -41,41 +41,17 @@ class Submission < ApplicationRecord
   end
 
   def serialized
-    # tests_data = tests_status
-    # if tests_exceptioned?
-    #   client = ExercismConfig::SetupDynamoDBClient.()
-    #   tests_data += client.query(
-    #     table_name: Exercism.config.dynamodb_tooling_jobs_table,
-    #     index_name: "submission_type",
-    #     expression_attribute_values: {
-    #       ":SU" => submission_uuid,
-    #       ":TP" => type,
-    #       ":JS" => :exceptioned
-    #     },
-    #     expression_attribute_names: {
-    #       "#SU": "submission_uuid",
-    #       "#TP": "type",
-    #       "#ID": "id",
-    #       "#JS": "job_status"
-    #     },
-    #     key_condition_expression: "#SU = :SU AND #TP = :TP",
-    #     filter_expression: "#JS = :JS",
-    #     projection_expression: "#ID"
-    #     key: {
-    #       submission_uuid: uuid,
-    #       type: :test_runner
-    #     },
-    #     attributes_to_get: %i[
-    #       execution_metadata
-    #     ]
-    #   ).item['execution_metadata']
-    # end
+    tests_data = tests_status
+    if tests_exceptioned?
+      job = ToolingJob.find(test_runs.last.tooling_job_id, full: true)
+      tests_data += "\n\n#{JSON.pretty_generate(job.execution_metadata)}"
+    end
 
     {
       id: id,
       track: track.title,
       exercise: exercise.title,
-      testsStatus: tests_status,
+      testsStatus: tests_data,
       representationStatus: representation_status,
       analysisStatus: analysis_status
     }

--- a/app/models/tooling_job.rb
+++ b/app/models/tooling_job.rb
@@ -1,0 +1,89 @@
+class ToolingJob
+  extend Mandate::Memoize
+  BASIC_ATTRIBUTES = %i[
+    id
+    submission_uuid
+    type
+    job_status
+  ].freeze
+
+  def self.find(id, full: false)
+    params = {
+      table_name: table_name,
+      key: { id: id }
+    }
+    params[:attributes_to_get] = BASIC_ATTRIBUTES unless full
+
+    new(client.get_item(params).item)
+  end
+
+  def self.find_queued(submission_uuid, type)
+    item = client.query(
+      table_name: table_name,
+      index_name: "submission_type",
+      expression_attribute_values: {
+        ":SU" => submission_uuid,
+        ":TP" => type,
+        ":JS" => :queued
+      },
+      expression_attribute_names: {
+        "#SU": "submission_uuid",
+        "#TP": "type",
+        "#ID": "id",
+        "#JS": "job_status"
+      },
+      key_condition_expression: "#SU = :SU AND #TP = :TP",
+      filter_expression: "#JS = :JS",
+      projection_expression: "#ID"
+    ).items.first
+    new(item)
+  end
+
+  attr_reader :id, :submission_uuid, :type, :job_status, :created_at
+  attr_reader :language, :exercise, :locked_until
+  attr_reader :execution_status, :execution_metadata, :execution_output
+  attr_reader :s3_uri
+
+  def initialize(params)
+    params.each { |key, value| send("#{key}=", value) }
+  end
+
+  def processed!
+    client.update_item(
+      table_name: table_name,
+      key: { id: id },
+      expression_attribute_names: { "#JS": "job_status" },
+      expression_attribute_values: { ":js": "processed" },
+      update_expression: "SET #JS = :js"
+    )
+  end
+
+  def cancelled!
+    client.update_item(
+      table_name: Exercism.config.dynamodb_tooling_jobs_table,
+      key: { id: id },
+      expression_attribute_names: { "#JS": "job_status" },
+      expression_attribute_values: { ":js": "cancelled" },
+      update_expression: "SET #JS = :js"
+    )
+  end
+
+  def ==(other)
+    id == other.id
+  end
+
+  def self.client
+    ExercismConfig::SetupDynamoDBClient.()
+  end
+
+  def self.table_name
+    Exercism.config.dynamodb_tooling_jobs_table
+  end
+  delegate :client, :table_name, to: self
+
+  private
+  attr_writer :id, :submission_uuid, :type, :job_status, :created_at
+  attr_writer :language, :exercise, :locked_until
+  attr_writer :execution_status, :execution_metadata, :execution_output
+  attr_writer :s3_uri
+end

--- a/app/views/maintaining/submissions/index.html.haml
+++ b/app/views/maintaining/submissions/index.html.haml
@@ -7,6 +7,10 @@
     font-size: 20px;
     margin-bottom: 16px;
   }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
   th {
     border: 1px solid #ddd;
     border-bottom: 1px solid #888;
@@ -18,7 +22,15 @@
     border: 1px solid #ddd;
     border-bottom: 1px solid #aaa;
     padding: 10px;
+    white-space: pre;
+    font:monospace;
   }
+  td:nth-child(1) { width:50px; }
+  td:nth-child(2) { width:50px; }
+  td:nth-child(3) { width:50px; }
+  td:nth-child(4) { width:auto; font-family: monospace;}
+  td:nth-child(5) { width:50px; }
+  td:nth-child(6) { width:50px; }
 
 #maintaining-submissions
   %h2.text-h3 Submissions

--- a/app/views/maintaining/submissions/index.html.haml
+++ b/app/views/maintaining/submissions/index.html.haml
@@ -1,107 +1,25 @@
 :css
-  body {
-    font-family: sans-serif;
+  #maintaining-submissions {
+    padding:25px 5%;
     font-size: 16px;
-    padding: 5%;
-  }
-  .field {
-    margin-bottom: 15px;
-  }
-  label {
-    display: block;
-    font-weight: bold;
-    margin-bottom: 5px;
-    font-weight: normal;
-  }
-  input,
-  textarea {
-    border: 1px solid #aaa;
-    padding: 10px;
-    border-radius: 3px;
-  }
-  select {
-    border: 1px solid #aaa;
-    padding: 7px;
-    border-radius: 3px;
-  }
-  table {
-    border-collapse: collapse;
   }
   h2 {
     font-size: 20px;
-    margin-bottom: 10px;
+    margin-bottom: 16px;
   }
   th {
     border: 1px solid #ddd;
     border-bottom: 1px solid #888;
     padding: 10px;
+    text-align:left;
+    font-weight:600px;
   }
   td {
     border: 1px solid #ddd;
     border-bottom: 1px solid #aaa;
     padding: 10px;
   }
-  hr {
-    margin: 20px 0;
-  }
-  button {
-    background: #009cab;
-    color: #fff;
-    display: inline-block;
-    padding: 10px 20px;
-    font-size: 16px;
-    border: none;
-  }
 
-  .page {
-    display: grid;
-    grid-template-columns: 50% 5% 45%;
-  }
-  .forms {
-    grid-row-start: 1;
-    grid-column-start: 3;
-    border-left: 1px solid #ddd;
-    padding-left: 5%;
-  }
-  .info {
-    grid-row-start: 1;
-    grid-column-start: 1;
-  }
-  hr {
-    border: 1px solid #ddd;
-  }
-.page
-  .forms
-    %h2 Create New Submission
-    = form_with url: tmp_submissions_path do
-      .field
-        = label_tag(:track_slug, "Track slug:")
-        = select_tag(:track_slug, options_for_select(Track.all.sort_by(&:title).map { |t| [t.title, t.slug] }))
-      .field
-        = label_tag(:exercise_slug, "Exercise slug:")
-        = text_field_tag(:exercise_slug, nil, placeholder: 'E.g. two-fer', required: true)
-      .field
-        = label_tag(:exercise_filename, "Exercise filename:")
-        = text_field_tag(:exercise_filename, nil, placeholder: 'E.g. two_fer.rb', required: true)
-      .field
-        = label_tag(:exercise_implementation, "Exercise implementation:")
-        = text_area_tag(:exercise_implementation, nil, size: "40x15", placeholder: "E.g.\n\nclass TwoFer\n  def self.two_fer(name = 'you')\n    \"One for #\{name\}, one for me.\"\n  end\nend", required: true)
-      .field
-        = button_tag "Submit submission"
-    %hr/
-    %h2 Create Track
-    = form_with url: tmp_tracks_path, remote: false do
-      .field
-        = label_tag(:track_slug, "Track slug:")
-        = text_field_tag(:track_slug, nil, placeholder: 'E.g. csharp', required: true)
-      .field
-        = label_tag(:track_title, "Track title:")
-        = text_field_tag(:track_title, nil, placeholder: 'E.g. C#', required: true)
-      .field
-        = label_tag(:repo_url, "GitHub Repo:")
-        = text_field_tag(:repo_url, nil, placeholder: 'https://github.com/exercism/csharp', required: true)
-      .field
-        = button_tag "Add track"
-  .info
-    %h2 Submissions
-    = ReactComponents::Maintaining::SubmissionsSummaryTable.new(@submissions)
+#maintaining-submissions
+  %h2.text-h3 Submissions
+  = ReactComponents::Maintaining::SubmissionsSummaryTable.new(@submissions)

--- a/db/migrate/20200513204406_create_submission_test_runs.rb
+++ b/db/migrate/20200513204406_create_submission_test_runs.rb
@@ -8,7 +8,6 @@ class CreateSubmissionTestRuns < ActiveRecord::Migration[6.0]
       t.json :tests, null: true
 
       t.integer :ops_status, limit: 2, null: false
-      t.text :ops_message
 
       t.json :raw_results, null: false
 

--- a/db/migrate/20200513204406_create_submission_test_runs.rb
+++ b/db/migrate/20200513204406_create_submission_test_runs.rb
@@ -2,6 +2,7 @@ class CreateSubmissionTestRuns < ActiveRecord::Migration[6.0]
   def change
     create_table :submission_test_runs do |t|
       t.belongs_to :submission, foreign_key: true, null: false
+      t.string :tooling_job_id, null: false
 
       t.string :status, null: false
       t.text :message, null: true

--- a/db/migrate/20200514172924_create_submission_analyses.rb
+++ b/db/migrate/20200514172924_create_submission_analyses.rb
@@ -4,7 +4,6 @@ class CreateSubmissionAnalyses < ActiveRecord::Migration[6.0]
       t.belongs_to :submission, foreign_key: true, null: false
 
       t.integer :ops_status, limit: 2, null: false
-      t.text :ops_message
 
       t.json :data, null: true
 

--- a/db/migrate/20200517182800_create_submission_representations.rb
+++ b/db/migrate/20200517182800_create_submission_representations.rb
@@ -4,7 +4,6 @@ class CreateSubmissionRepresentations < ActiveRecord::Migration[6.0]
       t.belongs_to :submission, foreign_key: true, null: false
 
       t.integer :ops_status, limit: 2, null: false
-      t.text :ops_message
 
       t.text :ast, null: true
       t.string :ast_digest, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,7 +152,6 @@ ActiveRecord::Schema.define(version: 2020_11_09_170425) do
   create_table "submission_analyses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
     t.integer "ops_status", limit: 2, null: false
-    t.text "ops_message"
     t.json "data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -186,7 +185,6 @@ ActiveRecord::Schema.define(version: 2020_11_09_170425) do
   create_table "submission_representations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
     t.integer "ops_status", limit: 2, null: false
-    t.text "ops_message"
     t.text "ast"
     t.string "ast_digest", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -196,11 +194,11 @@ ActiveRecord::Schema.define(version: 2020_11_09_170425) do
 
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
+    t.string "tooling_job_id", null: false
     t.string "status", null: false
     t.text "message"
     t.json "tests"
     t.integer "ops_status", limit: 2, null: false
-    t.text "ops_message"
     t.json "raw_results", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/commands/submission/analysis/process_test.rb
+++ b/test/commands/submission/analysis/process_test.rb
@@ -4,18 +4,16 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "creates analysis record" do
     submission = create :submission
     ops_status = 200
-    ops_message = "some ops message"
     status = "foobar"
     comments = [{ 'foo' => 'bar' }]
     data = { 'status' => status, 'comments' => comments }
 
-    Submission::Analysis::Process.(submission.uuid, ops_status, ops_message, data)
+    Submission::Analysis::Process.(submission.uuid, ops_status, data)
 
     assert_equal 1, submission.reload.analyses.size
     analysis = submission.reload.analyses.first
 
     assert_equal ops_status, analysis.ops_status
-    assert_equal ops_message, analysis.ops_message
     assert_equal status.to_sym, analysis.status
     assert_equal comments, analysis.send(:comments)
     assert_equal data, analysis.send(:data)
@@ -24,7 +22,7 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "handle ops error" do
     submission = create :submission
     data = { 'status' => :pass, 'comments' => [] }
-    Submission::Analysis::Process.(submission.uuid, 500, "", data)
+    Submission::Analysis::Process.(submission.uuid, 500, data)
 
     assert submission.reload.analysis_exceptioned?
   end
@@ -32,7 +30,7 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "handle approval" do
     submission = create :submission
     data = { 'status' => :approve, 'comments' => [] }
-    Submission::Analysis::Process.(submission.uuid, 200, "", data)
+    Submission::Analysis::Process.(submission.uuid, 200, data)
 
     assert submission.reload.analysis_approved?
   end
@@ -40,7 +38,7 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "handle inconclusive" do
     submission = create :submission
     data = { 'status' => :refer_to_mentor, 'comments' => [] }
-    Submission::Analysis::Process.(submission.uuid, 200, "", data)
+    Submission::Analysis::Process.(submission.uuid, 200, data)
 
     assert submission.reload.analysis_inconclusive?
   end
@@ -48,7 +46,7 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "handle disapproval" do
     submission = create :submission
     data = { 'status' => :disapprove, 'comments' => [] }
-    Submission::Analysis::Process.(submission.uuid, 200, "", data)
+    Submission::Analysis::Process.(submission.uuid, 200, data)
 
     assert submission.reload.analysis_disapproved?
   end
@@ -56,7 +54,7 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
   test "handle ambiguous" do
     submission = create :submission
     data = { 'status' => :ambiguous, 'comments' => [] }
-    Submission::Analysis::Process.(submission.uuid, 200, "", data)
+    Submission::Analysis::Process.(submission.uuid, 200, data)
 
     assert submission.reload.analysis_exceptioned?
   end
@@ -68,6 +66,6 @@ class Submission::Analysis::ProcessTest < ActiveSupport::TestCase
     SubmissionChannel.expects(:broadcast!).with(submission)
     SubmissionsChannel.expects(:broadcast!).with(submission.solution)
 
-    Submission::Analysis::Process.(submission.uuid, 200, "", data)
+    Submission::Analysis::Process.(submission.uuid, 200, data)
   end
 end

--- a/test/commands/submission/representation/process_test.rb
+++ b/test/commands/submission/representation/process_test.rb
@@ -4,16 +4,14 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
   test "creates submission representation record" do
     submission = create :submission
     ops_status = 200
-    ops_message = "some ops message"
     ast = "here(lives(an(ast)))"
 
-    Submission::Representation::Process.(submission.uuid, ops_status, ops_message, ast, {})
+    Submission::Representation::Process.(submission.uuid, ops_status, ast, {})
 
     assert_equal 1, submission.reload.representations.size
     representation = submission.reload.representations.first
 
     assert_equal ops_status, representation.ops_status
-    assert_equal ops_message, representation.ops_message
     assert_equal ast, representation.ast
   end
 
@@ -23,7 +21,7 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
     submission = create :submission
     mapping = { 'foo' => 'bar' }
 
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, mapping)
+    Submission::Representation::Process.(submission.uuid, 200, ast, mapping)
 
     assert_equal 1, Exercise::Representation.count
     representation = Exercise::Representation.first
@@ -44,20 +42,20 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
     submission_2 = create :submission, solution: solution
     submission_3 = create :submission, solution: solution
 
-    Submission::Representation::Process.(submission_1.uuid, 200, "", "ast 1", {})
-    Submission::Representation::Process.(submission_2.uuid, 200, "", "ast 1", {})
+    Submission::Representation::Process.(submission_1.uuid, 200, "ast 1", {})
+    Submission::Representation::Process.(submission_2.uuid, 200, "ast 1", {})
 
     assert_equal 2, Submission::Representation.count
     assert_equal 1, Exercise::Representation.count
 
-    Submission::Representation::Process.(submission_3.uuid, 200, "", "ast 2", {})
+    Submission::Representation::Process.(submission_3.uuid, 200, "ast 2", {})
     assert_equal 3, Submission::Representation.count
     assert_equal 2, Exercise::Representation.count
   end
 
   test "handle ops error" do
     submission = create :submission
-    Submission::Representation::Process.(submission.uuid, 500, "", "ast", {})
+    Submission::Representation::Process.(submission.uuid, 500, "ast", {})
 
     assert submission.reload.representation_exceptioned?
   end
@@ -72,7 +70,7 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
       action: :approve
 
     submission = create :submission, exercise: exercise
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, {})
+    Submission::Representation::Process.(submission.uuid, 200, ast, {})
 
     assert submission.reload.representation_approved?
   end
@@ -87,7 +85,7 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
       action: :disapprove
 
     submission = create :submission, exercise: exercise
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, {})
+    Submission::Representation::Process.(submission.uuid, 200, ast, {})
 
     assert submission.reload.representation_disapproved?
   end
@@ -107,7 +105,7 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
       feedback_markdown: feedback
 
     submission = create :submission, exercise: exercise
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, {})
+    Submission::Representation::Process.(submission.uuid, 200, ast, {})
 
     assert submission.reload.representation_disapproved?
     assert_equal 1, submission.reload.discussion_posts.size
@@ -125,7 +123,7 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
       action: :pending
 
     submission = create :submission, exercise: exercise
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, {})
+    Submission::Representation::Process.(submission.uuid, 200, ast, {})
 
     assert submission.reload.representation_inconclusive?
   end
@@ -144,6 +142,6 @@ class Submission::Representation::ProcessTest < ActiveSupport::TestCase
     SubmissionChannel.expects(:broadcast!).with(submission)
     SubmissionsChannel.expects(:broadcast!).with(submission.solution)
 
-    Submission::Representation::Process.(submission.uuid, 200, "", ast, {})
+    Submission::Representation::Process.(submission.uuid, 200, ast, {})
   end
 end

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -8,8 +8,9 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     message = "some barfoo message"
     tests = [{ 'foo' => 'bar' }]
     results = { 'status' => status, 'message' => message, 'tests' => tests }
+    job = create_test_runner_job!(submission, execution_status: ops_status, results: results)
 
-    Submission::TestRun::Process.(submission.uuid, ops_status, results)
+    Submission::TestRun::Process.(job)
 
     assert_equal 1, submission.reload.test_runs.size
     tr = submission.reload.test_runs.first
@@ -24,7 +25,9 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "handle ops error" do
     submission = create :submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
-    Submission::TestRun::Process.(submission.uuid, 500, results)
+    job = create_test_runner_job!(submission, execution_status: 500, results: results)
+
+    Submission::TestRun::Process.(job)
 
     assert submission.reload.tests_exceptioned?
   end
@@ -32,7 +35,9 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "handle tests pass" do
     submission = create :submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
-    Submission::TestRun::Process.(submission.uuid, 200, results)
+    job = create_test_runner_job!(submission, execution_status: 200, results: results)
+
+    Submission::TestRun::Process.(job)
 
     assert submission.reload.tests_passed?
   end
@@ -40,12 +45,13 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "handle tests fail" do
     submission = create :submission
     results = { 'status' => 'fail', 'message' => "", 'tests' => [] }
+    job = create_test_runner_job!(submission, execution_status: 200, results: results)
 
     # Cancel representation and analysis
     ToolingJob::Cancel.expects(:call).with(submission.uuid, :analyzer)
     ToolingJob::Cancel.expects(:call).with(submission.uuid, :representer)
 
-    Submission::TestRun::Process.(submission.uuid, 200, results)
+    Submission::TestRun::Process.(job)
 
     assert submission.reload.tests_failed?
   end
@@ -53,12 +59,13 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "handle tests error" do
     submission = create :submission
     results = { 'status' => 'error', 'message' => "", 'tests' => [] }
+    job = create_test_runner_job!(submission, execution_status: 200, results: results)
 
     # Cancel representation and analysis
     ToolingJob::Cancel.expects(:call).with(submission.uuid, :analyzer)
     ToolingJob::Cancel.expects(:call).with(submission.uuid, :representer)
 
-    Submission::TestRun::Process.(submission.uuid, 200, results)
+    Submission::TestRun::Process.(job)
 
     assert submission.reload.tests_errored?
   end
@@ -66,7 +73,9 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "handle bad status" do
     submission = create :submission
     results = { 'status' => 'oops', 'message' => "", 'tests' => [] }
-    Submission::TestRun::Process.(submission.uuid, 200, results)
+    job = create_test_runner_job!(submission, execution_status: 200, results: results)
+
+    Submission::TestRun::Process.(job)
 
     assert submission.reload.tests_exceptioned?
   end
@@ -74,12 +83,13 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "broadcast" do
     submission = create :submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
+    job = create_test_runner_job!(submission, execution_status: 200, results: results)
 
     SubmissionChannel.expects(:broadcast!).with(submission)
     SubmissionsChannel.expects(:broadcast!).with(submission.solution)
     Submission::TestRunsChannel.expects(:broadcast!).with(kind_of(Submission::TestRun))
 
-    Submission::TestRun::Process.(submission.uuid, 200, results)
+    Submission::TestRun::Process.(job)
 
     assert_equal submission.test_runs.size, 1
   end

--- a/test/commands/tooling_job/cancel_test.rb
+++ b/test/commands/tooling_job/cancel_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class ToolingJob::CancelTest < ActiveSupport::TestCase
   test "cancels test runner job" do
     submission = create_submission
-    id = write_submission_to_dynamodb(submission, :test_runner)
+    job = create_test_runner_job!(submission)
 
     ToolingJob::Cancel.(submission.uuid, :test_runner)
 
-    assert_equal "cancelled", dynamodb_job_status(id)
+    assert_equal "cancelled", dynamodb_job_status(job.id)
   end
 
   test "set tests status to cancelled" do
     submission = create_submission
-    write_submission_to_dynamodb(submission, :test_runner)
+    create_test_runner_job!(submission)
 
     ToolingJob::Cancel.(submission.uuid, :test_runner)
 
@@ -21,16 +21,16 @@ class ToolingJob::CancelTest < ActiveSupport::TestCase
 
   test "cancels analysis job" do
     submission = create_submission
-    id = write_submission_to_dynamodb(submission, :analyzer)
+    job = create_tooling_job!(submission, :analyzer)
 
     ToolingJob::Cancel.(submission.uuid, :analyzer)
 
-    assert_equal "cancelled", dynamodb_job_status(id)
+    assert_equal "cancelled", dynamodb_job_status(job.id)
   end
 
   test "set analysis status to cancelled" do
     submission = create_submission
-    write_submission_to_dynamodb(submission, :analyzer)
+    create_tooling_job!(submission, :analyzer)
 
     ToolingJob::Cancel.(submission.uuid, :analyzer)
 
@@ -39,16 +39,16 @@ class ToolingJob::CancelTest < ActiveSupport::TestCase
 
   test "cancels representation job" do
     submission = create_submission
-    id = write_submission_to_dynamodb(submission, :representer)
+    job = create_tooling_job!(submission, :representer)
 
     ToolingJob::Cancel.(submission.uuid, :representer)
 
-    assert_equal "cancelled", dynamodb_job_status(id)
+    assert_equal "cancelled", dynamodb_job_status(job.id)
   end
 
   test "set representation status to cancelled" do
     submission = create_submission
-    write_submission_to_dynamodb(submission, :representer)
+    create_tooling_job!(submission, :representer)
 
     ToolingJob::Cancel.(submission.uuid, :representer)
 
@@ -68,21 +68,5 @@ class ToolingJob::CancelTest < ActiveSupport::TestCase
       %i[job_status]
     )
     attrs["job_status"]
-  end
-
-  def write_submission_to_dynamodb(submission, type)
-    SecureRandom.uuid.tap do |id|
-      write_to_dynamodb(
-        Exercism.config.dynamodb_tooling_jobs_table,
-        {
-          "id" => id,
-          "type" => type,
-          "submission_uuid" => submission.uuid,
-          "execution_status" => "job-status",
-          "job_status" => "queued",
-          "output" => { "results.json" => "#{submission.id}/results.json" }
-        }
-      )
-    end
   end
 end

--- a/test/commands/tooling_job/process_test.rb
+++ b/test/commands/tooling_job/process_test.rb
@@ -2,30 +2,18 @@ require 'test_helper'
 
 class ToolingJob::ProcessTest < ActiveSupport::TestCase
   test "proxies to test run" do
-    id = SecureRandom.uuid
-    type = "test_runner"
-    submission_uuid = "submission-uuid"
+    submission = create :submission
     execution_status = "job-status"
     results = { 'some' => 'result' }
-
-    write_to_dynamodb(
-      Exercism.config.dynamodb_tooling_jobs_table,
-      {
-        "id" => id,
-        "type" => type,
-        "submission_uuid" => submission_uuid,
-        "execution_status" => execution_status,
-        "execution_output" => { "results.json" => results.to_json }
-      }
+    job = create_test_runner_job!(
+      submission,
+      execution_status: execution_status,
+      results: results
     )
 
-    Submission::TestRun::Process.expects(:call).with(
-      submission_uuid,
-      execution_status,
-      results
-    )
+    Submission::TestRun::Process.expects(:call).with(job)
 
-    ToolingJob::Process.(id)
+    ToolingJob::Process.(job.id)
   end
 
   test "proxies to representer" do

--- a/test/commands/tooling_job/process_test.rb
+++ b/test/commands/tooling_job/process_test.rb
@@ -7,13 +7,7 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
     submission_uuid = "submission-uuid"
     execution_status = "job-status"
     results = { 'some' => 'result' }
-    s3_key = "#{id}/results.json"
 
-    upload_to_s3(
-      Exercism.config.aws_tooling_jobs_bucket,
-      s3_key,
-      results.to_json
-    )
     write_to_dynamodb(
       Exercism.config.dynamodb_tooling_jobs_table,
       {
@@ -21,14 +15,13 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
         "type" => type,
         "submission_uuid" => submission_uuid,
         "execution_status" => execution_status,
-        "output" => { "results.json" => s3_key }
+        "execution_output" => { "results.json" => results.to_json }
       }
     )
 
     Submission::TestRun::Process.expects(:call).with(
       submission_uuid,
       execution_status,
-      "Nothing to report",
       results
     )
 
@@ -41,21 +34,8 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
     submission_uuid = "submission-uuid"
     execution_status = "job-status"
     representation_contents = "some\nrepresentation"
-    representation_s3_key = "#{id}/representation.txt"
-
     mapping_contents = { 'foo' => 'bar' }
-    mapping_s3_key = "#{id}/mapping.json"
 
-    upload_to_s3(
-      Exercism.config.aws_tooling_jobs_bucket,
-      representation_s3_key,
-      representation_contents
-    )
-    upload_to_s3(
-      Exercism.config.aws_tooling_jobs_bucket,
-      mapping_s3_key,
-      mapping_contents.to_json
-    )
     write_to_dynamodb(
       Exercism.config.dynamodb_tooling_jobs_table,
       {
@@ -63,9 +43,9 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
         "type" => type,
         "submission_uuid" => submission_uuid,
         "execution_status" => execution_status,
-        "output" => {
-          "representation.txt" => representation_s3_key,
-          "mapping.json" => mapping_s3_key
+        "execution_output" => {
+          "representation.txt" => representation_contents,
+          "mapping.json" => mapping_contents.to_json
         }
       }
     )
@@ -73,7 +53,6 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
     Submission::Representation::Process.expects(:call).with(
       submission_uuid,
       execution_status,
-      "Nothing to report",
       representation_contents,
       mapping_contents
     )
@@ -87,13 +66,7 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
     submission_uuid = "submission-uuid"
     execution_status = "job-status"
     analysis = { 'some' => 'result' }
-    s3_key = "#{id}/analysis.json"
 
-    upload_to_s3(
-      Exercism.config.aws_tooling_jobs_bucket,
-      s3_key,
-      analysis.to_json
-    )
     write_to_dynamodb(
       Exercism.config.dynamodb_tooling_jobs_table,
       {
@@ -101,14 +74,13 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
         "type" => type,
         "submission_uuid" => submission_uuid,
         "execution_status" => execution_status,
-        "output" => { "analysis.json" => s3_key }
+        "execution_output" => { "analysis.json" => analysis.to_json }
       }
     )
 
     Submission::Analysis::Process.expects(:call).with(
       submission_uuid,
       execution_status,
-      "Nothing to report",
       analysis
     )
 
@@ -121,13 +93,7 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
     submission = create :submission
     execution_status = "job-status"
     analysis = { 'some' => 'result' }
-    s3_key = "#{id}/analysis.json"
 
-    upload_to_s3(
-      Exercism.config.aws_tooling_jobs_bucket,
-      s3_key,
-      analysis.to_json
-    )
     write_to_dynamodb(
       Exercism.config.dynamodb_tooling_jobs_table,
       {
@@ -135,17 +101,12 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
         "type" => type,
         "submission_uuid" => submission.uuid,
         "execution_status" => execution_status,
-        "output" => { "analysis.json" => s3_key }
+        "execution_output" => { "analysis.json" => analysis.to_json }
       }
     )
 
     ToolingJob::Process.(id)
 
-    attrs = read_from_dynamodb(
-      Exercism.config.dynamodb_tooling_jobs_table,
-      { id: id },
-      %i[job_status]
-    )
-    assert_equal "processed", attrs["job_status"]
+    assert_equal "processed", ToolingJob.find(id).job_status
   end
 end

--- a/test/factories/submission/analyses.rb
+++ b/test/factories/submission/analyses.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :submission_analysis, class: 'Submission::Analysis' do
     submission
     ops_status { 200 }
-    ops_message { "success" }
     data do
       {
         status: "pass",

--- a/test/factories/submission/representations.rb
+++ b/test/factories/submission/representations.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :submission_representation, class: 'Submission::Representation' do
     submission
     ops_status { 200 }
-    ops_message { "success" }
     ast { SecureRandom.uuid }
   end
 end

--- a/test/factories/submission/test_runs.rb
+++ b/test/factories/submission/test_runs.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :submission_test_run, class: 'Submission::TestRun' do
     submission
+    tooling_job_id { SecureRandom.uuid }
+
     ops_status { 200 }
     raw_results do
       {

--- a/test/factories/submission/test_runs.rb
+++ b/test/factories/submission/test_runs.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :submission_test_run, class: 'Submission::TestRun' do
     submission
     ops_status { 200 }
-    ops_message { "success" }
     raw_results do
       {
         status: "pass",

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -34,7 +34,6 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
     Submission::TestRun::Process.(
       basics_submission_1.uuid,
       200,
-      'success',
       {
         status: :pass, message: nil, tests: [{ name: 'test1', status: 'pass' }]
       }
@@ -46,7 +45,6 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
     Submission::Analysis::Process.(
       basics_submission_1.uuid,
       200,
-      'success',
       { status: :refer_to_mentor, comments: [] }
     )
     assert basics_submission_1.reload.analysis_inconclusive?
@@ -63,7 +61,6 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
     Submission::Representation::Process.(
       basics_submission_1.uuid,
       200,
-      'success',
       'some ast',
       { 'some' => 'mapping' }
     )

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -31,13 +31,14 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
 
     # Simulate a test run being returned
     # It should pass
-    Submission::TestRun::Process.(
-      basics_submission_1.uuid,
-      200,
-      {
+    job = create_test_runner_job!(
+      basics_submission_1,
+      execution_status: 200,
+      results: {
         status: :pass, message: nil, tests: [{ name: 'test1', status: 'pass' }]
       }
     )
+    Submission::TestRun::Process.(job)
     assert basics_submission_1.reload.tests_passed?
 
     # Simulate an analysis being returned


### PR DESCRIPTION
Goes with:
- https://github.com/exercism/tooling-orchestrator/pull/18
- https://github.com/exercism/tooling-invoker/pull/23

Refactors the tooling jobs across the pathway to simplify things:
- Removes S3 for storing results (this will come back, but as as secondary action via the website, not via the orchestrator, which will speed things up)
- Uses one key for all the job metadata
- Adds a ToolingJob model wrapping the DynamoDB table
- Renders errors out on the maintaining dashboard (this was the cause of all this).

There's some small work to replicate the changes for representers and analyzers, but I'll do that once this is all good.