### PR TITLE
Use EFS for tooling

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+        uses: actions/setup-ruby@5f29a1cd8dfebf420691c4c9a0e832e2fae5a526
         with:
           ruby-version: 2.6.6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       ###
       # Setup Ruby - this needs to match the version in the Gemfile
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+        uses: actions/setup-ruby@5f29a1cd8dfebf420691c4c9a0e832e2fae5a526
         with:
           ruby-version: 2.6.6
 
@@ -82,6 +82,7 @@ jobs:
           MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
           S3_PORT: ${{ job.services.s3.ports['9090'] }}
         run: |
+          gem install bundler:2.1.4
           bundle config path vendor/bundle # This is needed for the caching above
           bundle install --jobs 4 --retry 3
           yarn install

--- a/app/commands/submission/analysis/init.rb
+++ b/app/commands/submission/analysis/init.rb
@@ -3,15 +3,15 @@ class Submission
     class Init
       include Mandate
 
-      initialize_with :submission_uuid, :language_slug, :exercise_slug, :s3_uri
+      initialize_with :job_id, :submission_uuid, :language_slug, :exercise_slug
 
       def call
         ToolingJob::Create.(
+          job_id,
           :analyzer,
           submission_uuid: submission_uuid,
           language: language_slug,
-          exercise: exercise_slug,
-          s3_uri: s3_uri
+          exercise: exercise_slug
         )
       end
     end

--- a/app/commands/submission/representation/init.rb
+++ b/app/commands/submission/representation/init.rb
@@ -3,15 +3,15 @@ class Submission
     class Init
       include Mandate
 
-      initialize_with :submission_uuid, :language_slug, :exercise_slug, :s3_uri
+      initialize_with :job_id, :submission_uuid, :language_slug, :exercise_slug
 
       def call
         ToolingJob::Create.(
+          job_id,
           :representer,
           submission_uuid: submission_uuid,
           language: language_slug,
-          exercise: exercise_slug,
-          s3_uri: s3_uri
+          exercise: exercise_slug
         )
       end
     end

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -3,15 +3,15 @@ class Submission
     class Init
       include Mandate
 
-      initialize_with :submission_uuid, :language_slug, :exercise_slug, :s3_uri
+      initialize_with :job_id, :submission_uuid, :language_slug, :exercise_slug
 
       def call
         ToolingJob::Create.(
+          job_id,
           :test_runner,
           submission_uuid: submission_uuid,
           language: language_slug,
-          exercise: exercise_slug,
-          s3_uri: s3_uri
+          exercise: exercise_slug
         )
       end
     end

--- a/app/commands/tooling_job/create.rb
+++ b/app/commands/tooling_job/create.rb
@@ -2,13 +2,13 @@ class ToolingJob
   class Create
     include Mandate
 
-    initialize_with :type, :attributes
+    initialize_with :id, :type, :attributes
 
     def call
       client.put_item(
         table_name: Exercism.config.dynamodb_tooling_jobs_table,
         item: attributes.merge(
-          id: SecureRandom.uuid,
+          id: id,
           created_at: Time.current.utc.to_i,
           type: type,
           job_status: :queued

--- a/app/commands/tooling_job/upload_files.rb
+++ b/app/commands/tooling_job/upload_files.rb
@@ -58,6 +58,8 @@ class ToolingJob
 
     memoize
     def folder
+      return "/mnt/tooling_jobs/#{job_id}" if Rails.env.production?
+
       "/tmp/exercism-tooling-jobs-efs/#{job_id}"
     end
   end

--- a/app/javascript/components/common/CopyToClipboardButton.tsx
+++ b/app/javascript/components/common/CopyToClipboardButton.tsx
@@ -10,7 +10,7 @@ const KEY_NAMES_LEGACY = Object.freeze({
 })
 
 export function CopyToClipboardButton({ textToCopy }: { textToCopy: string }) {
-  if (navigator.clipboard === undefined) {
+  if (window.navigator.clipboard === undefined) {
     return null
   }
 
@@ -18,7 +18,7 @@ export function CopyToClipboardButton({ textToCopy }: { textToCopy: string }) {
   const [justCopied, setJustCopied] = useState(false)
 
   const copyTextToClipboard = async () => {
-    await navigator.clipboard.writeText(textToCopy)
+    await window.navigator.clipboard.writeText(textToCopy)
     setJustCopied(true)
   }
 

--- a/app/models/tooling_job.rb
+++ b/app/models/tooling_job.rb
@@ -42,7 +42,6 @@ class ToolingJob
   attr_reader :id, :submission_uuid, :type, :job_status, :created_at
   attr_reader :language, :exercise, :locked_until
   attr_reader :execution_status, :execution_metadata, :execution_output
-  attr_reader :s3_uri
 
   def initialize(params)
     params.each { |key, value| send("#{key}=", value) }

--- a/test/commands/submission/analysis/init_test.rb
+++ b/test/commands/submission/analysis/init_test.rb
@@ -4,15 +4,20 @@ class Submission::Analysis::InitTest < ActiveSupport::TestCase
   test "calls to publish_message" do
     solution = create :concept_solution
     submission_uuid = SecureRandom.compact_uuid
-    s3_uri = "s3://..."
+    job_id = SecureRandom.uuid
 
     ToolingJob::Create.expects(:call).with(
+      job_id,
       :analyzer,
       submission_uuid: submission_uuid,
       language: solution.track.slug,
-      exercise: solution.exercise.slug,
-      s3_uri: s3_uri
+      exercise: solution.exercise.slug
     )
-    Submission::Analysis::Init.(submission_uuid, solution.track.slug, solution.exercise.slug, s3_uri)
+    Submission::Analysis::Init.(
+      job_id,
+      submission_uuid,
+      solution.track.slug,
+      solution.exercise.slug
+    )
   end
 end

--- a/test/commands/submission/create_test.rb
+++ b/test/commands/submission/create_test.rb
@@ -15,7 +15,7 @@ class Submission::CreateTest < ActiveSupport::TestCase
       { filename: filename_2, content: content_2 }
     ]
 
-    Submission::UploadWithExercise.expects(:call)
+    ToolingJob::UploadFiles.expects(:call)
     Submission::TestRun::Init.expects(:call)
 
     # TODO: Move to iteration::create
@@ -59,10 +59,6 @@ class Submission::CreateTest < ActiveSupport::TestCase
       { filename: filename_2, content: content_2 }
     ]
 
-    # We'll call upload so stub it
-    Submission::UploadWithExercise.stubs(:call)
-    ToolingJob::Create.stubs(:call)
-
     # Do it once successfully
     Submission::Create.(solution, files, :cli)
 
@@ -81,8 +77,6 @@ class Submission::CreateTest < ActiveSupport::TestCase
   test "award rookie badge job is enqueued" do
     # Generic setup
     files = [{ filename: 'foo.bar', content: "foobar" }]
-    Submission::UploadWithExercise.stubs(:call)
-    ToolingJob::Create.stubs(:call)
 
     # Create user and solution
     user = create :user

--- a/test/commands/submission/representation/init_test.rb
+++ b/test/commands/submission/representation/init_test.rb
@@ -4,15 +4,20 @@ class Submission::Representation::InitTest < ActiveSupport::TestCase
   test "calls to publish_message" do
     solution = create :concept_solution
     submission_uuid = SecureRandom.compact_uuid
-    s3_uri = "s3://..."
+    job_id = SecureRandom.uuid
 
     ToolingJob::Create.expects(:call).with(
+      job_id,
       :representer,
       submission_uuid: submission_uuid,
       language: solution.track.slug,
-      exercise: solution.exercise.slug,
-      s3_uri: s3_uri
+      exercise: solution.exercise.slug
     )
-    Submission::Representation::Init.(submission_uuid, solution.track.slug, solution.exercise.slug, s3_uri)
+    Submission::Representation::Init.(
+      job_id,
+      submission_uuid,
+      solution.track.slug,
+      solution.exercise.slug
+    )
   end
 end

--- a/test/commands/submission/test_run/init_test.rb
+++ b/test/commands/submission/test_run/init_test.rb
@@ -3,21 +3,21 @@ require 'test_helper'
 class Submission::TestRun::InitTest < ActiveSupport::TestCase
   test "calls to publish_message" do
     solution = create :concept_solution
+    job_id = SecureRandom.uuid
     submission_uuid = SecureRandom.compact_uuid
-    s3_uri = "s3://..."
 
     ToolingJob::Create.expects(:call).with(
+      job_id,
       :test_runner,
       submission_uuid: submission_uuid,
       language: solution.track.slug,
-      exercise: solution.exercise.slug,
-      s3_uri: s3_uri
+      exercise: solution.exercise.slug
     )
     Submission::TestRun::Init.(
+      job_id,
       submission_uuid,
       solution.track.slug,
-      solution.exercise.slug,
-      s3_uri
+      solution.exercise.slug
     )
   end
 end

--- a/test/commands/tooling_job/create_test.rb
+++ b/test/commands/tooling_job/create_test.rb
@@ -21,7 +21,7 @@ class ToolingJob::CreateTest < ActiveSupport::TestCase
         }
       )
 
-      ToolingJob::Create.(type, { foo: :bar })
+      ToolingJob::Create.(SecureRandom.uuid, type, { foo: :bar })
     end
   end
 end

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -21,7 +21,6 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
     basics_solution = Solution::Create.(user, concept_exercise_basics)
 
     # Submit an submission
-    Submission::UploadWithExercise.stubs(:call)
     ToolingJob::Create.stubs(:call)
     basics_submission_1 = Submission::Create.(
       basics_solution,


### PR DESCRIPTION
This changes things so that we use EFS instead of S3. It's one of those changes that is quite small but requires changes all the way through the stack, so I've decided to do it now, before getting representers and analyzers fully working in the next couple of weeks.

This goes with:
- https://github.com/exercism/tooling-orchestrator/pull/19
- https://github.com/exercism/tooling-invoker/pull/25
- Terraform changes (yet to PR)