### PR TITLE
<Tooltip> make react-query lazy-fire

### DIFF
--- a/app/javascript/components/tooltips/Tooltip.tsx
+++ b/app/javascript/components/tooltips/Tooltip.tsx
@@ -1,7 +1,21 @@
 import React, { useEffect, useState } from 'react'
 import { usePopper } from 'react-popper'
 import { useQuery } from 'react-query'
-import { useStatefulTooltip } from '../../hooks/use-stateful-tooltip'
+import {
+  useStatefulTooltip,
+  dispatchError,
+  dispatchLoaded,
+  dispatchShow,
+  // dispatchHide,
+  dispatchRequestHideFromRefHover,
+  dispatchRequestHideFromRefFocus,
+  dispatchRequestShowFromRefHover,
+  dispatchRequestShowFromRefFocus,
+  dispatchRequestHideFromHover,
+  dispatchRequestHideFromFocus,
+  dispatchRequestShowFromHover,
+  dispatchRequestShowFromFocus,
+} from '../../hooks/use-stateful-tooltip'
 
 interface TooltipProps {
   id: string
@@ -63,22 +77,12 @@ export const Tooltip = ({
   // useEffect for responding to the reference element's request to show when hovered
   useEffect(() => {
     if (hoverRequestToShow) {
-      return dispatch({
-        id: id,
-        action: {
-          type: 'request-show-from-ref-hover',
-        },
-      })
+      return dispatchRequestShowFromRefHover(dispatch, id)
     }
 
     // setTimeout used to fire this dispatch AFTER the tooltip self-hover has time to fire
     const timeoutRef = setTimeout(() => {
-      dispatch({
-        id: id,
-        action: {
-          type: 'request-hide-from-ref-hover',
-        },
-      })
+      dispatchRequestHideFromRefHover(dispatch, id)
     }, 0)
 
     return () => {
@@ -89,22 +93,12 @@ export const Tooltip = ({
   // useEffect for responding to the reference element's request to show when focused
   useEffect(() => {
     if (focusRequestToShow) {
-      return dispatch({
-        id: id,
-        action: {
-          type: 'request-show-from-ref-focus',
-        },
-      })
+      return dispatchRequestShowFromRefFocus(dispatch, id)
     }
 
     // setTimeout used to fire this dispatch AFTER the tooltip self-focus has time to fire
     const timeoutRef = setTimeout(() => {
-      dispatch({
-        id: id,
-        action: {
-          type: 'request-hide-from-ref-focus',
-        },
-      })
+      dispatchRequestHideFromRefFocus(dispatch, id)
     }, 0)
 
     return () => {
@@ -116,12 +110,7 @@ export const Tooltip = ({
   useEffect(() => {
     if (isError) {
       removeOpenTooltip(id)
-      return dispatch({
-        id: id,
-        action: {
-          type: 'error',
-        },
-      })
+      return dispatchError(dispatch, id)
     }
 
     switch (showState) {
@@ -129,21 +118,11 @@ export const Tooltip = ({
         if (isLoading) {
           return
         }
-        dispatch({
-          id: id,
-          action: {
-            type: 'loaded',
-          },
-        })
+        dispatchLoaded(dispatch, id)
         break
       case 'invisible':
         addOpenTooltip(id, dispatch as React.Dispatch<unknown>)
-        dispatch({
-          id: id,
-          action: {
-            type: 'show',
-          },
-        })
+        dispatchShow(dispatch, id)
         break
       case 'visible':
         closeOtherOpenTooltips(id)
@@ -196,38 +175,10 @@ export const Tooltip = ({
       {...popper.attributes.popper}
       role="tooltip"
       tabIndex={showState === 'visible' ? undefined : -1}
-      onFocus={() =>
-        dispatch({
-          id: id,
-          action: {
-            type: 'request-show-focus',
-          },
-        })
-      }
-      onBlur={() =>
-        dispatch({
-          id: id,
-          action: {
-            type: 'request-hide-focus',
-          },
-        })
-      }
-      onMouseEnter={() =>
-        dispatch({
-          id: id,
-          action: {
-            type: 'request-show-hover',
-          },
-        })
-      }
-      onMouseLeave={() =>
-        dispatch({
-          id: id,
-          action: {
-            type: 'request-hide-hover',
-          },
-        })
-      }
+      onFocus={() => dispatchRequestShowFromFocus(dispatch, id)}
+      onBlur={() => dispatchRequestHideFromFocus(dispatch, id)}
+      onMouseEnter={() => dispatchRequestShowFromHover(dispatch, id)}
+      onMouseLeave={() => dispatchRequestHideFromHover(dispatch, id)}
       dangerouslySetInnerHTML={{ __html: htmlContent }}
     ></div>
   )

--- a/app/javascript/components/tooltips/Tooltip.tsx
+++ b/app/javascript/components/tooltips/Tooltip.tsx
@@ -233,21 +233,6 @@ export const Tooltip = ({
   hoverRequestToShow,
   focusRequestToShow,
 }: TooltipProps): JSX.Element | null => {
-  // Retrieve the HTML contents from the contentEndpoint
-  const { isLoading, isError, data: htmlContent } = useQuery<string>(id, () => {
-    const controller = new AbortController()
-    const signal = controller.signal
-    return Object.assign(
-      // Create a fetch request for the tooltip content, assign the abort controller to the promise
-      // https://react-query.tanstack.com/docs/guides/query-cancellation#using-fetch
-      fetch(contentEndpoint, {
-        method: 'get',
-        signal,
-      }).then((res) => res.text()),
-      { cancel: () => controller.abort() }
-    )
-  })
-
   const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null)
 
   const [{ showState }, dispatch] = useReducer(
@@ -261,6 +246,28 @@ export const Tooltip = ({
     // The line below controls the offset appearance of the tooltip from the reference element
     modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
   })
+
+  // Retrieve the HTML contents from the contentEndpoint
+  const { isLoading, isError, data: htmlContent } = useQuery<string>(
+    id,
+    () => {
+      const controller = new AbortController()
+      const signal = controller.signal
+      return Object.assign(
+        // Create a fetch request for the tooltip content, assign the abort controller to the promise
+        // https://react-query.tanstack.com/docs/guides/query-cancellation#using-fetch
+        fetch(contentEndpoint, {
+          method: 'get',
+          signal,
+        }).then((res) => res.text()),
+        { cancel: () => controller.abort() }
+      )
+    },
+    {
+      // Enable the query to fetch only if it isn't in a hidden or error state
+      enabled: !(showState == 'hidden' || showState == 'error'),
+    }
+  )
 
   // useEffect for responding to the reference element's request to show when hovered
   useEffect(() => {

--- a/app/javascript/components/tooltips/Tooltip.tsx
+++ b/app/javascript/components/tooltips/Tooltip.tsx
@@ -265,7 +265,7 @@ export const Tooltip = ({
     },
     {
       // Enable the query to fetch only if it isn't in a hidden or error state
-      enabled: !(showState == 'hidden' || showState == 'error'),
+      enabled: showState != 'hidden' && showState != 'error',
     }
   )
 

--- a/app/javascript/hooks/use-stateful-tooltip.ts
+++ b/app/javascript/hooks/use-stateful-tooltip.ts
@@ -1,0 +1,242 @@
+import { useReducer } from 'react'
+
+type TooltipState = {
+  requestHover: boolean
+  requestFocus: boolean
+  hover: boolean
+  focus: boolean
+  showState: ShowState
+}
+
+type ShowState = 'hidden' | 'loading' | 'invisible' | 'visible' | 'error'
+
+type TooltipAction =
+  | ErrorAction
+  | RequestShowFromRefHoverAction
+  | RequestHideFromRefHoverAction
+  | RequestShowFromRefFocusAction
+  | RequestHideFromRefFocusAction
+  | RequestShowFromHoverAction
+  | RequestHideFromHoverAction
+  | RequestShowFromFocusAction
+  | RequestHideFromFocusAction
+  | LoadedAction
+  | ShowAction
+  | HideAction
+
+type ErrorAction = {
+  type: 'error'
+}
+
+type RequestShowFromRefHoverAction = {
+  type: 'request-show-from-ref-hover'
+}
+
+type RequestHideFromRefHoverAction = {
+  type: 'request-hide-from-ref-hover'
+}
+
+type RequestShowFromRefFocusAction = {
+  type: 'request-show-from-ref-focus'
+}
+
+type RequestHideFromRefFocusAction = {
+  type: 'request-hide-from-ref-focus'
+}
+
+type RequestShowFromHoverAction = {
+  type: 'request-show-hover'
+}
+
+type RequestHideFromHoverAction = {
+  type: 'request-hide-hover'
+}
+
+type RequestShowFromFocusAction = {
+  type: 'request-show-focus'
+}
+
+type RequestHideFromFocusAction = {
+  type: 'request-hide-focus'
+}
+
+type LoadedAction = {
+  type: 'loaded'
+}
+
+type ShowAction = {
+  type: 'show'
+}
+
+type HideAction = {
+  type: 'hide'
+}
+
+type DispatchAction = {
+  id: string
+  action: TooltipAction
+}
+
+type OpenTooltip = [string, React.Dispatch<unknown>]
+
+interface ShowReducer {
+  (state: TooltipState, payload: DispatchAction): TooltipState
+}
+
+function initialTooltipState(): TooltipState {
+  return {
+    requestHover: false,
+    requestFocus: false,
+    hover: false,
+    focus: false,
+    showState: 'hidden',
+  }
+}
+
+/**
+ * OpenTooltips maintains an array of open tooltips
+ * Only 1 should be active at once, but given the chance of race conditions
+ * A array is used to track potentially multiple open
+ */
+
+const openTooltips: OpenTooltip[] = []
+
+const indexOfOpenTooltip = (id: string) =>
+  openTooltips.findIndex(([openId]) => openId === id)
+
+const hasOpenTooltip = (id: string) => {
+  return indexOfOpenTooltip(id) === -1
+    ? openTooltips.length > 0
+    : openTooltips.length > 1
+}
+
+const addOpenTooltip = (
+  id: string,
+  dispatcher: React.Dispatch<unknown>
+): void => {
+  if (openTooltips.find(([openId]) => openId === id)) {
+    return
+  }
+
+  openTooltips.push([id, dispatcher])
+}
+
+const removeOpenTooltip = (id: string): void => {
+  const index = indexOfOpenTooltip(id)
+  if (index !== -1) {
+    openTooltips.splice(index, 1)
+  }
+}
+
+const closeOtherOpenTooltips = (id: string): void => {
+  openTooltips.forEach(([openId, openDispatch]) => {
+    if (openId !== id) {
+      openDispatch({
+        id: openId,
+        action: {
+          type: 'hide',
+        },
+      })
+    }
+  })
+}
+
+const shouldShow = (state: TooltipState): boolean => {
+  return state.focus || state.hover || state.requestFocus || state.requestHover
+}
+
+const handleShowRequest = (state: TooltipState): ShowState => {
+  return shouldShow(state) && state.showState === 'hidden'
+    ? 'loading'
+    : state.showState
+}
+
+const handleHideRequest = (state: TooltipState): ShowState => {
+  return !shouldShow(state) ? 'hidden' : state.showState
+}
+
+/**
+ * tooltipReducer
+ * This serves as a state reducer for the <Tooltip /> Component for use with
+ * the useReducer hook.
+ */
+const tooltipReducer: ShowReducer = function (state, body) {
+  const { id, action } = body
+  const nextState: TooltipState = { ...state }
+
+  // Use action to update the next state
+  switch (action.type) {
+    case 'request-show-from-ref-hover':
+      nextState.requestHover = true && !hasOpenTooltip(id)
+      nextState.showState = handleShowRequest(nextState)
+      break
+    case 'request-hide-from-ref-hover':
+      nextState.requestHover = false
+      nextState.showState = handleHideRequest(nextState)
+      break
+    case 'request-show-from-ref-focus':
+      nextState.requestFocus = true
+      nextState.showState = handleShowRequest(nextState)
+      break
+    case 'request-hide-from-ref-focus':
+      nextState.requestFocus = false
+      nextState.showState = handleHideRequest(nextState)
+      break
+    case 'request-show-hover':
+      nextState.hover = true && !hasOpenTooltip(id)
+      nextState.showState = handleShowRequest(nextState)
+      break
+    case 'request-hide-hover':
+      nextState.hover = false
+      nextState.showState = handleHideRequest(nextState)
+      break
+    case 'request-show-focus':
+      nextState.focus = true
+      nextState.showState = handleShowRequest(nextState)
+      break
+    case 'request-hide-focus':
+      nextState.focus = false
+      nextState.showState = handleHideRequest(nextState)
+      break
+    case 'loaded':
+      nextState.showState = 'invisible'
+      break
+    case 'show':
+      nextState.showState = 'visible'
+      break
+    case 'hide':
+      nextState.showState = 'hidden'
+      break
+    case 'error':
+      nextState.showState = 'error'
+      break
+    default:
+      throw new Error('unhandled tooltip reducer action')
+  }
+
+  return nextState
+}
+
+interface UseStatefulTooltip {
+  state: TooltipState
+  dispatch: React.Dispatch<DispatchAction>
+  addOpenTooltip: typeof addOpenTooltip
+  removeOpenTooltip: typeof removeOpenTooltip
+  closeOtherOpenTooltips: typeof closeOtherOpenTooltips
+}
+
+export function useStatefulTooltip(): UseStatefulTooltip {
+  const [state, dispatch] = useReducer(
+    tooltipReducer,
+    null,
+    initialTooltipState
+  )
+
+  return {
+    state,
+    dispatch,
+    addOpenTooltip,
+    removeOpenTooltip,
+    closeOtherOpenTooltips,
+  }
+}

--- a/app/javascript/hooks/use-stateful-tooltip.ts
+++ b/app/javascript/hooks/use-stateful-tooltip.ts
@@ -240,3 +240,43 @@ export function useStatefulTooltip(): UseStatefulTooltip {
     closeOtherOpenTooltips,
   }
 }
+
+interface DispatchHelper {
+  (dispatch: React.Dispatch<DispatchAction>, id: string): void
+}
+
+export const dispatchError: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'error' } })
+
+export const dispatchLoaded: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'loaded' } })
+
+export const dispatchShow: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'show' } })
+
+export const dispatchHide: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'hide' } })
+
+export const dispatchRequestHideFromRefHover: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-hide-from-ref-hover' } })
+
+export const dispatchRequestHideFromRefFocus: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-hide-from-ref-focus' } })
+
+export const dispatchRequestShowFromRefHover: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-show-from-ref-hover' } })
+
+export const dispatchRequestShowFromRefFocus: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-show-from-ref-focus' } })
+
+export const dispatchRequestHideFromHover: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-hide-hover' } })
+
+export const dispatchRequestHideFromFocus: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-hide-hover' } })
+
+export const dispatchRequestShowFromHover: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-show-hover' } })
+
+export const dispatchRequestShowFromFocus: DispatchHelper = (dispatch, id) =>
+  dispatch({ id, action: { type: 'request-show-focus' } })

--- a/app/javascript/hooks/use-tooltip-content-query.ts
+++ b/app/javascript/hooks/use-tooltip-content-query.ts
@@ -1,0 +1,46 @@
+import { useQuery } from 'react-query'
+
+function fetchContent(endpoint: string, signal: AbortSignal) {
+  return fetch(endpoint, {
+    method: 'get',
+    signal,
+  }).then((res) => {
+    if (res.status != 200 && res.status != 304) {
+      return Promise.reject(
+        `No content available. HTTP response status ${res.status}`
+      )
+    }
+
+    return res.text()
+  })
+}
+
+// Create a fetch request for the tooltip content, assign the abort controller to the promise
+// https://react-query.tanstack.com/docs/guides/query-cancellation#using-fetch
+function query(endpoint: string) {
+  return () => {
+    const controller = new AbortController()
+    const signal = controller.signal
+    return Object.assign(fetchContent(endpoint, signal), {
+      cancel: () => controller.abort(),
+    })
+  }
+}
+
+export function useTooltipContentQuery(
+  id: string,
+  endpoint: string,
+  enabled: boolean
+): {
+  isLoading: boolean
+  isError: boolean
+  htmlContent: string | undefined
+} {
+  const { isLoading, isError, data: htmlContent } = useQuery<string>(
+    id,
+    query(endpoint),
+    { enabled }
+  )
+
+  return { isLoading, isError, htmlContent }
+}

--- a/app/javascript/hooks/use-tooltip-content-query.ts
+++ b/app/javascript/hooks/use-tooltip-content-query.ts
@@ -5,7 +5,7 @@ function fetchContent(endpoint: string, signal: AbortSignal) {
     method: 'get',
     signal,
   }).then((res) => {
-    if (res.status != 200 && res.status != 304) {
+    if (![200, 304].includes(res.status)) {
       return Promise.reject(
         `No content available. HTTP response status ${res.status}`
       )


### PR DESCRIPTION
By default, react-query fires its query when the Component is mounted. This is a problem as it may trigger unnecessary requests. react-query has an option to disable the query setting the `enabled` option to false. So now, while the tool-tip is in a `hidden` or `error` state, the query is disabled.

--- 

I've been able to get it going locally now, see image for gif of current lazy loading

![lazy_load](https://user-images.githubusercontent.com/8953691/101799024-47ac9280-3ad1-11eb-8743-780588c71162.gif)
