### PR TITLE
Fix distinction between mentors and students

### DIFF
--- a/app/css/components/mentor/discussion.css
+++ b/app/css/components/mentor/discussion.css
@@ -250,7 +250,8 @@
             overflow-y: scroll;
 
             @apply pb-64;
-            & .student-info {
+            & .student-info,
+            & .mentor-info {
                 @apply bg-backgroundColorA;
                 @apply flex;
 

--- a/app/helpers/react_components/mentoring/session.rb
+++ b/app/helpers/react_components/mentoring/session.rb
@@ -8,7 +8,7 @@ module ReactComponents
           "mentoring-session",
           {
             user_id: current_user.id,
-            partner: {
+            student: {
               id: student.id,
               name: student.name,
               handle: student.handle,

--- a/app/helpers/react_components/student/mentoring_session.rb
+++ b/app/helpers/react_components/student/mentoring_session.rb
@@ -10,11 +10,7 @@ module ReactComponents
             id: discussion.uuid,
             is_finished: discussion.finished?,
             user_id: current_user.id,
-            student: {
-              id: student.id,
-              handle: student.handle
-            },
-            partner: {
+            mentor: {
               id: mentor.id,
               name: mentor.name,
               handle: mentor.handle,
@@ -43,7 +39,7 @@ module ReactComponents
       end
 
       private
-      delegate :student, :mentor, :track, :exercise, to: :discussion
+      delegate :mentor, :track, :exercise, to: :discussion
 
       def iterations
         comment_counts = ::Solution::MentorDiscussionPost.

--- a/app/javascript/components/mentoring/Session.tsx
+++ b/app/javascript/components/mentoring/Session.tsx
@@ -4,7 +4,7 @@ import { CloseButton } from './session/CloseButton'
 import { SessionInfo } from './session/SessionInfo'
 import { Guidance } from './session/Guidance'
 import { Scratchpad } from './session/Scratchpad'
-import { PartnerInfo } from './session/PartnerInfo'
+import { StudentInfo } from './session/StudentInfo'
 import { IterationView } from './session/IterationView'
 
 import { DiscussionDetails } from './discussion/DiscussionDetails'
@@ -63,7 +63,7 @@ export type Iteration = {
   }
 }
 
-export type Partner = {
+export type Student = {
   id: number
   avatarUrl: string
   name: string
@@ -134,7 +134,7 @@ export type MentoringRequest = {
 }
 
 export type SessionProps = {
-  partner: Partner
+  student: Student
   track: Track
   exercise: Exercise
   links: Links
@@ -157,7 +157,7 @@ export const TabsContext = createContext<TabContext>({
 export const Session = (props: SessionProps): JSX.Element => {
   const [session, setSession] = useState(props)
   const {
-    partner,
+    student,
     track,
     exercise,
     links,
@@ -176,7 +176,7 @@ export const Session = (props: SessionProps): JSX.Element => {
       <div className="lhs">
         <header className="discussion-header">
           <CloseButton url={links.mentorDashboard} />
-          <SessionInfo student={partner} track={track} exercise={exercise} />
+          <SessionInfo student={student} track={track} exercise={exercise} />
           {discussion ? (
             <DiscussionActions
               {...discussion}
@@ -213,19 +213,19 @@ export const Session = (props: SessionProps): JSX.Element => {
               </Tab>
             </div>
             <Tab.Panel id="discussion" context={TabsContext}>
-              <PartnerInfo partner={partner} />
+              <StudentInfo student={student} />
               {discussion ? (
                 <DiscussionDetails
                   discussion={discussion}
                   iterations={iterations}
-                  student={partner}
+                  student={student}
                   relationship={relationship}
                   userId={userId}
                 />
               ) : (
                 <RequestDetails
                   iterations={iterations}
-                  student={partner}
+                  student={student}
                   request={request}
                   userId={userId}
                 />

--- a/app/javascript/components/mentoring/discussion/DiscussionDetails.tsx
+++ b/app/javascript/components/mentoring/discussion/DiscussionDetails.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import {
   Discussion,
   Iteration,
-  Partner,
+  Student,
   StudentMentorRelationship,
 } from '../Session'
 import { FinishedWizard } from './FinishedWizard'
@@ -17,7 +17,7 @@ export const DiscussionDetails = ({
 }: {
   discussion: Discussion
   iterations: readonly Iteration[]
-  student: Partner
+  student: Student
   relationship: StudentMentorRelationship
   userId: number
 }): JSX.Element => {
@@ -29,7 +29,7 @@ export const DiscussionDetails = ({
       <DiscussionPostList
         endpoint={discussion.links.posts}
         iterations={iterations}
-        student={student}
+        userIsStudent={false}
         discussionId={discussion.id}
         userId={userId}
       />

--- a/app/javascript/components/mentoring/discussion/DiscussionPostList.tsx
+++ b/app/javascript/components/mentoring/discussion/DiscussionPostList.tsx
@@ -4,7 +4,7 @@ import { useQuery, queryCache } from 'react-query'
 import { DiscussionPost, DiscussionPostProps } from './DiscussionPost'
 import { DiscussionPostChannel } from '../../../channels/discussionPostChannel'
 import { Loading } from '../../common/Loading'
-import { Iteration, Partner } from '../Session'
+import { Iteration, Student } from '../Session'
 import { sendRequest } from '../../../utils/send-request'
 import { useIsMounted } from 'use-is-mounted'
 import { typecheck } from '../../../utils/typecheck'
@@ -17,14 +17,14 @@ export const DiscussionPostList = ({
   endpoint,
   discussionId,
   iterations,
-  student,
   userId,
+  userIsStudent,
 }: {
   endpoint: string
   discussionId: string
   iterations: readonly Iteration[]
-  student: Partner
   userId: number
+  userIsStudent: boolean
 }): JSX.Element | null => {
   const isMountedRef = useIsMounted()
   const { cacheKey } = useContext(PostsContext)
@@ -90,8 +90,7 @@ export const DiscussionPostList = ({
             <React.Fragment key={iteration.idx}>
               <IterationMarker
                 iteration={iteration}
-                student={student}
-                userId={userId}
+                userIsStudent={userIsStudent}
               />
               {iteration.posts.map((post) => {
                 return (

--- a/app/javascript/components/mentoring/discussion/FinishedWizard.tsx
+++ b/app/javascript/components/mentoring/discussion/FinishedWizard.tsx
@@ -2,7 +2,7 @@ import React, { useReducer, useEffect, useRef } from 'react'
 import { MentorAgainStep } from './finished-wizard/MentorAgainStep'
 import { FavoriteStep } from './finished-wizard/FavoriteStep'
 import { FinishStep } from './finished-wizard/FinishStep'
-import { Partner, StudentMentorRelationship } from '../Session'
+import { Student, StudentMentorRelationship } from '../Session'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 
 type State = {
@@ -26,7 +26,7 @@ type Action =
   | { type: 'RESET' }
 
 type Props = {
-  student: Partner
+  student: Student
   relationship: StudentMentorRelationship
   defaultStep: ModalStep
 }

--- a/app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.tsx
+++ b/app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.tsx
@@ -6,7 +6,7 @@ import { typecheck } from '../../../../utils/typecheck'
 import { Loading } from '../../../common'
 import { GraphicalIcon } from '../../../common/GraphicalIcon'
 import { ErrorBoundary, useErrorHandler } from '../../../ErrorBoundary'
-import { Partner, StudentMentorRelationship } from '../../Session'
+import { Student, StudentMentorRelationship } from '../../Session'
 
 const DEFAULT_ERROR = new Error('Unable to mark student as a favorite')
 
@@ -22,7 +22,7 @@ export const FavoriteStep = ({
   onFavorite,
   onSkip,
 }: {
-  student: Partner
+  student: Student
   relationship: StudentMentorRelationship
   onFavorite: (relationship: StudentMentorRelationship) => void
   onSkip: () => void

--- a/app/javascript/components/mentoring/discussion/finished-wizard/FinishStep.tsx
+++ b/app/javascript/components/mentoring/discussion/finished-wizard/FinishStep.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Partner, StudentMentorRelationship } from '../../Session'
+import { Student, StudentMentorRelationship } from '../../Session'
 import { GraphicalIcon } from '../../../common/GraphicalIcon'
 
 export const FinishStep = ({
@@ -8,7 +8,7 @@ export const FinishStep = ({
   onReset,
 }: {
   relationship: StudentMentorRelationship
-  student: Partner
+  student: Student
   onReset: () => void
 }): JSX.Element => {
   return (

--- a/app/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.tsx
+++ b/app/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.tsx
@@ -6,7 +6,7 @@ import { typecheck } from '../../../../utils/typecheck'
 import { Loading } from '../../../common'
 import { GraphicalIcon } from '../../../common/GraphicalIcon'
 import { ErrorBoundary, useErrorHandler } from '../../../ErrorBoundary'
-import { Partner, StudentMentorRelationship } from '../../Session'
+import { Student, StudentMentorRelationship } from '../../Session'
 
 type SuccessFn = (relationship: StudentMentorRelationship) => void
 type Choice = 'yes' | 'no'
@@ -25,7 +25,7 @@ export const MentorAgainStep = ({
   onYes,
   onNo,
 }: {
-  student: Partner
+  student: Student
   relationship: StudentMentorRelationship
   onYes: SuccessFn
   onNo: SuccessFn

--- a/app/javascript/components/mentoring/request/RequestDetails.tsx
+++ b/app/javascript/components/mentoring/request/RequestDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { DiscussionPost } from '../discussion/DiscussionPost'
-import { Iteration, Partner, MentoringRequest } from '../Session'
+import { Iteration, Student, MentoringRequest } from '../Session'
 import { IterationMarker } from '../session/IterationMarker'
 
 export const RequestDetails = ({
@@ -10,7 +10,7 @@ export const RequestDetails = ({
   userId,
 }: {
   iterations: readonly Iteration[]
-  student: Partner
+  student: Student
   request: MentoringRequest
   userId: number
 }): JSX.Element => {
@@ -18,11 +18,7 @@ export const RequestDetails = ({
   return (
     /* TODO: This wrapper is needed to make the styling correct. Maybe unscope the iteration marker? */
     <div className="discussion">
-      <IterationMarker
-        iteration={latestIteration}
-        student={student}
-        userId={userId}
-      />
+      <IterationMarker iteration={latestIteration} userIsStudent={false} />
       <DiscussionPost
         id={-1}
         authorId={-1}

--- a/app/javascript/components/mentoring/session/AutomatedFeedbackSummary.tsx
+++ b/app/javascript/components/mentoring/session/AutomatedFeedbackSummary.tsx
@@ -2,18 +2,16 @@ import React from 'react'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { RepresenterFeedback } from './RepresenterFeedback'
 import { AnalyzerFeedback } from './AnalyzerFeedback'
-import { Partner, AutomatedFeedback } from '../Session'
+import { Student, AutomatedFeedback } from '../Session'
 
 export const AutomatedFeedbackSummary = ({
   automatedFeedback,
-  student,
-  userId,
+  userIsStudent,
 }: {
   automatedFeedback: AutomatedFeedback
-  student: Partner
-  userId: number
+  userIsStudent: boolean
 }): JSX.Element => {
-  const addressedTo = userId === student.id ? 'You' : student.handle
+  const addressedTo = userIsStudent ? 'You' : 'Your student'
 
   return (
     <details className="c-details auto-feedback">

--- a/app/javascript/components/mentoring/session/IterationMarker.tsx
+++ b/app/javascript/components/mentoring/session/IterationMarker.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { timeFormat } from '../../../utils/time'
-import { Iteration, Partner } from '../Session'
+import { Iteration } from '../Session'
 import { AutomatedFeedbackSummary } from './AutomatedFeedbackSummary'
 
 export const IterationMarker = ({
   iteration,
-  student,
-  userId,
+  userIsStudent,
 }: {
   iteration: Iteration
-  student: Partner
-  userId: number
+  userIsStudent: boolean
 }): JSX.Element => {
   return (
     <React.Fragment>
@@ -25,9 +23,8 @@ export const IterationMarker = ({
       </div>
       {iteration.automatedFeedback ? (
         <AutomatedFeedbackSummary
-          student={student}
+          userIsStudent={userIsStudent}
           automatedFeedback={iteration.automatedFeedback}
-          userId={userId}
         />
       ) : null}
     </React.Fragment>

--- a/app/javascript/components/mentoring/session/SessionInfo.tsx
+++ b/app/javascript/components/mentoring/session/SessionInfo.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { TrackIcon } from '../../common/TrackIcon'
 import { Avatar } from '../../common/Avatar'
-import { Partner, Track, Exercise } from '../Session'
+import { Student, Track, Exercise } from '../Session'
 
 export const SessionInfo = ({
   student,
   track,
   exercise,
 }: {
-  student: Partner
+  student: Student
   track: Track
   exercise: Exercise
 }): JSX.Element => {

--- a/app/javascript/components/mentoring/session/StudentInfo.tsx
+++ b/app/javascript/components/mentoring/session/StudentInfo.tsx
@@ -1,21 +1,21 @@
 import React from 'react'
-import { Partner } from '../Session'
+import { Student } from '../Session'
 import { Avatar, Reputation } from '../../common'
 import { FavoriteButton } from './FavoriteButton'
 import { PreviousSessionsLink } from './PreviousSessionsLink'
 
-export const PartnerInfo = ({ partner }: { partner: Partner }): JSX.Element => {
+export const StudentInfo = ({ student }: { student: Student }): JSX.Element => {
   return (
     <div className="student-info">
       <div className="info">
         <div className="subtitle">Who you&apos;re mentoring</div>
         <div className="name-block">
-          <div className="name">{partner.name}</div>
-          <Reputation value={partner.reputation.toString()} type="primary" />
+          <div className="name">{student.name}</div>
+          <Reputation value={student.reputation.toString()} type="primary" />
         </div>
-        <div className="handle">{partner.handle}</div>
+        <div className="handle">{student.handle}</div>
         <div className="bio">
-          {partner.bio}
+          {student.bio}
           <span
             className="flags"
             dangerouslySetInnerHTML={{
@@ -25,22 +25,22 @@ export const PartnerInfo = ({ partner }: { partner: Partner }): JSX.Element => {
           {/*TODO: Map these to codes like above {student.languagesSpoken.join(', ')}*/}
         </div>
         <div className="options">
-          {partner.links ? <PartnerInfoActions partner={partner} /> : null}
-          <PreviousSessionsLink numSessions={partner.numPreviousSessions} />
+          {student.links ? <StudentInfoActions student={student} /> : null}
+          <PreviousSessionsLink numSessions={student.numPreviousSessions} />
         </div>
       </div>
-      <Avatar src={partner.avatarUrl} handle={partner.handle} />
+      <Avatar src={student.avatarUrl} handle={student.handle} />
     </div>
   )
 }
 
-const PartnerInfoActions = ({ partner }: { partner: Partner }) => {
+const StudentInfoActions = ({ student }: { student: Student }) => {
   return (
     <div className="options">
-      {partner.isFavorite !== undefined && partner.links?.favorite ? (
+      {student.isFavorite !== undefined && student.links?.favorite ? (
         <FavoriteButton
-          isFavorite={partner.isFavorite}
-          endpoint={partner.links.favorite}
+          isFavorite={student.isFavorite}
+          endpoint={student.links.favorite}
         />
       ) : null}
     </div>

--- a/app/javascript/components/student/MentoringSession.tsx
+++ b/app/javascript/components/student/MentoringSession.tsx
@@ -4,10 +4,10 @@ import { CloseButton } from '../mentoring/session/CloseButton'
 import { DiscussionPostList } from '../mentoring/discussion/DiscussionPostList'
 import { AddDiscussionPost } from '../mentoring/discussion/AddDiscussionPost'
 import { NewMessageAlert } from '../mentoring/discussion/NewMessageAlert'
-import { Iteration, Partner, Track, Exercise } from '../mentoring/Session'
+import { Iteration, Track, Exercise } from '../mentoring/Session'
 import { IterationView } from '../mentoring/session/IterationView'
 import { PostsWrapper } from '../mentoring/discussion/PostsContext'
-import { PartnerInfo } from '../mentoring/session/PartnerInfo'
+import { MentorInfo } from './mentoring-session/MentorInfo'
 import { SessionInfo } from './mentoring-session/SessionInfo'
 
 type Links = {
@@ -15,13 +15,22 @@ type Links = {
   exercise: string
 }
 
+export type Mentor = {
+  id: number
+  avatarUrl: string
+  name: string
+  bio: string
+  handle: string
+  reputation: number
+  numPreviousSessions: number
+}
+
 export const MentoringSession = ({
   id,
   isFinished,
   links,
   iterations,
-  student,
-  partner,
+  mentor,
   track,
   exercise,
   userId,
@@ -30,8 +39,7 @@ export const MentoringSession = ({
   isFinished: boolean
   links: Links
   iterations: readonly Iteration[]
-  student: Partner
-  partner: Partner
+  mentor: Mentor
   track: Track
   exercise: Exercise
   userId: number
@@ -41,7 +49,7 @@ export const MentoringSession = ({
       <div className="lhs">
         <header className="discussion-header">
           <CloseButton url={links.exercise} />
-          <SessionInfo track={track} exercise={exercise} mentor={partner} />
+          <SessionInfo track={track} exercise={exercise} mentor={mentor} />
         </header>
         <IterationView
           iterations={iterations}
@@ -51,11 +59,11 @@ export const MentoringSession = ({
       <div className="rhs">
         <PostsWrapper discussionId={id}>
           <div id="panel-discussion">
-            <PartnerInfo partner={partner} />
+            <MentorInfo mentor={mentor} />
             <DiscussionPostList
               endpoint={links.posts}
               iterations={iterations}
-              student={student}
+              userIsStudent={true}
               discussionId={id}
               userId={userId}
             />

--- a/app/javascript/components/student/mentoring-session/MentorInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/MentorInfo.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Mentor } from '../MentoringSession'
+import { Avatar, Reputation } from '../../common'
+import { PreviousSessionsLink } from '../../mentoring/session/PreviousSessionsLink'
+
+export const MentorInfo = ({ mentor }: { mentor: Mentor }): JSX.Element => {
+  return (
+    <div className="mentor-info">
+      <div className="info">
+        <div className="subtitle">Who's your mentor?</div>
+        <div className="name-block">
+          <div className="name">{mentor.name}</div>
+          <Reputation value={mentor.reputation.toString()} type="primary" />
+        </div>
+        <div className="handle">{mentor.handle}</div>
+        <div className="bio">
+          {mentor.bio}
+          <span
+            className="flags"
+            dangerouslySetInnerHTML={{
+              __html: '&#127468;&#127463; &#127466;&#127480;',
+            }}
+          />
+        </div>
+        <div className="options">
+          <PreviousSessionsLink numSessions={mentor.numPreviousSessions} />
+        </div>
+      </div>
+      <Avatar src={mentor.avatarUrl} handle={mentor.handle} />
+    </div>
+  )
+}

--- a/app/javascript/components/student/mentoring-session/SessionInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/SessionInfo.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { TrackIcon } from '../../common/TrackIcon'
 import { ExerciseIcon } from '../../common/ExerciseIcon'
-import { Partner, Track, Exercise } from '../../mentoring/Session'
+import { Mentor } from '../MentoringSession'
+import { Track, Exercise } from '../../mentoring/Session'
 
 export const SessionInfo = ({
   mentor,
   track,
   exercise,
 }: {
-  mentor: Partner
+  mentor: Mentor
   track: Track
   exercise: Exercise
 }): JSX.Element => {

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -113,7 +113,7 @@ import { Iteration } from '../components/track/IterationSummary'
 import { ExerciseInstructions, Submission } from '../components/editor/types'
 import {
   Iteration as MentoringSessionIteration,
-  Partner as MentoringSessionPartner,
+  Student as MentoringSessionStudent,
   Track as MentoringSessionTrack,
   Exercise as MentoringSessionExercise,
   Links as MentoringSessionLinks,
@@ -122,6 +122,7 @@ import {
   StudentMentorRelationship,
   MentoringRequest,
 } from '../components/mentoring/Session'
+import { Mentor as StudentMentoringSessionMentor } from '../components/student/MentoringSession'
 import * as Tooltips from '../components/tooltips'
 import * as Dropdowns from '../components/dropdowns'
 
@@ -167,7 +168,7 @@ initReact({
       mentorSolution={camelizeKeysAs<MentoringSessionMentorSolution>(
         data.mentor_solution
       )}
-      partner={camelizeKeysAs<MentoringSessionPartner>(data.partner)}
+      student={camelizeKeysAs<MentoringSessionStudent>(data.student)}
       track={camelizeKeysAs<MentoringSessionTrack>(data.track)}
       exercise={camelizeKeysAs<MentoringSessionExercise>(data.exercise)}
       iterations={camelizeKeysAs<MentoringSessionIteration[]>(data.iterations)}
@@ -193,8 +194,7 @@ initReact({
     <Student.MentoringSession
       id={data.id}
       isFinished={data.is_finished}
-      student={camelizeKeysAs<MentoringSessionPartner>(data.student)}
-      partner={camelizeKeysAs<MentoringSessionPartner>(data.partner)}
+      mentor={camelizeKeysAs<StudentMentoringSessionMentor>(data.mentor)}
       iterations={camelizeKeysAs<MentoringSessionIteration[]>(data.iterations)}
       track={camelizeKeysAs<MentoringSessionTrack>(data.track)}
       exercise={camelizeKeysAs<MentoringSessionExercise>(data.exercise)}

--- a/test/helpers/react_components/mentoring/session_test.rb
+++ b/test/helpers/react_components/mentoring/session_test.rb
@@ -30,7 +30,7 @@ module Mentoring
         "mentoring-session",
         {
           user_id: mentor.id,
-          partner: {
+          student: {
             id: student.id,
             name: student.name,
             handle: student.handle,

--- a/test/javascript/components/mentoring/Session.test.js
+++ b/test/javascript/components/mentoring/Session.test.js
@@ -56,7 +56,7 @@ test('highlights currently selected iteration', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -108,7 +108,7 @@ test('shows back button', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -165,7 +165,7 @@ test('hides latest label if on old iteration', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -223,7 +223,7 @@ test('switches to posts tab when comment success', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -287,7 +287,7 @@ test('switches tabs', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -353,7 +353,7 @@ test('go to previous iteration', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />
@@ -411,7 +411,7 @@ test('go to next iteration', async () => {
       exercise={exercise}
       links={links}
       track={track}
-      partner={student}
+      student={student}
       iterations={iterations}
       discussion={discussion}
     />

--- a/test/javascript/components/mentoring/discussion/DiscussionPostList.test.js
+++ b/test/javascript/components/mentoring/discussion/DiscussionPostList.test.js
@@ -63,7 +63,7 @@ test('displays all posts', async () => {
       iterations={iterations}
       endpoint="https://exercism.test/posts"
       onPostsChange={() => {}}
-      student={student}
+      userIsStudent={true}
     />
   )
 


### PR DESCRIPTION
@kntsoriano This reverts some of the work you did changing Student to Partner and instead splits them out into more separate concepts. 

As I understand it, your work was in trying to keep the distinction between Students and Mentors DRY and avoid duplication, but I think the net result for both me and Erik was that it made it a bit more confusing. The main source of the reason for this is the shared `PartnerInfo` component. I've duplicated this (and they are slightly different too) and added `Student` and `Mentor` as similar concepts. I've also added a `userIsStudent` flag that we can use rather than having to compare students and mentors to each other, which I think was one reason to unify them.

I think its really hard for you to know what is intended to be the same and what is different so these decisions can be quite hard to make. With my wider big-picture hat, I think this is a better refactor. As this is a change to your work and you may disagree, I've PR'd it separately so we can discuss if if you want to first, but feel free just to merge if you're happy! 🙂 

You may need to fix the tests up. I still can't run them locally 🙁 