### PR TITLE
Add styling to guidance tab

### DIFF
--- a/app/css/application.css
+++ b/app/css/application.css
@@ -75,7 +75,7 @@
 }
 
 .theme-dark {
-    --backgroundColorA: var(--c-000000);
+    --backgroundColorA: var(--c-111111);
     --backgroundColorB: var(--c-282339);
     --backgroundColorC: var(--c-322C44);
     --borderColor3: var(--c-8480A0);

--- a/app/css/components/accordion-section.css
+++ b/app/css/components/accordion-section.css
@@ -1,0 +1,18 @@
+.c-accordion-section {
+    @apply border-t-1 border-b-1 border-borderColor7;
+    @apply py-16;
+    & > button {
+        @apply flex items-center;
+        & > .c-icon {
+            height: 24px;
+            width: 24px;
+            @apply mr-24;
+        }
+        & > .--title {
+            @apply text-16 font-semibold leading-paragraph;
+        }
+    }
+    & > div {
+        @apply pt-16;
+    }
+}

--- a/app/css/components/mentor/discussion.css
+++ b/app/css/components/mentor/discussion.css
@@ -232,149 +232,58 @@
             overflow-y: scroll;
         }
 
-        & .student-info {
-            @apply bg-backgroundColorA;
-            @apply flex;
+        & #panel-discussion {
+            & .student-info {
+                @apply bg-backgroundColorA;
+                @apply flex;
 
-            @apply py-16 px-24 mb-8;
+                @apply py-16 px-24 mb-8;
 
-            & .subtitle {
-                @apply text-textColor6 leading-paragraph mb-6;
-            }
-            & .name-block {
-                @apply flex items-center;
-                & .name {
-                    @apply text-h5 mr-12;
+                & .subtitle {
+                    @apply text-textColor6 leading-paragraph mb-6;
                 }
-            }
-            & .handle {
-                @apply text-16 text-textColor6 font-medium leading-regular;
-                @apply mb-6;
-            }
-            & .bio {
-                @apply text-15 leading-huge mr-40 mb-20;
-                & .flags {
-                    @apply ml-8;
-                }
-            }
-            & .options {
-                @apply flex items-center;
-
-                & .button-wrapper {
-                    @apply flex;
-                    width: 173px;
-                    height: 36px;
-
-                    & button {
-                        @apply flex-grow text-textColor6;
-                    }
-
-                    & button.unfavorite-button {
-                        @apply border-orange;
-                        @apply bg-lightOrange;
-                        @apply text-orange;
-                        &.hover {
-                            @apply text-red;
-                            @apply border-red;
-                            @apply bg-lightRed;
-                        }
-                    }
-                }
-                & .previous-sessions {
-                    @apply flex items-center ml-24;
-                    @apply font-semibold text-textColor6 leading-huge;
-                    & .c-icon {
-                        height: 14px;
-                        width: 14px;
-                        @apply ml-12;
-                    }
-                }
-            }
-            & .c-rounded-bg-img {
-                height: 64px;
-                width: 64px;
-                @apply ml-16;
-            }
-        }
-
-        & .discussion {
-            & .iteration-marker {
-                @apply flex items-center;
-                @apply mx-24 py-8 px-16;
-                @apply bg-backgroundColorD rounded-8;
-                @apply text-textColor6 leading-paragraph;
-
-                & .info {
-                    @apply flex-grow flex items-center;
-                    @apply text-15;
-                    & .c-icon {
-                        height: 16px;
-                        width: 16px;
-                        @apply mr-8;
-                    }
-
-                    & strong {
-                        @apply font-medium text-textColor1 mr-6;
-                    }
-                }
-                & time {
-                }
-            }
-
-            & details.auto-feedback {
-                @apply mx-24 mt-8;
-                @apply relative;
-                @apply border-1 border-borderColor6 rounded-8;
-                @apply py-8 px-16;
-
-                &:before {
-                    content: "";
-                    top: -8px;
-                    height: 8px;
-                    left: 24px;
-
-                    @apply absolute;
-                    @apply border-l-1 border-borderColor6;
-                }
-
-                & summary {
+                & .name-block {
                     @apply flex items-center;
-                    & .info-icon {
-                        height: 16px;
-                        width: 16px;
-                        @apply text-orange mr-12;
-                    }
-                    & .info {
-                        @apply flex-grow;
-                        @apply text-15 text-textColor6 font-medium leading-paragraph;
+                    & .name {
+                        @apply text-h5 mr-12;
                     }
                 }
-                & .feedback {
-                    @apply border-t-1 border-borderColor6;
-                    @apply mt-8 pt-12 mb-12;
-                    @apply flex flex-col items-start;
+                & .handle {
+                    @apply text-16 text-textColor6 font-medium leading-regular;
+                    @apply mb-6;
+                }
+                & .bio {
+                    @apply text-15 leading-huge mr-40 mb-20;
+                    & .flags {
+                        @apply ml-8;
+                    }
+                }
+                & .options {
+                    @apply flex items-center;
 
-                    & .byline {
-                        @apply flex items-center mb-12;
+                    & .button-wrapper {
+                        @apply flex;
+                        width: 173px;
+                        height: 36px;
 
-                        & .c-rounded-bg-img {
-                            @apply mr-8;
-                            height: 32px;
-                            width: 32px;
+                        & button {
+                            @apply flex-grow text-textColor6;
                         }
-                        & .name {
-                            @apply mr-12;
-                            @apply text-14 leading-paragraph text-textColor6 font-medium;
-                        }
-                        & .c-icon {
-                            @apply text-textColor6;
+
+                        & button.unfavorite-button {
+                            @apply border-orange;
+                            @apply bg-lightOrange;
+                            @apply text-orange;
+                            &.hover {
+                                @apply text-red;
+                                @apply border-red;
+                                @apply bg-lightRed;
+                            }
                         }
                     }
-                    & .more {
-                        @apply border-1 border-borderColor6 rounded-8;
-                        @apply px-16 py-6;
-                        @apply font-medium leading-huge text-textColor6;
-                        @apply flex items-center;
+                    & .previous-sessions {
+                        @apply flex items-center ml-24;
+                        @apply font-semibold text-textColor6 leading-huge;
                         & .c-icon {
                             height: 14px;
                             width: 14px;
@@ -382,59 +291,155 @@
                         }
                     }
                 }
+                & .c-rounded-bg-img {
+                    height: 64px;
+                    width: 64px;
+                    @apply ml-16;
+                }
             }
 
-            & .post {
-                @apply pt-20 pb-16 px-24 bg-backgroundColorA;
+            & .discussion {
+                & .iteration-marker {
+                    @apply flex items-center;
+                    @apply mx-24 py-8 px-16;
+                    @apply bg-backgroundColorD rounded-8;
+                    @apply text-textColor6 leading-paragraph;
 
-                &:hover {
-                    @apply bg-backgroundColorB;
-                    & .post-header {
-                        & .edit-button {
-                            @apply visible;
-                        }
-                    }
-                }
-
-                & .post-header {
-                    @apply flex items-center mb-8;
-
-                    & .author {
+                    & .info {
                         @apply flex-grow flex items-center;
-
-                        & .c-rounded-bg-img {
-                            height: 32px;
-                            width: 32px;
-                            @apply mr-12;
-                        }
-                        & .handle {
-                            @apply font-mono font-semibold text-16 text-darkGray;
-                        }
-                        & .tag {
-                            height: 30px;
-                            @apply flex items-center ml-16 rounded-100;
-                            @apply font-medium text-textColor6 px-12;
-                            @apply border-1 border-borderColor4;
-                        }
-                    }
-
-                    & .edit-button {
-                        @apply flex items-center ml-32 p-8;
-                        @apply text-textColor6 font-medium leading-huge;
-                        @apply invisible;
+                        @apply text-15;
                         & .c-icon {
-                            @apply mr-12;
                             height: 16px;
                             width: 16px;
+                            @apply mr-8;
+                        }
+
+                        & strong {
+                            @apply font-medium text-textColor1 mr-6;
+                        }
+                    }
+                    & time {
+                    }
+                }
+
+                & details.auto-feedback {
+                    @apply mx-24 mt-8;
+                    @apply relative;
+                    @apply border-1 border-borderColor6 rounded-8;
+                    @apply py-8 px-16;
+
+                    &:before {
+                        content: "";
+                        top: -8px;
+                        height: 8px;
+                        left: 24px;
+
+                        @apply absolute;
+                        @apply border-l-1 border-borderColor6;
+                    }
+
+                    & summary {
+                        @apply flex items-center;
+                        & .info-icon {
+                            height: 16px;
+                            width: 16px;
+                            @apply text-orange mr-12;
+                        }
+                        & .info {
+                            @apply flex-grow;
+                            @apply text-15 text-textColor6 font-medium leading-paragraph;
+                        }
+                    }
+                    & .feedback {
+                        @apply border-t-1 border-borderColor6;
+                        @apply mt-8 pt-12 mb-12;
+                        @apply flex flex-col items-start;
+
+                        & .byline {
+                            @apply flex items-center mb-12;
+
+                            & .c-rounded-bg-img {
+                                @apply mr-8;
+                                height: 32px;
+                                width: 32px;
+                            }
+                            & .name {
+                                @apply mr-12;
+                                @apply text-14 leading-paragraph text-textColor6 font-medium;
+                            }
+                            & .c-icon {
+                                @apply text-textColor6;
+                            }
+                        }
+                        & .more {
+                            @apply border-1 border-borderColor6 rounded-8;
+                            @apply px-16 py-6;
+                            @apply font-medium leading-huge text-textColor6;
+                            @apply flex items-center;
+                            & .c-icon {
+                                height: 14px;
+                                width: 14px;
+                                @apply ml-12;
+                            }
                         }
                     }
                 }
-                & .post-content {
-                }
-                & .post-at {
-                    @apply text-textColor6 leading-huge;
+
+                & .post {
+                    @apply pt-20 pb-16 px-24 bg-backgroundColorA;
+
+                    &:hover {
+                        @apply bg-backgroundColorB;
+                        & .post-header {
+                            & .edit-button {
+                                @apply visible;
+                            }
+                        }
+                    }
+
+                    & .post-header {
+                        @apply flex items-center mb-8;
+
+                        & .author {
+                            @apply flex-grow flex items-center;
+
+                            & .c-rounded-bg-img {
+                                height: 32px;
+                                width: 32px;
+                                @apply mr-12;
+                            }
+                            & .handle {
+                                @apply font-mono font-semibold text-16 text-darkGray;
+                            }
+                            & .tag {
+                                height: 30px;
+                                @apply flex items-center ml-16 rounded-100;
+                                @apply font-medium text-textColor6 px-12;
+                                @apply border-1 border-borderColor4;
+                            }
+                        }
+
+                        & .edit-button {
+                            @apply flex items-center ml-32 p-8;
+                            @apply text-textColor6 font-medium leading-huge;
+                            @apply invisible;
+                            & .c-icon {
+                                @apply mr-12;
+                                height: 16px;
+                                width: 16px;
+                            }
+                        }
+                    }
+                    & .post-content {
+                    }
+                    & .post-at {
+                        @apply text-textColor6 leading-huge;
+                    }
                 }
             }
+        }
+        & #panel-guidance {
+            @apply py-16 px-24;
         }
     }
 }

--- a/app/css/components/published-solution.css
+++ b/app/css/components/published-solution.css
@@ -1,6 +1,7 @@
 @import "../styles";
 
 .c-published-solution {
+    @apply flex flex-col;
     @apply shadow-base bg-backgroundColorA;
     @apply px-24 py-16;
 
@@ -10,7 +11,8 @@
         & > .--exercise {
             @apply flex flex-grow;
 
-            & > .c-exercise-icon {
+            & > .c-exercise-icon,
+            & > .c-rounded-bg-img {
                 height: 48px;
                 width: 48px;
                 @apply mr-16;

--- a/app/css/components/textual-content.css
+++ b/app/css/components/textual-content.css
@@ -6,6 +6,7 @@
             @apply text-18;
         }
         & > * {
+            @apply mt-16;
             @apply mb-16;
         }
 
@@ -28,6 +29,8 @@
     &.--small {
         & * {
             @apply text-15;
+            @apply mt-12;
+            @apply mt-12;
         }
 
         /************/
@@ -40,6 +43,9 @@
         & h3 {
             @apply text-h4 mb-8;
             @apply text-18 mb-8;
+        }
+        & * + h3 {
+            @apply mt-32;
         }
 
         /******************/
@@ -98,6 +104,7 @@
             margin-left: 14px;
             & li {
                 margin-left: 6px;
+                @apply mt-0;
                 @apply mb-8;
             }
         }

--- a/app/helpers/react_components/mentoring/discussion.rb
+++ b/app/helpers/react_components/mentoring/discussion.rb
@@ -9,10 +9,6 @@ module ReactComponents
           {
             discussion_id: discussion.uuid,
             user_id: current_user.id,
-            mentor: {
-              handle: mentor.handle,
-              avatar_url: mentor.avatar_url
-            },
             student: {
               name: student.name,
               handle: student.handle,
@@ -88,7 +84,12 @@ module ReactComponents
           num_stars: ms.num_stars,
           num_comments: ms.num_comments,
           published_at: ms.published_at,
-          web_url: Exercism::Routes.private_solution_url(ms)
+          web_url: Exercism::Routes.private_solution_url(ms),
+          mentor: {
+            handle: mentor.handle,
+            avatar_url: mentor.avatar_url
+          },
+          language: ms.editor_language
         }
       end
 

--- a/app/helpers/react_components/mentoring/discussion.rb
+++ b/app/helpers/react_components/mentoring/discussion.rb
@@ -9,6 +9,10 @@ module ReactComponents
           {
             discussion_id: discussion.uuid,
             user_id: current_user.id,
+            mentor: {
+              handle: mentor.handle,
+              avatar_url: mentor.avatar_url
+            },
             student: {
               name: student.name,
               handle: student.handle,
@@ -31,7 +35,8 @@ module ReactComponents
               title: exercise.title
             },
             iterations: iterations,
-            links: links
+            links: links,
+            mentor_solution: mentor_solution
           }
         )
       end
@@ -72,21 +77,22 @@ module ReactComponents
         end
       end
 
-      memoize
-      delegate :student, to: :discussion
+      def mentor_solution
+        ms = Solution.for(mentor, exercise)
+        return nil unless ms
 
-      memoize
-      delegate :mentor, to: :discussion
-
-      memoize
-      def track
-        discussion.solution.track
+        {
+          snippet: ms.snippet,
+          num_loc: ms.num_loc,
+          num_stars: ms.num_stars,
+          num_comments: ms.num_comments,
+          published_at: ms.published_at,
+          web_url: Exercism::Routes.private_solution_url(ms)
+        }
       end
 
       memoize
-      def exercise
-        discussion.solution.exercise
-      end
+      delegate :student, :mentor, :exercise, :track, to: :discussion
 
       memoize
       def scratchpad

--- a/app/helpers/react_components/mentoring/discussion.rb
+++ b/app/helpers/react_components/mentoring/discussion.rb
@@ -36,7 +36,8 @@ module ReactComponents
             },
             iterations: iterations,
             links: links,
-            mentor_solution: mentor_solution
+            mentor_solution: mentor_solution,
+            notes: notes
           }
         )
       end
@@ -89,6 +90,24 @@ module ReactComponents
           published_at: ms.published_at,
           web_url: Exercism::Routes.private_solution_url(ms)
         }
+      end
+
+      # TODO
+      def notes
+        '
+<h3>Talking points</h3>
+<ul>
+  <li>
+    <code>each_cons</code> instead of an iterator
+    <code>with_index</code>: In Ruby, you rarely have to write
+    iterators that need to keep track of the index. Enumerable has
+    powerful methods that do that for us.
+  </li>
+  <li>
+    <code>chars</code>: instead of <code>split("")</code>.
+  </li>
+</ul>
+        '.strip
       end
 
       memoize

--- a/app/helpers/react_components/mentoring/discussion.rb
+++ b/app/helpers/react_components/mentoring/discussion.rb
@@ -35,9 +35,9 @@ module ReactComponents
               title: exercise.title
             },
             iterations: iterations,
-            links: links,
             mentor_solution: mentor_solution,
-            notes: notes
+            notes: notes,
+            links: links
           }
         )
       end

--- a/app/helpers/view_components/published_solution.rb
+++ b/app/helpers/view_components/published_solution.rb
@@ -17,8 +17,8 @@ module ViewComponents
           published_at: solution.published_at,
           num_stars: solution.num_stars,
           num_comments: solution.num_comments,
-          num_lines: solution.num_loc, # TODO
-          snippet: solution.snippet, # TODO
+          num_lines: solution.num_loc,
+          snippet: solution.snippet,
           highlightjs_language: "csharp" # TODO
         },
         layout: false

--- a/app/helpers/view_components/published_solution.rb
+++ b/app/helpers/view_components/published_solution.rb
@@ -15,10 +15,10 @@ module ViewComponents
           exercise_title: solution.exercise.title,
           track_title: solution.track.title,
           published_at: solution.published_at,
-          num_stars: 10, # TODO
-          num_comments: 2, # TODO
-          num_lines: 9, # TODO
-          snippet: snippet, # TODO
+          num_stars: solution.num_stars,
+          num_comments: solution.num_comments,
+          num_lines: solution.num_loc, # TODO
+          snippet: solution.snippet, # TODO
           highlightjs_language: "csharp" # TODO
         },
         layout: false
@@ -26,19 +26,5 @@ module ViewComponents
 
     private
     attr_reader :solution
-
-    def snippet
-      '
-public class Year
-{
-  public static bool IsLeap(int year)
-  {
-      if (year % 4 != 0) return false
-      if (year % 100 == 0 && year % 400) return false
-      return true;
-  }
-}
-      '.strip
-    end
   end
 end

--- a/app/javascript/components/common/Accordion.tsx
+++ b/app/javascript/components/common/Accordion.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { GraphicalIcon } from './GraphicalIcon'
 
 export type AccordionContext = {
   id: string
@@ -25,7 +26,7 @@ export const Accordion = ({
 }): JSX.Element => {
   return (
     <Context.Provider value={{ isOpen, id, onClick }}>
-      {children}
+      <div className="c-accordion-section">{children}</div>
     </Context.Provider>
   )
 }
@@ -45,7 +46,12 @@ const AccordionHeader = ({
       aria-controls={`accordion-panel-${id}`}
       id={`accordion-header-${id}`}
     >
-      {children}
+      {isOpen ? (
+        <GraphicalIcon icon="minus-circle" />
+      ) : (
+        <GraphicalIcon icon="plus-circle" />
+      )}
+      <div className="--title">{children}</div>
     </button>
   )
 }

--- a/app/javascript/components/mentoring/Discussion.tsx
+++ b/app/javascript/components/mentoring/Discussion.tsx
@@ -92,6 +92,7 @@ type DiscussionProps = {
   discussionId: number
   iterations: readonly Iteration[]
   userId: number
+  notes: string
 }
 
 export type TabIndex = 'discussion' | 'scratchpad' | 'guidance'
@@ -106,6 +107,7 @@ export const Discussion = ({
   discussionId,
   iterations,
   userId,
+  notes,
 }: DiscussionProps): JSX.Element => {
   const [currentIteration, setCurrentIteration] = useState(
     iterations[iterations.length - 1]
@@ -195,6 +197,7 @@ export const Discussion = ({
             onAfterPostHighlight={() => {
               setHasNewMessages(false)
             }}
+            notes={notes}
           />
 
           <section className="comment-section">

--- a/app/javascript/components/mentoring/Discussion.tsx
+++ b/app/javascript/components/mentoring/Discussion.tsx
@@ -84,6 +84,20 @@ export type Exercise = {
   title: string
 }
 
+export type MentorSolution = {
+  snippet: string
+  numLoc: string
+  numStars: string
+  numComments: string
+  publishedAt: string
+  webUrl: string
+  mentor: {
+    handle: string
+    avatarUrl: string
+  }
+  language: string
+}
+
 type DiscussionProps = {
   student: Student
   track: Track
@@ -93,6 +107,7 @@ type DiscussionProps = {
   iterations: readonly Iteration[]
   userId: number
   notes: string
+  mentorSolution: MentorSolution
 }
 
 export type TabIndex = 'discussion' | 'scratchpad' | 'guidance'
@@ -108,6 +123,7 @@ export const Discussion = ({
   iterations,
   userId,
   notes,
+  mentorSolution,
 }: DiscussionProps): JSX.Element => {
   const [currentIteration, setCurrentIteration] = useState(
     iterations[iterations.length - 1]
@@ -198,6 +214,9 @@ export const Discussion = ({
               setHasNewMessages(false)
             }}
             notes={notes}
+            mentorSolution={mentorSolution}
+            track={track}
+            exercise={exercise}
           />
 
           <section className="comment-section">

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -1,15 +1,18 @@
 import React, { useState, useCallback } from 'react'
 import { Accordion } from '../../common/Accordion'
+import { GraphicalIcon } from '../../common/GraphicalIcon'
+import { Avatar } from '../../common/Avatar'
+import { Icon } from '../../common/Icon'
 
 export const Guidance = (): JSX.Element => {
   const [accordionState, setAccordionState] = useState([
     {
-      id: 'solution',
-      isOpen: true,
-    },
-    {
       id: 'notes',
       isOpen: false,
+    },
+    {
+      id: 'solution',
+      isOpen: true,
     },
     {
       id: 'feedback',
@@ -45,7 +48,90 @@ export const Guidance = (): JSX.Element => {
   )
 
   return (
-    <div>
+    <>
+      <Accordion id="notes" isOpen={isOpen('notes')} onClick={handleClick}>
+        <Accordion.Header>Mentor notes</Accordion.Header>
+        <Accordion.Panel>
+          <div className="c-textual-content --small">
+            {/* TODO: REPLACE THIS */}
+            <h3>Talking points</h3>
+            <ul>
+              <li>
+                <code>each_cons</code> instead of an iterator{' '}
+                <code>with_index</code>: In Ruby, you rarely have to write
+                iterators that need to keep track of the index. Enumerable has
+                powerful methods that do that for us.
+              </li>
+              <li>
+                <code>chars</code>: instead of <code>split('')</code>.
+              </li>
+              <li>
+                <code>each_char</code>: if an <code>Array</code> is not
+                specifically necessary or wanted.
+              </li>
+              <li>
+                <code>attr_reader</code>: instead of the instance variable,{' '}
+                <a
+                  href="https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables"
+                  target="_blank"
+                >
+                  explained here
+                </a>
+                .
+              </li>
+              <li>
+                <code>private</code> attr_reader: Following the 'rule' for
+                encapsulation: if it doesn't need to be public, make it private.{' '}
+                <a
+                  href="http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html"
+                  target="_blank"
+                >
+                  This link
+                </a>{' '}
+                may come in handy for a first introduction.
+              </li>
+              <li>
+                <code>unless</code>, inline: With <code>unless</code> instead of{' '}
+                <code>if</code>, we can show what "good" looks like for the
+                conditional statement.
+              </li>
+              <li>
+                <code>error</code>: Custom error message? (Only if the first
+                submission meets the Minimal Solution.)
+              </li>
+              <li>
+                <code>map(&amp;:join)</code>: instead of map with block, but at
+                this point in the track it's okay to just accept it if students
+                use it, no need to require it or dive into the subject of{' '}
+                <code>Symbol#to_proc</code>.
+              </li>
+              <li>
+                <code>each_char</code>: may be preferable over{' '}
+                <code>chars</code> as it returns an <code>Enumerator</code> that
+                will yield each character without creating an intermediate{' '}
+                <code>Array</code>. More: <code>String#chars</code> with a block
+                has a deprecation warning in more recent Ruby versions.{' '}
+                <code>str.chars</code> is a shorthand for{' '}
+                <code>str.each_char.to_a</code>.
+              </li>
+            </ul>
+            <h3>Mentor Research</h3>
+            <ul>
+              <li>
+                The Iteration article mentioned above isn't ideal, but it's one
+                of the few I know of that does more than comparing{' '}
+                <code>each</code> and <code>map</code>, PLUS don't uses hashes
+                for examples. Other suggestions welcome.
+              </li>
+              <li>
+                <code>each_cons</code> raises an ArgumentError for arguments
+                &lt;= 0; it returns the array if the argument &gt;= the array.
+              </li>
+            </ul>
+            {/* TODO: END REPLACE */}
+          </div>
+        </Accordion.Panel>
+      </Accordion>
       <Accordion
         id="solution"
         isOpen={isOpen('solution')}
@@ -53,13 +139,87 @@ export const Guidance = (): JSX.Element => {
       >
         <Accordion.Header>How you solved the exercise</Accordion.Header>
         <Accordion.Panel>
-          <p>Solution here</p>
-        </Accordion.Panel>
-      </Accordion>
-      <Accordion id="notes" isOpen={isOpen('notes')} onClick={handleClick}>
-        <Accordion.Header>Mentor notes</Accordion.Header>
-        <Accordion.Panel>
-          <p>Notes here</p>
+          {/* TOOD: Replace "#" with mentor_solution.web_url */}
+          <a href="#" className="c-published-solution">
+            <header className="--header">
+              <div className="--exercise">
+                {/* TODO: Replace with mentor.handle and mentor.avatar_url */}
+                <Avatar
+                  handle="iHiD"
+                  src="https://avatars2.githubusercontent.com/u/5337876?s=460&v=4"
+                />
+
+                <div className="--info">
+                  <div className="--exercise-title">Your Solution</div>
+                  {/* TODO: Replace "Leap" and "Ruby" */}
+                  <div className="--track-title">to Leap in Ruby</div>
+                </div>
+
+                {/*TODO: If mentor_solution.published_at? */}
+                <div className="--counts">
+                  <div className="--count">
+                    <Icon
+                      icon="star"
+                      alt="Number of times solution has been stared"
+                    />
+                    {/*TODO: Replace with num_stars */}
+                    <div className="--num">10</div>
+                  </div>
+                  <div className="--count">
+                    <Icon
+                      icon="comment"
+                      alt="Number of times solution has been commented on"
+                    />
+                    {/*TODO: Replace with num_comments */}
+                    <div className="--num">2</div>
+                  </div>
+                </div>
+              </div>
+            </header>
+            <pre>
+              {/* TODO: Replcae with mentor_solution.snippet */}
+              <code className="language-csharp hljs">
+                <span className="hljs-keyword">public</span>{' '}
+                <span className="hljs-keyword">class</span>{' '}
+                <span className="hljs-title">Year</span>
+                <span className="hljs-function">
+                  <span className="hljs-keyword">public</span>{' '}
+                  <span className="hljs-keyword">static</span>{' '}
+                  <span className="hljs-built_in">bool</span>{' '}
+                  <span className="hljs-title">IsLeap</span>(
+                  <span className="hljs-params">
+                    <span className="hljs-built_in">int</span> year
+                  </span>
+                  )
+                </span>
+                <span className="hljs-keyword">if</span> (year %{' '}
+                <span className="hljs-number">4</span> !={' '}
+                <span className="hljs-number">0</span>){' '}
+                <span className="hljs-keyword">return</span>{' '}
+                <span className="hljs-function">
+                  <span className="hljs-literal">false</span>
+                  <span className="hljs-title">if</span> (
+                  <span className="hljs-params">
+                    year % <span className="hljs-number">100</span> =={' '}
+                    <span className="hljs-number">0</span> &amp;&amp; year %{' '}
+                    <span className="hljs-number">400</span>
+                  </span>
+                  ) <span className="hljs-keyword">return</span>{' '}
+                  <span className="hljs-literal">false</span>
+                  <span className="hljs-keyword">return</span>{' '}
+                  <span className="hljs-literal">true</span>
+                </span>
+                ;
+              </code>
+            </pre>
+            <footer className="--footer">
+              <div className="locs">
+                <GraphicalIcon icon="loc" />
+                {/* TODO: Replace with mentor_solution.num_loc */}
+                <div className="num">9 lines</div>
+              </div>
+            </footer>
+          </a>
         </Accordion.Panel>
       </Accordion>
       <Accordion
@@ -72,6 +232,6 @@ export const Guidance = (): JSX.Element => {
           <p>Feedback here</p>
         </Accordion.Panel>
       </Accordion>
-    </div>
+    </>
   )
 }

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -15,7 +15,7 @@ export const Guidance = ({
   exercise,
 }: {
   notes: string
-  mentorSolution: MentorSolutionProps
+  mentorSolution?: MentorSolutionProps
   track: Track
   exercise: Exercise
 }): JSX.Element => {
@@ -70,20 +70,22 @@ export const Guidance = ({
           <MentorNotes notes={notes} />
         </Accordion.Panel>
       </Accordion>
-      <Accordion
-        id="solution"
-        isOpen={isOpen('solution')}
-        onClick={handleClick}
-      >
-        <Accordion.Header>How you solved the exercise</Accordion.Header>
-        <Accordion.Panel>
-          <MentorSolution
-            solution={mentorSolution}
-            track={track}
-            exercise={exercise}
-          />
-        </Accordion.Panel>
-      </Accordion>
+      {mentorSolution ? (
+        <Accordion
+          id="solution"
+          isOpen={isOpen('solution')}
+          onClick={handleClick}
+        >
+          <Accordion.Header>How you solved the exercise</Accordion.Header>
+          <Accordion.Panel>
+            <MentorSolution
+              solution={mentorSolution}
+              track={track}
+              exercise={exercise}
+            />
+          </Accordion.Panel>
+        </Accordion>
+      ) : null}
       <Accordion
         id="feedback"
         isOpen={isOpen('feedback')}

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -24,9 +24,10 @@ export const Guidance = (): JSX.Element => {
     (id: string) => {
       setAccordionState(
         accordionState.map((state) => {
+          const isOpen = id === state.id && !state.isOpen
           return {
             id: state.id,
-            isOpen: id === state.id,
+            isOpen: isOpen,
           }
         })
       )

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -3,6 +3,7 @@ import { Accordion } from '../../common/Accordion'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { Avatar } from '../../common/Avatar'
 import { Icon } from '../../common/Icon'
+import { MentorNotes } from './MentorNotes'
 
 export const Guidance = ({ notes }: { notes: string }): JSX.Element => {
   const [accordionState, setAccordionState] = useState([
@@ -53,10 +54,7 @@ export const Guidance = ({ notes }: { notes: string }): JSX.Element => {
       <Accordion id="notes" isOpen={isOpen('notes')} onClick={handleClick}>
         <Accordion.Header>Mentor notes</Accordion.Header>
         <Accordion.Panel>
-          <div
-            className="c-textual-content --small"
-            dangerouslySetInnerHTML={{ __html: notes }}
-          />
+          <MentorNotes notes={notes} />
         </Accordion.Panel>
       </Accordion>
       <Accordion

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -53,7 +53,7 @@ export const Guidance = (): JSX.Element => {
         <Accordion.Header>Mentor notes</Accordion.Header>
         <Accordion.Panel>
           <div className="c-textual-content --small">
-            {/* TODO: REPLACE THIS */}
+            {/* TODO: Replace with `notes` */}
             <h3>Talking points</h3>
             <ul>
               <li>

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -1,11 +1,24 @@
 import React, { useState, useCallback } from 'react'
 import { Accordion } from '../../common/Accordion'
-import { GraphicalIcon } from '../../common/GraphicalIcon'
-import { Avatar } from '../../common/Avatar'
-import { Icon } from '../../common/Icon'
 import { MentorNotes } from './MentorNotes'
+import {
+  MentorSolution as MentorSolutionProps,
+  Track,
+  Exercise,
+} from '../Discussion'
+import { MentorSolution } from './MentorSolution'
 
-export const Guidance = ({ notes }: { notes: string }): JSX.Element => {
+export const Guidance = ({
+  notes,
+  mentorSolution,
+  track,
+  exercise,
+}: {
+  notes: string
+  mentorSolution: MentorSolutionProps
+  track: Track
+  exercise: Exercise
+}): JSX.Element => {
   const [accordionState, setAccordionState] = useState([
     {
       id: 'notes',
@@ -64,87 +77,11 @@ export const Guidance = ({ notes }: { notes: string }): JSX.Element => {
       >
         <Accordion.Header>How you solved the exercise</Accordion.Header>
         <Accordion.Panel>
-          {/* TOOD: Replace "#" with mentor_solution.web_url */}
-          <a href="#" className="c-published-solution">
-            <header className="--header">
-              <div className="--exercise">
-                {/* TODO: Replace with mentor.handle and mentor.avatar_url */}
-                <Avatar
-                  handle="iHiD"
-                  src="https://avatars2.githubusercontent.com/u/5337876?s=460&v=4"
-                />
-
-                <div className="--info">
-                  <div className="--exercise-title">Your Solution</div>
-                  {/* TODO: Replace "Leap" and "Ruby" */}
-                  <div className="--track-title">to Leap in Ruby</div>
-                </div>
-
-                {/*TODO: If mentor_solution.published_at? */}
-                <div className="--counts">
-                  <div className="--count">
-                    <Icon
-                      icon="star"
-                      alt="Number of times solution has been stared"
-                    />
-                    {/*TODO: Replace with num_stars */}
-                    <div className="--num">10</div>
-                  </div>
-                  <div className="--count">
-                    <Icon
-                      icon="comment"
-                      alt="Number of times solution has been commented on"
-                    />
-                    {/*TODO: Replace with num_comments */}
-                    <div className="--num">2</div>
-                  </div>
-                </div>
-              </div>
-            </header>
-            <pre>
-              {/* TODO: Replcae with mentor_solution.snippet */}
-              <code className="language-csharp hljs">
-                <span className="hljs-keyword">public</span>{' '}
-                <span className="hljs-keyword">class</span>{' '}
-                <span className="hljs-title">Year</span>
-                <span className="hljs-function">
-                  <span className="hljs-keyword">public</span>{' '}
-                  <span className="hljs-keyword">static</span>{' '}
-                  <span className="hljs-built_in">bool</span>{' '}
-                  <span className="hljs-title">IsLeap</span>(
-                  <span className="hljs-params">
-                    <span className="hljs-built_in">int</span> year
-                  </span>
-                  )
-                </span>
-                <span className="hljs-keyword">if</span> (year %{' '}
-                <span className="hljs-number">4</span> !={' '}
-                <span className="hljs-number">0</span>){' '}
-                <span className="hljs-keyword">return</span>{' '}
-                <span className="hljs-function">
-                  <span className="hljs-literal">false</span>
-                  <span className="hljs-title">if</span> (
-                  <span className="hljs-params">
-                    year % <span className="hljs-number">100</span> =={' '}
-                    <span className="hljs-number">0</span> &amp;&amp; year %{' '}
-                    <span className="hljs-number">400</span>
-                  </span>
-                  ) <span className="hljs-keyword">return</span>{' '}
-                  <span className="hljs-literal">false</span>
-                  <span className="hljs-keyword">return</span>{' '}
-                  <span className="hljs-literal">true</span>
-                </span>
-                ;
-              </code>
-            </pre>
-            <footer className="--footer">
-              <div className="locs">
-                <GraphicalIcon icon="loc" />
-                {/* TODO: Replace with mentor_solution.num_loc */}
-                <div className="num">9 lines</div>
-              </div>
-            </footer>
-          </a>
+          <MentorSolution
+            solution={mentorSolution}
+            track={track}
+            exercise={exercise}
+          />
         </Accordion.Panel>
       </Accordion>
       <Accordion

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -4,7 +4,7 @@ import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { Avatar } from '../../common/Avatar'
 import { Icon } from '../../common/Icon'
 
-export const Guidance = (): JSX.Element => {
+export const Guidance = ({ notes }: { notes: string }): JSX.Element => {
   const [accordionState, setAccordionState] = useState([
     {
       id: 'notes',
@@ -53,84 +53,10 @@ export const Guidance = (): JSX.Element => {
       <Accordion id="notes" isOpen={isOpen('notes')} onClick={handleClick}>
         <Accordion.Header>Mentor notes</Accordion.Header>
         <Accordion.Panel>
-          <div className="c-textual-content --small">
-            {/* TODO: Replace with `notes` */}
-            <h3>Talking points</h3>
-            <ul>
-              <li>
-                <code>each_cons</code> instead of an iterator{' '}
-                <code>with_index</code>: In Ruby, you rarely have to write
-                iterators that need to keep track of the index. Enumerable has
-                powerful methods that do that for us.
-              </li>
-              <li>
-                <code>chars</code>: instead of <code>split('')</code>.
-              </li>
-              <li>
-                <code>each_char</code>: if an <code>Array</code> is not
-                specifically necessary or wanted.
-              </li>
-              <li>
-                <code>attr_reader</code>: instead of the instance variable,{' '}
-                <a
-                  href="https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables"
-                  target="_blank"
-                >
-                  explained here
-                </a>
-                .
-              </li>
-              <li>
-                <code>private</code> attr_reader: Following the 'rule' for
-                encapsulation: if it doesn't need to be public, make it private.{' '}
-                <a
-                  href="http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html"
-                  target="_blank"
-                >
-                  This link
-                </a>{' '}
-                may come in handy for a first introduction.
-              </li>
-              <li>
-                <code>unless</code>, inline: With <code>unless</code> instead of{' '}
-                <code>if</code>, we can show what "good" looks like for the
-                conditional statement.
-              </li>
-              <li>
-                <code>error</code>: Custom error message? (Only if the first
-                submission meets the Minimal Solution.)
-              </li>
-              <li>
-                <code>map(&amp;:join)</code>: instead of map with block, but at
-                this point in the track it's okay to just accept it if students
-                use it, no need to require it or dive into the subject of{' '}
-                <code>Symbol#to_proc</code>.
-              </li>
-              <li>
-                <code>each_char</code>: may be preferable over{' '}
-                <code>chars</code> as it returns an <code>Enumerator</code> that
-                will yield each character without creating an intermediate{' '}
-                <code>Array</code>. More: <code>String#chars</code> with a block
-                has a deprecation warning in more recent Ruby versions.{' '}
-                <code>str.chars</code> is a shorthand for{' '}
-                <code>str.each_char.to_a</code>.
-              </li>
-            </ul>
-            <h3>Mentor Research</h3>
-            <ul>
-              <li>
-                The Iteration article mentioned above isn't ideal, but it's one
-                of the few I know of that does more than comparing{' '}
-                <code>each</code> and <code>map</code>, PLUS don't uses hashes
-                for examples. Other suggestions welcome.
-              </li>
-              <li>
-                <code>each_cons</code> raises an ArgumentError for arguments
-                &lt;= 0; it returns the array if the argument &gt;= the array.
-              </li>
-            </ul>
-            {/* TODO: END REPLACE */}
-          </div>
+          <div
+            className="c-textual-content --small"
+            dangerouslySetInnerHTML={{ __html: notes }}
+          />
         </Accordion.Panel>
       </Accordion>
       <Accordion

--- a/app/javascript/components/mentoring/discussion/Guidance.tsx
+++ b/app/javascript/components/mentoring/discussion/Guidance.tsx
@@ -8,11 +8,11 @@ export const Guidance = (): JSX.Element => {
   const [accordionState, setAccordionState] = useState([
     {
       id: 'notes',
-      isOpen: false,
+      isOpen: true,
     },
     {
       id: 'solution',
-      isOpen: true,
+      isOpen: false,
     },
     {
       id: 'feedback',

--- a/app/javascript/components/mentoring/discussion/MentorNotes.tsx
+++ b/app/javascript/components/mentoring/discussion/MentorNotes.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export const MentorNotes = ({ notes }: { notes?: string }): JSX.Element => {
+  if (notes) {
+    return (
+      <React.Fragment>
+        <div
+          className="c-textual-content --small"
+          dangerouslySetInnerHTML={{ __html: notes }}
+        />
+        <p>CTA to improve notes here</p>
+      </React.Fragment>
+    )
+  } else {
+    return <p>CTA to contribute notes here</p>
+  }
+}

--- a/app/javascript/components/mentoring/discussion/MentorSolution.tsx
+++ b/app/javascript/components/mentoring/discussion/MentorSolution.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { GraphicalIcon } from '../../common/GraphicalIcon'
+import { Avatar } from '../../common/Avatar'
+import { Icon } from '../../common/Icon'
+import {
+  MentorSolution as MentorSolutionProps,
+  Track,
+  Exercise,
+} from '../Discussion'
+import { useHighlighting } from '../../../utils/highlight'
+
+const PublishDetails = ({ solution }: { solution: MentorSolutionProps }) => {
+  return (
+    <div className="--counts">
+      <div className="--count">
+        <Icon icon="star" alt="Number of times solution has been stared" />
+        <div className="--num">{solution.numStars}</div>
+      </div>
+      <div className="--count">
+        <Icon
+          icon="comment"
+          alt="Number of times solution has been commented on"
+        />
+        <div className="--num">{solution.numComments}</div>
+      </div>
+    </div>
+  )
+}
+
+export const MentorSolution = ({
+  solution,
+  track,
+  exercise,
+}: {
+  solution: MentorSolutionProps
+  track: Track
+  exercise: Exercise
+}): JSX.Element => {
+  const snippetRef = useHighlighting<HTMLDivElement>()
+
+  return (
+    <a href={solution.webUrl} className="c-published-solution">
+      <header className="--header">
+        <div className="--exercise">
+          <Avatar
+            handle={solution.mentor.handle}
+            src={solution.mentor.avatarUrl}
+          />
+
+          <div className="--info">
+            <div className="--exercise-title">Your Solution</div>
+            <div className="--track-title">
+              to {exercise.title} in {track.title}
+            </div>
+          </div>
+          {solution.publishedAt ? <PublishDetails solution={solution} /> : null}
+        </div>
+      </header>
+      <div ref={snippetRef}>
+        <pre>
+          <code dangerouslySetInnerHTML={{ __html: solution.snippet }} />
+        </pre>
+      </div>
+      <footer className="--footer">
+        <div className="locs">
+          <GraphicalIcon icon="loc" />
+          <div className="num">{solution.numLoc} lines</div>
+        </div>
+      </footer>
+    </a>
+  )
+}

--- a/app/javascript/components/mentoring/discussion/MentoringPanelList.tsx
+++ b/app/javascript/components/mentoring/discussion/MentoringPanelList.tsx
@@ -5,7 +5,14 @@ import { Scratchpad } from './Scratchpad'
 import { Guidance } from './Guidance'
 import { StudentInfo } from './StudentInfo'
 import { GraphicalIcon } from '../../common'
-import { TabIndex, Student, Iteration } from '../Discussion'
+import {
+  TabIndex,
+  Student,
+  Iteration,
+  MentorSolution,
+  Track,
+  Exercise,
+} from '../Discussion'
 import { DiscussionPostProps } from './DiscussionPost'
 
 type MentoringPanelListLinks = {
@@ -30,6 +37,9 @@ export const MentoringPanelList = ({
   onAfterPostHighlight,
   highlightedPost,
   notes,
+  mentorSolution,
+  track,
+  exercise,
 }: {
   links: MentoringPanelListLinks
   discussionId: number
@@ -42,6 +52,9 @@ export const MentoringPanelList = ({
   onAfterPostHighlight: () => void
   highlightedPost: DiscussionPostProps | null
   notes: string
+  mentorSolution: MentorSolution
+  track: Track
+  exercise: Exercise
 }): JSX.Element => {
   return (
     <>
@@ -82,7 +95,12 @@ export const MentoringPanelList = ({
           <Scratchpad endpoint={links.scratchpad} discussionId={discussionId} />
         </Tab.Panel>
         <Tab.Panel id="guidance" context={TabsContext}>
-          <Guidance notes={notes} />
+          <Guidance
+            notes={notes}
+            mentorSolution={mentorSolution}
+            track={track}
+            exercise={exercise}
+          />
         </Tab.Panel>
       </TabsContext.Provider>
     </>

--- a/app/javascript/components/mentoring/discussion/MentoringPanelList.tsx
+++ b/app/javascript/components/mentoring/discussion/MentoringPanelList.tsx
@@ -29,6 +29,7 @@ export const MentoringPanelList = ({
   onPostHighlight,
   onAfterPostHighlight,
   highlightedPost,
+  notes,
 }: {
   links: MentoringPanelListLinks
   discussionId: number
@@ -40,6 +41,7 @@ export const MentoringPanelList = ({
   onPostHighlight: (element: HTMLDivElement) => void
   onAfterPostHighlight: () => void
   highlightedPost: DiscussionPostProps | null
+  notes: string
 }): JSX.Element => {
   return (
     <>
@@ -80,7 +82,7 @@ export const MentoringPanelList = ({
           <Scratchpad endpoint={links.scratchpad} discussionId={discussionId} />
         </Tab.Panel>
         <Tab.Panel id="guidance" context={TabsContext}>
-          <Guidance />
+          <Guidance notes={notes} />
         </Tab.Panel>
       </TabsContext.Provider>
     </>

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -25,6 +25,7 @@ import '../../css/components/details'
 import '../../css/components/flash'
 import '../../css/components/icon'
 import '../../css/components/iteration-summary'
+import '../../css/components/accordion-section'
 
 import '../../css/components/heading-with-count'
 import '../../css/components/notification'

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -111,6 +111,7 @@ import {
   Track as MentorDiscussionTrack,
   Exercise as MentorDiscussionExercise,
   Links as MentorDiscussionLinks,
+  MentorSolution as MentorDiscussionMentorSolution,
 } from '../components/mentoring/Discussion'
 import * as Tooltips from '../components/tooltips'
 import * as Dropdowns from '../components/dropdowns'
@@ -158,6 +159,9 @@ initReact({
       iterations={camelizeKeysAs<MentorDiscussionIteration[]>(data.iterations)}
       links={camelizeKeysAs<MentorDiscussionLinks>(data.links)}
       notes={data.notes}
+      mentorSolution={camelizeKeysAs<MentorDiscussionMentorSolution>(
+        data.mentor_solution
+      )}
     />
   ),
   'student-tracks-list': (data: any) => (

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -157,6 +157,7 @@ initReact({
       exercise={camelizeKeysAs<MentorDiscussionExercise>(data.exercise)}
       iterations={camelizeKeysAs<MentorDiscussionIteration[]>(data.iterations)}
       links={camelizeKeysAs<MentorDiscussionLinks>(data.links)}
+      notes={data.notes}
     />
   ),
   'student-tracks-list': (data: any) => (

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -35,6 +35,9 @@ class Solution < ApplicationRecord
     Solution.find_by(exercise: exercise, user: user)
   end
 
+  delegate :instructions, :introduction, to: :git_exercise
+  delegate :solution_files, to: :exercise, prefix: 'exercise'
+
   def git_type
     self.class.name.sub("Solution", "").downcase
   end
@@ -75,8 +78,35 @@ class Solution < ApplicationRecord
     update_column(:mentoring_status, :none)
   end
 
-  delegate :instructions, :introduction, to: :git_exercise
-  delegate :solution_files, to: :exercise, prefix: 'exercise'
+  # TODO
+  def num_loc
+    9
+  end
+
+  # TODO
+  def num_stars
+    9
+  end
+
+  # TODO
+  def num_comments
+    9
+  end
+
+  # TODO
+  def snippet
+    '
+public class Year
+{
+  public static bool IsLeap(int year)
+  {
+      if (year % 4 != 0) return false
+      if (year % 100 == 0 && year % 400) return false
+      return true;
+  }
+}
+    '.strip
+  end
 
   def editor_language
     track.slug

--- a/app/views/icons/_minus_circle.html
+++ b/app/views/icons/_minus_circle.html
@@ -1,0 +1,18 @@
+<symbol id="minus-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+  ><defs
+    ><style>
+      .a {
+        fill: none;
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.5px;
+      }
+    </style></defs
+  ><title>subtract-circle</title
+  ><line class="a" x1="7.5" y1="12" x2="16.5" y2="12" /><circle
+    class="a"
+    cx="12"
+    cy="12"
+    r="11.25"
+/></symbol>

--- a/app/views/icons/_plus_circle.html
+++ b/app/views/icons/_plus_circle.html
@@ -1,0 +1,19 @@
+<symbol id="plus-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+  ><defs
+    ><style>
+      .a {
+        fill: none;
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.5px;
+      }
+    </style></defs
+  ><title>add-circle</title
+  ><line class="a" x1="12" y1="7.5" x2="12" y2="16.5" /><line
+    class="a"
+    x1="7.5"
+    y1="12"
+    x2="16.5"
+    y2="12" /><circle class="a" cx="12" cy="12" r="11.25"
+/></symbol>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -65,6 +65,8 @@
     = render "icons/failed_check_circle"
     = render "icons/skipped_check_circle"
     = render "icons/plus_square"
+    = render "icons/plus_circle"
+    = render "icons/minus_circle"
     = render "icons/reset"
     = render "icons/search"
     = render "icons/loc"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,22 +48,23 @@ karlo.update!(accepted_privacy_policy_at: Time.current, accepted_terms_at: Time.
 
 track_slugs = %w[05ab1e ada arm64-assembly ballerina bash c ceylon cfml clojure clojurescript coffeescript common-lisp coq cpp crystal csharp d dart delphi elixir elm emacs-lisp erlang factor forth fortran fsharp gleam gnu-apl go groovy haskell haxe idris io j java javascript julia kotlin lfe lua mips nim nix objective-c ocaml perl5 pharo-smalltalk php plsql pony powershell prolog purescript python r racket raku reasonml ruby rust scala scheme shen sml solidity swift system-verilog tcl typescript vbnet vimscript x86-64-assembly zig]
 track_slugs.each do |track_slug|
-  puts "Adding Track: #{track_slug}"
-
-  repo_url = "https://github.com/exercism/#{track_slug}"
-  repo = Git::Repository.new(repo_url: repo_url)
-
-  # Find the first commit in the repo
-  first_commit = repo.head_commit
-  Rugged::Walker.walk(repo.send(:rugged_repo),
-    show: repo.head_commit.oid,
-    sort: Rugged::SORT_DATE | Rugged::SORT_TOPO,
-    simplify: true
-  ) do |commit|
-    first_commit = commit
-  end
-
+  next unless track_slug == "ruby"
   begin
+    puts "Adding Track: #{track_slug}"
+
+    repo_url = "https://github.com/exercism/#{track_slug}"
+    repo = Git::Repository.new(repo_url: repo_url)
+
+    # Find the first commit in the repo
+    first_commit = repo.head_commit
+    Rugged::Walker.walk(repo.send(:rugged_repo),
+      show: repo.head_commit.oid,
+      sort: Rugged::SORT_DATE | Rugged::SORT_TOPO,
+      simplify: true
+    ) do |commit|
+      first_commit = commit
+    end
+
     git_track = Git::Track.new(repo.head_commit.oid, repo_url: repo_url)
     track = Track::Create.(
       track_slug, 
@@ -77,7 +78,8 @@ track_slugs.each do |track_slug|
   rescue StandardError => e
     # puts e.message
     # puts e.backtrace
-    puts "Error seeding Track #{track_slug}: #{e}"
+    puts "Error seeding Track #{track_slug}: #{e.message}"
+    puts e.backtrace
   end
 end
 

--- a/test/helpers/react_components/mentoring/discussion_test.rb
+++ b/test/helpers/react_components/mentoring/discussion_test.rb
@@ -27,10 +27,6 @@ module Mentoring
         {
           discussion_id: discussion.uuid,
           user_id: student.id,
-          mentor: {
-            handle: mentor.handle,
-            avatar_url: mentor.avatar_url
-          },
           student: {
             name: student.name,
             handle: student.handle,

--- a/test/helpers/react_components/mentoring/discussion_test.rb
+++ b/test/helpers/react_components/mentoring/discussion_test.rb
@@ -3,11 +3,12 @@ require_relative "../react_component_test_case"
 module Mentoring
   class DiscussionTest < ReactComponentTestCase
     test "mentoring discussion renders correctly" do
+      mentor = create :user
       student = create :user
       track = create :track
       exercise = create :concept_exercise, track: track
       solution = create :concept_solution, user: student, track: track
-      discussion = create :solution_mentor_discussion, solution: solution
+      discussion = create :solution_mentor_discussion, solution: solution, mentor: mentor
 
       iteration_1 = create :iteration, solution: solution
       iteration_2 = create :iteration, solution: solution
@@ -26,6 +27,10 @@ module Mentoring
         {
           discussion_id: discussion.uuid,
           user_id: student.id,
+          mentor: {
+            handle: mentor.handle,
+            avatar_url: mentor.avatar_url
+          },
           student: {
             name: student.name,
             handle: student.handle,
@@ -85,6 +90,8 @@ module Mentoring
               }
             }
           ],
+          mentor_solution: nil,
+          notes: %{<h3>Talking points</h3>\n<ul>\n  <li>\n    <code>each_cons</code> instead of an iterator\n    <code>with_index</code>: In Ruby, you rarely have to write\n    iterators that need to keep track of the index. Enumerable has\n    powerful methods that do that for us.\n  </li>\n  <li>\n    <code>chars</code>: instead of <code>split("")</code>.\n  </li>\n</ul>}, # rubocop:disable Layout/LineLength
           links: {
             mentor_dashboard: Exercism::Routes.mentor_dashboard_path,
             exercise: Exercism::Routes.track_exercise_path(track, exercise),

--- a/test/javascript/components/mentoring/discussion/Guidance.test.js
+++ b/test/javascript/components/mentoring/discussion/Guidance.test.js
@@ -7,30 +7,42 @@ import { Guidance } from '../../../../../app/javascript/components/mentoring/dis
 test('how you solved the exercise is open by default', async () => {
   render(<Guidance />)
 
-  expect(
-    screen.getByRole('button', { name: 'How you solved the exercise' })
-  ).toHaveAttribute('aria-expanded', 'true')
   expect(screen.getByRole('button', { name: 'Mentor notes' })).toHaveAttribute(
     'aria-expanded',
-    'false'
+    'true'
   )
   expect(
+    screen.getByRole('button', { name: 'How you solved the exercise' })
+  ).toHaveAttribute('aria-expanded', 'false')
+  expect(
     screen.getByRole('button', { name: 'Automated feedback' })
+  ).toHaveAttribute('aria-expanded', 'false')
+})
+
+test('open and close same accordion', async () => {
+  render(<Guidance />)
+
+  userEvent.click(screen.getByRole('button', { name: 'Mentor notes' }))
+
+  expect(
+    await screen.findByRole('button', { name: 'Mentor notes' })
   ).toHaveAttribute('aria-expanded', 'false')
 })
 
 test('only one accordion is open at a time', async () => {
   render(<Guidance />)
 
-  userEvent.click(screen.getByRole('button', { name: 'Mentor notes' }))
-
-  expect(
+  userEvent.click(
     screen.getByRole('button', { name: 'How you solved the exercise' })
-  ).toHaveAttribute('aria-expanded', 'false')
+  )
+
   expect(screen.getByRole('button', { name: 'Mentor notes' })).toHaveAttribute(
     'aria-expanded',
-    'true'
+    'false'
   )
+  expect(
+    screen.getByRole('button', { name: 'How you solved the exercise' })
+  ).toHaveAttribute('aria-expanded', 'true')
   expect(
     screen.getByRole('button', { name: 'Automated feedback' })
   ).toHaveAttribute('aria-expanded', 'false')

--- a/test/javascript/components/mentoring/discussion/Guidance.test.js
+++ b/test/javascript/components/mentoring/discussion/Guidance.test.js
@@ -47,3 +47,10 @@ test('only one accordion is open at a time', async () => {
     screen.getByRole('button', { name: 'Automated feedback' })
   ).toHaveAttribute('aria-expanded', 'false')
 })
+
+test('displays notes', async () => {
+  const notes = '<h2>Notes</h2>'
+  render(<Guidance notes={notes} />)
+
+  expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument()
+})

--- a/test/javascript/components/mentoring/discussion/Guidance.test.js
+++ b/test/javascript/components/mentoring/discussion/Guidance.test.js
@@ -12,9 +12,6 @@ test('how you solved the exercise is open by default', async () => {
     'true'
   )
   expect(
-    screen.getByRole('button', { name: 'How you solved the exercise' })
-  ).toHaveAttribute('aria-expanded', 'false')
-  expect(
     screen.getByRole('button', { name: 'Automated feedback' })
   ).toHaveAttribute('aria-expanded', 'false')
 })
@@ -32,20 +29,15 @@ test('open and close same accordion', async () => {
 test('only one accordion is open at a time', async () => {
   render(<Guidance />)
 
-  userEvent.click(
-    screen.getByRole('button', { name: 'How you solved the exercise' })
-  )
+  userEvent.click(screen.getByRole('button', { name: 'Automated feedback' }))
 
   expect(screen.getByRole('button', { name: 'Mentor notes' })).toHaveAttribute(
     'aria-expanded',
     'false'
   )
   expect(
-    screen.getByRole('button', { name: 'How you solved the exercise' })
-  ).toHaveAttribute('aria-expanded', 'true')
-  expect(
     screen.getByRole('button', { name: 'Automated feedback' })
-  ).toHaveAttribute('aria-expanded', 'false')
+  ).toHaveAttribute('aria-expanded', 'true')
 })
 
 test('displays notes', async () => {
@@ -53,4 +45,13 @@ test('displays notes', async () => {
   render(<Guidance notes={notes} />)
 
   expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument()
+})
+
+test('hides how you solved the solution if mentor solution is null', async () => {
+  const notes = '<h2>Notes</h2>'
+  render(<Guidance notes={notes} />)
+
+  expect(
+    screen.queryByRole('button', { name: 'How you solved the exercise' })
+  ).not.toBeInTheDocument()
 })

--- a/test/javascript/components/mentoring/discussion/MentorNotes.test.js
+++ b/test/javascript/components/mentoring/discussion/MentorNotes.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { MentorNotes } from '../../../../../app/javascript/components/mentoring/discussion/MentorNotes'
+
+test('shows CTA to contribute notes when notes isnt present', async () => {
+  render(<MentorNotes />)
+
+  expect(screen.getByText('CTA to contribute notes here')).toBeInTheDocument()
+})
+
+test('shows CTA to improve notes when notes is present', async () => {
+  render(<MentorNotes notes="<p>Notes</p>" />)
+
+  expect(screen.getByText('CTA to improve notes here')).toBeInTheDocument()
+})

--- a/test/javascript/components/mentoring/discussion/MentorSolution.test.js
+++ b/test/javascript/components/mentoring/discussion/MentorSolution.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { MentorSolution } from '../../../../../app/javascript/components/mentoring/discussion/MentorSolution'
+
+test('shows CTA to contribute notes when notes isnt present', async () => {
+  const solution = {
+    mentor: {
+      handle: 'handle',
+      avatarUrl: 'url',
+    },
+  }
+  const exercise = { title: 'Exercise' }
+  const track = { title: 'Track' }
+
+  render(
+    <MentorSolution solution={solution} exercise={exercise} track={track} />
+  )
+
+  expect(
+    screen.queryByTitle('Number of times solution has been starred')
+  ).not.toBeInTheDocument()
+})

--- a/test/system/components/mentoring/discussion_test.rb
+++ b/test/system/components/mentoring/discussion_test.rb
@@ -386,6 +386,31 @@ module Components
 
         assert_css "h3", text: "Talking points"
       end
+
+      test "mentor sees own solution" do
+        mentor = create :user, handle: "mentor"
+        exercise = create :concept_exercise
+        solution = create :concept_solution, exercise: exercise
+        mentor_solution = create :concept_solution, exercise: exercise, user: mentor
+        discussion = create :solution_mentor_discussion,
+          solution: solution,
+          mentor: mentor,
+          requires_mentor_action_since: 1.day.ago
+        create :iteration, solution: solution
+        create :scratchpad_page, content_markdown: "# Some notes", author: mentor, about: exercise
+
+        use_capybara_host do
+          sign_in!(mentor)
+          visit test_components_mentoring_discussion_path(discussion_id: discussion.id)
+          click_on "Guidance"
+          click_on "How you solved the exercise"
+
+          assert_link "Your Solution", href: Exercism::Routes.private_solution_url(mentor_solution)
+          assert_text "to Strings in Ruby"
+          assert_css "img[src='#{mentor.avatar_url}']"\
+            "[alt=\"Uploaded avatar of mentor\"]"
+        end
+      end
     end
   end
 end

--- a/test/system/components/mentoring/discussion_test.rb
+++ b/test/system/components/mentoring/discussion_test.rb
@@ -366,6 +366,26 @@ module Components
         assert_text "Loading"
         assert_no_text "Mark as nothing to do"
       end
+
+      test "mentor sees mentor notes" do
+        mentor = create :user, handle: "author"
+        exercise = create :concept_exercise
+        solution = create :concept_solution, exercise: exercise
+        discussion = create :solution_mentor_discussion,
+          solution: solution,
+          mentor: mentor,
+          requires_mentor_action_since: 1.day.ago
+        create :iteration, solution: solution
+        create :scratchpad_page, content_markdown: "# Some notes", author: mentor, about: exercise
+
+        use_capybara_host do
+          sign_in!(mentor)
+          visit test_components_mentoring_discussion_path(discussion_id: discussion.id)
+          click_on "Guidance"
+        end
+
+        assert_css "h3", text: "Talking points"
+      end
     end
   end
 end


### PR DESCRIPTION
@kntsoriano This adds styling to the guidance tab. It's going to need a little bit of work from you. Take a read of the comments - I've added TODOs for the various bits. I think it should be a quick one 🙂 

There is also a bug/missing-feature. Clicking an Accordion Heading that is open should close it (so that all the sections become closed). Could you fix that on this PR too please?