### PR TITLE
Add a fix for a Popper issue that causes JS test warnings

### DIFF
--- a/test/javascript/components/Editor/features/storage.test.js
+++ b/test/javascript/components/Editor/features/storage.test.js
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Editor } from '../../../../../app/javascript/components/Editor'
+import { awaitPopper } from '../../../support/await-popper'
 
 test('populates files', async () => {
   const server = setupServer(
@@ -65,6 +66,7 @@ test('loads data from storage', async () => {
       assignment={{ overview: '', generalHints: [], tasks: [] }}
     />
   )
+  await awaitPopper()
 
   expect(queryByText('Value: class')).toBeInTheDocument()
 

--- a/test/javascript/components/Editor/features/tabs.test.js
+++ b/test/javascript/components/Editor/features/tabs.test.js
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Editor } from '../../../../../app/javascript/components/Editor'
+import { awaitPopper } from '../../../support/await-popper'
 
 test('switches tabs', async () => {
   render(
@@ -43,6 +44,7 @@ test('opens instructions tab by default', async () => {
       assignment={{ overview: '', generalHints: [], tasks: [] }}
     />
   )
+  await awaitPopper()
 
   expect(
     screen.getByRole('tab', { name: 'Instructions', selected: true })
@@ -87,6 +89,7 @@ test('opens results tab by default if tests have previously ran', async () => {
       }}
     />
   )
+  await awaitPopper()
 
   expect(
     await screen.findByRole('tab', { name: 'Results', selected: true })

--- a/test/javascript/components/dropdowns/Dropdown.test.js
+++ b/test/javascript/components/dropdowns/Dropdown.test.js
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { Dropdown } from '../../../../app/javascript/components/dropdowns/Dropdown'
 import userEvent from '@testing-library/user-event'
+import { awaitPopper } from '../../support/await-popper'
 
 test('button should not be focused on render', async () => {
   const menuButton = {
@@ -13,6 +14,7 @@ test('button should not be focused on render', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   expect(screen.getByRole('button', { name: 'Open menu' })).not.toHaveFocus()
 })
@@ -25,6 +27,7 @@ test('down arrow opens menu on first item', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   fireEvent.keyDown(screen.getByRole('button'), {
     key: 'ArrowDown',
@@ -42,6 +45,7 @@ test('down arrow moves down menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {
@@ -60,6 +64,7 @@ test('down arrow wraps around menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 2' }), {
@@ -78,6 +83,7 @@ test('up arrow opens menu on last item', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   fireEvent.keyDown(screen.getByRole('button'), {
     key: 'ArrowUp',
@@ -95,6 +101,7 @@ test('up arrow moves up menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 2' }), {
@@ -113,6 +120,7 @@ test('up arrow wraps around menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {
@@ -131,6 +139,7 @@ test('tab closes menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {
@@ -151,6 +160,7 @@ test('escape closes menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {
@@ -172,6 +182,7 @@ test('enter closes menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {
@@ -193,6 +204,7 @@ test('space closes menu', async () => {
   const menuItems = [{ html: 'Item 1' }, { html: 'Item 2' }]
 
   render(<Dropdown menuButton={menuButton} menuItems={menuItems} />)
+  await awaitPopper()
 
   userEvent.click(screen.getByRole('button', { name: 'Open menu' }))
   fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Item 1' }), {

--- a/test/javascript/components/mentoring/discussion/DiscussionPost.test.js
+++ b/test/javascript/components/mentoring/discussion/DiscussionPost.test.js
@@ -3,6 +3,7 @@ import { fireEvent, render, waitFor, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { DiscussionPost } from '../../../../../app/javascript/components/mentoring/discussion/DiscussionPost'
 import { stubRange } from '../../../support/code-mirror-helpers'
+import { awaitPopper } from '../../../support/await-popper'
 
 stubRange()
 
@@ -21,6 +22,7 @@ test('does not display student tag if author is mentor', async () => {
   }
 
   const { queryByText } = render(<DiscussionPost {...post} />)
+  await awaitPopper()
 
   expect(queryByText('Student')).not.toBeInTheDocument()
 })
@@ -64,6 +66,7 @@ test('highlights code blocks', async () => {
   }
 
   render(<DiscussionPost {...post} />)
+  await awaitPopper()
 
   expect(screen.getByText('class')).toHaveAttribute('class', 'hljs-keyword')
   expect(screen.getByText('Hello')).toHaveAttribute('class', 'hljs-title')

--- a/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
+++ b/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
@@ -6,6 +6,7 @@ import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { FavoriteStep } from '../../../../../../app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep'
 import { silenceConsole } from '../../../../support/silence-console'
+import { awaitPopper } from '../../../../support/await-popper'
 
 test('disables buttons when choosing to favorite', async () => {
   const student = { handle: 'student' }
@@ -40,6 +41,8 @@ test('shows loading message when choosing to favorite', async () => {
   server.listen()
 
   render(<FavoriteStep student={student} relationship={relationship} />)
+  await awaitPopper()
+
   userEvent.click(screen.getByRole('button', { name: 'Add to favorites' }))
 
   expect(await screen.findByText('Loading')).toBeInTheDocument()

--- a/test/javascript/support/await-popper.js
+++ b/test/javascript/support/await-popper.js
@@ -1,0 +1,13 @@
+import { act } from '@testing-library/react'
+
+// There is an issue where createPopper() runs its first update() asynchronously,
+// which leads to the Render not actually being completed.
+//
+// Calling:
+// await awaitPopper()
+// should fix it
+//
+// Read more here: https://github.com/popperjs/react-popper/issues/350
+export function awaitPopper() {
+  return act(async () => await null)
+}


### PR DESCRIPTION
@kntsoriano This addresses some of the warnings that CI gave us for JS. 

This post explains it: https://github.com/popperjs/react-popper/issues/350#issuecomment-691148800

---

Explanation of `await act(async () => await null)` by @sleeplessByte

- act does NOT wait until react settles. What it does is finish the current render completely (so the entire tree), and flushes events to the queue.
- act therefore works if your component rerenders / updates because of code (say: an effect, a setState, something like that)
- this is why that is suggested as a fix.

Now why doesn't act fix this?

- react-popper doesn't use a "react-system" event to schedule an update
- react therefore has nothing to flush, and think it's done
- narrator: it's not, the update still comes in after the test finishes, as it's wainting in the javascript microtask queue

(the update that is scheduled is done by createPopper, and not as part of the render cycle, so think of this as going outside of react, and thus react not knowing it was scheduled)

`await act(async () => await null)` is interesting.

setTimeout causes this too (if you don't waitFor a change)

So let's first look at `await act(...)`

This is: wait until the return value of the expression `act()` resolves.
`act()` returns a Promise, so this is "wait until that promise settles"

`async () => await null`

```js
async function flush() {
  return await new Promise((resolve) => resolve())
}
```

```
function flush() {
  return new Promise((resolve) => resolve())
}
to work too
```

When does the promise resolve?

`await` usually is used to settle a Promise, right?

And `async` is used to make a function return a Promise

```js
function flush() {
  return new Promise((resolve) => resolve())
}
async function flush() {
  return new Promise((resolve) => resolve())
}
```

These two functions are exactly the same. Why? `async` won't wrap a promise if a promise is returned

So, in the same way:
```js
await flush()
await (await flush())
```
these are the same because it won't unwrap a promise if it's ...not a promise

In other words, you can safely do:
```js
const result = await maybeAPromiseMaybeNot
```

Thus far, all is fine.

However.

There is 1 tiny tiny hackymchack difference between:
```js
null // as in doing nothing
await null
```

They should be the same but they're not

`await null` also flushes the Promise microtask queue

Now there are 60 minute long talks about what resolves first and how the event loop has multiple queues
the only thing that's important is that flushing the microtask queue means the update scheduled by create popper actually executes inside act, because it's now at the front of the queue
and because it executes inside act, act will wait for it
and act wait for it, so no warning

Promise handling is always asynchronous, as all promise actions pass through the internal “promise jobs” queue, also called “microtask queue” (V8 term).

https://javascript.info/article/event-loop/eventLoop.svg
https://javascript.info/article/event-loop/eventLoop-full.svg

This is super low-level stuff you almost never need

`act` does one event loop cycle, if I understood correctly.
Immediately after every macrotask, the engine executes all tasks from microtask queue, prior to running any other macrotasks or rendering or anything else.

so basically by flushing the microtask queue (read: make it part of this cycle/render/task/whatever you want to call it) everything is solved
