### PR TITLE
Improve reputation serializer

### DIFF
--- a/app/css/pages/journey.css
+++ b/app/css/pages/journey.css
@@ -174,6 +174,9 @@
                             @apply text-textColor1 font-semibold;
                         }
                     }
+                    & .generic {
+                        @apply text-16 text-textColor6;
+                    }
                     & date {
                         @apply ml-16 text-textLight;
                     }

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -51,6 +51,8 @@ class User::ReputationToken < ApplicationRecord
   def icon_name
     return exercise.icon_name if exercise
     return track.icon_name if track
+
+    :reputation # TODO: Choose an icon
   end
 
   def description
@@ -72,9 +74,7 @@ class User::ReputationToken < ApplicationRecord
     "You contributed to Exercism"
   end
 
-  def link_url
-    return external_link if external_link.present?
-
+  def internal_link
     nil
   end
 end

--- a/app/serializers/serialize_reputation_tokens.rb
+++ b/app/serializers/serialize_reputation_tokens.rb
@@ -16,8 +16,15 @@ class SerializeReputationTokens
       value: token.value,
       description: token.description,
       icon_name: token.icon_name,
-      link_url: token.link_url,
-      awarded_at: token.created_at.iso8601
+      internal_link: token.internal_link,
+      external_link: token.external_link,
+      awarded_at: token.created_at.iso8601,
+      track: if token.track
+               {
+                 title: token.track.title,
+                 icon_name: token.track.icon_name
+               }
+             end
     }
   end
 end

--- a/app/serializers/serialize_reputation_tokens.rb
+++ b/app/serializers/serialize_reputation_tokens.rb
@@ -12,6 +12,13 @@ class SerializeReputationTokens
   end
 
   def serialize_token(token)
+    if token.track
+      track_hash = {
+        title: token.track.title,
+        icon_name: token.track.icon_name
+      }
+    end
+
     {
       value: token.value,
       description: token.description,
@@ -19,12 +26,7 @@ class SerializeReputationTokens
       internal_link: token.internal_link,
       external_link: token.external_link,
       awarded_at: token.created_at.iso8601,
-      track: if token.track
-               {
-                 title: token.track.title,
-                 icon_name: token.track.icon_name
-               }
-             end
+      track: track_hash
     }
   end
 end

--- a/app/views/journey/reputation.html.haml
+++ b/app/views/journey/reputation.html.haml
@@ -41,4 +41,4 @@
                 Generic
               %date 3 mins ago
           = render ViewComponents::Reputation.new("+50", flashy: true)
-          = graphical_icon "chevron-right", css_class: 'action-button'
+          = graphical_icon "external-link", css_class: 'action-button'

--- a/app/views/journey/reputation.html.haml
+++ b/app/views/journey/reputation.html.haml
@@ -37,10 +37,8 @@
           .info
             .title You contributed to the TwoFer exercise on the Elixir Track
             .extra
-              .exercise
-                in
-                = graphical_icon("sample-track")
-                .name Elixir
+              .generic
+                Generic
               %date 3 mins ago
           = render ViewComponents::Reputation.new("+50", flashy: true)
           = graphical_icon "chevron-right", css_class: 'action-button'

--- a/test/serializers/serialize_reputation_tokens_test.rb
+++ b/test/serializers/serialize_reputation_tokens_test.rb
@@ -3,9 +3,11 @@ require 'test_helper'
 class SerializeReputationTokensTest < ActiveSupport::TestCase
   test "basic to_hash" do
     exercise = create :concept_exercise
+    track = create :track
     token = create :user_reputation_token,
       created_at: Time.current - 1.week,
       exercise: exercise,
+      track: track,
       external_link: "https://google.com"
 
     expected = {
@@ -13,8 +15,32 @@ class SerializeReputationTokensTest < ActiveSupport::TestCase
         value: token.value,
         description: "You authored Datetime",
         icon_name: "sample-exercise-butterflies",
-        link_url: "https://google.com",
-        awarded_at: token.created_at.iso8601
+        internal_link: nil,
+        external_link: "https://google.com",
+        awarded_at: token.created_at.iso8601,
+        track: {
+          title: track.title,
+          icon_name: track.icon_name
+        }
+      }]
+    }
+
+    assert_equal expected, SerializeReputationTokens.([token])
+  end
+
+  test "works with empty token" do
+    token = create :user_reputation_token,
+      created_at: Time.current - 1.week
+
+    expected = {
+      tokens: [{
+        value: token.value,
+        description: "You contributed to Exercism",
+        icon_name: :reputation,
+        internal_link: nil,
+        external_link: nil,
+        awarded_at: token.created_at.iso8601,
+        track: nil
       }]
     }
 


### PR DESCRIPTION
<img width="1240" alt="Screenshot 2021-01-20 at 22 30 30" src="https://user-images.githubusercontent.com/286476/105248893-1c58a100-5b6f-11eb-86d1-7c1752ba9215.png">

@kntsoriano Note the "generic" on the second one where the track is missing, and also the external link on the second one.