### PR TITLE
Add exercise completion endpoint

### DIFF
--- a/app/commands/user_track/monitor_changes.rb
+++ b/app/commands/user_track/monitor_changes.rb
@@ -1,0 +1,65 @@
+class UserTrack
+  class MonitorChanges
+    include Mandate
+
+    def self.call(*args, &block)
+      new(*args, &block).()
+    end
+
+    def initialize(user_track, &block)
+      @user_track = user_track
+      @block = block
+    end
+
+    def call
+      # Get the initial state. We need the first three to be arrays,
+      # not ActiveRecord::Relations, as we need the SQL to run before
+      # the block is called below.
+      available_exercise_ids = user_track.available_exercise_ids
+      available_concept_ids = user_track.available_concept_ids
+      concept_progressions = user_track.concept_progressions
+
+      # This triggers the action that we're monitor.
+      # For example, we might complete an exercise here
+      block.()
+
+      # Now we reload the user_track, knowing that the data has changed.
+      updated_user_track = UserTrack.find(user_track.id)
+
+      # Work out which exercise and concepts are newly avaliable
+      unlocked_exercise_ids = updated_user_track.available_exercise_ids - available_exercise_ids
+      unlocked_concept_ids = updated_user_track.available_concept_ids - available_concept_ids
+
+      # Build a before and after of each concept progression and keep any that have changed
+      concept_progressions = updated_user_track.concept_progressions.map do |id, data|
+        {
+          id: id,
+          total: data[:total],
+          from: concept_progressions[id][:completed],
+          to: data[:completed]
+        }
+      end
+      concept_progressions.reject! { |cp| cp[:to] == cp[:from] }
+
+      # Inject the concept into each result, and remove id
+      progressed_concepts = Track::Concept.where(
+        id: concept_progressions.map { |c| c[:id] }
+      ).index_by(&:id)
+
+      concept_progressions.map do |cp|
+        cp[:concept] = progressed_concepts[cp[:id]]
+        cp.delete(:id)
+      end
+
+      # And finally return it all as a neat hash
+      {
+        unlocked_exercises: Exercise.where(id: unlocked_exercise_ids),
+        unlocked_concepts: Track::Concept.where(id: unlocked_concept_ids),
+        concept_progressions: concept_progressions
+      }
+    end
+
+    private
+    attr_reader :user_track, :block
+  end
+end

--- a/app/controllers/api/exercises_controller.rb
+++ b/app/controllers/api/exercises_controller.rb
@@ -1,0 +1,53 @@
+module API
+  class ExercisesController < BaseController
+    def complete
+      begin
+        @track = Track.find(params[:track_id])
+      rescue StandardError
+        return render_404(:track_not_found)
+      end
+
+      begin
+        @exercise = @track.exercises.find(params[:id])
+      rescue StandardError
+        return render_404(:exercise_not_found)
+      end
+
+      @user_track = UserTrack.for(current_user, @track)
+      return render_404(:track_not_joined) unless @user_track
+
+      @solution = Solution.for(current_user, @exercise)
+      return render_404(:solution_not_found) unless @solution
+
+      changes = UserTrack::MonitorChanges.(@user_track) do
+        Solution::Complete.(@solution, @user_track)
+      end
+
+      output = {
+        unlocked_exercises: changes[:unlocked_exercises].map do |exercise|
+          {
+            slug: exercise.slug,
+            title: exercise.title,
+            icon_name: exercise.icon_name
+          }
+        end,
+        unlocked_concepts: changes[:unlocked_concepts].map do |concept|
+          {
+            slug: concept.slug,
+            name: concept.name
+          }
+        end,
+        concept_progressions: changes[:concept_progressions].map do |data|
+          {
+            slug: data[:concept].slug,
+            name: data[:concept].name,
+            from: data[:from],
+            to: data[:to],
+            total: data[:total]
+          }
+        end
+      }
+      render json: output, status: :ok
+    end
+  end
+end

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -26,6 +26,7 @@ class Tracks::ExercisesController < ApplicationController
 
   def edit; end
 
+  # TODO: Delete when this is working via the API
   def complete
     Solution::Complete.(@solution, @user_track)
     redirect_to action: :show

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -39,6 +39,7 @@ class UserTrack < ApplicationRecord
     :num_exercises,
     :num_exercises_for_concept, :num_completed_exercises_for_concept,
     :concept_available?, :concept_learnt?, :concept_mastered?,
+    :concept_progressions, :available_exercise_ids, :available_concept_ids,
     to: :summary
 
   memoize

--- a/app/models/user_track/summary.rb
+++ b/app/models/user_track/summary.rb
@@ -77,6 +77,16 @@ class UserTrack
       mapped_concepts.values.count(&:mastered?)
     end
 
+    memoize
+    def concept_progressions
+      mapped_concepts.each.with_object({}) do |(_, concept), h|
+        h[concept.id] = {
+          completed: concept.num_completed_exercises,
+          total: concept.num_exercises
+        }
+      end
+    end
+
     #################
     # Private stuff #
     #################

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,11 @@ Rails.application.routes.draw do
       get "ping" => "ping#index"
       get "validate_token" => "validate_token#index"
 
-      resources :tracks, only: %i[index show]
+      resources :tracks, only: %i[index show] do
+        resources :exercises, only: [] do
+          patch :complete, on: :member
+        end
+      end
       get "/scratchpad/:category/:title" => "scratchpad_pages#show", as: :scratchpad_page
       patch "/scratchpad/:category/:title" => "scratchpad_pages#update"
       resources :bug_reports, only: %i[create]

--- a/test/commands/user_track/monitor_changes_test.rb
+++ b/test/commands/user_track/monitor_changes_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Solution::CompleteWithSummaryTest < ActiveSupport::TestCase
+  test "sets solution as completed" do
+    track = create :track
+    concept_1 = create :track_concept, track: track
+    concept_2 = create :track_concept, track: track
+
+    concept_exercise_1 = create :concept_exercise, track: track, slug: "foo"
+    concept_exercise_1.taught_concepts << concept_1
+    practice_exercise = create :practice_exercise, track: track, slug: "prac"
+    practice_exercise.prerequisites << concept_1
+
+    concept_exercise_2 = create :concept_exercise, track: track, slug: "bar"
+    concept_exercise_2.prerequisites << concept_1
+    concept_exercise_2.taught_concepts << concept_2
+
+    user = create :user
+    user_track = create :user_track, user: user, track: track
+    solution = create :concept_solution, user: user, exercise: concept_exercise_1
+
+    summary = UserTrack::MonitorChanges.(user_track) do
+      Solution::Complete.(solution, user_track)
+    end
+
+    assert_equal [practice_exercise, concept_exercise_2], summary[:unlocked_exercises]
+    assert_equal [concept_2], summary[:unlocked_concepts]
+
+    expected = [{
+      concept: concept_1,
+      from: 0,
+      to: 1,
+      total: 2
+    }]
+    assert_equal expected, summary[:concept_progressions]
+  end
+end

--- a/test/controllers/api/exercises_controller_test.rb
+++ b/test/controllers/api/exercises_controller_test.rb
@@ -1,0 +1,154 @@
+require_relative './base_test_case'
+
+module API
+  class ExercisesControllerTest < API::BaseTestCase
+    ############
+    # Complete #
+    ############
+    test "renders 404 when track not found" do
+      setup_user
+
+      patch complete_api_track_exercise_path("ruby", "bob"),
+        headers: @headers, as: :json
+
+      assert_response 404
+      assert_equal(
+        {
+          "error" => {
+            "type" => "track_not_found",
+            "message" => I18n.t("api.errors.track_not_found")
+          }
+        },
+        JSON.parse(response.body)
+      )
+    end
+
+    test "renders 404 when exercise not found" do
+      setup_user
+
+      patch complete_api_track_exercise_path(create(:track).slug, "bob"),
+        headers: @headers, as: :json
+
+      assert_response 404
+      assert_equal(
+        {
+          "error" => {
+            "type" => "exercise_not_found",
+            "message" => I18n.t("api.errors.exercise_not_found")
+          }
+        },
+        JSON.parse(response.body)
+      )
+    end
+
+    test "renders 404 when track not joined" do
+      setup_user
+
+      exercise = create :concept_exercise
+      patch complete_api_track_exercise_path(exercise.track.slug, exercise.slug),
+        headers: @headers, as: :json
+
+      assert_response 404
+      assert_equal(
+        {
+          "error" => {
+            "type" => "track_not_joined",
+            "message" => I18n.t("api.errors.track_not_joined")
+          }
+        },
+        JSON.parse(response.body)
+      )
+    end
+
+    test "renders 404 when solution not found" do
+      setup_user
+
+      exercise = create :concept_exercise
+      create :user_track, track: exercise.track, user: @current_user
+      patch complete_api_track_exercise_path(exercise.track.slug, exercise.slug),
+        headers: @headers, as: :json
+
+      assert_response 404
+      assert_equal(
+        {
+          "error" => {
+            "type" => "solution_not_found",
+            "message" => I18n.t("api.errors.solution_not_found")
+          }
+        },
+        JSON.parse(response.body)
+      )
+    end
+
+    test "completes exercise" do
+      setup_user
+
+      exercise = create :concept_exercise
+      create :user_track, track: exercise.track, user: @current_user
+      solution = create :concept_solution, exercise: exercise, user: @current_user
+
+      patch complete_api_track_exercise_path(exercise.track.slug, exercise.slug),
+        headers: @headers, as: :json
+
+      assert_response 200
+      assert solution.reload.completed?
+    end
+
+    test "renders changes in user_track" do
+      setup_user
+
+      track = create :track
+      concept_1 = create :track_concept, track: track
+      concept_2 = create :track_concept, track: track
+
+      concept_exercise_1 = create :concept_exercise, track: track, slug: "foo"
+      concept_exercise_1.taught_concepts << concept_1
+      practice_exercise = create :practice_exercise, track: track, slug: "prac"
+      practice_exercise.prerequisites << concept_1
+
+      concept_exercise_2 = create :concept_exercise, track: track, slug: "bar"
+      concept_exercise_2.prerequisites << concept_1
+      concept_exercise_2.taught_concepts << concept_2
+
+      create :user_track, track: track, user: @current_user
+      create :concept_solution, exercise: concept_exercise_1, user: @current_user
+
+      patch complete_api_track_exercise_path(track.slug, concept_exercise_1.slug),
+        headers: @headers, as: :json
+
+      assert_response 200
+      assert_equal(
+        {
+          "unlocked_exercises" => [
+            {
+              "slug" => practice_exercise.slug,
+              "title" => practice_exercise.title,
+              "icon_name" => practice_exercise.icon_name
+            },
+            {
+              "slug" => concept_exercise_2.slug,
+              "title" => concept_exercise_2.title,
+              "icon_name" => concept_exercise_2.icon_name
+            }
+          ],
+          "unlocked_concepts" => [
+            {
+              "slug" => concept_2.slug,
+              "name" => concept_2.name
+            }
+          ],
+          "concept_progressions" => [
+            {
+              "slug" => concept_1.slug,
+              "name" => concept_1.name,
+              "from" => 0,
+              "to" => 1,
+              "total" => 2
+            }
+          ]
+        },
+        JSON.parse(response.body)
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds an endpoint for completing exercises:
```PATCH /api/v1/tracks/ruby/exercises/bob/complete```

The endpoint will expect a param for any iterations that are published:
```
published_iteration_idx: [1,2,3]
```

Currently the modal is only boolean, so for now, just set that to `true` in React, rather than an event. Once I've finalised the design with @taiyab for that bit, I'll add the endpoint.

The endpoint returns the data required to render the modal:
```
        {
          "unlocked_exercises" => [
            {
              "slug" => practice_exercise.slug,
              "title" => practice_exercise.title,
              "icon_name" => practice_exercise.icon_name
            },
            {
              "slug" => concept_exercise_2.slug,
              "title" => concept_exercise_2.title,
              "icon_name" => concept_exercise_2.icon_name
            }
          ],
          "unlocked_concepts" => [
            {
              "slug" => concept_2.slug,
              "name" => concept_2.name
            }
          ],
          "concept_progressions" => [
            {
              "slug" => concept_1.slug,
              "name" => concept_1.name,
              "from" => 0,
              "to" => 1,
              "total" => 2
            }
          ]
        },
```

There will no doubt be other data I've missed too.

In the last bit, the `to`, `total` represent the concept in that progress (so if to is 3, and total is 5, then 3 out of 5 exercises have been completed, or to put it another way the bar is 60% complete. The `from` is the value that it was at before this exercise was completed. When we animate those bars, this is the start value for the animation.

---

In terms of the code, a lot of the final code in the controller should probably be moved into a serializer, but let's work out exactly what we need first, and then we can refactor that later.