### PR TITLE
Add websockets to iteration summary

### DIFF
--- a/app/channels/solution_channel.rb
+++ b/app/channels/solution_channel.rb
@@ -1,0 +1,15 @@
+class SolutionChannel < ApplicationCable::Channel
+  def subscribed
+    solution = Solution.find_by!(uuid: params[:id])
+
+    stream_for solution
+  end
+
+  def unsubscribed; end
+
+  def self.broadcast!(solution)
+    broadcast_to solution,
+      solution: SerializeSolutionForStudent.(solution),
+      latest_iteration: SerializeIteration.(solution.latest_iteration)
+  end
+end

--- a/app/controllers/temp/solutions_controller.rb
+++ b/app/controllers/temp/solutions_controller.rb
@@ -1,0 +1,14 @@
+module Temp
+  class SolutionsController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def show
+      solution = Solution.find_by!(uuid: params[:id])
+
+      render json: {
+        solution: SerializeSolutionForStudent.(solution),
+        latest_iteration: SerializeIteration.(solution.latest_iteration)
+      }
+    end
+  end
+end

--- a/app/helpers/react_components/student/solution_summary.rb
+++ b/app/helpers/react_components/student/solution_summary.rb
@@ -5,6 +5,7 @@ module ReactComponents
 
       def to_s
         super("student-solution-summary", {
+          solution_id: iteration.solution.uuid,
           iteration: SerializeIteration.(iteration),
           is_practice_exercise: iteration.exercise.practice_exercise?,
           links: links

--- a/app/helpers/react_components/student/solution_summary.rb
+++ b/app/helpers/react_components/student/solution_summary.rb
@@ -6,13 +6,24 @@ module ReactComponents
       def to_s
         super("student-solution-summary", {
           solution_id: iteration.solution.uuid,
-          iteration: SerializeIteration.(iteration),
+          request: request,
           is_practice_exercise: iteration.exercise.practice_exercise?,
           links: links
         })
       end
 
       private
+      def request
+        {
+          endpoint: Exercism::Routes.temp_solution_url(iteration.solution.uuid),
+          options: {
+            initialData: {
+              latest_iteration: SerializeIteration.(iteration)
+            }
+          }
+        }
+      end
+
       def links
         {
           tests_passed_locally_article: "#",

--- a/app/javascript/channels/solutionChannel.ts
+++ b/app/javascript/channels/solutionChannel.ts
@@ -1,0 +1,39 @@
+import consumer from '../utils/action-cable-consumer'
+import { camelizeKeys } from 'humps'
+import { Iteration } from '../components/types'
+
+export type ChannelResponse = {
+  solution: Solution
+  latestIteration: Iteration
+}
+
+/* TODO: We have yet to have an official Solution type */
+type Solution = any
+
+export class SolutionChannel {
+  subscription: ActionCable.Channel
+
+  constructor(
+    solution: Solution,
+    onReceive: (response: ChannelResponse) => void
+  ) {
+    this.subscription = consumer.subscriptions.create(
+      {
+        channel: 'SolutionChannel',
+        id: solution.id,
+      },
+      {
+        received: (response: {
+          solution: Solution
+          latest_iteration: Iteration
+        }) => {
+          onReceive(camelizeKeys(response) as ChannelResponse)
+        },
+      }
+    )
+  }
+
+  disconnect() {
+    this.subscription.unsubscribe()
+  }
+}

--- a/app/javascript/components/common/SearchableList.tsx
+++ b/app/javascript/components/common/SearchableList.tsx
@@ -57,7 +57,7 @@ export const SearchableList = ({
     isFetching,
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
-    cacheKey,
+    [cacheKey, request.endpoint, request.query],
     request,
     isMountedRef
   )

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -18,7 +18,11 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
     latestData,
     isFetching,
     refetch,
-  } = usePaginatedRequestQuery('mentor-discussion-list', request, isMountedRef)
+  } = usePaginatedRequestQuery(
+    ['mentor-discussion-list', request.endpoint, request.query],
+    request,
+    isMountedRef
+  )
 
   const setTrack = (track) => {
     setQuery({ track: track, page: 1 })

--- a/app/javascript/components/mentoring/Queue.jsx
+++ b/app/javascript/components/mentoring/Queue.jsx
@@ -44,7 +44,11 @@ export function Queue({ sortOptions, tracks, ...props }) {
     isFetching,
     resolvedData,
     latestData,
-  } = usePaginatedRequestQuery('mentor-solutions-list', request, isMountedRef)
+  } = usePaginatedRequestQuery(
+    ['mentor-solutions-list', request.endpoint, request.query],
+    request,
+    isMountedRef
+  )
 
   return (
     <div className="queue-section-content">

--- a/app/javascript/components/student/SolutionSummary.tsx
+++ b/app/javascript/components/student/SolutionSummary.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Iteration } from '../types'
 import { Header } from './solution-summary/Header'
 import { IterationLink } from './solution-summary/IterationLink'
 import { CommunitySolutions } from './solution-summary/CommunitySolutions'
 import { Mentoring } from './solution-summary/Mentoring'
 import { ProminentLink } from '../common'
+import { SolutionChannel } from '../../channels/solutionChannel'
 
 export type SolutionSummaryLinks = {
   testsPassLocallyArticle: string
@@ -14,14 +15,31 @@ export type SolutionSummaryLinks = {
 }
 
 export const SolutionSummary = ({
-  iteration,
+  solutionId,
+  iteration: initialIteration,
   isPracticeExercise,
   links,
 }: {
+  solutionId: string
   iteration: Iteration
   isPracticeExercise: boolean
   links: SolutionSummaryLinks
 }): JSX.Element => {
+  const [iteration, setIteration] = useState(initialIteration)
+
+  useEffect(() => {
+    const solutionChannel = new SolutionChannel(
+      { id: solutionId },
+      (response) => {
+        setIteration(response.latestIteration)
+      }
+    )
+
+    return () => {
+      solutionChannel.disconnect()
+    }
+  }, [iteration, setIteration, solutionId])
+
   return (
     <section className="latest-iteration">
       <Header

--- a/app/javascript/components/student/TracksList.jsx
+++ b/app/javascript/components/student/TracksList.jsx
@@ -36,7 +36,11 @@ export function TracksList({ statusOptions, tagOptions, ...props }) {
     latestData,
     isError,
     isFetching,
-  } = usePaginatedRequestQuery('track-list', request, isMountedRef)
+  } = usePaginatedRequestQuery(
+    ['track-list', request.endpoint, request.query],
+    request,
+    isMountedRef
+  )
 
   return (
     <div className="c-tracks-list">

--- a/app/javascript/components/student/solution-summary/IterationLink.tsx
+++ b/app/javascript/components/student/solution-summary/IterationLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { GraphicalIcon } from '../../common'
-import { IterationSummary } from '../../track'
+import { IterationSummary } from '../../track/IterationSummary'
 import { Iteration } from '../../types'
 
 export const IterationLink = ({

--- a/app/javascript/components/track/IterationSummary.tsx
+++ b/app/javascript/components/track/IterationSummary.tsx
@@ -11,12 +11,16 @@ const SUBMISSION_METHOD_LABELS = {
   api: 'API',
 }
 
-export function IterationSummary(props: {
+type IterationSummaryProps = {
   iteration: Iteration
   className?: string
-}): JSX.Element {
-  const [iteration, setIteration] = useState(props.iteration)
-  const [className, setClassName] = useState(props.className)
+}
+
+export const IterationSummaryWithWebsockets = ({
+  iteration: initialIteration,
+  ...props
+}: IterationSummaryProps): JSX.Element => {
+  const [iteration, setIteration] = useState(initialIteration)
   const channel = useRef<IterationChannel | undefined>()
 
   useEffect(() => {
@@ -34,6 +38,13 @@ export function IterationSummary(props: {
     }
   }, [channel, iteration, setIteration])
 
+  return <IterationSummary iteration={iteration} {...props} />
+}
+
+export function IterationSummary({
+  iteration,
+  className,
+}: IterationSummaryProps): JSX.Element {
   return (
     <div className={`c-iteration-summary ${className}`}>
       <SubmissionMethodIcon submissionMethod={iteration.submissionMethod} />

--- a/app/javascript/components/track/index.ts
+++ b/app/javascript/components/track/index.ts
@@ -1,1 +1,1 @@
-export { IterationSummary } from './IterationSummary'
+export { IterationSummaryWithWebsockets } from './IterationSummary'

--- a/app/javascript/hooks/request-query.ts
+++ b/app/javascript/hooks/request-query.ts
@@ -2,6 +2,7 @@ import {
   PaginatedQueryConfig,
   PaginatedQueryResult,
   QueryConfig,
+  QueryKey,
   QueryResult,
   usePaginatedQuery,
   useQuery,
@@ -41,12 +42,12 @@ function handleFetch(
 }
 
 export function usePaginatedRequestQuery<TResult = unknown, TError = unknown>(
-  key: string,
+  key: QueryKey,
   request: PaginatedRequest,
   isMountedRef: React.MutableRefObject<boolean>
 ): PaginatedQueryResult<TResult, TError> {
   return usePaginatedQuery<TResult, TError>(
-    [key, request.endpoint, request.query],
+    key,
     () => {
       return handleFetch(request, isMountedRef)
     },

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -206,6 +206,7 @@ initReact({
   ),
   'student-solution-summary': (data: any) => (
     <Student.SolutionSummary
+      solutionId={data.solution_id}
       iteration={camelizeKeysAs<Iteration>(data.iteration)}
       links={camelizeKeysAs<SolutionSummaryLinks>(data.links)}
       isPracticeExercise={data.is_practice_exercise}

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -107,7 +107,10 @@ import { Links as TryMentoringButtonLinks } from '../components/mentoring/TryMen
 import { Track as MentoringQueueTrack } from '../components/mentoring/queue/TrackFilterList'
 import { Exercise as MentoringQueueExercise } from '../components/mentoring/queue/ExerciseFilterList'
 import * as Student from '../components/student'
-import { SolutionSummaryLinks } from '../components/student/SolutionSummary'
+import {
+  SolutionSummaryLinks,
+  SolutionSummaryRequest,
+} from '../components/student/SolutionSummary'
 import * as Track from '../components/track'
 import * as Journey from '../components/journey'
 import { Editor } from '../components/Editor'
@@ -207,7 +210,7 @@ initReact({
   'student-solution-summary': (data: any) => (
     <Student.SolutionSummary
       solutionId={data.solution_id}
-      iteration={camelizeKeysAs<Iteration>(data.iteration)}
+      request={camelizeKeysAs<SolutionSummaryRequest>(data.request)}
       links={camelizeKeysAs<SolutionSummaryLinks>(data.links)}
       isPracticeExercise={data.is_practice_exercise}
     />

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -236,7 +236,7 @@ initReact({
     )
   },
   'track-iteration-summary': (data: any) => (
-    <Track.IterationSummary
+    <Track.IterationSummaryWithWebsockets
       iteration={camelizeKeysAs<Iteration>(data.iteration)}
       className={data.class_name}
     />

--- a/app/serializers/serialize_solution_for_student.rb
+++ b/app/serializers/serialize_solution_for_student.rb
@@ -1,0 +1,29 @@
+class SerializeSolutionForStudent
+  include Mandate
+
+  initialize_with :solution
+
+  def call
+    {
+      id: solution.uuid,
+      url: Exercism::Routes.private_solution_url(solution),
+      status: solution.status, # TODO: This is probably going to cause n+1s
+      mentoring_status: solution.mentoring_status,
+      num_views: 1270, # TODO
+      num_stars: 10, # TODO
+      num_comments: 2, # TODO
+      num_iterations: 3, # TODO
+      num_locs: "9 - 18", # TODO
+      last_submitted_at: solution.submissions.last&.created_at&.iso8601,
+      published_at: solution.published_at&.iso8601,
+      exercise: {
+        title: solution.exercise.title,
+        icon_name: solution.exercise.icon_name
+      },
+      track: {
+        title: solution.track.title,
+        icon_name: solution.track.icon_name
+      }
+    }
+  end
+end

--- a/app/serializers/serialize_solutions_for_student.rb
+++ b/app/serializers/serialize_solutions_for_student.rb
@@ -4,30 +4,6 @@ class SerializeSolutionsForStudent
   initialize_with :solutions
 
   def call
-    solutions.map { |s| serialize_solution(s) }
-  end
-
-  def serialize_solution(solution)
-    {
-      id: solution.uuid,
-      url: Exercism::Routes.private_solution_url(solution),
-      status: solution.status, # TODO: This is probably going to cause n+1s
-      mentoring_status: solution.mentoring_status,
-      num_views: 1270, # TODO
-      num_stars: 10, # TODO
-      num_comments: 2, # TODO
-      num_iterations: 3, # TODO
-      num_locs: "9 - 18", # TODO
-      last_submitted_at: solution.submissions.last&.created_at&.iso8601,
-      published_at: solution.published_at&.iso8601,
-      exercise: {
-        title: solution.exercise.title,
-        icon_name: solution.exercise.icon_name
-      },
-      track: {
-        title: solution.track.title,
-        icon_name: solution.track.icon_name
-      }
-    }
+    solutions.map { |s| SerializeSolutionForStudent.(s) }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,6 +216,7 @@ Rails.application.routes.draw do
 
   # TODO: Remove these before launching
   namespace :temp do
+    resources :solutions, only: [:show]
     resources :tracks, only: [:create]
     resources :modals, only: [] do
       collection do


### PR DESCRIPTION
1. In this PR, we now have two version of `<IterationSummary />` one with websockets and one without. In the Rails app, when rendering the `<IterationSummary />` directly, we use the version with websockets.