### PR TITLE
Support legacy test runners

### DIFF
--- a/app/css/components/details.css
+++ b/app/css/components/details.css
@@ -1,10 +1,7 @@
 .c-details {
     & > summary {
         @apply cursor-pointer;
-
-        &::-webkit-details-marker {
-            @apply hidden;
-        }
+        list-style-type: none;
 
         & > .c-icon.--closed-icon,
         & > .c-icon.--open-icon {

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -241,6 +241,9 @@
                     }
                 }
             }
+            & .v1-output {
+                @apply px-24 pb-48;
+            }
             & .tests-list {
                 @apply px-32 pb-16;
 

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -145,7 +145,6 @@
         @apply flex flex-col;
 
         & .react-monaco-editor-container {
-            @apply pt-20;
         }
 
         & .monaco-editor {

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -185,10 +185,8 @@
                     & > .--summary {
                         @apply flex items-center;
                         @apply mb-8;
+                        list-style-type: none;
 
-                        &::-webkit-details-marker {
-                            @apply hidden;
-                        }
                         & .--summary-title {
                             @apply flex-grow;
                             @apply text-h2 text-18 leading-huge;
@@ -253,9 +251,7 @@
                         @apply font-semibold text-14 text-darkGray;
                         @apply border-2 border-lightGray rounded-100;
                         @apply py-8 px-24 mb-12;
-                        &::-webkit-details-marker {
-                            @apply hidden;
-                        }
+                        list-style-type: none;
                         & .c-icon.indicator {
                             height: 24px;
                             width: 24px;
@@ -272,9 +268,7 @@
                     & .--summary {
                         @apply flex items-center;
                         @apply py-8 px-24 mb-12;
-                        &::-webkit-details-marker {
-                            @apply hidden;
-                        }
+                        list-style-type: none;
 
                         & .--status {
                             @apply flex-grow-0 flex-shrink-0 mr-24 flex items-center justify-center;

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -243,6 +243,7 @@
             }
             & .v1-output {
                 @apply px-24 pb-48;
+                white-space: pre-wrap;
             }
             & .tests-list {
                 @apply px-32 pb-16;

--- a/app/helpers/react_components/student/exercise_status_chart.rb
+++ b/app/helpers/react_components/student/exercise_status_chart.rb
@@ -13,7 +13,7 @@ module ReactComponents
               tooltip: Exercism::Routes.tooltip_track_exercise_url(track, "$SLUG")
             }
           },
-          style: "height: #{height}px"
+          style: "min-height: #{height}px"
         )
       end
 

--- a/app/javascript/components/editor/FileEditor.tsx
+++ b/app/javascript/components/editor/FileEditor.tsx
@@ -49,6 +49,7 @@ export function FileEditor({
     scrollBeyondLastLine: false,
     fontFamily: "'Source Code Pro', monospace",
     fontSize: 14,
+    padding: { top: 20 },
     scrollbar: {
       useShadows: true,
       verticalHasArrows: false,

--- a/app/javascript/components/editor/TestRunFailure.tsx
+++ b/app/javascript/components/editor/TestRunFailure.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { TestRun } from './types'
+import { TestsGroupList } from './TestsGroupList'
+
+export const TestRunFailure = ({
+  testRun,
+}: {
+  testRun: TestRun
+}): JSX.Element => {
+  return testRun.version == 2 ? (
+    <TestsGroupList tests={testRun.tests} />
+  ) : (
+    <pre className="v1-output">
+      <code dangerouslySetInnerHTML={{ __html: testRun.output }} />
+    </pre>
+  )
+}

--- a/app/javascript/components/editor/TestRunSummary.tsx
+++ b/app/javascript/components/editor/TestRunSummary.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useCallback, useRef } from 'react'
 import { TestRun, TestRunStatus } from './types'
 import { TestRunChannel } from '../../channels/testRunChannel'
 import { fetchJSON } from '../../utils/fetch-json'
-import { TestsGroupList } from './TestsGroupList'
+import { TestRunSummaryHeaderMessage } from './TestRunSummaryHeaderMessage'
+import { TestRunFailure } from './TestRunFailure'
 
 export const TestRunSummary = ({
   testRun,
@@ -113,7 +114,7 @@ TestRunSummary.Header = ({ testRun }: { testRun: TestRun }) => {
       return (
         <div className="summary-status failed" role="status">
           <span className="--dot" />
-          {testRun.version === 2 ? '1 test failure' : 'Tests failed'}
+          <TestRunSummaryHeaderMessage version={testRun.version} />
         </div>
       )
     case TestRunStatus.PASS:
@@ -138,13 +139,7 @@ TestRunSummary.Content = ({
   switch (testRun.status) {
     case TestRunStatus.PASS:
     case TestRunStatus.FAIL:
-      return testRun.version == 2 ? (
-        <TestsGroupList tests={testRun.tests} />
-      ) : (
-        <pre className="v1-output">
-          <code dangerouslySetInnerHTML={{ __html: testRun.output }} />
-        </pre>
-      )
+      return <TestRunFailure testRun={testRun} />
     case TestRunStatus.ERROR:
       return (
         <div role="status">

--- a/app/javascript/components/editor/TestRunSummary.tsx
+++ b/app/javascript/components/editor/TestRunSummary.tsx
@@ -112,7 +112,8 @@ TestRunSummary.Header = ({ testRun }: { testRun: TestRun }) => {
     case TestRunStatus.FAIL:
       return (
         <div className="summary-status failed" role="status">
-          <span className="--dot" />1 test failure
+          <span className="--dot" />
+          {testRun.version === 2 ? '1 test failure' : 'Tests failed'}
         </div>
       )
     case TestRunStatus.PASS:
@@ -137,7 +138,13 @@ TestRunSummary.Content = ({
   switch (testRun.status) {
     case TestRunStatus.PASS:
     case TestRunStatus.FAIL:
-      return <TestsGroupList tests={testRun.tests} />
+      return testRun.version == 2 ? (
+        <TestsGroupList tests={testRun.tests} />
+      ) : (
+        <pre className="v1-output">
+          <code dangerouslySetInnerHTML={{ __html: testRun.output }} />
+        </pre>
+      )
     case TestRunStatus.ERROR:
       return (
         <div role="status">

--- a/app/javascript/components/editor/TestRunSummaryHeaderMessage.tsx
+++ b/app/javascript/components/editor/TestRunSummaryHeaderMessage.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export const TestRunSummaryHeaderMessage = ({
+  version,
+}: {
+  version: number
+}): JSX.Element => {
+  return version === 2 ? <span>1 test failure</span> : <span>Tests failed</span>
+}

--- a/app/javascript/components/editor/file-editor/themes.ts
+++ b/app/javascript/components/editor/file-editor/themes.ts
@@ -7,7 +7,7 @@ export const setupThemes = (): void => {
     inherit: true,
     rules: [
       {
-        background: 'F8F8FF',
+        background: 'FBFCFE',
         token: '',
       },
       {
@@ -242,11 +242,12 @@ export const setupThemes = (): void => {
     ],
     colors: {
       'editor.foreground': '#000000',
-      'editor.background': '#F8F8FF',
+      'editor.background': '#FBFCFE',
       'editor.selectionBackground': '#B4D5FE',
       'editor.lineHighlightBackground': '#FFFEEB',
       'editorCursor.foreground': '#666666',
       'editorWhitespace.foreground': '#BBBBBB',
+      'editorLineNumber.foreground': '#5C5589',
     },
   })
 

--- a/app/javascript/components/editor/types.ts
+++ b/app/javascript/components/editor/types.ts
@@ -17,8 +17,10 @@ type SubmissionLinks = {
 export type TestRun = {
   id: number | null
   submissionUuid: string
+  version: number
   status: TestRunStatus
   message: string
+  output: string
   tests: Test[]
 }
 

--- a/app/javascript/components/editor/useSubmission.ts
+++ b/app/javascript/components/editor/useSubmission.ts
@@ -52,9 +52,11 @@ function reducer(state: State, action: Action): State {
           testRun: {
             id: null,
             submissionUuid: action.payload.submission.id,
+            version: 0,
             status: TestRunStatus.QUEUED,
             tests: [],
             message: '',
+            output: '',
           },
         },
         status: SubmissionStatus.CREATED,

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -6,9 +6,10 @@ class Submission::TestRun < ApplicationRecord
   scope :ops_successful, -> { where(ops_status: 200) }
 
   before_create do
+    self.version = raw_results[:version].to_i
     self.status = raw_results.fetch(:status, :error) unless self.status
     self.message = raw_results[:message] unless self.message
-    self.tests = raw_results[:tests] unless self.tests
+    self.output = raw_results[:output] unless self.output
   end
 
   def status
@@ -37,7 +38,7 @@ class Submission::TestRun < ApplicationRecord
 
   memoize
   def test_results
-    tests.to_a.map do |test|
+    raw_results[:tests].to_a.map do |test|
       TestResult.new(HashWithIndifferentAccess.new(test))
     end
   end

--- a/app/serializers/serialize_submission_test_run.rb
+++ b/app/serializers/serialize_submission_test_run.rb
@@ -9,8 +9,10 @@ class SerializeSubmissionTestRun
     {
       id: test_run.id,
       submission_uuid: test_run.submission.uuid,
+      version: test_run.version,
       status: status,
       message: message,
+      output: test_run.output.present? ? Ansi::To::Html.new(test_run.output).to_html : nil,
       tests: test_run.test_results
     }
   end

--- a/app/serializers/serialize_submission_test_run.rb
+++ b/app/serializers/serialize_submission_test_run.rb
@@ -12,7 +12,7 @@ class SerializeSubmissionTestRun
       version: test_run.version,
       status: status,
       message: message,
-      output: test_run.output.present? ? Ansi::To::Html.new(test_run.output).to_html : nil,
+      output: output,
       tests: test_run.test_results
     }
   end
@@ -32,6 +32,12 @@ class SerializeSubmissionTestRun
     # TODO: Decide how this is corrolated with the
     # errors upstream and move into i18n.
     "Some error occurred"
+  end
+
+  def output
+    return if test_run.output.blank?
+
+    Ansi::To::Html.new(test_run.output).to_html
   end
 
   OPS_ERROR_STATUS = "ops_error".freeze

--- a/db/migrate/20210328124220_add_version_to_test_run.rb
+++ b/db/migrate/20210328124220_add_version_to_test_run.rb
@@ -1,0 +1,7 @@
+class AddVersionToTestRun < ActiveRecord::Migration[6.1]
+  def change
+    # TODO: What should the default be?
+    add_column :submission_test_runs, :version, :tinyint, default: 0, null: false
+    remove_column :submission_test_runs, :tests
+  end
+end

--- a/db/migrate/20210328130408_add_output_to_test_runs.rb
+++ b/db/migrate/20210328130408_add_output_to_test_runs.rb
@@ -1,0 +1,5 @@
+class AddOutputToTestRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submission_test_runs, :output, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_27_174746) do
+ActiveRecord::Schema.define(version: 2021_03_28_130408) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
@@ -333,11 +333,12 @@ ActiveRecord::Schema.define(version: 2021_03_27_174746) do
     t.string "tooling_job_id", null: false
     t.string "status", null: false
     t.text "message"
-    t.json "tests"
     t.integer "ops_status", limit: 2, null: false
     t.json "raw_results", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "version", limit: 1, default: 2, null: false
+    t.text "output"
     t.index ["submission_id"], name: "index_submission_test_runs_on_submission_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,7 +48,7 @@ karlo.update!(accepted_privacy_policy_at: Time.current, accepted_terms_at: Time.
 
 track_slugs = %w[05ab1e ada arm64-assembly ballerina bash c ceylon cfml clojure clojurescript coffeescript common-lisp coq cpp crystal csharp d dart delphi elixir elm emacs-lisp erlang factor forth fortran fsharp gleam gnu-apl go groovy haskell haxe idris io j java javascript julia kotlin lfe lua mips nim nix objective-c ocaml perl5 pharo-smalltalk php plsql pony powershell prolog purescript python r racket raku reasonml ruby rust scala scheme shen sml solidity swift system-verilog tcl typescript vbnet vimscript x86-64-assembly zig]
 track_slugs.each do |track_slug|
-  next unless track_slug == "ruby" || track_slug == "csharp"
+  next unless %w[ruby csharp prolog].include?(track_slug)
 
   begin
     puts "Adding Track: #{track_slug}"

--- a/test/channels/submission/test_runs_channel_test.rb
+++ b/test/channels/submission/test_runs_channel_test.rb
@@ -10,13 +10,7 @@ class Submission::TestRunsChannelTest < ActionCable::Channel::TestCase
 
     assert_broadcast_on(
       submission.id,
-      test_run: {
-        id: test_run.id,
-        submission_uuid: test_run.submission.uuid,
-        status: 'ops_error',
-        message: "Some error occurred",
-        tests: []
-      }
+      test_run: SerializeSubmissionTestRun.(test_run)
     ) do
       Submission::TestRunsChannel.broadcast!(test_run)
     end

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -6,8 +6,9 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     ops_status = 201
     status = "foobar"
     message = "some barfoo message"
+    version = 5
     tests = [{ 'foo' => 'bar' }]
-    results = { 'status' => status, 'message' => message, 'tests' => tests }
+    results = { 'version' => version, 'status' => status, 'message' => message, 'tests' => tests }
     job = create_test_runner_job!(submission, execution_status: ops_status, results: results)
 
     Submission::TestRun::Process.(job)
@@ -17,7 +18,7 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     assert_equal ops_status, tr.ops_status
     assert_equal status.to_sym, tr.status
     assert_equal message, tr.message
-    assert_equal tests, tr.tests
+    assert_equal version, tr.version
     assert_equal results, tr.send(:raw_results)
   end
 

--- a/test/javascript/components/Editor/TestRunFailure.test.tsx
+++ b/test/javascript/components/Editor/TestRunFailure.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { screen, render } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { TestRunFailure } from '../../../../app/javascript/components/editor/TestRunFailure'
+import {
+  TestRun,
+  TestRunStatus,
+  TestStatus,
+} from '../../../../app/javascript/components/editor/types'
+
+test('shows test run output for version 1 test runner', async () => {
+  const testRun: TestRun = {
+    id: null,
+    submissionUuid: '123',
+    status: TestRunStatus.FAIL,
+    message: '',
+    tests: [],
+    version: 1,
+    output: 'Unable to run tests',
+  }
+
+  render(<TestRunFailure testRun={testRun} />)
+
+  expect(screen.getByText('Unable to run tests')).toBeInTheDocument()
+})
+
+test('shows tests for version 2 test runner', async () => {
+  const testRun: TestRun = {
+    id: null,
+    submissionUuid: '123',
+    status: TestRunStatus.FAIL,
+    message: '',
+    tests: [
+      {
+        name: 'equal to 1',
+        status: TestStatus.FAIL,
+        testCode: '212',
+        message: 'Failed test',
+        output: '',
+      },
+    ],
+    version: 2,
+    output: '',
+  }
+
+  render(<TestRunFailure testRun={testRun} />)
+
+  expect(screen.getByText('equal to 1')).toBeInTheDocument()
+})

--- a/test/javascript/components/Editor/TestRunSummary.test.js
+++ b/test/javascript/components/Editor/TestRunSummary.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { TestRunSummary } from '../../../../app/javascript/components/editor/TestRunSummary'
 import { TestRunStatus } from '../../../../app/javascript/components/editor/types'
@@ -50,6 +50,24 @@ test('show header when test run fails', async () => {
     />
   )
 
-  expect(queryByText('1 test failure')).toBeInTheDocument()
+  expect(queryByText('Tests failed')).toBeInTheDocument()
   expect(queryByText('All tests passed')).not.toBeInTheDocument()
+})
+
+test('shows test failures', async () => {
+  render(
+    <TestRunSummary
+      testRun={{
+        id: null,
+        submissionUuid: '123',
+        status: TestRunStatus.FAIL,
+        message: '',
+        tests: [],
+        version: 1,
+        output: 'Unable to run tests',
+      }}
+    />
+  )
+
+  expect(screen.getByText('Unable to run tests')).toBeInTheDocument()
 })

--- a/test/javascript/components/Editor/TestRunSummaryHeaderMessage.test.tsx
+++ b/test/javascript/components/Editor/TestRunSummaryHeaderMessage.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { screen, render } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { TestRunSummaryHeaderMessage } from '../../../../app/javascript/components/editor/TestRunSummaryHeaderMessage'
+
+test('returns message for version 1 test runner', async () => {
+  render(<TestRunSummaryHeaderMessage version={1} />)
+
+  expect(screen.getByText('Tests failed')).toBeInTheDocument()
+})
+
+test('returns message for version 2 test runner', async () => {
+  render(<TestRunSummaryHeaderMessage version={2} />)
+
+  expect(screen.getByText('1 test failure')).toBeInTheDocument()
+})

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -14,11 +14,13 @@ class Submission::TestRunTest < ActiveSupport::TestCase
   end
 
   test "explodes raw_results" do
+    version = 5
     status = "foobar"
     message = "some barfoo message"
     tests = [{ 'status' => 'pass' }]
 
     raw_results = {
+      version: version,
       status: status,
       message: message,
       tests: tests
@@ -26,7 +28,7 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     tr = create :submission_test_run, raw_results: raw_results
     assert_equal status.to_sym, tr.status
     assert_equal message, tr.message
-    assert_equal tests, tr.tests
+    assert_equal version, tr.version
     assert_equal 1, tr.test_results.size
   end
 
@@ -67,7 +69,7 @@ class Submission::TestRunTest < ActiveSupport::TestCase
       'output' => output
     }]
 
-    tr = create :submission_test_run, tests: tests
+    tr = create :submission_test_run, raw_results: { tests: tests }
     assert_equal 1, tr.test_results.size
     result = tr.test_results.first
 

--- a/test/system/flows/edit_solution_test.rb
+++ b/test/system/flows/edit_solution_test.rb
@@ -23,7 +23,7 @@ module Components
             submission: Submission.last,
             status: "pass",
             ops_status: 200,
-            tests: [{ name: :test_a_name_given, status: :pass, output: "Hello" }]
+            raw_results: { tests: [{ name: :test_a_name_given, status: :pass, output: "Hello" }] }
           create :submission_file, submission: Submission.last
           Submission::TestRunsChannel.broadcast!(test_run)
           click_on "Submit"


### PR DESCRIPTION
@kntsoriano @ErikSchierboom This adds support for legacy test runners. It adds two things:
- `version`: 
  - `1` for the legacy test runners (which just show output). (Erik is currently building 50 of these!)
  - `2` for the new test runners which show everything properly.
- `output`: Used to output the results of a legacy test runner.

I've got it working end-to-end through to React. I've not updated the Ruby tests yet, but will do before merging. 
@kntsoriano Could you add tests for the React end for this pls?

This also adds prolog to the seeds. Prolog has a v1 legacy test runner, which you can use to test end-to-end.

The output looks like this:
<img width="608" alt="Screenshot 2021-03-28 at 14 15 37" src="https://user-images.githubusercontent.com/286476/112753611-15676800-8fd0-11eb-9fd0-9b589ae1694e.png">

If we get ANSI support at the test-runner end, the website will support the rendering of that too.