### PR TITLE
Add collapsable iteration header

### DIFF
--- a/app/css/components/details.css
+++ b/app/css/components/details.css
@@ -16,7 +16,7 @@
 
     &[open] {
         & > summary {
-            & > .--closed-icon {
+            & .--closed-icon {
                 @apply hidden !important;
             }
         }
@@ -24,7 +24,7 @@
 
     &:not([open]) {
         & > summary {
-            & > .--open-icon {
+            & .--open-icon {
                 @apply hidden !important;
             }
         }

--- a/app/css/pages/iterations-index.css
+++ b/app/css/pages/iterations-index.css
@@ -38,6 +38,25 @@
             & .header {
                 @apply flex items-center py-12 px-24;
                 @apply border-b-1 border-borderLight border-opacity-50;
+
+                & .opener {
+                    @apply pl-24 ml-32;
+                    @apply border-l-1 border-borderColor5;
+                }
+                & .--closed-icon,
+                & .--open-icon {
+                    height: 32px;
+                    width: 32px;
+
+                    @apply flex flex-shrink-0 items-center justify-center;
+                    @apply border-borderColor4 border-1 rounded-circle;
+                    @apply text-textColor6;
+
+                    & .c-icon {
+                        height: 14px;
+                        width: 14px;
+                    }
+                }
             }
             & .content {
                 @apply flex-grow overflow-hidden;

--- a/app/views/tracks/iterations/index/_iterations.html.haml
+++ b/app/views/tracks/iterations/index/_iterations.html.haml
@@ -1,9 +1,12 @@
 .lg-container.container
   %section.iterations
-    - iterations.each do |iteration|
-      .iteration
-        .header
+    - iterations.each.with_index do |iteration, idx|
+      %details.iteration.c-details{ open: idx.zero? }
+        %summary.header
           = ReactComponents::Track::IterationSummary.new(iteration)
+          .opener
+            .--closed-icon= graphical_icon 'chevron-right'
+            .--open-icon= graphical_icon 'chevron-down'
         .content
           .files
             %pre


### PR DESCRIPTION
@kntsoriano Small addition to the iterations header. I'll merge this in the you can apply it to your work.

Note that this is very similar to [this](https://github.com/exercism/website/blob/main/app/javascript/components/editor/InstructionsPanel.tsx#L82-L94) so you can probably copy/paste that code (and any test code you wrote).

You could also generalise it into a `Details` component if you wanted to. I think it's stable enough for that.