### PR TITLE
Add notifications API endpoint

### DIFF
--- a/app/commands/notification/retrieve.rb
+++ b/app/commands/notification/retrieve.rb
@@ -10,9 +10,11 @@ class Notification
 
     def initialize(user,
                    page: 1,
+                   per_page: self.class.notifications_per_page,
                    sorted: true, paginated: true)
       @user = user
       @page = page
+      @per_page = per_page
 
       @sorted = sorted
       @paginated = paginated
@@ -27,7 +29,7 @@ class Notification
     end
 
     private
-    attr_reader :user, :page, :criteria, :order,
+    attr_reader :user, :page, :per_page, :criteria, :order,
       :track_slug, :exercise_slugs
 
     %i[sorted paginated].each do |attr|
@@ -44,7 +46,7 @@ class Notification
 
     def paginate!
       @notifications = @notifications.
-        page(page).per(self.class.notifications_per_page)
+        page(page).per(per_page)
     end
   end
 end

--- a/app/commands/notification/retrieve.rb
+++ b/app/commands/notification/retrieve.rb
@@ -2,15 +2,9 @@ class Notification
   class Retrieve
     include Mandate
 
-    # Use class method rather than constant for
-    # easier stubbing during testing
-    def self.notifications_per_page
-      10
-    end
-
     def initialize(user,
                    page: 1,
-                   per_page: self.class.notifications_per_page,
+                   per_page: 10,
                    sorted: true, paginated: true)
       @user = user
       @page = page
@@ -45,8 +39,7 @@ class Notification
     end
 
     def paginate!
-      @notifications = @notifications.
-        page(page).per(per_page)
+      @notifications = @notifications.page(page).per(per_page)
     end
   end
 end

--- a/app/commands/notification/retrieve.rb
+++ b/app/commands/notification/retrieve.rb
@@ -1,0 +1,50 @@
+class Notification
+  class Retrieve
+    include Mandate
+
+    # Use class method rather than constant for
+    # easier stubbing during testing
+    def self.notifications_per_page
+      10
+    end
+
+    def initialize(user,
+                   page: 1,
+                   sorted: true, paginated: true)
+      @user = user
+      @page = page
+
+      @sorted = sorted
+      @paginated = paginated
+    end
+
+    def call
+      setup!
+      sort! if sorted?
+      paginate! if paginated?
+
+      @notifications
+    end
+
+    private
+    attr_reader :user, :page, :criteria, :order,
+      :track_slug, :exercise_slugs
+
+    %i[sorted paginated].each do |attr|
+      define_method("#{attr}?") { instance_variable_get("@#{attr}") }
+    end
+
+    def setup!
+      @notifications = user.notifications.unread
+    end
+
+    def sort!
+      @notifications = @notifications.order(id: :asc)
+    end
+
+    def paginate!
+      @notifications = @notifications.
+        page(page).per(self.class.notifications_per_page)
+    end
+  end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,15 @@
+module API
+  class NotificationsController < BaseController
+    def index
+      notifications = Notification::Retrieve.(
+        current_user,
+        page: params[:page]
+      )
+
+      render json: SerializePaginatedCollection.(
+        notifications,
+        SerializeNotifications
+      )
+    end
+  end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -3,7 +3,8 @@ module API
     def index
       notifications = Notification::Retrieve.(
         current_user,
-        page: params[:page]
+        page: params[:page],
+        per: params[:per_page]
       )
 
       render json: SerializePaginatedCollection.(

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -4,7 +4,7 @@ module API
       notifications = Notification::Retrieve.(
         current_user,
         page: params[:page],
-        per: params[:per_page]
+        per_page: params[:per_page]
       )
 
       render json: SerializePaginatedCollection.(

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -23,6 +23,11 @@ class Notification < ApplicationRecord
     I18n.t("notifications.#{i18n_key}.#{version}", i18n_params).strip
   end
 
+  # TODO
+  def url
+    "/"
+  end
+
   def type_key
     type.split("::").last.underscore.split("_notification").first.to_sym
   end

--- a/app/serializers/serialize_notifications.rb
+++ b/app/serializers/serialize_notifications.rb
@@ -1,0 +1,21 @@
+class SerializeNotifications
+  include Mandate
+
+  initialize_with :notifications
+
+  def call
+    notifications.
+      map { |r| serialize_notification(r) }
+  end
+
+  private
+  def serialize_notification(notification)
+    {
+      # TODO: Maybe expose a UUID instead?
+      id: notification.id,
+      text: notification.text,
+      read: notification.read?,
+      url: notification.url
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
         resources :initial_files, only: %i[index], controller: "solutions/initial_files"
       end
 
+      resources :notifications, only: [:index] do
+      end
+
       resources :mentor_requests, only: %i[index] do
         collection do
           get :tracks

--- a/test/commands/notification/retrieve_test.rb
+++ b/test/commands/notification/retrieve_test.rb
@@ -32,6 +32,18 @@ class Notification::RetrieveTest < ActiveSupport::TestCase
     assert_equal 25, notifications.total_count
   end
 
+  test "per_page works" do
+    user = create :user
+
+    25.times { create :notification, user: user }
+
+    notifications = Notification::Retrieve.(user, page: 2, per_page: 4)
+    assert_equal 2, notifications.current_page
+    assert_equal 7, notifications.total_pages
+    assert_equal 4, notifications.limit_value
+    assert_equal 25, notifications.total_count
+  end
+
   test "returns relationship unless paginated" do
     user = create :user
     create :notification, user: user

--- a/test/commands/notification/retrieve_test.rb
+++ b/test/commands/notification/retrieve_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Notification::RetrieveTest < ActiveSupport::TestCase
+  test "only retrieves unread notificatons" do
+    user = create :user
+    unread = create :notification, read_at: nil, user: user
+    create :notification, read_at: Time.current, user: user
+    create :notification, read_at: nil
+
+    assert_equal [unread], Notification::Retrieve.(user)
+  end
+
+  test "orders by id" do
+    user = create :user
+
+    first = create :notification, user: user
+    second = create :notification, user: user
+    third = create :notification, user: user
+
+    assert_equal [first, second, third], Notification::Retrieve.(user)
+  end
+
+  test "pagination works" do
+    user = create :user
+
+    25.times { create :notification, user: user }
+
+    notifications = Notification::Retrieve.(user, page: 2)
+    assert_equal 2, notifications.current_page
+    assert_equal 3, notifications.total_pages
+    assert_equal 10, notifications.limit_value
+    assert_equal 25, notifications.total_count
+  end
+
+  test "returns relationship unless paginated" do
+    user = create :user
+    create :notification, user: user
+
+    notifications = Notification::Retrieve.(user, paginated: false)
+    assert notifications.is_a?(ActiveRecord::Relation)
+    refute_respond_to notifications, :current_page
+  end
+end

--- a/test/controllers/api/notifications_controller_test.rb
+++ b/test/controllers/api/notifications_controller_test.rb
@@ -1,0 +1,43 @@
+require_relative './base_test_case'
+
+class API::NotificationsControllerTest < API::BaseTestCase
+  ###
+  # Index
+  ###
+  test "index should return 401 with incorrect token" do
+    get api_notifications_path, as: :json
+
+    assert_response 401
+    expected = { error: {
+      type: "invalid_auth_token",
+      message: I18n.t('api.errors.invalid_auth_token')
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  test "index retrieves notifications" do
+    user = create :user
+    setup_user(user)
+
+    notification = create :notification, user: user
+
+    get api_notifications_path, headers: @headers, as: :json
+    assert_response 200
+
+    # TODO: Check JSON
+    expected = {
+      results: [{
+        id: notification.id,
+        text: notification.text,
+        read: false,
+        url: "/"
+      }],
+      meta: {
+        current_page: 1, total_count: 1, total_pages: 1
+      }
+    }.with_indifferent_access
+
+    assert_equal expected, JSON.parse(response.body)
+  end
+end

--- a/test/serializers/serialize_notifications_test.rb
+++ b/test/serializers/serialize_notifications_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class SerializeNotificationsTest < ActiveSupport::TestCase
+  test "basic request" do
+    user = create :user
+    notification = create :notification, user: user
+
+    notifications = Notification::Retrieve.(user)
+
+    expected = [
+      {
+        id: notification.id,
+        text: notification.text,
+        read: false,
+        url: "/"
+      }
+    ]
+
+    assert_equal expected, SerializeNotifications.(notifications)
+  end
+end


### PR DESCRIPTION
@kntsoriano This is the basic notifications API endpoint for you.

In the menu, we just want to show `5` notifications, but we want to show the link to more if there are `> 5` in total

<img width="595" alt="Screenshot 2021-02-09 at 22 40 37" src="https://user-images.githubusercontent.com/286476/107438068-da949800-6b27-11eb-870f-8acb647b2251.png">
