### PR TITLE
Add extra blocks to the completed exercise modal

### DIFF
--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -44,6 +44,9 @@ class Tracks::ExercisesController < ApplicationController
     else
       @concepts = @exercise.prerequisites
     end
+
+    @unlocked_exercises = @track.exercises.limit(2)
+    @unlocked_concepts = @track.concepts.limit(2)
   end
 
   # TODO: Remove

--- a/app/css/components/concept-icon.css
+++ b/app/css/components/concept-icon.css
@@ -13,6 +13,7 @@
         padding: 3px;
 
         font-size: 11px;
+        @apply font-semibold;
     }
 
     &.c--medium {

--- a/app/css/modals/completed-exercise.css
+++ b/app/css/modals/completed-exercise.css
@@ -19,7 +19,7 @@
         }
     }
 
-    & .concepts {
+    & .progressed-concepts {
         & .concept {
             @apply flex items-center py-16 px-24;
             @apply shadow-lg rounded-8;
@@ -49,5 +49,48 @@
             height: 32px;
             @apply ml-24;
         }
+    }
+
+    & .unlocks {
+        @apply flex mt-32;
+        & .unlocked-exercises,
+        & .unlocked-concepts {
+            @apply flex-grow pr-40;
+            min-width: 50%;
+        }
+        & h3 {
+            @apply flex text-h5 mb-16;
+
+            & .c-icon {
+                height: 24px;
+                width: 24px;
+                @apply mx-8;
+            }
+        }
+        & .exercises,
+        & .concepts {
+            @apply flex flex-wrap;
+        }
+        & .exercise,
+        & .concept {
+            @apply flex items-center py-8 px-12 mr-8 mb-8;
+            @apply rounded-8 shadow-base;
+            @apply cursor-default;
+
+            & .c-icon,
+            & .c-concept-icon {
+                @apply mr-12;
+            }
+            & .c-icon {
+                height: 24px;
+                width: 24px;
+            }
+            & .title {
+                @apply text-16 leading-paragraph font-medium truncate;
+                max-width: 160px;
+            }
+        }
+    }
+    & .unlocked-concepts {
     }
 }

--- a/app/views/tracks/exercises/completed.html.haml
+++ b/app/views/tracks/exercises/completed.html.haml
@@ -7,7 +7,7 @@
         %br
         #{@exercise.title}!
 
-    .concepts
+    .progressed-concepts
       - @concepts.each do |concept|
         - mastered = @user_track.concept_mastered?(concept)
 
@@ -22,3 +22,31 @@
             = icon "completed-check-circle", "Concept Completed", css_class: "completed"
           - else
             .completed
+
+    - if @unlocked_exercises.present? || @unlocked_concepts.present?
+      .unlocks
+        - if @unlocked_exercises.present?
+          .unlocked-exercises
+            %h3
+              You've unlocked
+              = graphical_icon :exercises
+              = pluralize @unlocked_exercises.size, "exercise"
+            .exercises
+              - @unlocked_exercises.each do |exercise|
+                .exercise
+                  = exercise_icon(exercise)
+                  .title
+                    = exercise.title
+
+        - if @unlocked_concepts.present?
+          .unlocked-concepts
+            %h3
+              You've unlocked
+              = graphical_icon :concepts
+              = pluralize @unlocked_concepts.size, "concept"
+            .concepts
+              - @unlocked_concepts.each do |concept|
+                .concept
+                  = render ViewComponents::ConceptIcon.new(concept, 'small')
+                  .title
+                    = concept.name


### PR DESCRIPTION
@kntsoriano This adds the bottom two sections to this modal. It also changes one class name. If you've started on this, you'll need to bring that in line.

<img width="1425" alt="Screenshot 2021-01-15 at 13 38 24" src="https://user-images.githubusercontent.com/286476/104733853-39d4d780-5737-11eb-81e1-6ac4054767c9.png">
