### PR TITLE
Don't change HTML content when dropdown is open

### DIFF
--- a/app/javascript/components/dropdowns/Notifications.tsx
+++ b/app/javascript/components/dropdowns/Notifications.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import consumer from '../../utils/action-cable-consumer'
 import { GraphicalIcon } from '../common/GraphicalIcon'
 import { NotificationsIcon } from './notifications/NotificationsIcon'
@@ -11,7 +11,7 @@ import { useRequestQuery } from '../../hooks/request-query'
 import { useIsMounted } from 'use-is-mounted'
 import { useErrorHandler, ErrorBoundary } from '../ErrorBoundary'
 import { Loading } from '../common/Loading'
-import { QueryStatus } from 'react-query'
+import { queryCache, QueryStatus } from 'react-query'
 
 export type APIResponse = {
   results: Notification[]
@@ -91,6 +91,7 @@ const DropdownContent = ({
 }
 
 const MAX_NOTIFICATIONS = 5
+const CACHE_KEY = 'notifications'
 
 export const Notifications = ({
   endpoint,
@@ -98,8 +99,9 @@ export const Notifications = ({
   endpoint: string
 }): JSX.Element => {
   const isMountedRef = useIsMounted()
+  const [isStale, setIsStale] = useState(false)
   const { data, error, status, refetch } = useRequestQuery<APIResponse>(
-    'notifications',
+    CACHE_KEY,
     { endpoint: endpoint, query: { per: MAX_NOTIFICATIONS }, options: {} },
     isMountedRef
   )
@@ -113,11 +115,22 @@ export const Notifications = ({
   useEffect(() => {
     const subscription = consumer.subscriptions.create(
       { channel: 'NotificationsChannel' },
-      { received: refetch }
+      {
+        received: () => {
+          setIsStale(true)
+        },
+      }
     )
 
     return () => subscription.unsubscribe()
   }, [refetch])
+
+  useEffect(() => {
+    if (!listAttributes.hidden) {
+      return
+    }
+    queryCache.invalidateQueries(CACHE_KEY).then(() => setIsStale(false))
+  }, [listAttributes.hidden, isStale])
 
   return (
     <React.Fragment>

--- a/test/system/flows/user_loads_notifications_test.rb
+++ b/test/system/flows/user_loads_notifications_test.rb
@@ -44,6 +44,28 @@ module Flows
       end
     end
 
+    test "only loads notifications when dropdown is closed" do
+      user = create :user
+      mentor = create :user, handle: "mrs-mentor"
+      discussion = create :solution_mentor_discussion, mentor: mentor
+
+      use_capybara_host do
+        sign_in!(user)
+        visit dashboard_path
+        find(".c-notification").click
+
+        create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+        NotificationsChannel.broadcast_changed(user)
+        wait_for_websockets
+
+        assert_no_text "mrs-mentor has started mentoring your solution to Bob in Ruby"
+
+        find(".c-notification").click
+        find(".c-notification").click
+        assert_text "mrs-mentor has started mentoring your solution to Bob in Ruby"
+      end
+    end
+
     test "user views unrevealed badges" do
       user = create :user
       badge = create :rookie_badge


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/130.

The issue linked above raises two issues:
1. When the user disconnects, there might be dropped websocket messages which instructs the notifications dropdown to refresh. We don't need to worry about this as `react-query` automatically refetches when the user reconnects.
2. When a websocket notifications comes in and the dropdown is open, there might be a chance where the dropdown might change its contents. To fix this, this PR just marks the data as stale and waits until the dropdown is closed before it refetches.