### PR TITLE
Add force_sync option to git track syncer

### DIFF
--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -14,8 +14,9 @@ module Git
   class SyncTrack < Sync
     include Mandate
 
-    def initialize(track)
+    def initialize(track, force_sync: false)
       super(track, track.synced_to_git_sha)
+      @force_sync = force_sync
       @track = track
     end
 
@@ -48,7 +49,7 @@ module Git
     end
 
     private
-    attr_reader :track
+    attr_reader :track, :force_sync
 
     def concepts
       # TODO: verify that all exercise concepts and prerequisites are in the concepts section
@@ -100,6 +101,7 @@ module Git
     end
 
     def track_needs_updating?
+      return true if force_sync
       return false if synced_to_head?
 
       track_config_modified?

--- a/test/commands/git/sync_track_test.rb
+++ b/test/commands/git/sync_track_test.rb
@@ -4,7 +4,17 @@ class Git::SyncTrackTest < ActiveSupport::TestCase
   test "no change when git sync SHA matches HEAD SHA" do
     track = create :track, slug: 'fsharp', synced_to_git_sha: "HEAD"
 
+    Git::SyncConceptExercise.expects(:call).never
     Git::SyncTrack.(track)
+
+    refute track.changed?
+  end
+
+  test "resyncs when force_sync is passed" do
+    track = create :track, slug: 'fsharp', synced_to_git_sha: "HEAD"
+
+    Git::SyncConceptExercise.expects(:call).at_least_once
+    Git::SyncTrack.(track, force_sync: true)
 
     refute track.changed?
   end

--- a/test/commands/git/sync_track_test.rb
+++ b/test/commands/git/sync_track_test.rb
@@ -4,7 +4,9 @@ class Git::SyncTrackTest < ActiveSupport::TestCase
   test "no change when git sync SHA matches HEAD SHA" do
     track = create :track, slug: 'fsharp', synced_to_git_sha: "HEAD"
 
+    Git::SyncConcept.expects(:call).never
     Git::SyncConceptExercise.expects(:call).never
+    # Git::SyncPracticeExercise.expects(:call).never # TOOD
     Git::SyncTrack.(track)
 
     refute track.changed?
@@ -13,7 +15,10 @@ class Git::SyncTrackTest < ActiveSupport::TestCase
   test "resyncs when force_sync is passed" do
     track = create :track, slug: 'fsharp', synced_to_git_sha: "HEAD"
 
+    Git::SyncConcept.expects(:call).at_least_once
     Git::SyncConceptExercise.expects(:call).at_least_once
+    # Git::SyncPracticeExercise.expects(:call).at_least_once # TOOD
+
     Git::SyncTrack.(track, force_sync: true)
 
     refute track.changed?


### PR DESCRIPTION
This adds a `force_sync` option that I can use in the bastion to sync things (and that we can have as a nightly task too). It's currently shallow (ie, it doesn't also force sync concepts and exercises). We can add that as a second step if desired.