### PR TITLE
Focus results tab if previous test results are present

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
 server: bin/rails server -p 3020
 assets: bin/webpack-dev-server
 anycable: RAILS_ENV=development bundle exec anycable --server-command "anycable-go --host=localhost --port 3334"
-js-tests: yarn test-watch

--- a/app/css/application.css
+++ b/app/css/application.css
@@ -39,3 +39,10 @@ code {
     width: 100%;
     height: 100%;
 }
+
+.js-focus-visible :focus {
+    outline: 5px auto -webkit-focus-ring-color;
+    &:not(.focus-visible) {
+        outline: none;
+    }
+}

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -1,3 +1,5 @@
+@import "../styles";
+
 #page-editor {
     --side-padding: 32px;
     --border-color: rgba(203, 201, 217, 0.5);
@@ -76,16 +78,57 @@
             @apply py-24 px-32 text-left;
 
             & .setting {
-                @apply flex;
+                @apply flex items-center justify-between;
                 @apply mb-16;
                 &:last-child {
                     @apply mb-0;
                 }
-            }
-            & .name {
-                @apply text-16 font-medium text-darkGray;
-                @apply mr-56;
-                width: 100px;
+
+                & .name {
+                    @apply text-16 font-medium text-darkGray;
+                    @apply mr-56;
+                    width: 100px;
+                }
+
+                & .options {
+                    @apply bg-borderLight rounded-100;
+                    @apply flex items-center;
+                    box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.2);
+
+                    & label {
+                        @apply block relative;
+                        & .label {
+                            @apply px-12 py-6;
+                            @apply cursor-pointer;
+                            @apply border-1 border-borderLight rounded-100;
+                            @apply text-textLight font-mono font-bold leading-regular;
+                        }
+
+                        /* Keep it here so it's discoverable by touch
+                         * for accessibility purposes */
+                        & input {
+                            @apply absolute;
+                            top: 0;
+                            left: 0;
+                            opacity: 0;
+                            &:checked + .label {
+                                @apply bg-lightBlue;
+                                @apply text-white;
+                            }
+
+                            /* It would be nice to DRY this up with application.css
+                             * but its tricky with the adjecent element. */
+                            &:focus {
+                                & + .label {
+                                    outline: 5px auto -webkit-focus-ring-color;
+                                }
+                                &:not(.focus-visible) + .label {
+                                    outline: none;
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -14,6 +14,7 @@ import {
   File,
   Keybindings,
   WrapSetting,
+  Themes,
 } from './editor/types'
 import { useRequest, APIError } from '../hooks/use-request'
 import { Iteration } from './track/IterationSummary'
@@ -74,7 +75,6 @@ function reducer(state: State, action: Action): State {
       return {
         ...state,
         apiError: undefined,
-        submission: undefined,
         status: EditorStatus.CREATING_SUBMISSION,
       }
     case ActionType.SUBMISSION_CREATED:
@@ -153,7 +153,7 @@ export function Editor({
   exampleSolution: string
 }) {
   const [tab, switchToTab] = useState(TabIndex.INSTRUCTIONS)
-  const [theme, setTheme] = useState('vs')
+  const [theme, setTheme] = useState(Themes.LIGHT)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false)
   const editorRef = useRef<FileEditorHandle>()
   const keyboardShortcutsRef = useRef<HTMLButtonElement>(null)

--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -299,7 +299,13 @@ export function Editor({
           return
         }
 
-        updateSubmission(typecheck<TestRun>(camelizeKeys(json), 'testRun'))
+        const testRun = typecheck<TestRun>(camelizeKeys(json), 'testRun')
+
+        if (testRun) {
+          switchToTab(TabIndex.RESULTS)
+        }
+
+        updateSubmission(testRun)
       }
     )
   }, [sendRequest, initialSubmission, updateSubmission])

--- a/app/javascript/components/editor/FileEditor.tsx
+++ b/app/javascript/components/editor/FileEditor.tsx
@@ -5,6 +5,7 @@ import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 import { initVimMode, VimMode } from 'monaco-vim'
 import { EmacsExtension } from 'monaco-emacs'
 import { Keybindings, File, WrapSetting } from './types'
+import { setupThemes } from './file-editor/themes'
 
 type FileRef = {
   filename: string
@@ -45,6 +46,16 @@ export function FileEditor({
     lightbulb: { enabled: true },
     automaticLayout: true,
     model: null,
+    scrollbar: {
+      useShadows: true,
+      verticalHasArrows: false,
+      horizontalHasArrows: false,
+      vertical: 'auto',
+      horizontal: 'auto',
+      verticalScrollbarSize: 18,
+      horizontalScrollbarSize: 18,
+      arrowSize: 30,
+    },
   }
   const [tab, setTab] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -104,6 +115,10 @@ export function FileEditor({
     editor.setModel(filesRef.current[0].model)
 
     editorDidMount({ getFiles, setFiles })
+  }
+
+  const handleEditorWillMount = () => {
+    setupThemes()
   }
 
   useEffect(() => {
@@ -188,6 +203,7 @@ export function FileEditor({
       <MonacoEditor
         language={language}
         editorDidMount={handleEditorDidMount}
+        editorWillMount={handleEditorWillMount}
         options={options}
         theme={theme}
       />

--- a/app/javascript/components/editor/file-editor/themes.ts
+++ b/app/javascript/components/editor/file-editor/themes.ts
@@ -1,0 +1,26 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { Themes } from '../types'
+
+export const setupThemes = (): void => {
+  monaco.editor.defineTheme(Themes.LIGHT, {
+    base: 'vs',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.foreground': '#000000',
+      'editor.background': '#EDF9FA',
+      'editorCursor.foreground': '#8B0000',
+      'editor.lineHighlightBackground': '#0000FF20',
+      'editorLineNumber.foreground': '#008800',
+      'editor.selectionBackground': '#88000030',
+      'editor.inactiveSelectionBackground': '#88000015',
+    },
+  })
+
+  monaco.editor.defineTheme(Themes.DARK, {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: {},
+  })
+}

--- a/app/javascript/components/editor/types.ts
+++ b/app/javascript/components/editor/types.ts
@@ -67,3 +67,8 @@ export enum Keybindings {
 }
 
 export type WrapSetting = 'off' | 'on' | 'wordWrapColumn' | 'bounded'
+
+export enum Themes {
+  LIGHT = 'light',
+  DARK = 'dark',
+}

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -8,6 +8,8 @@ require('turbolinks').start()
 require('@rails/activestorage').start()
 require('channels')
 
+import 'focus-visible'
+
 // TODO: Let's get all of these loading automatically
 // without needing to be specified individually here.
 import '../../css/application.css'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "actioncable": "^5.2.4-3",
     "core-js": "^3.6.5",
     "dayjs": "^1.8.35",
+    "focus-visible": "^5.2.0",
     "fontfaceobserver": "^2.1.0",
     "global": "^4.4.0",
     "humps": "^2.0.1",

--- a/test/javascript/components/Editor.test.js
+++ b/test/javascript/components/Editor.test.js
@@ -7,67 +7,6 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Editor } from '../../../app/javascript/components/Editor'
 
-test('clears current submission when resubmitting', async () => {
-  const server = setupServer(
-    rest.post('https://exercism.test/submissions', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          submission: {
-            id: 2,
-            uuid: '123',
-            tests_status: 'queued',
-            links: {
-              cancel: 'https://exercism.test/cancel',
-              testRun: 'https://exercism.test/test_run',
-            },
-          },
-        })
-      )
-    }),
-    rest.get('https://exercism.test/test_run', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          test_run: {
-            id: null,
-            submission_uuid: '123',
-            status: 'queued',
-            message: '',
-            tests: [],
-          },
-        })
-      )
-    })
-  )
-  server.listen()
-
-  const { getByText, queryByText } = render(
-    <Editor
-      endpoint="https://exercism.test/submissions"
-      files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]}
-    />
-  )
-  fireEvent.click(getByText('Run Tests'))
-  await waitFor(() =>
-    expect(
-      queryByText("We've queued your code and will run it shortly.")
-    ).toBeInTheDocument()
-  )
-  fireEvent.click(getByText('Run Tests'))
-
-  await waitFor(() =>
-    expect(
-      queryByText("We've queued your code and will run it shortly.")
-    ).not.toBeInTheDocument()
-  )
-  await waitFor(() =>
-    expect(
-      queryByText("We've queued your code and will run it shortly.")
-    ).toBeInTheDocument()
-  )
-
-  server.close()
-})
-
 test('shows message when test times out', async () => {
   const server = setupServer(
     rest.post('https://exercism.test/submissions', (req, res, ctx) => {
@@ -291,10 +230,10 @@ test('change theme', async () => {
   )
 
   fireEvent.click(getByTitle('Settings'))
-  fireEvent.change(getByLabelText('Theme'), { target: { value: 'vs-dark' } })
+  fireEvent.click(getByLabelText('Dark'))
 
   await waitFor(() => {
-    expect(queryByText('Theme: vs-dark')).toBeInTheDocument()
+    expect(queryByText('Theme: dark')).toBeInTheDocument()
   })
 })
 
@@ -304,7 +243,8 @@ test('change keybindings', async () => {
   )
 
   fireEvent.click(getByTitle('Settings'))
-  fireEvent.change(getByLabelText('Keybindings'), { target: { value: 'vim' } })
+  fireEvent.click(getByLabelText('Vim'))
+  fireEvent.click(document)
 
   await waitFor(() => {
     expect(queryByText('Keybindings: vim')).toBeInTheDocument()
@@ -317,7 +257,7 @@ test('change wrapping', async () => {
   )
 
   fireEvent.click(getByTitle('Settings'))
-  fireEvent.change(getByLabelText('Wrap'), { target: { value: 'off' } })
+  fireEvent.click(getByLabelText('Off'))
 
   await waitFor(() => {
     expect(queryByText('Wrap: off')).toBeInTheDocument()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,6 +4670,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"


### PR DESCRIPTION
If we get a previous test results from the API request, we switch to the results tab. Otherwise, the instructions tab is selected by default.