### PR TITLE
Add force_sync option to track syncing job

### DIFF
--- a/app/jobs/sync_track_job.rb
+++ b/app/jobs/sync_track_job.rb
@@ -1,7 +1,7 @@
 class SyncTrackJob < ApplicationJob
   queue_as :default
 
-  def perform(track)
-    Git::SyncTrack.(track)
+  def perform(track, force_sync: false)
+    Git::SyncTrack.(track, force_sync: force_sync)
   end
 end

--- a/test/jobs/sync_track_job_test.rb
+++ b/test/jobs/sync_track_job_test.rb
@@ -4,7 +4,7 @@ class SyncTrackJobTest < ActiveJob::TestCase
   test "track is synced from git" do
     track = create :track, slug: 'csharp'
 
-    Git::SyncTrack.expects(:call).with(track)
+    Git::SyncTrack.expects(:call).with(track, force_sync: false)
     SyncTrackJob.perform_now(track)
   end
 end


### PR DESCRIPTION
This allows us to do `Track.find_each{|t|SyncTrackJob.perform_later(t, force_sync: true)}` to force a refresh of everything.
