### PR TITLE
Patch: Fix tooltip dispatch helper

### DIFF
--- a/app/javascript/hooks/use-stateful-tooltip.ts
+++ b/app/javascript/hooks/use-stateful-tooltip.ts
@@ -273,7 +273,7 @@ export const dispatchRequestHideFromHover: DispatchHelper = (dispatch, id) =>
   dispatch({ id, action: { type: 'request-hide-hover' } })
 
 export const dispatchRequestHideFromFocus: DispatchHelper = (dispatch, id) =>
-  dispatch({ id, action: { type: 'request-hide-hover' } })
+  dispatch({ id, action: { type: 'request-hide-focus' } })
 
 export const dispatchRequestShowFromHover: DispatchHelper = (dispatch, id) =>
   dispatch({ id, action: { type: 'request-show-hover' } })


### PR DESCRIPTION
When tabbing through the concepts, if tab action caused focus to the tool-tip (which can happen if the the html sent over the wire contains a focusable element (e.g. a hyperlink <a />)) it would become stuck open because the helper was sending the wrong action to the state reducer.

This fixes that behaviour.