### PR TITLE
Mentoring UI: Update link to analyzer tooling documentation

### DIFF
--- a/app/views/mentor/solutions/_analysis.html.haml
+++ b/app/views/mentor/solutions/_analysis.html.haml
@@ -9,7 +9,7 @@
   .analysis-section
     %h3
       Automatic Analysis
-      =link_to "https://github.com/exercism/automated-mentoring-support" do
+      =link_to "https://github.com/exercism/v3-docs/tree/master/anatomy/track-tooling/analyzers" do
         = graphical_icon "info-circle", style: :solid
     .recommendation
       %strong Recommendation:


### PR DESCRIPTION
The old link points to the deprecated repository: I hope the new link is a reasonable one?