### PR TITLE
Fix concept map test

### DIFF
--- a/app/javascript/components/concept-map/ConceptMap.tsx
+++ b/app/javascript/components/concept-map/ConceptMap.tsx
@@ -27,7 +27,7 @@ export const ConceptMap = ({
   levels,
   connections,
   status,
-  exercise_counts = {},
+  exerciseCounts = {},
 }: IConceptMap): JSX.Element => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const fontLoaded = useFontLoaded('Poppins')
@@ -69,9 +69,9 @@ export const ConceptMap = ({
                     name={concept.name}
                     webUrl={concept.webUrl}
                     tooltipUrl={concept.tooltipUrl}
-                    exercises={exercise_counts[slug]?.exercises ?? 0}
+                    exercises={exerciseCounts[slug]?.exercises ?? 0}
                     exercisesCompleted={
-                      exercise_counts[slug]?.exercises_completed ?? 0
+                      exerciseCounts[slug]?.exercisesCompleted ?? 0
                     }
                     handleEnter={() => setActiveSlug(slug)}
                     handleLeave={unsetActiveSlug}

--- a/app/javascript/components/concept-map/concept-map-types.ts
+++ b/app/javascript/components/concept-map/concept-map-types.ts
@@ -55,8 +55,8 @@ export interface IConceptMap {
   levels: ConceptLayer[]
   connections: ConceptConnection[]
   status: { [key: string]: ConceptStatus }
-  exercise_counts: {
-    [key: string]: { exercises: number; exercises_completed: number }
+  exerciseCounts: {
+    [key: string]: { exercises: number; exercisesCompleted: number }
   }
 }
 

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -99,7 +99,7 @@ initReact({
         levels={mapData.levels}
         connections={mapData.connections}
         status={mapData.status}
-        exercise_counts={mapData.exercise_counts}
+        exerciseCounts={mapData.exerciseCounts}
       />
     )
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/javascript/components/concept-map/ConceptMap.test.tsx
+++ b/test/javascript/components/concept-map/ConceptMap.test.tsx
@@ -3,108 +3,90 @@ import React from 'react'
 import '@testing-library/jest-dom'
 
 // Test deps
-import {
-  getByText,
-  getByTitle,
-  queryByTitle,
-  render,
-} from '@testing-library/react'
+import { screen, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
 // Component
 import { ConceptMap } from '../../../../app/javascript/components/concept-map/ConceptMap'
-import {
-  ConceptStatus,
-  IConcept as Concept,
-  ConceptConnection,
-  ConceptLayer,
-} from '../../../../app/javascript/components/concept-map/concept-map-types'
 
 describe('<ConceptMap />', () => {
   test('renders empty component', () => {
-    const { container } = renderMap([], [], [], {}, {})
+    const { container } = render(
+      <ConceptMap
+        concepts={[]}
+        levels={[[]]}
+        connections={[]}
+        status={{}}
+        exercise_counts={{}}
+      />
+    )
     const map = container.querySelector('.c-concepts-map')
     expect(map).not.toBeNull()
   })
 
-  test('renders single incomplete concept', () => {
+  test('renders single incomplete concept', async () => {
     const testConcept = concept('test')
-    const { container } = renderMap(
-      [testConcept],
-      [[testConcept.slug]],
-      [],
-      {
-        test: 'unavailable',
-      },
-      {
-        test: {
-          exercises: 1,
-          exercises_completed: 0,
-        },
-      }
+
+    render(
+      <ConceptMap
+        concepts={[testConcept]}
+        levels={[[testConcept.slug]]}
+        connections={[]}
+        status={{
+          test: 'unavailable',
+        }}
+        exercise_counts={{
+          test: {
+            exercises: 1,
+            exercises_completed: 0,
+          },
+        }}
+      />
     )
-    const conceptEl = getByText(container, 'Test')
-    expect(conceptEl).toBeInTheDocument()
-    const completeIconEl = queryByTitle(
-      container,
-      'You have mastered this concept'
-    )
-    expect(completeIconEl).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test')).toBeInTheDocument()
+      expect(
+        screen.queryByTitle('You have mastered this concept')
+      ).not.toBeInTheDocument()
+    })
   })
 
-  test('renders single completed concept', () => {
+  test('renders single completed concept', async () => {
     const testConcept = concept('test')
-    const { container } = renderMap(
-      [testConcept],
-      [[testConcept.slug]],
-      [],
-      {
-        test: 'completed',
-      },
-      {
-        test: {
-          exercises: 1,
-          exercises_completed: 1,
-        },
-      }
+    render(
+      <ConceptMap
+        concepts={[testConcept]}
+        levels={[[testConcept.slug]]}
+        connections={[]}
+        status={{
+          test: 'completed',
+        }}
+        exercise_counts={{
+          test: {
+            exercises: 1,
+            exercises_completed: 1,
+          },
+        }}
+      />
     )
-    const conceptEl = getByText(container, 'Test')
-    expect(conceptEl).toBeInTheDocument()
-    const completeIconEl = getByTitle(
-      container,
-      'You have mastered this concept'
-    )
-    expect(completeIconEl).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test')).toBeInTheDocument()
+      expect(
+        screen.getByTitle('You have mastered this concept')
+      ).toBeInTheDocument()
+    })
   })
 })
 
-const concept = (conceptName: string): Concept => {
+const concept = (conceptName: string) => {
   return {
     slug: conceptName,
     name: slugToTitlecase(conceptName),
     webUrl: `link-for-${conceptName}`,
     tooltipUrl: `tooltop-link-for${conceptName}`,
   }
-}
-
-const renderMap = (
-  concepts: Concept[],
-  levels: ConceptLayer[],
-  connections: ConceptConnection[],
-  status: { [key: string]: ConceptStatus },
-  exercise_counts: {
-    [key: string]: { exercises: number; exercises_completed: number }
-  }
-) => {
-  return render(
-    <ConceptMap
-      concepts={concepts}
-      levels={levels}
-      connections={connections}
-      status={status}
-      exercise_counts={exercise_counts}
-    />
-  )
 }
 
 function slugToTitlecase(slug: string): string {

--- a/test/javascript/components/concept-map/ConceptMap.test.tsx
+++ b/test/javascript/components/concept-map/ConceptMap.test.tsx
@@ -17,7 +17,7 @@ describe('<ConceptMap />', () => {
       levels: [[]],
       connections: [],
       status: {},
-      exercise_counts: {},
+      exerciseCounts: {},
     }
 
     const { container } = await waitForConceptMapReady(config)
@@ -33,7 +33,7 @@ describe('<ConceptMap />', () => {
       levels: [[testConcept.slug]],
       connections: [],
       status: { test: 'unavailable' },
-      exercise_counts: { test: { exercises: 1, exercises_completed: 0 } },
+      exerciseCounts: { test: { exercises: 1, exercisesCompleted: 0 } },
     }
 
     await waitForConceptMapReady(config)
@@ -51,7 +51,7 @@ describe('<ConceptMap />', () => {
       levels: [[testConcept.slug]],
       connections: [],
       status: { test: 'unavailable' },
-      exercise_counts: { test: { exercises: 1, exercises_completed: 1 } },
+      exerciseCounts: { test: { exercises: 1, exercisesCompleted: 1 } },
     }
 
     await waitForConceptMapReady(config)
@@ -69,7 +69,7 @@ const waitForConceptMapReady = async (config: IConceptMap) => {
       levels={config.levels}
       connections={config.connections}
       status={config.status}
-      exercise_counts={config.exercise_counts}
+      exerciseCounts={config.exerciseCounts}
     />
   )
 

--- a/test/javascript/components/concept-map/ConceptMap.test.tsx
+++ b/test/javascript/components/concept-map/ConceptMap.test.tsx
@@ -1,9 +1,9 @@
 // Deps
 import React from 'react'
+import '@testing-library/jest-dom'
 
 // Test deps
 import {
-  getByTestId,
   getByText,
   getByTitle,
   queryByTitle,
@@ -22,26 +22,38 @@ import {
 
 describe('<ConceptMap />', () => {
   test('renders empty component', () => {
-    const { container } = renderMap([], [], [], {})
+    const { container } = renderMap([], [], [], {}, {})
     const map = container.querySelector('.c-concepts-map')
     expect(map).not.toBeNull()
   })
 
   test('renders single incomplete concept', () => {
     const testConcept = concept('test')
-    const { container } = renderMap([testConcept], [[testConcept.slug]], [], {
-      test: 'locked',
-    })
+    const { container } = renderMap(
+      [testConcept],
+      [[testConcept.slug]],
+      [],
+      {
+        test: 'unavailable',
+      },
+      {
+        test: {
+          exercises: 1,
+          exercises_completed: 0,
+        },
+      }
+    )
     const conceptEl = getByText(container, 'Test')
+    expect(conceptEl).toBeInTheDocument()
     const completeIconEl = queryByTitle(
       container,
       'You have mastered this concept'
     )
-    expect(completeIconEl).toBeNull()
+    expect(completeIconEl).not.toBeInTheDocument()
   })
 
   test('renders single completed concept', () => {
-    const testConcept = concept('test', { state: 'completed' })
+    const testConcept = concept('test')
     const { container } = renderMap(
       [testConcept],
       [[testConcept.slug]],
@@ -57,26 +69,21 @@ describe('<ConceptMap />', () => {
       }
     )
     const conceptEl = getByText(container, 'Test')
+    expect(conceptEl).toBeInTheDocument()
     const completeIconEl = getByTitle(
       container,
       'You have mastered this concept'
     )
+    expect(completeIconEl).toBeInTheDocument()
   })
 })
 
-const concept = (
-  conceptName: string,
-  options: {
-    index?: number
-    state?: ConceptStatus
-  } = {}
-): Concept => {
-  const index = options.index ?? 0
-
+const concept = (conceptName: string): Concept => {
   return {
     slug: conceptName,
     name: slugToTitlecase(conceptName),
     webUrl: `link-for-${conceptName}`,
+    tooltipUrl: `tooltop-link-for${conceptName}`,
   }
 }
 

--- a/test/javascript/tsconfig.json
+++ b/test/javascript/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["webpack-env", "app/javascript/declarations", "jest"]
+  },
+  "includes": ["**/*.spec.ts", "**/*.spec.tsx"]
+}

--- a/test/javascript/tsconfig.json
+++ b/test/javascript/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["webpack-env", "app/javascript/declarations", "jest"]
+    "types": ["webpack-env", "../../app/javascript/declarations", "jest"]
   },
   "includes": ["**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,14 @@
     "strict": true,
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["webpack-env", "app/javascript/declarations", "jest"]
+    "types": ["webpack-env", "app/javascript/declarations"]
   },
-  "exclude": ["**/*.spec.ts", "node_modules", "vendor", "public"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "node_modules",
+    "vendor",
+    "public"
+  ],
   "compileOnSave": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["webpack-env", "app/javascript/declarations"]
+    "types": ["webpack-env", "app/javascript/declarations", "jest"]
   },
   "exclude": ["**/*.spec.ts", "node_modules", "vendor", "public"],
   "compileOnSave": false


### PR DESCRIPTION
The concept  map component starts hidden, then unhides itself when it
detects that all styles have been loaded. This wasn't being accounted
for in the tests. So now it is using a `waitFor` promise to allow the
component to reach a steady state before testing the assertion.

close #312 