### PR TITLE
Add settings panel

### DIFF
--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -14,7 +14,13 @@ import { Settings } from './editor/Settings'
 import { FileEditor, FileEditorHandle } from './editor/FileEditor'
 import { fetchJSON } from '../../utils/fetch-json'
 import { typecheck } from '../../utils/typecheck'
-import { Submission, TestRun, TestRunStatus, File } from './editor/types'
+import {
+  Submission,
+  TestRun,
+  TestRunStatus,
+  File,
+  Keybindings,
+} from './editor/types'
 import { Iteration } from '../track/IterationSummary'
 import { GraphicalIcon } from '../common/GraphicalIcon'
 import { Icon } from '../common/Icon'
@@ -145,6 +151,9 @@ export function Editor({
   exampleSolution: string
 }) {
   const [theme, setTheme] = useState('vs')
+  const [keybindings, setKeybindings] = useState<Keybindings>(
+    Keybindings.DEFAULT
+  )
   const [tab, setTab] = useState<TabIndex>(TabIndex.INSTRUCTIONS)
   const isMountedRef = useIsMounted()
   const [{ submission, status, apiError }, dispatch] = useReducer(reducer, {
@@ -336,7 +345,7 @@ export function Editor({
           <Icon icon="keyboard" alt="Keyboard Shortcuts" />
         </button>
 
-        <Settings setTheme={setTheme} />
+        <Settings setTheme={setTheme} setKeybindings={setKeybindings} />
 
         <button className="more-btn">
           <Icon icon="more-horizontal" alt="Open more options" />
@@ -351,6 +360,7 @@ export function Editor({
             ref={editor.ref}
             language={language}
             theme={theme}
+            keybindings={keybindings}
             onRunTests={runTests}
           />
         ))}

--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -10,6 +10,7 @@ import { TestRunSummary } from './editor/TestRunSummary'
 import { Submitting } from './editor/Submitting'
 import { Tab } from './editor/Tab'
 import { TabPanel } from './editor/TabPanel'
+import { Settings } from './editor/Settings'
 import { FileEditor, FileEditorHandle } from './editor/FileEditor'
 import { fetchJSON } from '../../utils/fetch-json'
 import { typecheck } from '../../utils/typecheck'
@@ -143,6 +144,7 @@ export function Editor({
   instructions: string
   exampleSolution: string
 }) {
+  const [theme, setTheme] = useState('vs')
   const [tab, setTab] = useState<TabIndex>(TabIndex.INSTRUCTIONS)
   const isMountedRef = useIsMounted()
   const [{ submission, status, apiError }, dispatch] = useReducer(reducer, {
@@ -334,9 +336,7 @@ export function Editor({
           <Icon icon="keyboard" alt="Keyboard Shortcuts" />
         </button>
 
-        <button className="settings-btn">
-          <Icon icon="settings" alt="Settings" />
-        </button>
+        <Settings setTheme={setTheme} />
 
         <button className="more-btn">
           <Icon icon="more-horizontal" alt="Open more options" />
@@ -350,6 +350,7 @@ export function Editor({
             file={editor.file}
             ref={editor.ref}
             language={language}
+            theme={theme}
             onRunTests={runTests}
           />
         ))}

--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -154,6 +154,9 @@ export function Editor({
   const [keybindings, setKeybindings] = useState<Keybindings>(
     Keybindings.DEFAULT
   )
+  const [wrap, setWrap] = useState<'off' | 'on' | 'wordWrapColumn' | 'bounded'>(
+    'on'
+  )
   const [tab, setTab] = useState<TabIndex>(TabIndex.INSTRUCTIONS)
   const isMountedRef = useIsMounted()
   const [{ submission, status, apiError }, dispatch] = useReducer(reducer, {
@@ -345,7 +348,11 @@ export function Editor({
           <Icon icon="keyboard" alt="Keyboard Shortcuts" />
         </button>
 
-        <Settings setTheme={setTheme} setKeybindings={setKeybindings} />
+        <Settings
+          setTheme={setTheme}
+          setKeybindings={setKeybindings}
+          setWrap={setWrap}
+        />
 
         <button className="more-btn">
           <Icon icon="more-horizontal" alt="Open more options" />
@@ -361,6 +368,7 @@ export function Editor({
             language={language}
             theme={theme}
             keybindings={keybindings}
+            wrap={wrap}
             onRunTests={runTests}
           />
         ))}

--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -349,6 +349,9 @@ export function Editor({
         </button>
 
         <Settings
+          theme={theme}
+          keybindings={keybindings}
+          wrap={wrap}
           setTheme={setTheme}
           setKeybindings={setKeybindings}
           setWrap={setWrap}

--- a/app/javascript/components/student/Editor.tsx
+++ b/app/javascript/components/student/Editor.tsx
@@ -20,6 +20,7 @@ import {
   TestRunStatus,
   File,
   Keybindings,
+  WrapSetting,
 } from './editor/types'
 import { Iteration } from '../track/IterationSummary'
 import { GraphicalIcon } from '../common/GraphicalIcon'
@@ -154,9 +155,7 @@ export function Editor({
   const [keybindings, setKeybindings] = useState<Keybindings>(
     Keybindings.DEFAULT
   )
-  const [wrap, setWrap] = useState<'off' | 'on' | 'wordWrapColumn' | 'bounded'>(
-    'on'
-  )
+  const [wrap, setWrap] = useState<WrapSetting>('on')
   const [tab, setTab] = useState<TabIndex>(TabIndex.INSTRUCTIONS)
   const isMountedRef = useIsMounted()
   const [{ submission, status, apiError }, dispatch] = useReducer(reducer, {

--- a/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
@@ -14,6 +14,7 @@ import ReconnectingWebsocket from 'reconnecting-websocket'
 import { v4 as uuidv4 } from 'uuid'
 import { initVimMode, VimMode } from 'monaco-vim'
 import { EmacsExtension } from 'monaco-emacs'
+import { Keybindings } from './types'
 
 export type FileEditorHandle = {
   getFile: () => File
@@ -23,12 +24,6 @@ type FileEditorProps = {
   file: File
   language: string
   onRunTests: () => void
-}
-
-export enum Keybindings {
-  DEFAULT = 'default',
-  VIM = 'vim',
-  EMACS = 'emacs',
 }
 
 const SAVE_INTERVAL = 500

--- a/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/ExercismMonacoEditor.tsx
@@ -33,7 +33,7 @@ export function ExercismMonacoEditor({
   editorDidMount,
   onRunTests,
   options,
-  value,
+  defaultValue,
   theme,
   keybindings,
 }: {
@@ -41,7 +41,7 @@ export function ExercismMonacoEditor({
   editorDidMount: (editor: monacoEditor.editor.IStandaloneCodeEditor) => void
   onRunTests: () => void
   options: monacoEditor.editor.IStandaloneEditorConstructionOptions
-  value: string | null | undefined
+  defaultValue: string | undefined
   theme: string
   keybindings: Keybindings
 }) {
@@ -149,7 +149,7 @@ export function ExercismMonacoEditor({
         language={language}
         editorDidMount={handleEditorDidMount}
         options={options}
-        value={value}
+        defaultValue={defaultValue}
         theme={theme}
       />
       <div ref={statusBarRef}></div>

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -17,10 +17,11 @@ type FileEditorProps = {
   file: File
   language: string
   onRunTests: () => void
+  theme: string
 }
 
 export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
-  ({ file, language, onRunTests }, ref) => {
+  ({ file, language, onRunTests, theme }, ref) => {
     const options: monacoEditor.editor.IStandaloneEditorConstructionOptions = {
       minimap: { enabled: false },
       wordWrap: 'on',
@@ -54,7 +55,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
           onRunTests={onRunTests}
           options={options}
           value={file.content}
-          theme={'vs'}
+          theme={theme}
           keybindings={Keybindings.DEFAULT}
         />
       </div>

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -4,8 +4,8 @@ import React, {
   useImperativeHandle,
   useCallback,
 } from 'react'
-import { File } from './types'
-import { ExercismMonacoEditor, Keybindings } from './ExercismMonacoEditor'
+import { File, Keybindings } from './types'
+import { ExercismMonacoEditor } from './ExercismMonacoEditor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 import { useLocalStorage } from '../../../utils/use-storage'
 
@@ -18,10 +18,11 @@ type FileEditorProps = {
   language: string
   onRunTests: () => void
   theme: string
+  keybindings: Keybindings
 }
 
 export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
-  ({ file, language, onRunTests, theme }, ref) => {
+  ({ file, language, onRunTests, theme, keybindings }, ref) => {
     const options: monacoEditor.editor.IStandaloneEditorConstructionOptions = {
       minimap: { enabled: false },
       wordWrap: 'on',
@@ -56,7 +57,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
           options={options}
           value={file.content}
           theme={theme}
-          keybindings={Keybindings.DEFAULT}
+          keybindings={keybindings}
         />
       </div>
     )

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -19,13 +19,14 @@ type FileEditorProps = {
   onRunTests: () => void
   theme: string
   keybindings: Keybindings
+  wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
 }
 
 export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
-  ({ file, language, onRunTests, theme, keybindings }, ref) => {
+  ({ file, language, onRunTests, theme, keybindings, wrap }, ref) => {
     const options: monacoEditor.editor.IStandaloneEditorConstructionOptions = {
       minimap: { enabled: false },
-      wordWrap: 'on',
+      wordWrap: wrap,
       glyphMargin: true,
       lightbulb: { enabled: true },
       automaticLayout: true,

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -4,7 +4,7 @@ import React, {
   useImperativeHandle,
   useCallback,
 } from 'react'
-import { File, Keybindings } from './types'
+import { File, Keybindings, WrapSetting } from './types'
 import { ExercismMonacoEditor } from './ExercismMonacoEditor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 import { useLocalStorage } from '../../../utils/use-storage'
@@ -19,7 +19,7 @@ type FileEditorProps = {
   onRunTests: () => void
   theme: string
   keybindings: Keybindings
-  wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
+  wrap: WrapSetting
 }
 
 export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(

--- a/app/javascript/components/student/editor/FileEditor.tsx
+++ b/app/javascript/components/student/editor/FileEditor.tsx
@@ -56,7 +56,7 @@ export const FileEditor = forwardRef<FileEditorHandle, FileEditorProps>(
           editorDidMount={editorDidMount}
           onRunTests={onRunTests}
           options={options}
-          value={file.content}
+          defaultValue={file.content}
           theme={theme}
           keybindings={keybindings}
         />

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { usePopper } from 'react-popper'
+import { Icon } from '../../common/Icon'
+
+export function Settings({ setTheme }: { setTheme: (theme: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const componentRef = useRef<HTMLDivElement>(null)
+  const { styles, attributes } = usePopper(
+    buttonRef.current,
+    panelRef.current,
+    {
+      placement: 'bottom',
+    }
+  )
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (componentRef.current?.contains(e.target as Node)) {
+      return
+    }
+
+    setOpen(false)
+  }
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [])
+
+  return (
+    <div ref={componentRef}>
+      <button
+        ref={buttonRef}
+        className="settings-btn"
+        type="button"
+        onClick={() => {
+          setOpen(!open)
+        }}
+      >
+        <Icon icon="settings" alt="Settings" />
+      </button>
+      <div ref={panelRef} style={styles.popper} {...attributes.popper}>
+        {open ? (
+          <div>
+            <label htmlFor="theme">Theme</label>
+            <select id="theme" onChange={(e) => setTheme(e.target.value)}>
+              <option value="vs">Light</option>
+              <option value="vs-dark">Dark</option>
+            </select>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -1,8 +1,15 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { usePopper } from 'react-popper'
 import { Icon } from '../../common/Icon'
+import { Keybindings } from './types'
 
-export function Settings({ setTheme }: { setTheme: (theme: string) => void }) {
+export function Settings({
+  setTheme,
+  setKeybindings,
+}: {
+  setTheme: (theme: string) => void
+  setKeybindings: (keybinding: Keybindings) => void
+}) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -50,6 +57,15 @@ export function Settings({ setTheme }: { setTheme: (theme: string) => void }) {
             <select id="theme" onChange={(e) => setTheme(e.target.value)}>
               <option value="vs">Light</option>
               <option value="vs-dark">Dark</option>
+            </select>
+            <label htmlFor="keybindings">Keybindings</label>
+            <select
+              id="keybindings"
+              onChange={(e) => setKeybindings(e.target.value as Keybindings)}
+            >
+              <option value={Keybindings.DEFAULT}>Default</option>
+              <option value={Keybindings.VIM}>Vim</option>
+              <option value={Keybindings.EMACS}>Emacs</option>
             </select>
           </div>
         ) : null}

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -6,9 +6,11 @@ import { Keybindings } from './types'
 export function Settings({
   setTheme,
   setKeybindings,
+  setWrap,
 }: {
   setTheme: (theme: string) => void
   setKeybindings: (keybinding: Keybindings) => void
+  setWrap: (wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded') => void
 }) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -66,6 +68,18 @@ export function Settings({
               <option value={Keybindings.DEFAULT}>Default</option>
               <option value={Keybindings.VIM}>Vim</option>
               <option value={Keybindings.EMACS}>Emacs</option>
+            </select>
+            <label htmlFor="wrap">Wrap</label>
+            <select
+              id="wrap"
+              onChange={(e) =>
+                setWrap(
+                  e.target.value as 'off' | 'on' | 'wordWrapColumn' | 'bounded'
+                )
+              }
+            >
+              <option value="on">On</option>
+              <option value="off">Off</option>
             </select>
           </div>
         ) : null}

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -22,7 +22,7 @@ export function Settings({
   const buttonRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const componentRef = useRef<HTMLDivElement>(null)
-  const { styles, attributes, update } = usePopper(
+  const { styles, attributes, update: updatePanelPosition } = usePopper(
     buttonRef.current,
     panelRef.current,
     {
@@ -30,28 +30,30 @@ export function Settings({
     }
   )
 
-  const handleClickOutside = (e: MouseEvent) => {
-    if (componentRef.current?.contains(e.target as Node)) {
-      return
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      const clickedOutsideComponent = !componentRef.current?.contains(
+        e.target as Node
+      )
+
+      if (clickedOutsideComponent) {
+        setOpen(false)
+      }
     }
 
-    setOpen(false)
-  }
-
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside)
+    document.addEventListener('click', handleClick)
 
     return () => {
-      document.removeEventListener('click', handleClickOutside)
+      document.removeEventListener('click', handleClick)
     }
   }, [])
 
   useEffect(() => {
-    if (!open || !update) {
+    if (!open || !updatePanelPosition) {
       return
     }
 
-    update()
+    updatePanelPosition()
   }, [open])
 
   return (

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -22,7 +22,7 @@ export function Settings({
   const buttonRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const componentRef = useRef<HTMLDivElement>(null)
-  const { styles, attributes } = usePopper(
+  const { styles, attributes, update } = usePopper(
     buttonRef.current,
     panelRef.current,
     {
@@ -45,6 +45,14 @@ export function Settings({
       document.removeEventListener('click', handleClickOutside)
     }
   }, [])
+
+  useEffect(() => {
+    if (!open || !update) {
+      return
+    }
+
+    update()
+  }, [open])
 
   return (
     <div ref={componentRef}>

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -4,10 +4,16 @@ import { Icon } from '../../common/Icon'
 import { Keybindings } from './types'
 
 export function Settings({
+  theme,
+  keybindings,
+  wrap,
   setTheme,
   setKeybindings,
   setWrap,
 }: {
+  theme: string
+  keybindings: Keybindings
+  wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
   setTheme: (theme: string) => void
   setKeybindings: (keybinding: Keybindings) => void
   setWrap: (wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded') => void
@@ -56,7 +62,11 @@ export function Settings({
         {open ? (
           <div>
             <label htmlFor="theme">Theme</label>
-            <select id="theme" onChange={(e) => setTheme(e.target.value)}>
+            <select
+              id="theme"
+              onChange={(e) => setTheme(e.target.value)}
+              value={theme}
+            >
               <option value="vs">Light</option>
               <option value="vs-dark">Dark</option>
             </select>
@@ -64,6 +74,7 @@ export function Settings({
             <select
               id="keybindings"
               onChange={(e) => setKeybindings(e.target.value as Keybindings)}
+              value={keybindings}
             >
               <option value={Keybindings.DEFAULT}>Default</option>
               <option value={Keybindings.VIM}>Vim</option>
@@ -77,6 +88,7 @@ export function Settings({
                   e.target.value as 'off' | 'on' | 'wordWrapColumn' | 'bounded'
                 )
               }
+              value={wrap}
             >
               <option value="on">On</option>
               <option value="off">Off</option>

--- a/app/javascript/components/student/editor/Settings.tsx
+++ b/app/javascript/components/student/editor/Settings.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { usePopper } from 'react-popper'
 import { Icon } from '../../common/Icon'
-import { Keybindings } from './types'
+import { Keybindings, WrapSetting } from './types'
 
 export function Settings({
   theme,
@@ -13,10 +13,10 @@ export function Settings({
 }: {
   theme: string
   keybindings: Keybindings
-  wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
+  wrap: WrapSetting
   setTheme: (theme: string) => void
   setKeybindings: (keybinding: Keybindings) => void
-  setWrap: (wrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded') => void
+  setWrap: (wrap: WrapSetting) => void
 }) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -91,11 +91,7 @@ export function Settings({
             <label htmlFor="wrap">Wrap</label>
             <select
               id="wrap"
-              onChange={(e) =>
-                setWrap(
-                  e.target.value as 'off' | 'on' | 'wordWrapColumn' | 'bounded'
-                )
-              }
+              onChange={(e) => setWrap(e.target.value as WrapSetting)}
               value={wrap}
             >
               <option value="on">On</option>

--- a/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
+++ b/app/javascript/components/student/editor/__mocks__/ExercismMonacoEditor.tsx
@@ -13,7 +13,7 @@ export function ExercismMonacoEditor({
   editorDidMount,
   onRunTests,
   options,
-  value,
+  defaultValue,
   theme,
   keybindings,
 }) {
@@ -39,11 +39,11 @@ export function ExercismMonacoEditor({
       <p>Language: {language}</p>
       <p>Keybindings: {keybindings}</p>
       <p>Wrap: {options.wordWrap}</p>
-      <p>Value: {value}</p>
+      <p>Value: {editor.getValue()}</p>
       <textarea
         ref={textareaRef}
         data-testid="editor-value"
-        defaultValue={value}
+        defaultValue={defaultValue}
       ></textarea>
     </div>
   )

--- a/app/javascript/components/student/editor/types.ts
+++ b/app/javascript/components/student/editor/types.ts
@@ -64,3 +64,5 @@ export enum Keybindings {
   VIM = 'vim',
   EMACS = 'emacs',
 }
+
+export type WrapSetting = 'off' | 'on' | 'wordWrapColumn' | 'bounded'

--- a/app/javascript/components/student/editor/types.ts
+++ b/app/javascript/components/student/editor/types.ts
@@ -58,3 +58,9 @@ export type File = {
   filename: string
   content: string
 }
+
+export enum Keybindings {
+  DEFAULT = 'default',
+  VIM = 'vim',
+  EMACS = 'emacs',
+}

--- a/test/javascript/components/student/Editor.test.js
+++ b/test/javascript/components/student/Editor.test.js
@@ -280,3 +280,16 @@ test('change theme', async () => {
     expect(queryByText('Theme: vs-dark')).toBeInTheDocument()
   })
 })
+
+test('change keybindings', async () => {
+  const { getByTitle, getByLabelText, queryByText } = render(
+    <Editor files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]} />
+  )
+
+  fireEvent.click(getByTitle('Settings'))
+  fireEvent.change(getByLabelText('Keybindings'), { target: { value: 'vim' } })
+
+  await waitFor(() => {
+    expect(queryByText('Keybindings: vim')).toBeInTheDocument()
+  })
+})

--- a/test/javascript/components/student/Editor.test.js
+++ b/test/javascript/components/student/Editor.test.js
@@ -267,3 +267,16 @@ test('switches tabs', async () => {
 
   server.close()
 })
+
+test('change theme', async () => {
+  const { getByTitle, getByLabelText, queryByText } = render(
+    <Editor files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]} />
+  )
+
+  fireEvent.click(getByTitle('Settings'))
+  fireEvent.change(getByLabelText('Theme'), { target: { value: 'vs-dark' } })
+
+  await waitFor(() => {
+    expect(queryByText('Theme: vs-dark')).toBeInTheDocument()
+  })
+})

--- a/test/javascript/components/student/Editor.test.js
+++ b/test/javascript/components/student/Editor.test.js
@@ -293,3 +293,16 @@ test('change keybindings', async () => {
     expect(queryByText('Keybindings: vim')).toBeInTheDocument()
   })
 })
+
+test('change wrapping', async () => {
+  const { getByTitle, getByLabelText, queryByText } = render(
+    <Editor files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]} />
+  )
+
+  fireEvent.click(getByTitle('Settings'))
+  fireEvent.change(getByLabelText('Wrap'), { target: { value: 'off' } })
+
+  await waitFor(() => {
+    expect(queryByText('Wrap: off')).toBeInTheDocument()
+  })
+})

--- a/test/javascript/components/student/Editor/Settings.test.js
+++ b/test/javascript/components/student/Editor/Settings.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { Settings } from '../../../../../app/javascript/components/student/editor/Settings'
+
+test('toggles settings panel when clicking on button', async () => {
+  const { getByTitle, queryByLabelText } = render(<Settings />)
+
+  fireEvent.click(getByTitle('Settings'))
+
+  await waitFor(() => expect(queryByLabelText('Theme')).toBeInTheDocument())
+
+  fireEvent.click(getByTitle('Settings'))
+
+  await waitFor(() => expect(queryByLabelText('Theme')).not.toBeInTheDocument())
+})
+
+test('hides settings panel when clicking outside the component', async () => {
+  const { getByTitle, queryByLabelText } = render(<Settings />)
+
+  fireEvent.click(getByTitle('Settings'))
+  await waitFor(() => expect(queryByLabelText('Theme')).toBeInTheDocument())
+
+  fireEvent.click(document)
+  await waitFor(() => expect(queryByLabelText('Theme')).not.toBeInTheDocument())
+})


### PR DESCRIPTION
This adds the settings panel to the editor.

## Screenshot
![Screen Shot 2020-11-30 at 7 47 28 PM](https://user-images.githubusercontent.com/1901520/100606769-e5bb9280-3344-11eb-8524-f1323375a18e.png)

(Closed and opened when clicking on the gear icon)

## Questions
1. Any suggestions for how to split the `<Editor />` component? It's getting pretty hard to read right now as the file is too long. I've been covering it with tests to make sure that we can easily refactor.
