### PR TITLE
improve responsiveness of concept map

### DIFF
--- a/app/css/components/tooltips/concept.css
+++ b/app/css/components/tooltips/concept.css
@@ -98,11 +98,11 @@
     /* Without this pseudo-element, unable to mouseover from concept to the tooltip */
     &::before {
         content: "";
-        width: 100%;
-        height: 8px;
+        width: 8px;
+        height: 100%;
         left: 0;
         top: 0;
-        transform: translateY(-100%);
+        transform: translateX(-100%);
         background: transparent;
         position: absolute;
     }
@@ -111,12 +111,12 @@
     /* Without this pseudo-element, unable to mouseover from concept to the tooltip */
     &::after {
         content: "";
-        width: 100%;
-        height: 8px;
-        left: 0;
-        bottom: 0;
-        transform: translateY(100%);
-        background: rgba(0, 0, 0, 0);
+        width: 8px;
+        height: 100%;
+        right: 0;
+        top: 0;
+        transform: translateX(100%);
+        background: transparent;
         position: absolute;
     }
 }

--- a/app/css/components/track/concept-map.css
+++ b/app/css/components/track/concept-map.css
@@ -40,7 +40,7 @@
 
                 background-color: var(--c-concept-map-card-background);
                 opacity: var(--c-concept-map-hover-opacity);
-                transition: opacity 120ms cubic-bezier(0.4, 0, 0.2, 1);
+                /* transition: opacity 120ms cubic-bezier(0.4, 0, 0.2, 1); */
 
                 &.unavailable,
                 &.no-exercises,
@@ -112,7 +112,7 @@
 
     & .connection {
         @apply absolute -z-1 top-0 left-0;
-        transition: opacity 120ms cubic-bezier(0.4, 0, 0.2, 1);
+        /* transition: opacity 120ms cubic-bezier(0.4, 0, 0.2, 1); */
         touch-action: none;
         opacity: var(--c-concept-map-hover-opacity);
         stroke-width: 2px;


### PR DESCRIPTION
Several small changes:
- move the invisible border to the L/R of the tool-tip
- removing some transitions that might cause the perception of unresponsiveness
- optimising the discovery of active slugs by indexing the result