### PR TITLE
Open keyboard shortcuts

### DIFF
--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -154,7 +154,9 @@ export function Editor({
 }) {
   const [tab, switchToTab] = useState(TabIndex.INSTRUCTIONS)
   const [theme, setTheme] = useState('vs')
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false)
   const editorRef = useRef<FileEditorHandle>()
+  const keyboardShortcutsRef = useRef<HTMLDivElement>()
   const [files] = useSaveFiles(initialFiles, () => {
     return editorRef.current?.getFiles() || []
   })
@@ -306,6 +308,32 @@ export function Editor({
     editorRef.current?.setFiles(initialFiles)
   }, [initialFiles])
 
+  const toggleKeyboardShortcuts = useCallback(() => {
+    setIsPaletteOpen(!isPaletteOpen)
+  }, [isPaletteOpen])
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (keyboardShortcutsRef.current?.contains(e.target as Node)) {
+        return
+      }
+
+      setIsPaletteOpen(false)
+    }
+
+    const handleBlur = () => {
+      setIsPaletteOpen(false)
+    }
+
+    document.addEventListener('click', handleClick)
+    window.addEventListener('blur', handleBlur)
+
+    return () => {
+      document.removeEventListener('click', handleClick)
+      window.addEventListener('blur', handleBlur)
+    }
+  }, [])
+
   return (
     <TabsContext.Provider value={{ tab, switchToTab }}>
       <div id="page-editor">
@@ -313,7 +341,10 @@ export function Editor({
           <Header.Back exercisePath={exercisePath} />
           <Header.Title trackTitle={trackTitle} exerciseTitle={exerciseTitle} />
           <Header.ActionHints />
-          <Header.ActionKeyboardShortcuts />
+          <Header.ActionKeyboardShortcuts
+            ref={keyboardShortcutsRef}
+            onClick={toggleKeyboardShortcuts}
+          />
           <Header.ActionSettings
             theme={theme}
             keybindings={keybindings}
@@ -338,6 +369,7 @@ export function Editor({
             wrap={wrap}
             onRunTests={runTests}
             onSubmit={submit}
+            isPaletteOpen={isPaletteOpen}
           />
         </div>
 

--- a/app/javascript/components/editor/FileEditor.tsx
+++ b/app/javascript/components/editor/FileEditor.tsx
@@ -26,6 +26,7 @@ export function FileEditor({
   keybindings,
   files,
   wrap,
+  isPaletteOpen,
 }: {
   editorDidMount: (editor: FileEditorHandle) => void
   language: string
@@ -35,6 +36,7 @@ export function FileEditor({
   keybindings: Keybindings
   files: File[]
   wrap: WrapSetting
+  isPaletteOpen: boolean
 }): JSX.Element {
   const options: monacoEditor.editor.IStandaloneEditorConstructionOptions = {
     minimap: { enabled: false },
@@ -45,6 +47,7 @@ export function FileEditor({
     model: null,
   }
   const [tab, setTab] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
   const filesRef = useRef<FileRef[]>(
     files.map((file) => ({
       filename: file.filename,
@@ -104,6 +107,21 @@ export function FileEditor({
   }
 
   useEffect(() => {
+    const editor = editorRef.current
+
+    if (!editor) {
+      return
+    }
+
+    if (isPaletteOpen) {
+      editor.focus()
+      editor.trigger(null, 'editor.action.quickCommand', {})
+    } else {
+      editor.focus()
+    }
+  }, [isPaletteOpen])
+
+  useEffect(() => {
     if (!editorRef.current || !statusBarRef.current) {
       return
     }
@@ -155,7 +173,7 @@ export function FileEditor({
   )
 
   return (
-    <div className="c-file-editor">
+    <div ref={containerRef} className="c-file-editor">
       <div className="tabs">
         {files.map((file, index) => (
           <button

--- a/app/javascript/components/editor/Header.tsx
+++ b/app/javascript/components/editor/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, forwardRef } from 'react'
 import { GraphicalIcon } from '../common/GraphicalIcon'
 import { Icon } from '../common/Icon'
 import { Settings } from './header/Settings'
@@ -33,10 +33,21 @@ Header.ActionHints = () => (
   <button className="btn-small hints-btn">Hints</button>
 )
 
-Header.ActionKeyboardShortcuts = () => (
-  <button className="keyboard-shortcuts-btn">
-    <Icon icon="keyboard" alt="Keyboard Shortcuts" />
-  </button>
+Header.ActionKeyboardShortcuts = forwardRef(
+  ({ onClick }: { onClick: () => void }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={() => {
+          onClick()
+        }}
+        className="keyboard-shortcuts-btn"
+      >
+        <Icon icon="keyboard" alt="Keyboard Shortcuts" />
+      </button>
+    )
+  }
 )
 
 Header.ActionSettings = Settings

--- a/app/javascript/components/editor/__mocks__/FileEditor.tsx
+++ b/app/javascript/components/editor/__mocks__/FileEditor.tsx
@@ -13,6 +13,7 @@ export function FileEditor({
   wrap,
   theme,
   keybindings,
+  isPaletteOpen,
 }): JSX.Element {
   const textareaRef = useRef(files.map(() => createRef()))
   const getFiles = useCallback(() => {
@@ -37,6 +38,7 @@ export function FileEditor({
       <p>Language: {language}</p>
       <p>Keybindings: {keybindings}</p>
       <p>Wrap: {wrap}</p>
+      <p>Palette open: {isPaletteOpen.toString()}</p>
       {files.map((file, i) => (
         <div key={file.filename}>
           <p>Value: {file.content}</p>

--- a/app/javascript/components/editor/header/Settings.tsx
+++ b/app/javascript/components/editor/header/Settings.tsx
@@ -44,7 +44,9 @@ export function Settings({
         {open ? (
           <div className="settings-dialog">
             <div className="setting">
-              <div className="name">Theme</div>
+              <label htmlFor="theme" className="name">
+                Theme
+              </label>{' '}
               <select
                 id="theme"
                 onChange={(e) => setTheme(e.target.value)}
@@ -55,7 +57,9 @@ export function Settings({
               </select>
             </div>
             <div className="setting">
-              <div className="name">Keybindings</div>
+              <label htmlFor="keybindings" className="name">
+                Keybindings
+              </label>
               <select
                 id="keybindings"
                 onChange={(e) => setKeybindings(e.target.value as Keybindings)}
@@ -67,7 +71,9 @@ export function Settings({
               </select>
             </div>
             <div className="setting">
-              <div className="name">Wrap</div>
+              <label htmlFor="wrap" className="name">
+                Wrap
+              </label>
               <select
                 id="wrap"
                 onChange={(e) => setWrap(e.target.value as WrapSetting)}

--- a/test/javascript/components/Editor.test.js
+++ b/test/javascript/components/Editor.test.js
@@ -382,3 +382,54 @@ test('revert to last submission', async () => {
 
   localStorage.clear()
 })
+
+test('toggle command palette when clicking on button', async () => {
+  const { getByTitle, queryByText } = render(
+    <Editor files={[{ filename: 'file', content: 'file' }]} />
+  )
+
+  fireEvent.click(getByTitle('Keyboard Shortcuts'))
+  await waitFor(() =>
+    expect(queryByText('Palette open: true')).toBeInTheDocument()
+  )
+  fireEvent.click(getByTitle('Keyboard Shortcuts'))
+  await waitFor(() =>
+    expect(queryByText('Palette open: false')).toBeInTheDocument()
+  )
+
+  localStorage.clear()
+})
+
+test('hide command palette when clicking on document', async () => {
+  const { getByTitle, queryByText } = render(
+    <Editor files={[{ filename: 'file', content: 'file' }]} />
+  )
+
+  fireEvent.click(getByTitle('Keyboard Shortcuts'))
+  await waitFor(() =>
+    expect(queryByText('Palette open: true')).toBeInTheDocument()
+  )
+  fireEvent.click(document)
+  await waitFor(() =>
+    expect(queryByText('Palette open: false')).toBeInTheDocument()
+  )
+
+  localStorage.clear()
+})
+
+test('hide command palette when window blurs', async () => {
+  const { getByTitle, queryByText } = render(
+    <Editor files={[{ filename: 'file', content: 'file' }]} />
+  )
+
+  fireEvent.click(getByTitle('Keyboard Shortcuts'))
+  await waitFor(() =>
+    expect(queryByText('Palette open: true')).toBeInTheDocument()
+  )
+  fireEvent.blur(window)
+  await waitFor(() =>
+    expect(queryByText('Palette open: false')).toBeInTheDocument()
+  )
+
+  localStorage.clear()
+})


### PR DESCRIPTION
Instead of our own keyboard shortcuts modal, we instead open Monaco's keyboard shortcuts when clicking on the "Keyboard shortcuts modal" button.

## Screenshot
![Screen Shot 2020-12-09 at 3 53 06 PM](https://user-images.githubusercontent.com/1901520/101600763-bc7ebe80-3a36-11eb-9115-e9a791ce3151.png)
