### PR TITLE
Use ansi for test results

### DIFF
--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -53,14 +53,31 @@ class Submission::TestRun < ApplicationRecord
 
   class TestResult
     def initialize(test)
-      @name = test[:name]
-      @status = test[:status].to_sym
-      @test_code = test[:test_code]
-      @message = test[:message]
-      @expected = test[:expected]
-      @output = test[:output]
-      @output_html = Ansi::To::Html.new(test[:output]).to_html if test[:output].present?
+      @test = test
     end
+
+    def to_h
+      {
+        name: test[:name],
+        status: test[:status].to_sym,
+        test_code: test[:test_code],
+        message: test[:message],
+        expected: test[:expected],
+        output: test[:output],
+        output_html: test[:output].present? ? Ansi::To::Html.new(test[:output]).to_html : nil
+      }
+    end
+
+    def to_json(*_args)
+      to_h.to_json
+    end
+
+    def as_json(*_args)
+      to_h
+    end
+
+    private
+    attr_reader :test
   end
   private_constant :TestResult
 end

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -59,7 +59,7 @@ class Submission::TestRun < ApplicationRecord
     def to_h
       {
         name: test[:name],
-        status: test[:status].to_sym,
+        status: test[:status].try(&:to_sym),
         test_code: test[:test_code],
         message: test[:message],
         expected: test[:expected],

--- a/app/serializers/serialize_submission_test_run.rb
+++ b/app/serializers/serialize_submission_test_run.rb
@@ -11,7 +11,7 @@ class SerializeSubmissionTestRun
       submission_uuid: test_run.submission.uuid,
       status: status,
       message: message,
-      tests: tests
+      tests: test_run.test_results
     }
   end
 
@@ -30,10 +30,6 @@ class SerializeSubmissionTestRun
     # TODO: Decide how this is corrolated with the
     # errors upstream and move into i18n.
     "Some error occurred"
-  end
-
-  def tests
-    test_run.test_results
   end
 
   OPS_ERROR_STATUS = "ops_error".freeze

--- a/app/serializers/serialize_submission_test_run.rb
+++ b/app/serializers/serialize_submission_test_run.rb
@@ -33,7 +33,7 @@ class SerializeSubmissionTestRun
   end
 
   def tests
-    test_run.tests
+    test_run.test_results
   end
 
   OPS_ERROR_STATUS = "ops_error".freeze

--- a/test/channels/submission/test_runs_channel_test.rb
+++ b/test/channels/submission/test_runs_channel_test.rb
@@ -13,9 +13,9 @@ class Submission::TestRunsChannelTest < ActionCable::Channel::TestCase
       test_run: {
         id: test_run.id,
         submission_uuid: test_run.submission.uuid,
-        status: "ops_error",
+        status: 'ops_error',
         message: "Some error occurred",
-        tests: nil
+        tests: []
       }
     ) do
       Submission::TestRunsChannel.broadcast!(test_run)

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -53,7 +53,7 @@ class Submission::TestRunTest < ActiveSupport::TestCase
   test "test_results" do
     name = "some name"
     status = "some status"
-    cmd = "some cmd"
+    test_code = "some cmd"
     message = "some message"
     expected = "Some expected"
     output = "\e[31mHello\e[0m\e[34mWorld\e[0"
@@ -61,7 +61,7 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     tests = [{
       'name' => name,
       'status' => status,
-      'cmd' => cmd,
+      'test_code' => test_code,
       'message' => message,
       'expected' => expected,
       'output' => output
@@ -71,12 +71,17 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal 1, tr.test_results.size
     result = tr.test_results.first
 
-    assert_equal name, result.name
-    assert_equal status.to_sym, result.status
-    assert_equal cmd, result.cmd
-    assert_equal message, result.message
-    assert_equal expected, result.expected
-    assert_equal "<span style='color:#A00;'>Hello</span><span style='color:#00A;'>World</span>", result.output_html
+    json = {
+      'name' => name,
+      'status' => status,
+      'test_code' => test_code,
+      'message' => message,
+      'expected' => expected,
+      'output' => output,
+      'output_html' => "<span style='color:#A00;'>Hello</span><span style='color:#00A;'>World</span>"
+    }.to_json
+
+    assert_equal json, result.to_json
   end
 
   # TODO: - Add a test for if the raw_results is empty

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -83,6 +83,7 @@ class Submission::TestRunTest < ActiveSupport::TestCase
 
     assert_equal test_as_hash, result.to_h
     assert_equal test_as_hash.to_json, result.to_json
+    assert_equal test_as_hash, result.as_json(1, 2, 3) # Test with arbitary args
   end
 
   # TODO: - Add a test for if the raw_results is empty

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -71,17 +71,18 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal 1, tr.test_results.size
     result = tr.test_results.first
 
-    json = {
-      'name' => name,
-      'status' => status,
-      'test_code' => test_code,
-      'message' => message,
-      'expected' => expected,
-      'output' => output,
-      'output_html' => "<span style='color:#A00;'>Hello</span><span style='color:#00A;'>World</span>"
-    }.to_json
+    test_as_hash = {
+      name: name,
+      status: status.to_sym,
+      test_code: test_code,
+      message: message,
+      expected: expected,
+      output: output,
+      output_html: "<span style='color:#A00;'>Hello</span><span style='color:#00A;'>World</span>"
+    }
 
-    assert_equal json, result.to_json
+    assert_equal test_as_hash, result.to_h
+    assert_equal test_as_hash.to_json, result.to_json
   end
 
   # TODO: - Add a test for if the raw_results is empty

--- a/test/serializers/serialize_submission_test_run_test.rb
+++ b/test/serializers/serialize_submission_test_run_test.rb
@@ -19,9 +19,19 @@ class SerializeSubmissionTestRunTest < ActiveSupport::TestCase
       submission_uuid: test_run.submission.uuid,
       status: :pass,
       message: test_run.message,
-      tests: [test]
+      tests: [
+        {
+          name: 'test_a_name_given',
+          status: 'pass',
+          test_code: nil,
+          message: nil,
+          expected: nil,
+          output: 'foobar',
+          output_html: "foobar"
+        }
+      ]
     }
-    assert_equal expected, actual
+    assert_equal expected.to_json, actual.to_json
   end
 
   test "status: proxies fail" do


### PR DESCRIPTION
This does two things:
1. It adds the output_html to the serializer so that React can use it
2. It uses test_results, not tests, in the serializer.
3. It makes the TestResult code saner by adding `as_json` and equivalent methods.