### PR TITLE
Add status field for discussion filtering

### DIFF
--- a/app/controllers/api/mentoring/discussions_controller.rb
+++ b/app/controllers/api/mentoring/discussions_controller.rb
@@ -11,9 +11,19 @@ module API
         order: params[:order]
       )
 
+      all_discussions = Mentor::Discussion.
+        joins(solution: :exercise).
+        includes(solution: [:user, { exercise: :track }]).
+        where(mentor: current_user)
+
       render json: SerializePaginatedCollection.(
         discussions,
-        serializer: SerializeMentorDiscussions
+        serializer: SerializeMentorDiscussions,
+        meta: {
+          requires_mentor_action_total: all_discussions.requires_mentor_action.count,
+          requires_student_action_total: all_discussions.requires_student_action.count,
+          finished_total: all_discussions.finished.count
+        }
       )
     end
 

--- a/app/controllers/api/mentoring/discussions_controller.rb
+++ b/app/controllers/api/mentoring/discussions_controller.rb
@@ -4,6 +4,7 @@ module API
     def index
       discussions = ::Mentor::Discussion::Retrieve.(
         current_user,
+        params[:status],
         page: params[:page],
         track_slug: params[:track],
         criteria: params[:criteria],
@@ -18,7 +19,9 @@ module API
 
     def tracks
       track_counts = Mentor::Discussion::Retrieve.(
-        current_user, sorted: false, paginated: false
+        current_user,
+        params[:status],
+        sorted: false, paginated: false
       ).group(:track_id).count
 
       tracks = Track.where(id: track_counts.keys).index_by(&:id)

--- a/app/css/components/mentor/header.css
+++ b/app/css/components/mentor/header.css
@@ -3,4 +3,5 @@
 /* See also track/header */
 
 .c-mentor-header {
+    @apply mb-40;
 }

--- a/app/css/components/mentor/inbox.css
+++ b/app/css/components/mentor/inbox.css
@@ -1,38 +1,88 @@
 .c-mentor-inbox {
-    @apply shadow-lg bg-backgroundColorA rounded-8;
+    & .tabs {
+        @apply mb-20;
 
-    & header.c-search-bar {
-        @apply py-16 px-24;
+        @apply flex items-center;
+        @apply flex-grow;
 
-        & .track-filter {
-            @apply mr-16;
-            /* Stop jumping around */
-            min-width: 75px;
-
-            & button {
-                @apply flex items-center;
-                & .c-track-icon {
-                    width: 42px;
-                    height: 42px;
-                    @apply mr-20;
-                }
-                & .action-icon {
-                    width: 13px;
-                    height: 13px;
-                }
-            }
-        }
-        & .--search {
-            @apply mr-16;
-            width: 60%;
-            max-width: 450px;
-        }
-        & .c-select {
-            margin-left: auto;
+        & .c-tab {
+            line-height: 40px;
         }
     }
-    & footer {
-        @apply px-24 py-16;
-        @apply border-lightGray border-t-1;
+    & .container {
+        @apply shadow-lg bg-backgroundColorA rounded-8;
+
+        & header.c-search-bar {
+            @apply py-16 px-24;
+
+            & .track-filter {
+                @apply mr-16;
+                /* Stop jumping around */
+                min-width: 75px;
+
+                & button {
+                    @apply flex items-center;
+                    & .c-track-icon {
+                        width: 42px;
+                        height: 42px;
+                        @apply mr-20;
+                    }
+                    & .action-icon {
+                        width: 13px;
+                        height: 13px;
+                    }
+                }
+                & .dropdown {
+                    @apply bg-backgroundColorA rounded-8 shadow-lg;
+                    @apply p-8;
+
+                    & label.c-radio-wrapper {
+                        --row-selected-background-color: var(
+                            --backgroundColorD
+                        );
+
+                        & .row {
+                            @apply flex items-center;
+                            @apply py-8 px-16;
+                            min-width: 360px;
+                        }
+
+                        & .c-radio {
+                            @apply text-20;
+                            @apply mr-20;
+                        }
+
+                        & .c-track-icon {
+                            width: 42px;
+                            height: 42px;
+                            @apply mr-16;
+                        }
+                        & .title {
+                            @apply flex-grow;
+                            @apply text-16 leading-150 font-medium;
+                        }
+                        & .count {
+                            width: 45px;
+                            @apply text-14 leading-150 font-medium text-center;
+                            @apply border-1 border-inputBorderColor rounded-100;
+                            @apply text-textColor3;
+                            @apply py-4;
+                        }
+                    }
+                }
+            }
+            & .--search {
+                @apply mr-16;
+                width: 60%;
+                max-width: 450px;
+            }
+            & .c-select {
+                margin-left: auto;
+            }
+        }
+        & footer {
+            @apply px-24 py-16;
+            @apply border-lightGray border-t-1;
+        }
     }
 }

--- a/app/css/components/tab-2.css
+++ b/app/css/components/tab-2.css
@@ -13,11 +13,20 @@
         width: 24px;
         @apply mr-16;
     }
+    & .count {
+        @apply ml-12;
+        @apply border-1 border-borderLight rounded-100 px-12;
+        @apply text-textColor6 text-13 leading-200 font-medium;
+    }
+
     &.selected {
         @apply text-anotherPurple;
         @apply border-anotherPurple;
         & .c-icon {
             filter: var(--another-purple-filter);
+        }
+        & .count {
+            @apply border-anotherPurple text-anotherPurple;
         }
     }
 }

--- a/app/css/pages/mentoring/inbox.css
+++ b/app/css/pages/mentoring/inbox.css
@@ -1,25 +1,4 @@
 @import "../../styles";
 
 #mentor-inbox-page {
-    & .c-mentor-nav {
-        @apply mb-40;
-    }
-
-    & header.header {
-        @apply flex flex-col items-center;
-        @apply mb-48;
-
-        & .c-icon {
-            height: 64px;
-            width: 64px;
-            @apply mb-16;
-        }
-        & h2 {
-            @apply text-h2;
-            @apply mb-8;
-        }
-        & .subtitle {
-            @apply text-18 leading-huge;
-        }
-    }
 }

--- a/app/css/pages/mentoring/queue.css
+++ b/app/css/pages/mentoring/queue.css
@@ -1,10 +1,6 @@
 @import "../../styles";
 
 #mentor-queue-page {
-    & .c-mentor-nav {
-        @apply mb-40;
-    }
-
     & header.header {
         @apply flex flex-col items-center;
         @apply mb-48;

--- a/app/helpers/react_components/mentoring/inbox.rb
+++ b/app/helpers/react_components/mentoring/inbox.rb
@@ -19,18 +19,21 @@ module ReactComponents
       ].freeze
       private_constant :SORT_OPTIONS
 
+      DEFAULT_STATUS = "requires_mentor_action".freeze
+      private_constant :DEFAULT_STATUS
+
       private
       def discussions_request
         {
           endpoint: Exercism::Routes.api_mentoring_discussions_path,
-          query: { status: "requires_mentor_action" }
+          query: { status: DEFAULT_STATUS }
         }
       end
 
       def tracks_request
         {
           endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
-          query: { status: "requires_mentor_action" }
+          query: { status: DEFAULT_STATUS }
         }
       end
     end

--- a/app/helpers/react_components/mentoring/inbox.rb
+++ b/app/helpers/react_components/mentoring/inbox.rb
@@ -21,11 +21,17 @@ module ReactComponents
 
       private
       def discussions_request
-        { endpoint: Exercism::Routes.api_mentoring_discussions_path }
+        {
+          endpoint: Exercism::Routes.api_mentoring_discussions_path,
+          query: { status: "requires_mentor_action" }
+        }
       end
 
       def tracks_request
-        { endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path }
+        {
+          endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
+          query: { status: "requires_mentor_action" }
+        }
       end
     end
   end

--- a/app/helpers/view_components/mentor/header.rb
+++ b/app/helpers/view_components/mentor/header.rb
@@ -18,7 +18,9 @@ module ViewComponents
       private
       def lhs
         tag.nav(class: "lhs") do
-          tag.div("Mentoring", class: "title") +
+          tag.div(class: "title") do
+            graphical_icon(:mentoring, hex: true) + tag.span("Mentoring")
+          end +
             tag.div(safe_join(tabs), class: 'tabs')
         end
       end
@@ -31,7 +33,7 @@ module ViewComponents
             Exercism::Routes.mentoring_inbox_path,
             class: tab_class(:workspace)
           ) do
-            graphical_icon(:mentoring) +
+            graphical_icon(:overview) +
               tag.span("Your Workspace") +
               tag.span("20", class: 'count') # TODO
           end,
@@ -40,7 +42,7 @@ module ViewComponents
             Exercism::Routes.mentoring_queue_path,
             class: tab_class(:queue)
           ) do
-            graphical_icon(:mentoring) +
+            graphical_icon(:queue) +
               tag.span("Queue") +
               tag.span("1,700", class: 'count')
           end,

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -25,7 +25,7 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
   )
 
   const setTrack = (track) => {
-    setQuery({ track: track, page: 1 })
+    setQuery({ ...request.query, track: track, page: 1 })
   }
 
   return (

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -34,37 +34,44 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
   }
 
   return (
-    <div>
-      <StatusTab
-        status="requires_mentor_action"
-        currentStatus={request.query.status}
-        setStatus={setStatus}
-      >
-        Inbox
-        {resolvedData ? (
-          <span>{resolvedData.meta.requiresMentorActionTotal}</span>
-        ) : null}
-      </StatusTab>
-      <StatusTab
-        status="requires_student_action"
-        currentStatus={request.query.status}
-        setStatus={setStatus}
-      >
-        Awaiting student
-        {resolvedData ? (
-          <span>{resolvedData.meta.requiresStudentActionTotal}</span>
-        ) : null}
-      </StatusTab>
-      <StatusTab
-        status="finished"
-        currentStatus={request.query.status}
-        setStatus={setStatus}
-      >
-        Finished
-        {resolvedData ? <span>{resolvedData.meta.finishedTotal}</span> : null}
-      </StatusTab>
-      <div className="c-mentor-inbox">
-        <div></div>
+    <div className="c-mentor-inbox">
+      <div className="tabs">
+        <StatusTab
+          status="requires_mentor_action"
+          currentStatus={request.query.status}
+          setStatus={setStatus}
+        >
+          Inbox
+          {resolvedData ? (
+            <div className="count">
+              {resolvedData.meta.requiresMentorActionTotal}
+            </div>
+          ) : null}
+        </StatusTab>
+        <StatusTab
+          status="requires_student_action"
+          currentStatus={request.query.status}
+          setStatus={setStatus}
+        >
+          Awaiting student
+          {resolvedData ? (
+            <div className="count">
+              {resolvedData.meta.requiresStudentActionTotal}
+            </div>
+          ) : null}
+        </StatusTab>
+        <StatusTab
+          status="finished"
+          currentStatus={request.query.status}
+          setStatus={setStatus}
+        >
+          Finished
+          {resolvedData ? (
+            <div className="count">{resolvedData.meta.finishedTotal}</div>
+          ) : null}
+        </StatusTab>
+      </div>
+      <div className="container">
         <header className="c-search-bar">
           <TrackFilter
             request={tracksRequest}

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { DiscussionList } from './inbox/DiscussionList'
+import { StatusTab } from './inbox/StatusTab'
 import { TextFilter } from './TextFilter'
 import { Sorter } from './Sorter'
 import { TrackFilter } from './inbox/TrackFilter'
@@ -28,36 +29,71 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
     setQuery({ ...request.query, track: track, page: 1 })
   }
 
+  const setStatus = (status) => {
+    setQuery({ ...request.query, status: status, page: 1 })
+  }
+
   return (
-    <div className="c-mentor-inbox">
-      <header className="c-search-bar">
-        <TrackFilter
-          request={tracksRequest}
-          value={request.query.track || null}
-          setTrack={setTrack}
+    <div>
+      <StatusTab
+        status="requires_mentor_action"
+        currentStatus={request.query.status}
+        setStatus={setStatus}
+      >
+        Inbox
+        {resolvedData ? (
+          <span>{resolvedData.meta.requiresMentorActionTotal}</span>
+        ) : null}
+      </StatusTab>
+      <StatusTab
+        status="requires_student_action"
+        currentStatus={request.query.status}
+        setStatus={setStatus}
+      >
+        Awaiting student
+        {resolvedData ? (
+          <span>{resolvedData.meta.requiresStudentActionTotal}</span>
+        ) : null}
+      </StatusTab>
+      <StatusTab
+        status="finished"
+        currentStatus={request.query.status}
+        setStatus={setStatus}
+      >
+        Finished
+        {resolvedData ? <span>{resolvedData.meta.finishedTotal}</span> : null}
+      </StatusTab>
+      <div className="c-mentor-inbox">
+        <div></div>
+        <header className="c-search-bar">
+          <TrackFilter
+            request={tracksRequest}
+            value={request.query.track || null}
+            setTrack={setTrack}
+          />
+          <TextFilter
+            filter={request.query.criteria}
+            setFilter={setCriteria}
+            id="discussion-filter"
+            placeholder="Filter by student or exercise name"
+          />
+          {isFetching ? <span>Fetching...</span> : null}
+          <Sorter
+            sortOptions={sortOptions}
+            order={request.query.order}
+            setOrder={setOrder}
+            id="discussion-sorter-sort"
+          />
+        </header>
+        <DiscussionList
+          latestData={latestData}
+          resolvedData={resolvedData}
+          status={status}
+          refetch={refetch}
+          request={request}
+          setPage={setPage}
         />
-        <TextFilter
-          filter={request.query.criteria}
-          setFilter={setCriteria}
-          id="discussion-filter"
-          placeholder="Filter by student or exercise name"
-        />
-        {isFetching ? <span>Fetching...</span> : null}
-        <Sorter
-          sortOptions={sortOptions}
-          order={request.query.order}
-          setOrder={setOrder}
-          id="discussion-sorter-sort"
-        />
-      </header>
-      <DiscussionList
-        latestData={latestData}
-        resolvedData={resolvedData}
-        status={status}
-        refetch={refetch}
-        request={request}
-        setPage={setPage}
-      />
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/mentoring/inbox/StatusTab.tsx
+++ b/app/javascript/components/mentoring/inbox/StatusTab.tsx
@@ -15,11 +15,13 @@ export const StatusTab = ({
     setStatus(status)
   }, [setStatus, status])
 
+  const selected = currentStatus === status
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={currentStatus === status}
+      disabled={selected}
+      className={`c-tab ${selected ? 'selected' : null}`}
     >
       {children}
     </button>

--- a/app/javascript/components/mentoring/inbox/StatusTab.tsx
+++ b/app/javascript/components/mentoring/inbox/StatusTab.tsx
@@ -1,0 +1,27 @@
+import React, { useCallback } from 'react'
+import { DiscussionStatus } from '../../types'
+
+export const StatusTab = ({
+  status,
+  currentStatus,
+  setStatus,
+  children,
+}: React.PropsWithChildren<{
+  status: DiscussionStatus
+  currentStatus: DiscussionStatus
+  setStatus: (status: DiscussionStatus) => void
+}>): JSX.Element => {
+  const handleClick = useCallback(() => {
+    setStatus(status)
+  }, [setStatus, status])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={currentStatus === status}
+    >
+      {children}
+    </button>
+  )
+}

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -23,6 +23,11 @@ export type SolutionForStudent = {
 
 export type SolutionStatus = 'started' | 'published' | 'completed' | 'iterated'
 
+export type DiscussionStatus =
+  | 'requires_mentor_action'
+  | 'requires_student_action'
+  | 'finished'
+
 export type CommunitySolution = {
   id: string
   snippet: string

--- a/app/javascript/images/icons/queue.svg
+++ b/app/javascript/images/icons/queue.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.75 7.76099C9.75 7.2087 10.1977 6.76099 10.75 6.76099H22.25C22.8023 6.76099 23.25 7.2087 23.25 7.76099V22.261C23.25 22.8133 22.8023 23.261 22.25 23.261H10.75C10.1977 23.261 9.75 22.8133 9.75 22.261V7.76099Z" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.75 20.261H6.75C5.92157 20.261 5.25 19.5894 5.25 18.761V5.26099C5.25 4.43256 5.92157 3.76099 6.75 3.76099H17.25C18.0784 3.76099 18.75 4.43256 18.75 5.26099V6.76099" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.25 17.261H2.25C1.42157 17.261 0.75 16.5894 0.75 15.761V2.26099C0.75 1.43256 1.42157 0.760986 2.25 0.760986H12.75C13.5784 0.760986 14.25 1.43256 14.25 2.26099V3.76099" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.25 11.261H20.25" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 10.511L13.5 11.261L15 9.76099" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.25 15.761H20.25" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 15.011L13.5 15.761L15 14.261" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.25 20.261H20.25" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 19.511L13.5 20.261L15 18.761" stroke="#5C5589" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+

--- a/app/views/mentoring/inbox/show.html.haml
+++ b/app/views/mentoring/inbox/show.html.haml
@@ -2,10 +2,4 @@
   = render ViewComponents::Mentor::Header.new(:workspace)
 
   .lg-container
-    %header.header
-      = graphical_icon "conversation-1", category: 'graphics'
-      %h2 Your Mentoring Inbox
-      .subtitle
-        The solutions that you've mentoring
-
     = ReactComponents::Mentoring::Inbox.new

--- a/test/controllers/api/mentoring/discussions_controller_test.rb
+++ b/test/controllers/api/mentoring/discussions_controller_test.rb
@@ -15,7 +15,8 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
 
     discussion = create :mentor_discussion, :requires_mentor_action, mentor: user
 
-    get api_mentoring_discussions_path, headers: @headers, as: :json
+    get api_mentoring_discussions_path(status: :requires_mentor_action),
+      headers: @headers, as: :json
     assert_response 200
 
     # TODO: Check JSON
@@ -42,7 +43,7 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
     create :mentor_discussion, :requires_mentor_action, solution: tournament_solution, mentor: @current_user
     create :mentor_discussion, :requires_mentor_action, solution: tournament_solution, mentor: @current_user
 
-    get tracks_api_mentoring_discussions_path(per: 1), headers: @headers, as: :json
+    get tracks_api_mentoring_discussions_path(per: 1, status: :requires_mentor_action), headers: @headers, as: :json
     assert_response 200
 
     expected = [

--- a/test/factories/mentor/discussions.rb
+++ b/test/factories/mentor/discussions.rb
@@ -13,5 +13,13 @@ FactoryBot.define do
     trait :requires_mentor_action do
       requires_mentor_action_since { Time.current }
     end
+
+    trait :requires_student_action do
+      requires_student_action_since { Time.current }
+    end
+
+    trait :finished do
+      finished_at { Time.current }
+    end
   end
 end

--- a/test/helpers/react_components/mentoring/inbox_test.rb
+++ b/test/helpers/react_components/mentoring/inbox_test.rb
@@ -7,8 +7,14 @@ class MentoringInboxTest < ReactComponentTestCase
     assert_component component,
       "mentoring-inbox",
       {
-        discussions_request: { endpoint: Exercism::Routes.api_mentoring_discussions_path },
-        tracks_request: { endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path },
+        discussions_request: {
+          endpoint: Exercism::Routes.api_mentoring_discussions_path,
+          query: { status: "requires_mentor_action" }
+        },
+        tracks_request: {
+          endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
+          query: { status: "requires_mentor_action" }
+        },
         sort_options: [
           { value: 'recent', label: 'Sort by Most Recent' },
           { value: 'exercise', label: 'Sort by Exercise' },

--- a/test/serializers/serialize_mentor_discussions_test.rb
+++ b/test/serializers/serialize_mentor_discussions_test.rb
@@ -12,7 +12,7 @@ class SerializeMentorDiscussionsTest < ActiveSupport::TestCase
       solution: solution,
       mentor: mentor
 
-    discussions = Mentor::Discussion::Retrieve.(mentor, page: 1)
+    discussions = Mentor::Discussion::Retrieve.(mentor, :requires_mentor_action, page: 1)
 
     expected = [
       {

--- a/test/system/components/mentoring/queue_test.rb
+++ b/test/system/components/mentoring/queue_test.rb
@@ -52,6 +52,7 @@ module Components
         visit mentoring_queue_path
         click_on "2"
 
+        sleep(1)
         assert_text "on Tournament"
       end
 


### PR DESCRIPTION
This adds the status field. It should be set to one of:
```
"requires_mentor_action"
"requires_student_action"
"finished"
```

Based on the "tab" (radio button) pressed on the mentor inbox. It should default to the first tab and "requires_mentor_action"