### PR TITLE
Revert to simpler localstorage hook

### DIFF
--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -9,7 +9,7 @@ import React, {
 import { File } from '../Editor'
 import { ExercismMonacoEditor } from './ExercismMonacoEditor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
-import { useStorage } from '../../../utils/use-storage'
+import { useLocalStorage } from '../../../utils/use-storage'
 
 export type FileEditorHandle = {
   getFile: () => File
@@ -34,7 +34,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
       glyphMargin: true,
       lightbulb: { enabled: true },
     })
-    const [content, setContent] = useStorage<string>(
+    const [content, setContent] = useLocalStorage<string>(
       `${file.filename}-editor-content`,
       file.content
     )
@@ -59,7 +59,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
     )
     const revertContent = useCallback(
       (e) => {
-        setContent(file.content)
+        editorRef.current?.setValue(file.content)
       },
       [setContent, file]
     )

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -34,7 +34,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
       glyphMargin: true,
       lightbulb: { enabled: true },
     })
-    const [content, setContent] = useLocalStorage<string>(
+    const [content, setContent] = useLocalStorage(
       `${file.filename}-editor-content`,
       file.content
     )

--- a/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
@@ -15,6 +15,11 @@ export function ExercismMonacoEditor({
     getValue: () => {
       return textareaRef.current?.value
     },
+    setValue: (value) => {
+      if (textareaRef.current) {
+        textareaRef.current.value = value
+      }
+    },
   }
 
   useEffect(() => {

--- a/app/javascript/utils/use-storage.ts
+++ b/app/javascript/utils/use-storage.ts
@@ -1,8 +1,34 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { StoredMemoryValue, useMutableMemoryValue } from 'use-memory-value'
 
 export function useStorage<T>(key: string, initialValue: T) {
   const memoryValue = new StoredMemoryValue<T>(key, true, initialValue)
 
   return useMutableMemoryValue(memoryValue)
+}
+
+export function useLocalStorage(key: string, initialValue: string) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = localStorage.getItem(key)
+
+      return item || initialValue
+    } catch (error) {
+      console.log(error)
+
+      return initialValue
+    }
+  })
+
+  const setValue = (value: string) => {
+    try {
+      setStoredValue(value)
+
+      localStorage.setItem(key, value)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return [storedValue, setValue]
 }

--- a/test/javascript/components/student/Editor/FileEditor.test.js
+++ b/test/javascript/components/student/Editor/FileEditor.test.js
@@ -6,7 +6,6 @@ import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { FileEditor } from '../../../../../app/javascript/components/student/editor/FileEditor'
-import localForage from 'localforage'
 
 test('change theme', async () => {
   const { queryByText, getByLabelText } = render(
@@ -15,9 +14,9 @@ test('change theme', async () => {
 
   fireEvent.change(getByLabelText('Theme'), { target: { value: 'vs-dark' } })
 
-  await waitFor(() => expect(queryByText('Theme: vs-dark')).toBeInTheDocument())
+  expect(queryByText('Theme: vs-dark')).toBeInTheDocument()
 
-  await localForage.clear()
+  localStorage.clear()
 })
 
 test('change wrapping', async () => {
@@ -27,9 +26,9 @@ test('change wrapping', async () => {
 
   fireEvent.change(getByLabelText('Wrap'), { target: { value: 'off' } })
 
-  await waitFor(() => expect(queryByText('Wrap: off')).toBeInTheDocument())
+  expect(queryByText('Wrap: off')).toBeInTheDocument()
 
-  await localForage.clear()
+  localStorage.clear()
 })
 
 test('apply correct syntax highlighting', async () => {
@@ -37,20 +36,20 @@ test('apply correct syntax highlighting', async () => {
     <FileEditor file={{ name: 'file', content: '' }} language="go" />
   )
 
-  await waitFor(() => expect(queryByText('Language: go')).toBeInTheDocument())
+  expect(queryByText('Language: go')).toBeInTheDocument()
 
-  await localForage.clear()
+  localStorage.clear()
 })
 
 test('loads data from storage', async () => {
-  await localForage.setItem('file-editor-content', 'class')
+  localStorage.setItem('file-editor-content', 'class')
   const { queryByText } = render(
     <FileEditor file={{ filename: 'file', content: '' }} language="go" />
   )
 
-  await waitFor(() => expect(queryByText('Value: class')).toBeInTheDocument())
+  expect(queryByText('Value: class')).toBeInTheDocument()
 
-  await localForage.clear()
+  localStorage.clear()
 })
 
 test('saves data to storage when data changed', async () => {
@@ -64,25 +63,26 @@ test('saves data to storage when data changed', async () => {
     jest.runOnlyPendingTimers()
   })
 
-  expect(await localForage.getItem('file-editor-content')).toEqual('code')
+  expect(localStorage.getItem('file-editor-content')).toEqual('code')
 
-  await localForage.clear()
+  localStorage.clear()
 })
 
 test('revert to last submission', async () => {
-  await localForage.setItem('file-editor-content', 'class')
+  localStorage.setItem('file-editor-content', 'class')
   const { queryByText } = render(
     <FileEditor file={{ filename: 'file', content: 'file' }} language="go" />
   )
 
-  await waitFor(() => expect(queryByText('Value: class')).toBeInTheDocument())
+  expect(queryByText('Value: class')).toBeInTheDocument()
 
   fireEvent.click(queryByText('Revert to last run code'))
+  await waitFor(() => {
+    jest.runOnlyPendingTimers()
+  })
 
-  await waitFor(() => expect(queryByText('Value: file')).toBeInTheDocument())
-  await waitFor(() =>
-    expect(queryByText('Revert to last run code')).not.toBeInTheDocument()
-  )
+  expect(queryByText('Value: file')).toBeInTheDocument()
+  expect(queryByText('Revert to last run code')).not.toBeInTheDocument()
 
-  await localForage.clear()
+  localStorage.clear()
 })


### PR DESCRIPTION
Closes https://github.com/exercism/v3-website/issues/289.

When using the`useMemory` hook, it somehow changes `''` to `null`, which causes the revert code to not run properly. I'm unsure what causes this, but I decided to use the `localStorage` for now in order for us to not have this problem.