### PR TITLE
Fix repo updates webhook

### DIFF
--- a/app/commands/webhooks/process_repo_update.rb
+++ b/app/commands/webhooks/process_repo_update.rb
@@ -7,15 +7,7 @@ module Webhooks
     def call
       return unless pushed_to_master?
 
-      # TODO: enable this once we're out of the monorepo
-      # Git::SyncTrack.(track)
-
-      # TODO: remove this this once we're out of the monorepo
-      Track.all.each do |track|
-        Git::SyncTrack.(track)
-      rescue StandardError => e
-        Rails.logger.error "Error syncing Track #{track.slug}: #{e}"
-      end
+      SyncTrackJob.perform_later(track)
     end
 
     private

--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -26,12 +26,12 @@ module Webhooks
     end
 
     def handle_ping_event!
-      return unless is_ping_event?
+      return unless ping_event?
 
-      render json: {}, status: :ok
+      head :no_content
     end
 
-    def is_ping_event?
+    def ping_event?
       github_event == 'ping'
     end
 

--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -9,6 +9,7 @@ module Webhooks
     skip_before_action :authenticate_user!
 
     before_action :verify_github_webhook!
+    before_action :handle_ping_event!
 
     layout false
 
@@ -22,6 +23,16 @@ module Webhooks
           message: "The auth token provided is invalid. Delivery: #{github_delivery}"
         }
       }, status: :forbidden
+    end
+
+    def handle_ping_event!
+      return unless is_ping_event?
+
+      render json: {}, status: :ok
+    end
+
+    def is_ping_event?
+      github_event == 'ping'
     end
 
     def signature_valid?
@@ -44,6 +55,10 @@ module Webhooks
 
     def github_delivery
       request.headers['HTTP_X_GITHUB_DELIVERY']
+    end
+
+    def github_event
+      request.headers['HTTP_X_GITHUB_EVENT']
     end
   end
 end

--- a/app/controllers/webhooks/repo_updates_controller.rb
+++ b/app/controllers/webhooks/repo_updates_controller.rb
@@ -1,7 +1,7 @@
 module Webhooks
   class RepoUpdatesController < BaseController
     def create
-      ::Webhooks::ProcessRepoUpdate.(params[:ref], params[:repo][:name])
+      ::Webhooks::ProcessRepoUpdate.(params[:ref], params[:repository][:name])
 
       render json: {}, status: :ok
     end

--- a/app/jobs/sync_track_job.rb
+++ b/app/jobs/sync_track_job.rb
@@ -1,0 +1,15 @@
+class SyncTrackJob < ApplicationJob
+  queue_as :default
+
+  def perform(_track)
+    # TODO: enable this once we're out of the monorepo
+    # Git::SyncTrack.(track)
+
+    # TODO: remove this this once we're out of the monorepo
+    Track.all.each do |track|
+      Git::SyncTrack.(track)
+    rescue StandardError => e
+      Rails.logger.error "Error syncing Track #{track.slug}: #{e}"
+    end
+  end
+end

--- a/test/commands/webhooks/process_repo_update_test.rb
+++ b/test/commands/webhooks/process_repo_update_test.rb
@@ -1,16 +1,19 @@
 require "test_helper"
 
 class Webhooks::ProcessRepoUpdateTest < ActiveSupport::TestCase
-  test "should sync track when pushing to master branch" do
+  test "should enqueue track sync job when pushing to master branch" do
     track = create :track, slug: 'csharp'
-    Git::SyncTrack.expects(:call).with(track)
 
     Webhooks::ProcessRepoUpdate.('refs/heads/master', 'csharp')
+
+    assert_enqueued_jobs 1, only: SyncTrackJob do
+      SyncTrackJob.perform_later(track)
+    end
   end
 
-  test "should not sync track when pushing to non-master branch" do
-    Git::SyncTrack.expects(:call).never
-
+  test "should not enqueue track sync job when pushing to non-master branch" do
     Webhooks::ProcessRepoUpdate.('refs/heads/develop', 'csharp')
+
+    assert_enqueued_jobs 0, only: SyncTrackJob
   end
 end

--- a/test/controllers/webhooks/base_test_case.rb
+++ b/test/controllers/webhooks/base_test_case.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 module Webhooks
   class BaseTestCase < ActionDispatch::IntegrationTest
-    def headers(payload)
+    def headers(payload, event: 'push')
       @headers = {
         'HTTP_X_GITHUB_DELIVERY' => SecureRandom.uuid,
-        'HTTP_X_HUB_SIGNATURE_256' => signature(payload)
+        'HTTP_X_HUB_SIGNATURE_256' => signature(payload),
+        'HTTP_X_GITHUB_EVENT' => event
       }
     end
 

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -19,7 +19,6 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
       ref: 'refs/heads/master',
       repository: { name: 'csharp' }
     }
-    create :track, slug: 'csharp'
 
     post webhooks_repo_updates_path, headers: headers(payload), as: :json, params: payload
     assert_response 200
@@ -30,9 +29,18 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
       ref: 'refs/heads/master',
       repository: { name: 'csharp' }
     }
-    create :track, slug: 'csharp'
     Webhooks::ProcessRepoUpdate.expects(:call).with('refs/heads/master', 'csharp')
 
     post webhooks_repo_updates_path, headers: headers(payload), as: :json, params: payload
+  end
+
+  test "create should return 200 when ping event is sent" do
+    payload = {
+      ref: 'refs/heads/master',
+      repository: { name: 'csharp' }
+    }
+
+    post webhooks_repo_updates_path, headers: headers(payload, event: 'ping'), as: :json, params: payload
+    assert_response 200
   end
 end

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -34,13 +34,13 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
     post webhooks_repo_updates_path, headers: headers(payload), as: :json, params: payload
   end
 
-  test "create should return 200 when ping event is sent" do
+  test "create should return 204 when ping event is sent" do
     payload = {
       ref: 'refs/heads/master',
       repository: { name: 'csharp' }
     }
 
     post webhooks_repo_updates_path, headers: headers(payload, event: 'ping'), as: :json, params: payload
-    assert_response 200
+    assert_response 204
   end
 end

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -4,7 +4,7 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
   test "create should return 403 when signature is invalid" do
     payload = {
       ref: 'refs/heads/master',
-      repo: { name: 'csharp' }
+      repository: { name: 'csharp' }
     }
 
     invalid_headers = headers(payload)
@@ -17,7 +17,7 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
   test "create should return 200 when signature is valid" do
     payload = {
       ref: 'refs/heads/master',
-      repo: { name: 'csharp' }
+      repository: { name: 'csharp' }
     }
     create :track, slug: 'csharp'
 
@@ -28,7 +28,7 @@ class Webhooks::RepoUpdatesControllerTest < Webhooks::BaseTestCase
   test "create should process repo update when signature is valid" do
     payload = {
       ref: 'refs/heads/master',
-      repo: { name: 'csharp' }
+      repository: { name: 'csharp' }
     }
     create :track, slug: 'csharp'
     Webhooks::ProcessRepoUpdate.expects(:call).with('refs/heads/master', 'csharp')

--- a/test/jobs/sync_track_job_test.rb
+++ b/test/jobs/sync_track_job_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class SyncTrackJobTest < ActiveJob::TestCase
+  test "track is synced" do
+    track = create :track, slug: 'csharp'
+
+    Git::SyncTrack.expects(:call).with(track)
+    SyncTrackJob.perform_now(track)
+  end
+end


### PR DESCRIPTION
This PR contains three things:

1. It fixes a bug where the repository name was fetched from the wrong object
1. It adds support for the GH ping event, which GH sends whenever the webhook is added
1. It uses a background job to do the actual track syncing, as otherwise the GH webhook UI would show a timeout for the webhook

![image](https://user-images.githubusercontent.com/135246/101598985-43ad4180-39f9-11eb-9633-69eaabc573d8.png)

Let me know if I've correctly handled the background job. Looking at the logs, I can see that a background task is queued for the track syncing, but I don't see any output of the background job. Is that normal?