### PR TITLE
Split up tests

### DIFF
--- a/.github/workflows/asset-tests.yml
+++ b/.github/workflows/asset-tests.yml
@@ -1,0 +1,58 @@
+name: Asset Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  asset-test:
+    if: github.repository == 'exercism/website'
+
+    runs-on: ubuntu-latest
+    steps:
+      ###
+      # Checkout using GitHub's checkout action
+      - uses: actions/checkout@v2
+
+      ###
+      # Setup Ruby - this needs to match the version in the Gemfile
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@a699edbce608a2c128dedad88e3b6a0e28687b3c
+        with:
+          ruby-version: 2.6.6
+          bundler-cache: true
+
+      ###
+      # Caching using GitHub's caching action
+
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      ###
+      # Install bundler and yarn dependencies
+      - name: Install dependencies
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+        run: |
+          yarn install
+
+      - name: Run asset tests
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+        run: bundle exec bin/webpack

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,112 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  code-coverage:
+    if: github.repository == 'exercism/website'
+
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_USER: exercism_v3
+          MYSQL_PASSWORD: exercism_v3
+          MYSQL_DATABASE: exercism_v3_test
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306
+
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+
+      aws:
+        image: "localstack/localstack:0.12.3"
+        ports:
+          - 4566
+
+    steps:
+      ###
+      # Checkout using GitHub's checkout action
+      - uses: actions/checkout@v2
+
+      ###
+      # Setup Ruby - this needs to match the version in the Gemfile
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@a699edbce608a2c128dedad88e3b6a0e28687b3c
+        with:
+          ruby-version: 2.6.6
+          bundler-cache: true
+
+      ###
+      # Caching using GitHub's caching action
+
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      ###
+      # Install bundler and yarn dependencies
+      - name: Install dependencies
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+        run: |
+          yarn install
+          bundle exec setup_exercism_config
+          bundle exec setup_exercism_local_aws
+
+      ###
+      # Setup code climate
+      - name: Setup Code Climate test-reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
+      ###
+      # Run the tests
+      - name: Build Code Coverage
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+          CAPTURE_CODE_COVERAGE: true
+        run: |
+          bundle exec rails test:zeitwerk
+
+          bundle exec rails test
+          ./cc-test-reporter format-coverage -t simplecov -o codeclimate.backend.json coverage/backend/.resultset.json
+
+          bundle exec rails test:system
+          ./cc-test-reporter format-coverage -t simplecov -o codeclimate.system.json coverage/backend/.resultset.json
+
+      ###
+      # Publish the coverage to CodeClimate
+      - name: Publish code coverage
+        #if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          GIT_BRANCH: ${GITHUB_REF/refs\/heads\//}
+          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+        run: |
+          ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.total.json
+          ./cc-test-reporter upload-coverage -i codeclimate.total.json

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       ###
       # Checkout using GitHub's checkout action
-      - uses: actions/checkout@v2#
+      - uses: actions/checkout@v2
       ###
 
       # Caching using GitHub's caching action

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -30,6 +30,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      ###
+      # Install bundler and yarn dependencies
+      - name: Install dependencies
+        run: yarn install
 
       ###
       # Run the tests

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -12,8 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ###
-      # Caching using GitHub's caching action
+      # Checkout using GitHub's checkout action
+      - uses: actions/checkout@v2#
+      ###
 
+      # Caching using GitHub's caching action
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,34 @@
+name: JS Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  js-test:
+    if: github.repository == 'exercism/website'
+
+    runs-on: ubuntu-latest
+    steps:
+      ###
+      # Caching using GitHub's caching action
+
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      ###
+      # Run the tests
+      - name: Run JS tests
+        run: yarn test

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Ruby Tests
 
 on:
   push:
@@ -6,8 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
-    # TODO: Change this to website when merging
+  ruby-tests:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
@@ -48,7 +47,6 @@ jobs:
 
       ###
       # Caching using GitHub's caching action
-
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -77,14 +75,6 @@ jobs:
           bundle exec setup_exercism_local_aws
 
       ###
-      # Setup code climate
-      - name: Setup Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
-      ###
       # Run the tests
       - name: Run Ruby tests
         env:
@@ -92,32 +82,6 @@ jobs:
           EXERCISM_CI: true
           AWS_PORT: ${{ job.services.aws.ports['4566'] }}
           MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
-          CAPTURE_CODE_COVERAGE: true
         run: |
           bundle exec rails test:zeitwerk
-
           bundle exec rails test
-          ./cc-test-reporter format-coverage -t simplecov -o codeclimate.backend.json coverage/backend/.resultset.json
-
-          bundle exec rails test:system
-          ./cc-test-reporter format-coverage -t simplecov -o codeclimate.system.json coverage/backend/.resultset.json
-
-      - name: Run JS tests
-        run: yarn test
-
-      - name: Run asset tests
-        env:
-          EXERCISM_ENV: test
-          EXERCISM_CI: true
-        run: bundle exec bin/webpack
-
-      ###
-      # Publish the coverage to CodeClimate
-      - name: Publish code coverage
-        #if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        env:
-          GIT_BRANCH: ${GITHUB_REF/refs\/heads\//}
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-        run: |
-          ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.total.json
-          ./cc-test-reporter upload-coverage -i codeclimate.total.json

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,84 @@
+name: System Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  system-tests:
+    if: github.repository == 'exercism/website'
+
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_USER: exercism_v3
+          MYSQL_PASSWORD: exercism_v3
+          MYSQL_DATABASE: exercism_v3_test
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306
+
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+
+      aws:
+        image: "localstack/localstack:0.12.3"
+        ports:
+          - 4566
+
+    steps:
+      ###
+      # Checkout using GitHub's checkout action
+      - uses: actions/checkout@v2
+
+      ###
+      # Setup Ruby - this needs to match the version in the Gemfile
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@a699edbce608a2c128dedad88e3b6a0e28687b3c
+        with:
+          ruby-version: 2.6.6
+          bundler-cache: true
+
+      ###
+      # Caching using GitHub's caching action
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      ###
+      # Install bundler and yarn dependencies
+      - name: Install dependencies
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+        run: |
+          yarn install
+          bundle exec setup_exercism_config
+          bundle exec setup_exercism_local_aws
+
+      ###
+      # Run the tests
+      - name: Run Ruby system tests
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+        run: bundle exec rails test:system


### PR DESCRIPTION
It's taking forever to see failures right at the end, so this splits the tests into multiple jobs.

There is one left over that generates code coverage, but which won't be used as a requirement for merge.