### PR TITLE
Pull monaco editor chunks correctly on production

### DIFF
--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -75,7 +75,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
 
     useEffect(() => {
       const interval = setInterval(() => {
-        setContent(editorRef.current?.getValue())
+        setContent(editorRef.current?.getValue() || '')
       }, SAVE_INTERVAL)
 
       return () => clearInterval(interval)

--- a/app/javascript/utils/use-storage.ts
+++ b/app/javascript/utils/use-storage.ts
@@ -30,5 +30,5 @@ export function useLocalStorage(key: string, initialValue: string) {
     }
   }
 
-  return [storedValue, setValue]
+  return [storedValue, setValue] as const
 }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -5,6 +5,20 @@ const aliases = {
 }
 
 environment.config.merge({ resolve: { alias: aliases } })
-environment.plugins.append('MonacoWebpackPlugin', new MonacoWebpackPlugin())
+
+let ASSET_HOST
+
+if (process.env.NODE_ENV === 'production') {
+  ASSET_HOST = 'https://exercism-assets-staging.s3.eu-west-2.amazonaws.com'
+} else {
+  ASSET_HOST = ''
+}
+
+environment.plugins.append(
+  'MonacoWebpackPlugin',
+  new MonacoWebpackPlugin({
+    publicPath: ASSET_HOST,
+  })
+)
 
 module.exports = environment

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,10 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
+environment.config.merge({
+  output: {
+    publicPath: 'https://exercism-assets-staging.s3.eu-west-2.amazonaws.com',
+  },
+})
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
## Description
On production, Monaco Editor isn't able to apply syntax highlighting because it loads the language chunks dynamically. We need to set the pack's `publicPath` in order to point the editor to where it should load the language chunks. We don't encounter this in development as we don't use a CDN to host our assets.

I'm not completely sure that this will work on production, but I'd like to get this merged in order to test if it does. Thus, I've held off on pulling the config from an environment variable such as `ASSET_HOST`, and just decided to hard code it for now.
We can improve further once we're sure that this fix works.