### PR TITLE
Sync authors and contributors

### DIFF
--- a/app/commands/git/sync_authors.rb
+++ b/app/commands/git/sync_authors.rb
@@ -1,0 +1,35 @@
+module Git
+  class SyncAuthors < Sync
+    include Mandate
+
+    def initialize(exercise)
+      super(exercise.track, exercise.synced_to_git_sha)
+      @exercise = exercise
+    end
+
+    def call
+      authors = ::User.where(handle: author_usernames_config)
+      authors.find_each { |author| ::Exercise::Authorship::Create.(exercise, author) }
+
+      # This is required to remove authors that were already added
+      exercise.update!(authors: authors)
+
+      # TODO: consider what to do with missing authors
+      missing_authors = author_usernames_config - authors.map(&:handle)
+      Rails.logger.error "Missing authors: #{missing_authors.join(', ')}" if missing_authors.present?
+    end
+
+    private
+    attr_reader :exercise
+
+    memoize
+    def author_usernames_config
+      head_git_exercise.authors.to_a.map { |a| a[:exercism_username] }
+    end
+
+    memoize
+    def head_git_exercise
+      Git::Exercise.new(exercise.slug, exercise.git_type, git_repo.head_sha, repo: git_repo)
+    end
+  end
+end

--- a/app/commands/git/sync_authors_and_contributors.rb
+++ b/app/commands/git/sync_authors_and_contributors.rb
@@ -1,0 +1,21 @@
+module Git
+  class SyncAuthorsAndContributors
+    include Mandate
+
+    def call
+      ::Exercise.all.each do |exercise|
+        begin
+          SyncAuthors.(exercise)
+        rescue StandardError => e
+          Rails.logger.error "Error syncing authors for #{exercise.track.slug}/#{exercise.slug}: #{e}"
+        end
+
+        begin
+          SyncContributors.(exercise)
+        rescue StandardError => e
+          Rails.logger.error "Error syncing contributors for #{exercise.track.slug}/#{exercise.slug}: #{e}"
+        end
+      end
+    end
+  end
+end

--- a/app/commands/git/sync_concept_exercise.rb
+++ b/app/commands/git/sync_concept_exercise.rb
@@ -21,8 +21,8 @@ module Git
         prerequisites: find_concepts(exercise_config[:prerequisites])
       )
 
-      update_authors!
-      update_contributors!
+      SyncAuthors.(exercise)
+      SyncContributors.(exercise)
     end
 
     private

--- a/app/commands/git/sync_contributors.rb
+++ b/app/commands/git/sync_contributors.rb
@@ -1,0 +1,35 @@
+module Git
+  class SyncContributors < Sync
+    include Mandate
+
+    def initialize(exercise)
+      super(exercise.track, exercise.synced_to_git_sha)
+      @exercise = exercise
+    end
+
+    def call
+      contributors = ::User.where(handle: contributor_usernames_config)
+      contributors.find_each { |contributor| ::Exercise::Contributorship::Create.(exercise, contributor) }
+
+      # This is required to remove contributors that were already added
+      exercise.update!(contributors: contributors)
+
+      # TODO: consider what to do with missing contributors
+      missing_contributors = contributor_usernames_config - contributors.map(&:handle)
+      Rails.logger.error "Missing contributors: #{missing_contributors.join(', ')}" if missing_contributors.present?
+    end
+
+    private
+    attr_reader :exercise
+
+    memoize
+    def contributor_usernames_config
+      head_git_exercise.contributors.to_a.map { |a| a[:exercism_username] }
+    end
+
+    memoize
+    def head_git_exercise
+      Git::Exercise.new(exercise.slug, exercise.git_type, git_repo.head_sha, repo: git_repo)
+    end
+  end
+end

--- a/app/commands/git/sync_practice_exercise.rb
+++ b/app/commands/git/sync_practice_exercise.rb
@@ -19,6 +19,9 @@ module Git
         synced_to_git_sha: head_git_exercise.synced_git_sha,
         prerequisites: find_concepts(exercise_config[:prerequisites])
       )
+
+      SyncAuthors.(exercise)
+      SyncContributors.(exercise)
     end
 
     private

--- a/lib/tasks/sync_authors_and_contributors.rake
+++ b/lib/tasks/sync_authors_and_contributors.rake
@@ -1,0 +1,4 @@
+desc 'Sync authors and contributors'
+task sync_authors_and_contributors: :environment do
+  Git::SyncAuthorsAndContributors.call
+end

--- a/lib/tasks/sync_authors_and_contributors.rake
+++ b/lib/tasks/sync_authors_and_contributors.rake
@@ -1,4 +1,4 @@
 desc 'Sync authors and contributors'
 task sync_authors_and_contributors: :environment do
-  Git::SyncAuthorsAndContributors.call
+  Git::SyncAuthorsAndContributors.()
 end

--- a/test/commands/git/sync_authors_and_contributors_test.rb
+++ b/test/commands/git/sync_authors_and_contributors_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Git::SyncAuthorsAndContributorsTest < ActiveSupport::TestCase
+  test "sync authors of all exercises" do
+    track_1 = create :track, slug: 'ruby'
+    track_2 = create :track, slug: 'csharp'
+    track_3 = create :track, slug: 'elixir'
+
+    exercise_1 = create :concept_exercise, track: track_1
+    exercise_2 = create :concept_exercise, track: track_2
+    exercise_3 = create :practice_exercise, track: track_2
+    exercise_4 = create :practice_exercise, track: track_3
+
+    Git::SyncAuthors.expects(:call).with(exercise_1)
+    Git::SyncAuthors.expects(:call).with(exercise_2)
+    Git::SyncAuthors.expects(:call).with(exercise_3)
+    Git::SyncAuthors.expects(:call).with(exercise_4)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+
+  test "sync contributors of all exercises" do
+    track_1 = create :track, slug: 'ruby'
+    track_2 = create :track, slug: 'csharp'
+    track_3 = create :track, slug: 'elixir'
+
+    exercise_1 = create :concept_exercise, track: track_1
+    exercise_2 = create :concept_exercise, track: track_2
+    exercise_3 = create :practice_exercise, track: track_2
+    exercise_4 = create :practice_exercise, track: track_3
+
+    Git::SyncContributors.expects(:call).with(exercise_1)
+    Git::SyncContributors.expects(:call).with(exercise_2)
+    Git::SyncContributors.expects(:call).with(exercise_3)
+    Git::SyncContributors.expects(:call).with(exercise_4)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+
+  test "continues syncing authors of other exercises when an error occurs" do
+    track_1 = create :track, slug: 'ruby'
+    track_2 = create :track, slug: 'csharp'
+    track_3 = create :track, slug: 'elixir'
+
+    exercise_1 = create :concept_exercise, track: track_1
+    exercise_2 = create :concept_exercise, track: track_2
+    exercise_3 = create :practice_exercise, track: track_2
+    exercise_4 = create :practice_exercise, track: track_3
+
+    Git::SyncAuthors.expects(:call).with(exercise_1).raises(RuntimeError)
+    Git::SyncAuthors.expects(:call).with(exercise_2)
+    Git::SyncAuthors.expects(:call).with(exercise_3)
+    Git::SyncAuthors.expects(:call).with(exercise_4)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+
+  test "continues syncing contributors of other exercises when an error occurs" do
+    track_1 = create :track, slug: 'ruby'
+    track_2 = create :track, slug: 'csharp'
+    track_3 = create :track, slug: 'elixir'
+
+    exercise_1 = create :concept_exercise, track: track_1
+    exercise_2 = create :concept_exercise, track: track_2
+    exercise_3 = create :practice_exercise, track: track_2
+    exercise_4 = create :practice_exercise, track: track_3
+
+    Git::SyncContributors.expects(:call).with(exercise_1)
+    Git::SyncContributors.expects(:call).with(exercise_2).raises(RuntimeError)
+    Git::SyncContributors.expects(:call).with(exercise_3)
+    Git::SyncContributors.expects(:call).with(exercise_4)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+
+  test "continues syncing contributors of exercise when authors syncing errors" do
+    exercise = create :concept_exercise
+
+    Git::SyncAuthors.expects(:call).with(exercise).raises(RuntimeError)
+    Git::SyncContributors.expects(:call).with(exercise)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+
+  test "continues syncing authors of exercise when contributors syncing errors" do
+    exercise = create :concept_exercise
+
+    Git::SyncAuthors.expects(:call).with(exercise)
+    Git::SyncContributors.expects(:call).with(exercise).raises(RuntimeError)
+
+    Git::SyncAuthorsAndContributors.()
+  end
+end


### PR DESCRIPTION
This PR allows (re-)syncing the authors and contributors of _all_ exercises.

The prime use case for this is when an author/contributor previously did not have an account at Exercism, but then later creates on. In that case, the user should retroactively be credited with their contributions.
