### PR TITLE
More JS fixes

### DIFF
--- a/test/javascript/components/Editor/features/submissions.test.js
+++ b/test/javascript/components/Editor/features/submissions.test.js
@@ -1,7 +1,8 @@
 jest.mock('../../../../../app/javascript/components/editor/FileEditor')
 
 import React from 'react'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, waitFor, act, await } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -39,7 +40,7 @@ test('shows message when test times out', async () => {
   )
   server.listen()
 
-  const { getByText, queryByText } = render(
+  const { findByText, queryByText } = render(
     <Editor
       endpoint="https://exercism.test/submissions"
       files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]}
@@ -47,7 +48,7 @@ test('shows message when test times out', async () => {
       assignment={{ overview: '', generalHints: [], tasks: [] }}
     />
   )
-  fireEvent.click(getByText('Run Tests'))
+  userEvent.click(await findByText('Run Tests'))
   await waitFor(() =>
     expect(
       queryByText("We've queued your code and will run it shortly.")
@@ -69,15 +70,15 @@ test('cancels a pending submission', async () => {
   )
   server.listen()
 
-  const { getByText, queryByText } = render(
+  const { findByText, queryByText } = render(
     <Editor
       endpoint="https://exercism.test/submissions"
       files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]}
       assignment={{ overview: '', generalHints: [], tasks: [] }}
     />
   )
-  fireEvent.click(getByText('Run Tests'))
-  fireEvent.click(getByText('Cancel'))
+  userEvent.click(await findByText('Run Tests'))
+  userEvent.click(await findByText('Cancel'))
 
   await waitFor(() =>
     expect(queryByText('Running tests...')).not.toBeInTheDocument()
@@ -104,7 +105,7 @@ test('disables submit button unless tests passed', async () => {
   )
   server.listen()
 
-  const { getByText } = render(
+  const { findByText } = render(
     <Editor
       endpoint="https://exercism.test/submissions"
       files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]}
@@ -124,8 +125,9 @@ test('disables submit button unless tests passed', async () => {
     />
   )
 
+  const submitBtn = await findByText('Submit')
   await waitFor(() => {
-    expect(getByText('Submit')).toBeDisabled()
+    expect(submitBtn).toBeDisabled()
   })
 
   server.close()

--- a/test/javascript/components/mentoring/Inbox.test.js
+++ b/test/javascript/components/mentoring/Inbox.test.js
@@ -11,6 +11,7 @@ import {
 } from '../../support/silence-console'
 import flushPromises from 'flush-promises'
 import { awaitPopper } from '../../support/await-popper'
+import { queryCache } from 'react-query'
 
 let server = setupServer(
   rest.get('https://exercism.test/tracks', (req, res, ctx) => {
@@ -55,6 +56,9 @@ test('page is set to 1 automatically', async () => {
 })
 
 test('page is reset to 1 when switching tracks', async () => {
+  await flushPromises()
+  await awaitPopper()
+
   await expectConsoleError(async () => {
     render(
       <Inbox
@@ -78,5 +82,9 @@ test('page is reset to 1 when switching tracks', async () => {
     )
 
     await waitFor(() => expect(screen.getByText('First')).toBeDisabled())
+
+    queryCache.cancelQueries()
+    await flushPromises()
+    await awaitPopper()
   })
 })

--- a/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
+++ b/test/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.test.js
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { FavoriteStep } from '../../../../../../app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep'
 import { silenceConsole } from '../../../../support/silence-console'
 import { awaitPopper } from '../../../../support/await-popper'
+import { TestQueryCache } from '../../../../support/TestQueryCache'
 
 test('disables buttons when choosing to favorite', async () => {
   const student = { handle: 'student' }
@@ -19,7 +20,11 @@ test('disables buttons when choosing to favorite', async () => {
   )
   server.listen()
 
-  render(<FavoriteStep student={student} relationship={relationship} />)
+  render(
+    <TestQueryCache>
+      <FavoriteStep student={student} relationship={relationship} />
+    </TestQueryCache>
+  )
   const favoriteButton = await screen.findByRole('button', {
     name: 'Add to favorites',
   })

--- a/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartDiscussionPanel.test.js
@@ -5,6 +5,7 @@ import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { StartDiscussionPanel } from '../../../../../app/javascript/components/mentoring/request/StartDiscussionPanel'
 import { silenceConsole } from '../../../support/silence-console'
+import { TestQueryCache } from '../../../support/TestQueryCache'
 import userEvent from '@testing-library/user-event'
 import flushPromises from 'flush-promises'
 
@@ -23,11 +24,13 @@ test('shows loading message while locking mentoring request', async () => {
   server.listen()
 
   render(
-    <StartDiscussionPanel
-      request={request}
-      iterations={iterations}
-      setDiscussion={() => null}
-    />
+    <TestQueryCache>
+      <StartDiscussionPanel
+        request={request}
+        iterations={iterations}
+        setDiscussion={() => null}
+      />
+    </TestQueryCache>
   )
   await flushPromises()
   userEvent.click(await screen.findByRole('button', { name: 'Send' }))

--- a/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
+++ b/test/javascript/components/mentoring/request/StartMentoringPanel.test.js
@@ -1,11 +1,13 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { StartMentoringPanel } from '../../../../../app/javascript/components/mentoring/request/StartMentoringPanel'
 import { silenceConsole } from '../../../support/silence-console'
 import userEvent from '@testing-library/user-event'
+import flushPromises from 'flush-promises'
+import { awaitPopper } from '../../../support/await-popper'
 
 test('shows loading message while locking mentoring request', async () => {
   const request = {
@@ -42,8 +44,12 @@ test('disables button while locking mentoring request', async () => {
     })
   )
   server.listen()
+  await flushPromises()
+  await awaitPopper()
 
-  render(<StartMentoringPanel request={request} setRequest={() => null} />)
+  act(() => {
+    render(<StartMentoringPanel request={request} setRequest={() => null} />)
+  })
   const button = await screen.findByRole('button', { name: 'Start mentoring' })
   userEvent.click(button)
 

--- a/test/javascript/components/mentoring/session/Scratchpad.test.js
+++ b/test/javascript/components/mentoring/session/Scratchpad.test.js
@@ -4,13 +4,15 @@ import {
   render,
   screen,
   waitForElementToBeRemoved,
+  act,
 } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import '@testing-library/jest-dom/extend-expect'
 import { Scratchpad } from '../../../../../app/javascript/components/mentoring/session/Scratchpad'
 import { stubRange } from '../../../support/code-mirror-helpers'
-import { act } from 'react-dom/test-utils'
+import flushPromises from 'flush-promises'
+import { awaitPopper } from '../../../support/await-popper'
 
 stubRange()
 
@@ -80,10 +82,17 @@ test('clears errors when resubmitting', async () => {
     })
   )
   server.listen()
+  await flushPromises()
+  await awaitPopper()
 
-  render(
-    <Scratchpad endpoint="https://exercism.test/scratchpad" discussionId={1} />
-  )
+  act(() => {
+    render(
+      <Scratchpad
+        endpoint="https://exercism.test/scratchpad"
+        discussionId={1}
+      />
+    )
+  })
   await waitForElementToBeRemoved(screen.queryByText('Loading'))
   act(() => {
     userEvent.click(screen.getByRole('button', { name: 'Save' }))

--- a/test/javascript/components/modals/PublishExerciseModal.test.js
+++ b/test/javascript/components/modals/PublishExerciseModal.test.js
@@ -10,7 +10,7 @@ import { silenceConsole } from '../../support/silence-console'
 test('shows loading status', async () => {
   const server = setupServer(
     rest.patch('https://exercism.test/publish', (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json({}))
+      return res(ctx.delay(10), ctx.status(200), ctx.json({}))
     })
   )
   server.listen()


### PR DESCRIPTION
@kntsoriano Couple more observations:
1. The `ctx.delay(10)` fixes lots as it forces things to be async, so they stop being flakey (ie the response has **never** come back by the time the first `expect` is hit. So this is a solid step forward
2. The `<TestQueryCache>` you added seems to work well.
3. When getting an `act` error that I can't track down, adding this at the end of the test, to clear everything before the test ends works well. It's not pleasant, but I prefer it to muting the console errors.
```js
queryCache.cancelQueries()
await flushPromises()
await awaitPopper()
```

I'll merge this then rebase the mentor flow PR