### PR TITLE
<Tooltip /> 😅 fixed TODO

### DIFF
--- a/app/javascript/components/tooltips/Tooltip.tsx
+++ b/app/javascript/components/tooltips/Tooltip.tsx
@@ -113,15 +113,7 @@ export const Tooltip = ({
         break
     }
 
-    // TODO: 🔥 I think this needs a cleanup, but this seems to cause problems
-    // return () => {
-    //   dispatch({
-    //     id: tooltipId,
-    //     action: {
-    //       type: 'hide',
-    //     },
-    //   })
-    // }
+    return () => removeOpenTooltip(id)
   }, [
     showState,
     id,


### PR DESCRIPTION
Tooltips weren't cleaning up after themselves properly if they were unmounted while open. For the ConceptTooltip, this was never a problem because they 'closed' themselves before turbolinks could navigate.  UserTooltip didn't have this protection, since they are mounted and unmounted in an open state by the react-bootloader.

This fixes that, so now they will try to remove themselves from the open tooltip on unmount