### PR TITLE
Fix wrong concepts being assigned to exercises

### DIFF
--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -113,7 +113,7 @@ module Git
       # Until then it's good to check each one and
       # return an error if one is found.
       concept_slugs.map do |concept_slug|
-        ::Track::Concept.find_by!(slug: concept_slug)
+        track.concepts.find_by!(slug: concept_slug)
       rescue StandardError
         Rails.logger.error "Missing concept: #{concept_slug}"
         nil


### PR DESCRIPTION
@ErikSchierboom This was breaking tracks by assigned concepts with the same slug to all tracks (e.g. every track shared the same `basics` concepts). 

As a general rule any time you use a `find` or `where` on a top-level object, it's a smell.

Also, I can't see any tests for this code at all. Could you tests in general, and also to ensure that each track gets its own things assigned pls 🙂 

I'll merge this now.