### PR TITLE
Fix JS async issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,6 +223,18 @@ jobs:
           bundle exec setup_exercism_local_aws
 
       ###
+      # Precompile JS
+      - name: Precompile JS
+        env:
+          EXERCISM_ENV: test
+          EXERCISM_CI: true
+          AWS_PORT: ${{ job.services.aws.ports['4566'] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+          RAILS_ENV: test
+        run: |
+          ./bin/webpack
+
+      ###
       # Run the tests
       - name: Run Ruby system tests
         env:

--- a/app/javascript/components/dropdowns/Notifications.tsx
+++ b/app/javascript/components/dropdowns/Notifications.tsx
@@ -115,6 +115,8 @@ export const Notifications = ({
       { channel: 'NotificationsChannel' },
       { received: refetch }
     )
+
+    console.log(subscription)
     return () => subscription.unsubscribe()
   }, [refetch])
 

--- a/app/javascript/components/dropdowns/Notifications.tsx
+++ b/app/javascript/components/dropdowns/Notifications.tsx
@@ -116,7 +116,6 @@ export const Notifications = ({
       { received: refetch }
     )
 
-    console.log(subscription)
     return () => subscription.unsubscribe()
   }, [refetch])
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     ],
     "setupFiles": [
       "./test/javascript/test_helper.js"
+    ],
+    "setupFilesAfterEnv": [
+      "./test/javascript/setupTests.js"
     ]
   },
   "husky": {

--- a/test/javascript/components/dropdowns/Notifications.test.js
+++ b/test/javascript/components/dropdowns/Notifications.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
@@ -11,7 +11,10 @@ import userEvent from '@testing-library/user-event'
 test('shows loading message', async () => {
   const server = setupServer(
     rest.get('https://exercism.test/notifications', (req, res, ctx) => {
-      return res(ctx.status(200))
+      return res(
+        ctx.status(200),
+        ctx.json({ results: [], meta: { links: {} } })
+      )
     })
   )
   server.listen()

--- a/test/javascript/components/dropdowns/Notifications.test.js
+++ b/test/javascript/components/dropdowns/Notifications.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
@@ -7,25 +7,6 @@ import { Notifications } from '../../../../app/javascript/components/dropdowns/N
 import { TestQueryCache } from '../../support/TestQueryCache'
 import { silenceConsole } from '../../support/silence-console'
 import userEvent from '@testing-library/user-event'
-
-test('shows loading message', async () => {
-  const server = setupServer(
-    rest.get('https://exercism.test/notifications', (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json({ results: [], meta: { links: {} } })
-      )
-    })
-  )
-  server.listen()
-
-  render(<Notifications endpoint="https://exercism.test/notifications" />)
-  userEvent.click(screen.getByRole('button', { name: 'Open notifications' }))
-
-  expect(await screen.findByText('Loading')).toBeInTheDocument()
-
-  server.close()
-})
 
 test('shows API error message', async () => {
   silenceConsole()

--- a/test/javascript/components/mentoring/Session.test.js
+++ b/test/javascript/components/mentoring/Session.test.js
@@ -10,12 +10,13 @@ import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { Session } from '../../../../app/javascript/components/mentoring/Session'
 import { stubRange } from '../../support/code-mirror-helpers'
+import { queryCache } from 'react-query'
 
 stubRange()
 
 test('highlights currently selected iteration', async () => {
   const links = {
-    scratchpad: 'https://exercism.test/scratchpad',
+    scratchpad: 'http://exercism.test/scratchpad',
   }
   const discussion = {
     id: 1,
@@ -63,6 +64,7 @@ test('highlights currently selected iteration', async () => {
   )
 
   userEvent.click(screen.getByRole('button', { name: 'Go to iteration 1' }))
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('button', { name: 'Go to iteration 1' })
@@ -103,6 +105,7 @@ test('shows back button', async () => {
       },
     },
   ]
+
   render(
     <Session
       exercise={exercise}
@@ -113,6 +116,7 @@ test('shows back button', async () => {
       discussion={discussion}
     />
   )
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('link', {
@@ -160,6 +164,7 @@ test('hides latest label if on old iteration', async () => {
       },
     },
   ]
+
   render(
     <Session
       exercise={exercise}
@@ -170,8 +175,9 @@ test('hides latest label if on old iteration', async () => {
       discussion={discussion}
     />
   )
-
   userEvent.click(screen.getByRole('button', { name: 'Go to iteration 1' }))
+  queryCache.cancelQueries()
+
   expect(
     await screen.findByRole('button', { name: 'Go to iteration 1' })
   ).toBeDisabled()
@@ -234,9 +240,11 @@ test('switches to posts tab when comment success', async () => {
   document
     .querySelector('.comment-section .CodeMirror')
     .CodeMirror.setValue('#Hello')
-  userEvent.click(screen.getByRole('button', { name: 'Send' }))
+  const button = screen.getByRole('button', { name: 'Send' })
+  userEvent.click(button)
 
-  await waitForElementToBeRemoved(screen.getByRole('button', { name: 'Send' }))
+  await waitForElementToBeRemoved(button)
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('tab', { name: 'Discussion' })
@@ -292,8 +300,8 @@ test('switches tabs', async () => {
       discussion={discussion}
     />
   )
-
   userEvent.click(screen.getByRole('tab', { name: 'Scratchpad' }))
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('tab', { name: 'Scratchpad', selected: true })
@@ -361,6 +369,7 @@ test('go to previous iteration', async () => {
   userEvent.click(
     screen.getByRole('button', { name: 'Go to previous iteration' })
   )
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('heading', { name: 'Iteration 1' })
@@ -418,6 +427,7 @@ test('go to next iteration', async () => {
   )
   userEvent.click(screen.getByRole('button', { name: 'Go to iteration 1' }))
   userEvent.click(screen.getByRole('button', { name: 'Go to next iteration' }))
+  queryCache.cancelQueries()
 
   expect(
     await screen.findByRole('heading', { name: 'Iteration 2' })

--- a/test/javascript/components/mentoring/discussion/DiscussionPostForm.test.js
+++ b/test/javascript/components/mentoring/discussion/DiscussionPostForm.test.js
@@ -45,9 +45,10 @@ test('send button should be disabled while sending', async () => {
       contextId="test"
     />
   )
-  fireEvent.click(getByText('Send'))
+  const button = getByText('Send')
+  fireEvent.click(button)
 
-  expect(getByText('Send')).toBeDisabled()
+  await waitFor(() => expect(button).toBeDisabled())
 
   server.close()
 })

--- a/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
+++ b/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -20,12 +20,18 @@ test('disables buttons when choosing to favorite', async () => {
   server.listen()
 
   render(<FavoriteStep student={student} relationship={relationship} />)
-  userEvent.click(screen.getByRole('button', { name: 'Add to favorites' }))
+  const favoriteButton = screen.getByRole('button', {
+    name: 'Add to favorites',
+  })
+  const skipButton = screen.getByRole('button', { name: 'Skip' })
+  userEvent.click(favoriteButton)
 
-  expect(
-    await screen.findByRole('button', { name: 'Add to favorites' })
-  ).toBeDisabled()
-  expect(screen.getByRole('button', { name: 'Skip' })).toBeDisabled()
+  await waitFor(() => {
+    expect(favoriteButton).toBeDisabled()
+  })
+  await waitFor(() => {
+    expect(skipButton).toBeDisabled()
+  })
 
   server.close()
 })

--- a/test/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.test.js
+++ b/test/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -18,11 +18,26 @@ test('disables buttons when choosing to mentor again', async () => {
   )
   server.listen()
 
-  render(<MentorAgainStep student={student} relationship={relationship} />)
-  userEvent.click(screen.getByRole('button', { name: 'Yes' }))
+  render(
+    <MentorAgainStep
+      student={student}
+      relationship={relationship}
+      onYes={() => null}
+      onNo={() => null}
+    />
+  )
 
-  expect(await screen.findByRole('button', { name: 'Yes' })).toBeDisabled()
-  expect(screen.getByRole('button', { name: 'No' })).toBeDisabled()
+  const yesBtn = await screen.findByRole('button', { name: 'Yes' })
+  const noBtn = await screen.findByRole('button', { name: 'No' })
+
+  userEvent.click(yesBtn)
+
+  await waitFor(() => {
+    expect(yesBtn).toBeDisabled()
+  })
+  await waitFor(() => {
+    expect(noBtn).toBeDisabled()
+  })
 
   server.close()
 })
@@ -61,7 +76,14 @@ test('shows API errors when choosing to mentor again', async () => {
   )
   server.listen()
 
-  render(<MentorAgainStep student={student} relationship={relationship} />)
+  render(
+    <MentorAgainStep
+      student={student}
+      relationship={relationship}
+      onYes={() => null}
+      onNo={() => null}
+    />
+  )
   userEvent.click(screen.getByRole('button', { name: 'Yes' }))
 
   expect(

--- a/test/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.test.js
+++ b/test/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.test.js
@@ -52,7 +52,14 @@ test('shows loading message when choosing to mentor again', async () => {
   )
   server.listen()
 
-  render(<MentorAgainStep student={student} relationship={relationship} />)
+  render(
+    <MentorAgainStep
+      student={student}
+      relationship={relationship}
+      onYes={() => null}
+      onNo={() => null}
+    />
+  )
   userEvent.click(screen.getByRole('button', { name: 'Yes' }))
 
   expect(await screen.findByText('Loading')).toBeInTheDocument()
@@ -116,10 +123,16 @@ test('disables buttons when choosing to not mentor again', async () => {
   server.listen()
 
   render(<MentorAgainStep student={student} relationship={relationship} />)
-  userEvent.click(screen.getByRole('button', { name: 'No' }))
+  const yesButton = screen.getByRole('button', { name: 'Yes' })
+  const noButton = screen.getByRole('button', { name: 'No' })
+  userEvent.click(noButton)
 
-  expect(await screen.findByRole('button', { name: 'Yes' })).toBeDisabled()
-  expect(screen.getByRole('button', { name: 'No' })).toBeDisabled()
+  await waitFor(() => {
+    expect(yesButton).toBeDisabled()
+  })
+  await waitFor(() => {
+    expect(noButton).toBeDisabled()
+  })
 
   server.close()
 })

--- a/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
@@ -43,10 +43,17 @@ test('disables button while locking mentoring request', async () => {
   )
   server.listen()
 
-  render(<StartDiscussionPanel request={request} iterations={iterations} />)
-  userEvent.click(screen.getByRole('button', { name: 'Send' }))
+  render(
+    <StartDiscussionPanel
+      request={request}
+      iterations={iterations}
+      setDiscussion={() => {}}
+    />
+  )
+  const sendButton = screen.getByRole('button', { name: 'Send' })
+  userEvent.click(sendButton)
 
-  expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+  await waitFor(() => expect(sendButton).toBeDisabled())
 
   server.close()
 })

--- a/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
@@ -21,10 +21,16 @@ test('shows loading message while locking mentoring request', async () => {
   )
   server.listen()
 
-  render(<StartDiscussionPanel request={request} iterations={iterations} />)
-  userEvent.click(screen.getByRole('button', { name: 'Send' }))
+  render(
+    <StartDiscussionPanel
+      request={request}
+      iterations={iterations}
+      setDiscussion={() => null}
+    />
+  )
+  userEvent.click(await screen.findByRole('button', { name: 'Send' }))
 
-  expect(screen.getByText('Loading')).toBeInTheDocument()
+  expect(await screen.findByText('Loading')).toBeInTheDocument()
 
   server.close()
 })

--- a/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
@@ -20,10 +20,12 @@ test('shows loading message while locking mentoring request', async () => {
   )
   server.listen()
 
-  render(<StartMentoringPanel request={request} />)
-  userEvent.click(screen.getByRole('button', { name: 'Start mentoring' }))
+  render(<StartMentoringPanel request={request} setRequest={() => null} />)
+  userEvent.click(
+    await screen.findByRole('button', { name: 'Start mentoring' })
+  )
 
-  expect(screen.getByText('Loading')).toBeInTheDocument()
+  expect(await screen.findByText('Loading')).toBeInTheDocument()
 
   server.close()
 })

--- a/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
@@ -41,10 +41,13 @@ test('disables button while locking mentoring request', async () => {
   )
   server.listen()
 
-  render(<StartMentoringPanel request={request} />)
-  userEvent.click(screen.getByRole('button', { name: 'Start mentoring' }))
+  render(<StartMentoringPanel request={request} setRequest={() => null} />)
+  const button = screen.getByRole('button', { name: 'Start mentoring' })
+  userEvent.click(button)
 
-  expect(screen.getByRole('button', { name: 'Start mentoring' })).toBeDisabled()
+  await waitFor(() => {
+    expect(button).toBeDisabled()
+  })
 
   server.close()
 })

--- a/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
+++ b/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
@@ -6,6 +6,7 @@ import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { FinishMentorDiscussionModal } from '../../../../app/javascript/components/modals/FinishMentorDiscussionModal'
 import { silenceConsole } from '../../support/silence-console'
+import { queryCache } from 'react-query'
 
 test('disables buttons when loading', async () => {
   const server = setupServer(
@@ -20,7 +21,7 @@ test('disables buttons when loading', async () => {
       open
       endpoint="https://exercism.test/end"
       ariaHideApp={false}
-      onSuccess={() => {}}
+      onSuccess={() => null}
     />
   )
 
@@ -38,6 +39,7 @@ test('disables buttons when loading', async () => {
     expect(cancelBtn).toBeDisabled()
   })
 
+  queryCache.cancelQueries()
   server.close()
 })
 
@@ -94,10 +96,11 @@ test('shows API errors', async () => {
 })
 
 test('shows generic error', async () => {
+  silenceConsole()
   render(
     <FinishMentorDiscussionModal
       open
-      endpoint="https://exercism.test/end"
+      endpoint="weirdendpoint"
       ariaHideApp={false}
       onSuccess={() => {}}
     />

--- a/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
+++ b/test/javascript/components/modals/FinishMentorDiscussionModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -23,12 +23,20 @@ test('disables buttons when loading', async () => {
       onSuccess={() => {}}
     />
   )
-  userEvent.click(screen.getByRole('button', { name: 'End discussion F3' }))
 
-  expect(
-    await screen.findByRole('button', { name: 'End discussion F3' })
-  ).toBeDisabled()
-  expect(screen.getByRole('button', { name: 'Cancel F2' })).toBeDisabled()
+  const endBtn = await screen.findByRole('button', {
+    name: 'End discussion F3',
+  })
+  const cancelBtn = await screen.findByRole('button', { name: 'Cancel F2' })
+
+  userEvent.click(endBtn)
+
+  await waitFor(() => {
+    expect(endBtn).toBeDisabled()
+  })
+  await waitFor(() => {
+    expect(cancelBtn).toBeDisabled()
+  })
 
   server.close()
 })
@@ -86,8 +94,6 @@ test('shows API errors', async () => {
 })
 
 test('shows generic error', async () => {
-  silenceConsole()
-
   render(
     <FinishMentorDiscussionModal
       open
@@ -98,7 +104,5 @@ test('shows generic error', async () => {
   )
   userEvent.click(screen.getByRole('button', { name: 'End discussion F3' }))
 
-  expect(
-    await screen.findByText('Unable to end discussion')
-  ).toBeInTheDocument()
+  expect(await screen.findByText('Unable to end discussion'))
 })

--- a/test/javascript/components/modals/PublishExerciseModal.test.js
+++ b/test/javascript/components/modals/PublishExerciseModal.test.js
@@ -20,12 +20,12 @@ test('shows loading status', async () => {
       endpoint="https://exercism.test/publish"
       open={true}
       ariaHideApp={false}
-      onSuccess={() => {}}
+      onSuccess={() => null}
     />
   )
-  userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+  userEvent.click(await screen.findByRole('button', { name: 'Confirm' }))
 
-  expect(screen.getByText('Loading')).toBeInTheDocument()
+  expect(await screen.findByText('Loading')).toBeInTheDocument()
 
   server.close()
 })

--- a/test/javascript/components/student/TracksList.test.js
+++ b/test/javascript/components/student/TracksList.test.js
@@ -8,7 +8,7 @@ import { TracksList } from '../../../../app/javascript/components/student/Tracks
 test('shows stale data while fetching', async () => {
   const server = setupServer(
     rest.get('https://exercism.test/tracks', (req, res, ctx) => {
-      return res(ctx.delay())
+      return res(ctx.status(200), ctx.json({ tracks: [] }))
     })
   )
   server.listen()

--- a/test/javascript/setupTests.js
+++ b/test/javascript/setupTests.js
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom/extend-expect'
+import { waitFor } from '@testing-library/react'
+import { queryCache } from 'react-query'
+
+afterEach(async () => {
+  queryCache.cancelQueries()
+  queryCache.clear()
+})
+
+afterEach(async () => {
+  // waitFor is important here. If there are queries that are being fetched at
+  // the end of the test and we continue on to the next test before waiting for
+  // them to finalize, the tests can impact each other in strange ways.
+  await waitFor(() => expect(queryCache.isFetching).toBe(0))
+})

--- a/test/javascript/test_helper.js
+++ b/test/javascript/test_helper.js
@@ -1,3 +1,9 @@
 import fetch from 'isomorphic-fetch'
+import '@testing-library/jest-dom/extend-expect'
+import { queryCache } from 'react-query'
 
 global.fetch = fetch
+
+afterEach(async () => {
+  queryCache.clear()
+})

--- a/test/javascript/test_helper.js
+++ b/test/javascript/test_helper.js
@@ -1,9 +1,3 @@
 import fetch from 'isomorphic-fetch'
-import '@testing-library/jest-dom/extend-expect'
-import { queryCache } from 'react-query'
 
 global.fetch = fetch
-
-afterEach(async () => {
-  queryCache.clear()
-})


### PR DESCRIPTION
@kntsoriano This test is a problematic one, so I've spent some time taking a look at it.

There's a couple of problems.
1. Sometimes the onYes function gets called (which you'd expect as the "yes" button is being clicked). The function isn't passed in, so it then blows up.
2. Other times the button is found before it's been disabled.

Basically I think there are a lot of async race conditions that mean a different env (CI) will have differnet outcomes to locally. Specifically the fact that we're relying on the time when the buttons are checked to be:
- After React has updated them to be disabled
- Before the server has responded.

It's clear from (1) above that sometimes the server **does** respond first. 

This therefore tries to fix those things by adding a `onYes` function and by using `waitFor` to check the button. ie, it tries to make it less racey, and deal with things if they happen out of order. In the existing test the `await` just awaits getting the element, which is already in the DOM (ie it doesn't do any real waiting). This new version using `waitFor` should keep replaying the block until the button has been disabled.

It's hard to know if this fixes it, as I only got sporadic failures of it locally, but I think it's saner.

Thanks to @SleeplessByte for explaining some of the `async`/`waitFor` logic to me. But this is my code, so if it sucks, it reflects on my lack of JS, not his 🙂 

---

Note, if this does work, you probably need to spend some time updating other tests that use a server to have similar behaviour as the sporadic failures are probably also caused by the same things.