### PR TITLE
Add temporary fixes for bad data

### DIFF
--- a/app/commands/git/sync_concept_exercise.rb
+++ b/app/commands/git/sync_concept_exercise.rb
@@ -12,7 +12,8 @@ module Git
 
       exercise.update!(
         slug: exercise_config[:slug],
-        title: exercise_config[:name],
+        # TODO: Remove this dance
+        title: (exercise_config[:name].presence || exercise_config[:slug].to_s.titleize),
         deprecated: exercise_config[:deprecated] || false,
         git_sha: head_git_exercise.commit.oid,
         synced_to_git_sha: head_git_exercise.commit.oid,

--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -106,7 +106,18 @@ module Git
     end
 
     def find_concepts(concept_slugs)
-      concept_slugs.map { |concept_slug| ::Track::Concept.find_by!(slug: concept_slug) }
+      # TODO: When we have the configlet check in place
+      # this should chnage to:
+      # Track::Concept.where(slug: concept_slugs)
+      #
+      # Until then it's good to check each one and
+      # return an error if one is found.
+      concept_slugs.map do |concept_slug|
+        ::Track::Concept.find_by!(slug: concept_slug)
+      rescue StandardError
+        Rails.logger.error "Missing concept: #{concept_slug}"
+        nil
+      end.compact
     end
 
     def fetch_git_repo!

--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -1,4 +1,7 @@
 module Git
+  class MissingCommitError < RuntimeError
+  end
+
   class Repository
     extend Mandate::Memoize
 
@@ -48,7 +51,7 @@ module Git
         raise 'wrong-type' if object.type != :commit
       end
     rescue Rugged::OdbError
-      raise 'not-found' unless update_on_failure
+      raise MissingCommitError unless update_on_failure
 
       fetch!
       lookup_commit(sha, update_on_failure: false)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,6 @@ user = User.create!(handle: 'iHiD', email: 'ihid@exercism.io', name: 'iHiD', pas
 user.confirm
 auth_token = user.auth_tokens.create!
 
-
 # This is all temporary and horrible while we have a monorepo
 repo_url = "https://github.com/exercism/v3"
 repo = Git::Repository.new(:v3, repo_url: repo_url)

--- a/test/models/user/activities/completed_exercise_activity_test.rb
+++ b/test/models/user/activities/completed_exercise_activity_test.rb
@@ -18,18 +18,20 @@ class User::Activities::CompletedExerciseActivityTest < ActiveSupport::TestCase
   end
 
   test "rendering_data is valid" do
-    user = create :user
-    exercise = create(:concept_exercise)
+    freeze_time do
+      user = create :user
+      exercise = create(:concept_exercise)
 
-    activity = User::Activities::CompletedExerciseActivity.create!(
-      user: user,
-      track: exercise.track,
-      params: { exercise: exercise }
-    )
-    assert_equal exercise.title, activity.rendering_data.exercise_title
-    assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
-    assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
-    assert_equal "You completed an exercise", activity.rendering_data.text
-    assert_equal Time.current, activity.rendering_data.occurred_at
+      activity = User::Activities::CompletedExerciseActivity.create!(
+        user: user,
+        track: exercise.track,
+        params: { exercise: exercise }
+      )
+      assert_equal exercise.title, activity.rendering_data.exercise_title
+      assert_equal exercise.icon_name, activity.rendering_data.exercise_icon_name
+      assert_equal "/tracks/csharp/exercises/datetime", activity.rendering_data.url
+      assert_equal "You completed an exercise", activity.rendering_data.text
+      assert_equal Time.current, activity.rendering_data.occurred_at
+    end
   end
 end


### PR DESCRIPTION
When trying to debug the Elixir track not working I found two issues:
1. Missing titles on update fail
2. Missing concepts cause the track sync to blow up.

These had the consequence of the track never getting synced to a new sha, so the git data not being found when the test runner was run.

I've added both of these as temporary fixes for now, with TODOs to remove once we prefix this with a configlet check.

(cc @neenjaw and @angelikatyborska  for your interest)