### PR TITLE
Fix incorrect use of Accordion

### DIFF
--- a/app/css/pages/iterations-index.css
+++ b/app/css/pages/iterations-index.css
@@ -71,7 +71,7 @@
                 }
 
                 & .files {
-                    @apply flex-grow px-24 py-12;
+                    @apply flex-grow;
                 }
 
                 & .information {

--- a/app/javascript/components/student/IterationPage.tsx
+++ b/app/javascript/components/student/IterationPage.tsx
@@ -75,19 +75,25 @@ export const IterationPage = ({
   }
 
   return (
-    <div className="lg-container.container">
+    <div className="lg-container container">
       <section className="iterations">
-        {resolvedData.iterations.map((iteration, i) => {
-          return (
-            <IterationReport
-              key={i}
-              iteration={iteration}
-              exercise={exercise}
-              track={track}
-              links={links}
-            />
-          )
-        })}
+        {resolvedData.iterations
+          .slice()
+          .sort((it1: Iteration, it2: Iteration) => {
+            return it2.idx > it1.idx ? 1 : -1
+          })
+          .map((iteration, i) => {
+            return (
+              <IterationReport
+                key={i}
+                iteration={iteration}
+                exercise={exercise}
+                track={track}
+                links={links}
+                isOpen={i == 0}
+              />
+            )
+          })}
       </section>
     </div>
   )

--- a/app/javascript/components/student/iteration-page/IterationReport.tsx
+++ b/app/javascript/components/student/iteration-page/IterationReport.tsx
@@ -4,54 +4,50 @@ import { Iteration } from '../../types'
 import { IterationFiles } from '../../mentoring/session/IterationFiles'
 import { Information } from './Information'
 import { Exercise, Track, Links } from '../IterationPage'
-import { Accordion } from '../../common/Accordion'
+import { GraphicalIcon } from '../../common/GraphicalIcon'
 
 export const IterationReport = ({
   iteration,
   exercise,
   track,
   links,
+  isOpen,
 }: {
   iteration: Iteration
   exercise: Exercise
   track: Track
   links: Links
+  isOpen: boolean
 }): JSX.Element => {
-  const [isOpen, setIsOpen] = useState(true)
-
   return (
-    <Accordion
-      id="notes"
-      isOpen={isOpen}
-      onClick={() => {
-        setIsOpen(!isOpen)
-      }}
-    >
-      <div className="iteration">
-        <Accordion.Header label={`View iteration ${iteration.idx} details`}>
-          <div className="header">
-            <IterationSummary iteration={iteration} />
+    <details open={isOpen} className="iteration c-details">
+      <summary className="header">
+        <IterationSummary iteration={iteration} />
+        <div className="opener">
+          <div className="--closed-icon">
+            <GraphicalIcon icon="chevron-right" />
           </div>
-        </Accordion.Header>
-        <Accordion.Panel>
-          <div className="content">
-            <div className="files">
-              <IterationFiles
-                endpoint={iteration.links.files}
-                language={track.highlightJsLanguage}
-              />
-            </div>
-            <div className="information">
-              <Information
-                iteration={iteration}
-                exercise={exercise}
-                track={track}
-                links={links}
-              />
-            </div>
+          <div className="--open-icon">
+            <GraphicalIcon icon="chevron-down" />
           </div>
-        </Accordion.Panel>
+        </div>
+      </summary>
+      <div className="content">
+        <div className="files">
+          <IterationFiles
+            endpoint={iteration.links.files}
+            language={track.highlightJsLanguage}
+          />
+        </div>
+        <div className="information">
+          <Information
+            iteration={iteration}
+            exercise={exercise}
+            track={track}
+            links={links}
+          />
+        </div>
       </div>
-    </Accordion>
+    </details>
   )
 }

--- a/app/javascript/components/student/iteration-page/IterationReport.tsx
+++ b/app/javascript/components/student/iteration-page/IterationReport.tsx
@@ -21,7 +21,7 @@ export const IterationReport = ({
 }): JSX.Element => {
   return (
     <details open={isOpen} className="iteration c-details">
-      <summary className="header">
+      <summary className="header" role="button">
         <IterationSummary iteration={iteration} />
         <div className="opener">
           <div className="--closed-icon">

--- a/app/views/tracks/iterations/index.html.haml
+++ b/app/views/tracks/iterations/index.html.haml
@@ -1,4 +1,3 @@
 #page-iterations-index
   = render ViewComponents::Track::ExerciseHeader.new(@track, @exercise, @solution, :iterations)
-  = render ViewComponents::ProminentLink.new("Learn more about solving exercises locally", "#")
   = ReactComponents::Student::IterationPage.new(@solution)

--- a/test/javascript/components/student/iteration-page/IterationReport.test.js
+++ b/test/javascript/components/student/iteration-page/IterationReport.test.js
@@ -1,23 +1,32 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { IterationReport } from '../../../../../app/javascript/components/student/iteration-page/IterationReport'
 
-test('opens and closes accordion', async () => {
+test('opens and closes detail blocks', async () => {
   const iteration = {
     idx: 1,
     links: {},
     createdAt: '',
   }
 
-  render(<IterationReport iteration={iteration} track={{}} exercise={{}} />)
-  const header = screen.getByRole('button', {
-    name: 'View iteration 1 details',
+  render(
+    <IterationReport
+      isOpen={false}
+      iteration={iteration}
+      track={{}}
+      exercise={{}}
+    />
+  )
+  const details = screen.getByRole('group')
+  const summary = screen.getByRole('button')
+
+  act(() => {
+    userEvent.click(summary)
   })
-  userEvent.click(header)
 
   await waitFor(() => {
-    expect(header).toHaveAttribute('aria-expanded', 'false')
+    expect(details).toHaveAttribute('open')
   })
 })


### PR DESCRIPTION
@kntsoriano I think you missed https://github.com/exercism/website/pull/555 when you did the Iterations Header.

The iterations shouldn't be an accordion as they should not open/close based on the state of the others. As such the Accordion's "tabs" approach doesn't make sense here. Instead we can use the details/summary block instead, which gives us all the a11y for free.

I spent some time earlier converting the Accordion to details/summary too, but then realised that that was wrong, and the way you've done that with tabs is more correct 🙂 