### PR TITLE
Hide pagination when totalPages <= 0

### DIFF
--- a/app/javascript/components/common/SearchableList.tsx
+++ b/app/javascript/components/common/SearchableList.tsx
@@ -131,7 +131,7 @@ const Results = ({
           setOrder={setOrder}
         />
       ) : null}
-      {latestData ? (
+      {latestData && latestData.meta.totalPages > 1 ? (
         <Pagination
           current={query.page}
           total={latestData.meta.totalPages}

--- a/app/javascript/components/mentoring/inbox/DiscussionList.jsx
+++ b/app/javascript/components/mentoring/inbox/DiscussionList.jsx
@@ -32,7 +32,7 @@ export function DiscussionList({ request, setPage }) {
           {resolvedData.results.map((conversation, key) => (
             <Discussion key={key} {...conversation} />
           ))}
-          {latestData && (
+          {latestData & (latestData.meta.totalPages > 1) && (
             <footer>
               <Pagination
                 current={request.query.currentPage}

--- a/app/javascript/components/mentoring/queue/SolutionList.jsx
+++ b/app/javascript/components/mentoring/queue/SolutionList.jsx
@@ -55,7 +55,7 @@ export function SolutionList({
       ) : (
         'No discussions found'
       )}
-      {latestData && (
+      {latestData && latestData.meta.totalPages > 1 && (
         <footer>
           <Pagination
             current={page}

--- a/test/javascript/components/common/SearchableList.test.js
+++ b/test/javascript/components/common/SearchableList.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render, waitFor, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { SearchableList } from '../../../../app/javascript/components/common/SearchableList'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+const ResultsComponent = () => {
+  return <div data-testid="results" />
+}
+
+test('hides pagination when totalPages < 1', async () => {
+  const server = setupServer(
+    rest.get('https://exercism.test/endpoint', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          results: [],
+          meta: {
+            totalPages: 1,
+          },
+        })
+      )
+    })
+  )
+  server.listen()
+
+  render(
+    <SearchableList
+      endpoint="https://exercism.test/endpoint"
+      cacheKey="key"
+      placeholder=""
+      categories={[]}
+      ResultsComponent={ResultsComponent}
+    />
+  )
+
+  expect(await screen.findByTestId('results')).toBeInTheDocument()
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('button', { name: 'Go to first page' })
+    ).not.toBeInTheDocument()
+  )
+
+  server.close()
+})

--- a/test/javascript/components/mentoring/queue/SolutionList.test.js
+++ b/test/javascript/components/mentoring/queue/SolutionList.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { SolutionList } from '../../../../../app/javascript/components/mentoring/queue/SolutionList'
+
+test('hides pagination when totalPages < 1', async () => {
+  const data = {
+    results: [],
+    meta: {
+      totalPages: 1,
+    },
+  }
+
+  render(
+    <SolutionList status="success" latestData={data} resolvedData={data} />
+  )
+
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('button', { name: 'Go to first page' })
+    ).not.toBeInTheDocument()
+  )
+})


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/124.

This should've been a change in just one place, but our other components haven't used our <SearchableList /> component yet. I will do this refactoring another time.