### PR TITLE
Fix jumpy lists

### DIFF
--- a/app/javascript/components/common/Pagination.tsx
+++ b/app/javascript/components/common/Pagination.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 type PaginationProps = {
+  disabled?: boolean
   current: number
   total: number
   around?: number
@@ -8,6 +9,7 @@ type PaginationProps = {
 }
 
 export function Pagination({
+  disabled = false,
   current = 1,
   total,
   setPage,
@@ -30,7 +32,7 @@ export function Pagination({
         onClick={() => {
           setPage(1)
         }}
-        disabled={current === 1}
+        disabled={disabled || current === 1}
         aria-label="Go to first page"
         aria-current={current === 1 ? 'page' : undefined}
       >
@@ -44,7 +46,7 @@ export function Pagination({
               onClick={() => {
                 setPage(page)
               }}
-              disabled={page === current}
+              disabled={disabled || page === current}
               aria-label={`Go to page ${page}`}
               aria-current={page === current ? 'page' : undefined}
             >
@@ -57,7 +59,7 @@ export function Pagination({
         onClick={() => {
           setPage(total)
         }}
-        disabled={current === total}
+        disabled={disabled || current === total}
         aria-label="Go to last page"
         aria-current={current === total ? 'page' : undefined}
       >

--- a/app/javascript/components/common/SearchableList.tsx
+++ b/app/javascript/components/common/SearchableList.tsx
@@ -50,10 +50,17 @@ export const SearchableList = ({
   const { request, setPage, setCriteria, setQuery, setOrder } = useList({
     endpoint: endpoint,
   })
-  const { status, resolvedData, latestData, error } = usePaginatedRequestQuery<
-    PaginatedResult,
-    Error | Response
-  >(cacheKey, request, isMountedRef)
+  const {
+    status,
+    resolvedData,
+    latestData,
+    isFetching,
+    error,
+  } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
+    cacheKey,
+    request,
+    isMountedRef
+  )
 
   const setFilter = useCallback(
     (filter) => {
@@ -73,6 +80,7 @@ export const SearchableList = ({
           value={request.query.criteria || ''}
           placeholder={placeholder}
         />
+        {isFetching ? <span>Fetching</span> : null}
         <FilterPanel
           setFilter={setFilter}
           categories={categories}
@@ -122,22 +130,23 @@ const Results = ({
 }) => {
   useErrorHandler(error, { defaultError: DEFAULT_ERROR })
 
+  if (!resolvedData) {
+    return null
+  }
+
   return (
     <React.Fragment>
-      {resolvedData ? (
-        <ResultsComponent
-          order={query.order}
-          results={resolvedData.results}
-          setOrder={setOrder}
-        />
-      ) : null}
-      {latestData ? (
-        <Pagination
-          current={query.page}
-          total={latestData.meta.totalPages}
-          setPage={setPage}
-        />
-      ) : null}
+      <ResultsComponent
+        order={query.order}
+        results={resolvedData.results}
+        setOrder={setOrder}
+      />
+      <Pagination
+        disabled={latestData === undefined}
+        current={query.page}
+        total={resolvedData.meta.totalPages}
+        setPage={setPage}
+      />
     </React.Fragment>
   )
 }

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -4,15 +4,21 @@ import { TextFilter } from './TextFilter'
 import { Sorter } from './Sorter'
 import { TrackFilter } from './inbox/TrackFilter'
 import { useList } from '../../hooks/use-list'
+import { usePaginatedRequestQuery } from '../../hooks/request-query'
+import { useIsMounted } from 'use-is-mounted'
 
 export function Inbox({ tracksRequest, sortOptions, ...props }) {
+  const { request, setCriteria, setOrder, setPage, setQuery } = useList(
+    props.discussionsRequest
+  )
+  const isMountedRef = useIsMounted()
   const {
-    request: discussionsRequest,
-    setCriteria,
-    setOrder,
-    setPage,
-    setQuery,
-  } = useList(props.discussionsRequest)
+    status,
+    resolvedData,
+    latestData,
+    isFetching,
+    refetch,
+  } = usePaginatedRequestQuery('mentor-discussion-list', request, isMountedRef)
 
   const setTrack = (track) => {
     setQuery({ track: track, page: 1 })
@@ -23,23 +29,31 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
       <header className="c-search-bar">
         <TrackFilter
           request={tracksRequest}
-          value={discussionsRequest.query.track || null}
+          value={request.query.track || null}
           setTrack={setTrack}
         />
         <TextFilter
-          filter={discussionsRequest.query.criteria}
+          filter={request.query.criteria}
           setFilter={setCriteria}
           id="discussion-filter"
           placeholder="Filter by student or exercise name"
         />
+        {isFetching ? <span>Fetching...</span> : null}
         <Sorter
           sortOptions={sortOptions}
-          order={discussionsRequest.query.order}
+          order={request.query.order}
           setOrder={setOrder}
           id="discussion-sorter-sort"
         />
       </header>
-      <DiscussionList request={discussionsRequest} setPage={setPage} />
+      <DiscussionList
+        latestData={latestData}
+        resolvedData={resolvedData}
+        status={status}
+        refetch={refetch}
+        request={request}
+        setPage={setPage}
+      />
     </div>
   )
 }

--- a/app/javascript/components/mentoring/Queue.jsx
+++ b/app/javascript/components/mentoring/Queue.jsx
@@ -39,11 +39,12 @@ export function Queue({ sortOptions, tracks, ...props }) {
     },
     isMountedRef
   )
-  const { status, resolvedData, latestData } = usePaginatedRequestQuery(
-    'mentor-solutions-list',
-    request,
-    isMountedRef
-  )
+  const {
+    status,
+    isFetching,
+    resolvedData,
+    latestData,
+  } = usePaginatedRequestQuery('mentor-solutions-list', request, isMountedRef)
 
   return (
     <div className="queue-section-content">
@@ -55,6 +56,7 @@ export function Queue({ sortOptions, tracks, ...props }) {
             id="mentoring-queue-student-name-filter"
             placeholder="Filter by student handle"
           />
+          {isFetching ? <span>Fetching...</span> : null}
           <Sorter
             sortOptions={sortOptions}
             order={request.query.order}

--- a/app/javascript/components/mentoring/inbox/DiscussionList.jsx
+++ b/app/javascript/components/mentoring/inbox/DiscussionList.jsx
@@ -1,25 +1,20 @@
 import React from 'react'
 import { Pagination } from '../../common/Pagination'
 import { Discussion } from './Discussion'
-import { usePaginatedRequestQuery } from '../../../hooks/request-query'
 import { Loading } from '../../common/Loading'
-import { useIsMounted } from 'use-is-mounted'
 
-export function DiscussionList({ request, setPage }) {
-  const isMountedRef = useIsMounted()
-  const {
-    isLoading,
-    isError,
-    isSuccess,
-    resolvedData,
-    latestData,
-    refetch,
-  } = usePaginatedRequestQuery('mentor-discussion-list', request, isMountedRef)
-
+export function DiscussionList({
+  resolvedData,
+  latestData,
+  request,
+  refetch,
+  status,
+  setPage,
+}) {
   return (
     <div>
-      {isLoading && <Loading />}
-      {isError && (
+      {status === 'loading' && <Loading />}
+      {status === 'error' && (
         <>
           <p>Something went wrong</p>
           <button onClick={() => refetch()} aria-label="Retry">
@@ -27,20 +22,19 @@ export function DiscussionList({ request, setPage }) {
           </button>
         </>
       )}
-      {isSuccess && (
+      {status === 'success' && (
         <div className="--conversations">
           {resolvedData.results.map((conversation, key) => (
             <Discussion key={key} {...conversation} />
           ))}
-          {latestData && (
-            <footer>
-              <Pagination
-                current={request.query.currentPage}
-                total={latestData.meta.totalPages}
-                setPage={setPage}
-              />
-            </footer>
-          )}
+          <footer>
+            <Pagination
+              disabled={latestData === undefined}
+              current={request.query.currentPage}
+              total={resolvedData.meta.totalPages}
+              setPage={setPage}
+            />
+          </footer>
         </div>
       )}
     </div>

--- a/app/javascript/components/mentoring/queue/SolutionList.jsx
+++ b/app/javascript/components/mentoring/queue/SolutionList.jsx
@@ -32,16 +32,18 @@ export function SolutionList({
       {status === 'success' && resolvedData.results.length > 0 ? (
         <>
           <div className="--solutions">
-            {resolvedData.results.map((solution, key) => (
-              <Solution
-                key={key}
-                {...solution}
-                showMoreInformation={(e) =>
-                  showTooltip(e.target, solution.tooltipUrl)
-                }
-                hideMoreInformation={() => hideTooltip()}
-              />
-            ))}
+            {resolvedData.results.length > 0
+              ? resolvedData.results.map((solution, key) => (
+                  <Solution
+                    key={key}
+                    {...solution}
+                    showMoreInformation={(e) =>
+                      showTooltip(e.target, solution.tooltipUrl)
+                    }
+                    hideMoreInformation={() => hideTooltip()}
+                  />
+                ))
+              : 'No discussions found'}
           </div>
           <div ref={setTooltipElement}>
             {tooltipTrigger ? (
@@ -51,19 +53,16 @@ export function SolutionList({
               />
             ) : null}
           </div>
+          <footer>
+            <Pagination
+              disabled={latestData === undefined}
+              current={page}
+              total={resolvedData.meta.totalPages}
+              setPage={setPage}
+            />
+          </footer>
         </>
-      ) : (
-        'No discussions found'
-      )}
-      {latestData && (
-        <footer>
-          <Pagination
-            current={page}
-            total={latestData.meta.totalPages}
-            setPage={setPage}
-          />
-        </footer>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/app/javascript/components/student/TracksList.jsx
+++ b/app/javascript/components/student/TracksList.jsx
@@ -43,7 +43,7 @@ export function TracksList({ statusOptions, tagOptions, ...props }) {
       <section className="c-search-bar">
         <div className="lg-container container">
           <Search dispatch={dispatch} />
-
+          {isFetching ? <p>Fetching</p> : null}
           <TagsFilter
             dispatch={dispatch}
             options={tagOptions}

--- a/test/javascript/components/mentoring/inbox/DiscussionList.test.js
+++ b/test/javascript/components/mentoring/inbox/DiscussionList.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { setConsole } from 'react-query'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
@@ -33,33 +33,10 @@ test('allow retry after loading error', async () => {
         query: { page: 2 },
         options: { retry: false },
       }}
+      status="error"
       setPage={setPage}
     />
   )
 
   await waitFor(() => expect(screen.getByText('Retry')).toBeInTheDocument())
-
-  server.use(
-    rest.get('https://exercism.test/conversations', (req, res, ctx) => {
-      return res(
-        ctx.json({
-          results: [
-            {
-              trackTitle: 'Ruby',
-              exerciseTitle: 'Bob',
-              isStarred: false,
-              isNewSubmission: false,
-              haveMentoredPreviously: false,
-            },
-          ],
-          meta: { totalPages: 2 },
-        })
-      )
-    })
-  )
-
-  fireEvent.click(screen.getByText('Retry'))
-
-  await waitFor(() => expect(screen.getByText('on Bob')).toBeInTheDocument())
-  expect(screen.queryByText('Retry')).not.toBeInTheDocument()
 })

--- a/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
+++ b/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { FinishMentorDiscussionModal } from '../../../../app/javascript/components/modals/FinishMentorDiscussionModal'
 import { silenceConsole } from '../../support/silence-console'
 import { queryCache } from 'react-query'
+import flushPromises from 'flush-promises'
 
 test('disables buttons when loading', async () => {
   const server = setupServer(
@@ -24,6 +25,7 @@ test('disables buttons when loading', async () => {
       onSuccess={() => null}
     />
   )
+  await flushPromises()
 
   const endBtn = await screen.findByRole('button', {
     name: 'End discussion F3',
@@ -59,6 +61,7 @@ test('shows loading message when loading', async () => {
       onSuccess={() => {}}
     />
   )
+  await flushPromises()
   userEvent.click(
     await screen.findByRole('button', { name: 'End discussion F3' })
   )


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/129.

## Description
In order to make the lists less jumpy, we need to do two things:

1. Use a paginated query instead of a normal query. The paginated query stores the `resolvedData` while it fetches in the background. When the request resolves, `resolvedData` is repopulated.
2. Instead of hiding the pagination footer while fetching, disable it instead.