### PR TITLE
Add clearing and delays to notifications

### DIFF
--- a/app/channels/notifications_channel.rb
+++ b/app/channels/notifications_channel.rb
@@ -6,7 +6,8 @@ class NotificationsChannel < ApplicationCable::Channel
   def self.broadcast_pending!(user, notification)
     NotificationsChannel.broadcast_to(user, {
                                         type: "notifications.pending",
-                                        clearance_path: notification.path
+                                        notification_id: notification.uuid,
+                                        notification_path: notification.path
                                       })
   end
 

--- a/app/channels/notifications_channel.rb
+++ b/app/channels/notifications_channel.rb
@@ -1,6 +1,13 @@
 class NotificationsChannel < ApplicationCable::Channel
-  def self.broadcast_changed(user)
+  def self.broadcast_changed!(user)
     NotificationsChannel.broadcast_to(user, { type: "notifications.changed" })
+  end
+
+  def self.broadcast_pending!(user, notification)
+    NotificationsChannel.broadcast_to(user, {
+                                        type: "notifications.pending",
+                                        clearance_path: notification.path
+                                      })
   end
 
   def subscribed

--- a/app/channels/reputation_channel.rb
+++ b/app/channels/reputation_channel.rb
@@ -1,5 +1,5 @@
 class ReputationChannel < ApplicationCable::Channel
-  def self.broadcast_changed(user)
+  def self.broadcast_changed!(user)
     ReputationChannel.broadcast_to(user, { type: "reputation.changed" })
   end
 

--- a/app/commands/user/activity/create.rb
+++ b/app/commands/user/activity/create.rb
@@ -19,7 +19,7 @@ class User::Activity
         params: params
       ).tap do
         # TODO: Broadcast new activity
-        # AcivitiiesChannel.broadcast_changed(user)
+        # AcivitiiesChannel.broadcast_changed!(user)
       end
     end
 

--- a/app/commands/user/notification/activate.rb
+++ b/app/commands/user/notification/activate.rb
@@ -1,0 +1,16 @@
+class User::Notification
+  class Activate
+    include Mandate
+
+    initialize_with :notification
+
+    def call
+      notification.with_lock do
+        if notification.pending?
+          notification.update_column(:status, :unread)
+          NotificationsChannel.broadcast_changed!(notification.user)
+        end
+      end
+    end
+  end
+end

--- a/app/commands/user/notification/create.rb
+++ b/app/commands/user/notification/create.rb
@@ -14,8 +14,11 @@ class User::Notification
         track: track,
         exercise: exercise,
         params: params
-      ).tap do
-        NotificationsChannel.broadcast_changed(user)
+      ).tap do |notification|
+        ActivateUserNotificationJob.set(wait: 5.seconds).
+          perform_later(notification)
+
+        NotificationsChannel.broadcast_pending!(user, notification)
       end
     end
   end

--- a/app/commands/user/notification/mark_relevant_as_read.rb
+++ b/app/commands/user/notification/mark_relevant_as_read.rb
@@ -1,0 +1,20 @@
+class User::Notification
+  class MarkRelevantAsRead
+    include Mandate
+
+    initialize_with :user, :path
+
+    def call
+      User::Notification.pending_or_unread.
+        where(
+          user: user,
+          path: path
+        ).update_all(
+          status: :read,
+          read_at: Time.current
+        )
+
+      NotificationsChannel.broadcast_changed!(user)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
   def mark_notifications_as_read!
+    return if devise_controller?
     return unless user_signed_in?
     return unless request.get?
     return unless is_navigational_format?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,22 @@ class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
   before_action :ensure_onboarded!
+  before_action :mark_notifications_as_read!
 
   def ensure_onboarded!
     return unless user_signed_in?
     return if current_user.onboarded?
 
     redirect_to user_onboarding_path
+  end
+
+  def mark_notifications_as_read!
+    return unless user_signed_in?
+    return unless request.get?
+    return unless is_navigational_format?
+    return if request.xhr?
+
+    User::Notification::MarkRelevantAsRead.(current_user, request.path)
   end
 
   def ensure_mentor!

--- a/app/jobs/activate_user_notification_job.rb
+++ b/app/jobs/activate_user_notification_job.rb
@@ -1,0 +1,7 @@
+class ActivateUserNotificationJob < ApplicationJob
+  queue_as :notifications
+
+  def perform(notification)
+    User::Notification::Activate.(notification)
+  end
+end

--- a/app/models/mentor/discussion.rb
+++ b/app/models/mentor/discussion.rb
@@ -38,6 +38,16 @@ class Mentor::Discussion < ApplicationRecord
     Mentor::StudentRelationship.find_by(mentor: mentor, student: student)
   end
 
+  def student_url
+    Exercism::Routes.track_exercise_mentor_discussion_url(
+      track, exercise, self
+    )
+  end
+
+  def mentor_url
+    Exercism::Routes.mentoring_discussion_url(self)
+  end
+
   def to_param
     uuid
   end

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -9,21 +9,18 @@ class User::Notification < ApplicationRecord
   belongs_to :track, optional: true
   belongs_to :exercise, optional: true
 
-  enum email_status: { pending: 0, skipped: 1, sent: 2, failed: 3 }
-
-  scope :read, -> { where.not(read_at: nil) }
-  scope :unread, -> { where(read_at: nil) }
+  enum status: { pending: 0, unread: 1, read: 2 }
+  enum email_status: { pending: 0, skipped: 1, sent: 2, failed: 3 }, _prefix: :email
 
   before_validation do
     self.uuid = SecureRandom.compact_uuid
   end
 
-  def read?
-    read_at.present?
-  end
-
   def read!
-    update_column(:read_at, Time.current)
+    update_columns(
+      status: :read,
+      read_at: Time.current
+    )
   end
 
   def cacheable_rendering_data

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -12,8 +12,15 @@ class User::Notification < ApplicationRecord
   enum status: { pending: 0, unread: 1, read: 2 }
   enum email_status: { pending: 0, skipped: 1, sent: 2, failed: 3 }, _prefix: :email
 
-  before_validation do
+  scope :pending_or_unread, -> { where(status: %i[pending unread]) }
+
+  before_validation on: :create do
     self.uuid = SecureRandom.compact_uuid
+    self.path = "/#{url.split('/')[3..].join('/')}"
+  end
+
+  def status
+    super.to_sym
   end
 
   def read!
@@ -38,10 +45,5 @@ class User::Notification < ApplicationRecord
     {
       is_read: read?
     }
-  end
-
-  # TODO
-  def url
-    "/"
   end
 end

--- a/app/models/user/notifications/mentor_replied_to_discussion_notification.rb
+++ b/app/models/user/notifications/mentor_replied_to_discussion_notification.rb
@@ -8,9 +8,8 @@ class User
         self.exercise = solution.exercise
       end
 
-      # TODO
       def url
-        "#"
+        discussion.student_url
       end
 
       def i18n_params
@@ -34,6 +33,10 @@ class User
       end
 
       private
+      def discussion
+        discussion_post.discussion
+      end
+
       def solution
         discussion_post.solution
       end

--- a/app/models/user/notifications/mentor_started_discussion_notification.rb
+++ b/app/models/user/notifications/mentor_started_discussion_notification.rb
@@ -8,9 +8,8 @@ class User
         self.exercise = solution.exercise
       end
 
-      # TODO
       def url
-        "#"
+        discussion.student_url
       end
 
       def i18n_params

--- a/app/models/user/notifications/student_replied_to_discussion_notification.rb
+++ b/app/models/user/notifications/student_replied_to_discussion_notification.rb
@@ -3,9 +3,8 @@ class User
     class StudentRepliedToDiscussionNotification < Notification
       params :discussion_post
 
-      # TODO
       def url
-        "#"
+        discussion.mentor_url
       end
 
       def i18n_params
@@ -31,6 +30,10 @@ class User
       private
       def student
         solution.user
+      end
+
+      def discussion
+        discussion_post.discussion
       end
 
       def solution

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,6 +9,7 @@
   - active_storage_purge
 
   # Custom
+  - notifications
   - critical
   - low
   - reputation

--- a/db/migrate/20210405122209_add_status_to_notifications.rb
+++ b/db/migrate/20210405122209_add_status_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddStatusToNotifications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_notifications, :status, :tinyint, null: false, default: 0
+  end
+end

--- a/db/migrate/20210405132138_add_path_to_notifications.rb
+++ b/db/migrate/20210405132138_add_path_to_notifications.rb
@@ -1,0 +1,6 @@
+class AddPathToNotifications < ActiveRecord::Migration[6.1]
+  def change
+    User::Notification.delete_all
+    add_column :user_notifications, :path, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_03_215602) do
+ActiveRecord::Schema.define(version: 2021_04_05_122209) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
@@ -443,6 +443,7 @@ ActiveRecord::Schema.define(version: 2021_04_03_215602) do
     t.datetime "read_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", limit: 1, default: 0, null: false
     t.index ["exercise_id"], name: "index_user_notifications_on_exercise_id"
     t.index ["track_id"], name: "index_user_notifications_on_track_id"
     t.index ["uniqueness_key"], name: "index_user_notifications_on_uniqueness_key", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_05_122209) do
+ActiveRecord::Schema.define(version: 2021_04_05_132138) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
@@ -444,6 +444,7 @@ ActiveRecord::Schema.define(version: 2021_04_05_122209) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status", limit: 1, default: 0, null: false
+    t.string "path", null: false
     t.index ["exercise_id"], name: "index_user_notifications_on_exercise_id"
     t.index ["track_id"], name: "index_user_notifications_on_track_id"
     t.index ["uniqueness_key"], name: "index_user_notifications_on_uniqueness_key", unique: true

--- a/test/channels/notifications_channel_test.rb
+++ b/test/channels/notifications_channel_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class NotificationsChannelTest < ActionCable::Channel::TestCase
+  test ".broadcast_pending! broadcasts path" do
+    user = create :user
+    notification = create :notification, user: user
+
+    assert_broadcast_on(
+      user,
+      type: "notifications.pending",
+      clearance_path: notification.path
+    ) do
+      NotificationsChannel.broadcast_pending!(user, notification)
+    end
+  end
+
+  test ".broadcast_changed! broadcasts message" do
+    user = create :user
+
+    assert_broadcast_on(
+      user,
+      type: "notifications.changed"
+    ) do
+      NotificationsChannel.broadcast_changed!(user)
+    end
+  end
+end

--- a/test/channels/notifications_channel_test.rb
+++ b/test/channels/notifications_channel_test.rb
@@ -8,7 +8,8 @@ class NotificationsChannelTest < ActionCable::Channel::TestCase
     assert_broadcast_on(
       user,
       type: "notifications.pending",
-      clearance_path: notification.path
+      notification_id: notification.uuid,
+      notification_path: notification.path
     ) do
       NotificationsChannel.broadcast_pending!(user, notification)
     end

--- a/test/commands/user/activity/create_test.rb
+++ b/test/commands/user/activity/create_test.rb
@@ -33,7 +33,7 @@ class User::Activity::CreateTest < ActiveSupport::TestCase
     type = :started_exercise
     exercise = create(:concept_exercise)
     params = { exercise: exercise }
-    User::ActivityChannel.expects(:broadcast_changed).with(user)
+    User::ActivityChannel.expects(:broadcast_changed!).with(user)
 
     User::Activity::Create.(type, user, params)
   end

--- a/test/commands/user/notification/activate.rb
+++ b/test/commands/user/notification/activate.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class User::Notifications::ActivateTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper
+
+  test "updates status" do
+    notification = create :notification
+
+    User::Notification::Activate.(notification)
+
+    assert_equal :unread, notification.status
+  end
+
+  test "broadcasts message" do
+    user = create :user
+    notification = create :notification, user: user
+    NotificationsChannel.expects(:broadcast_changed!).with(user)
+
+    User::Notification::Activate.(notification)
+  end
+
+  test "does not update or publish if already unread" do
+    notification = create :notification, status: :unread
+
+    NotificationsChannel.expects(:broadcast_changed!).never
+    User::Notification::Activate.(notification)
+    assert_equal :unread, notification.status
+  end
+
+  test "does not update or publish if read" do
+    notification = create :notification, status: :read
+
+    NotificationsChannel.expects(:broadcast_changed!).never
+    User::Notification::Activate.(notification)
+    assert_equal :read, notification.status
+  end
+end

--- a/test/commands/user/notification/create_test.rb
+++ b/test/commands/user/notification/create_test.rb
@@ -41,7 +41,10 @@ class User::Notifications::CreateTest < ActiveSupport::TestCase
     type = :mentor_started_discussion
     discussion = create(:mentor_discussion)
     params = { discussion: discussion }
-    NotificationsChannel.expects(:broadcast_pending!).with(user, notification)
+    NotificationsChannel.expects(:broadcast_pending!).with do |u, n|
+      assert_equal u, user
+      assert n.is_a?(User::Notification)
+    end
 
     User::Notification::Create.(user, type, params)
   end

--- a/test/commands/user/notification/mark_relevant_as_read_test.rb
+++ b/test/commands/user/notification/mark_relevant_as_read_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class User::Notifications::MarkRelevantAsReadTest < ActiveSupport::TestCase
+  test "clears correct notifications" do
+    user = create :user
+    discussion = create(:mentor_discussion)
+    discussion_post_1 = create(:mentor_discussion_post, discussion: discussion)
+    discussion_post_2 = create(:mentor_discussion_post, discussion: discussion)
+    relevant_1 = create :mentor_started_discussion_notification, status: :pending, user: user,
+                                                                 params: { discussion: discussion }
+    relevant_2 = create :mentor_replied_to_discussion_notification, status: :pending, user: user,
+                                                                    params: { discussion_post: discussion_post_1 }
+    relevant_3 = create :mentor_replied_to_discussion_notification, status: :pending, user: user,
+                                                                    params: { discussion_post: discussion_post_2 }
+    irrelevant_1 = create :mentor_started_discussion_notification, status: :pending, params: { discussion: discussion }
+    irrelevant_2 = create :mentor_started_discussion_notification, status: :pending, user: user
+    irrelevant_3 = create :mentor_replied_to_discussion_notification, status: :pending, user: user
+    irrelevant_4 = create :mentor_replied_to_discussion_notification, status: :pending,
+                                                                      params: { discussion_post: discussion_post_2 }
+
+    User::Notification::MarkRelevantAsRead.(user, relevant_1.path)
+
+    assert_equal [relevant_1, relevant_2, relevant_3], User::Notification.read
+    assert_equal [irrelevant_1, irrelevant_2, irrelevant_3, irrelevant_4], User::Notification.pending
+  end
+
+  test "broadcasts message" do
+    user = create :user
+    notification = create :notification, user: user
+    NotificationsChannel.expects(:broadcast_changed!).with(user)
+
+    User::Notification::Activate.(notification)
+  end
+end

--- a/test/commands/user/notification/retrieve_test.rb
+++ b/test/commands/user/notification/retrieve_test.rb
@@ -3,9 +3,10 @@ require 'test_helper'
 class User::Notification::RetrieveTest < ActiveSupport::TestCase
   test "only retrieves unread notificatons" do
     user = create :user
-    unread = create :notification, read_at: nil, user: user
-    create :notification, read_at: Time.current, user: user
-    create :notification, read_at: nil
+    unread = create :notification, status: :unread, user: user
+    create :notification, status: :read, user: user
+    create :notification, status: :pending, user: user
+    create :notification, status: :unread
 
     assert_equal [unread], User::Notification::Retrieve.(user)
   end
@@ -13,9 +14,9 @@ class User::Notification::RetrieveTest < ActiveSupport::TestCase
   test "orders by id" do
     user = create :user
 
-    first = create :notification, user: user
-    second = create :notification, user: user
-    third = create :notification, user: user
+    first = create :notification, user: user, status: :unread
+    second = create :notification, user: user, status: :unread
+    third = create :notification, user: user, status: :unread
 
     assert_equal [first, second, third], User::Notification::Retrieve.(user)
   end
@@ -23,7 +24,7 @@ class User::Notification::RetrieveTest < ActiveSupport::TestCase
   test "pagination works" do
     user = create :user
 
-    25.times { create :notification, user: user }
+    25.times { create :notification, user: user, status: :unread }
 
     notifications = User::Notification::Retrieve.(user, page: 2)
     assert_equal 2, notifications.current_page
@@ -35,7 +36,7 @@ class User::Notification::RetrieveTest < ActiveSupport::TestCase
   test "per_page works" do
     user = create :user
 
-    25.times { create :notification, user: user }
+    25.times { create :notification, user: user, status: :unread }
 
     notifications = User::Notification::Retrieve.(user, page: 2, per_page: 4)
     assert_equal 2, notifications.current_page

--- a/test/controllers/api/notifications_controller_test.rb
+++ b/test/controllers/api/notifications_controller_test.rb
@@ -14,6 +14,7 @@ class API::NotificationsControllerTest < API::BaseTestCase
     mentor = create :user
     notification = create :mentor_started_discussion_notification,
       user: user,
+      status: :unread,
       params: {
         discussion: create(:mentor_discussion, mentor: mentor)
       }

--- a/test/factories/notifications/mentor_replied_to_discussion_notification.rb
+++ b/test/factories/notifications/mentor_replied_to_discussion_notification.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :mentor_replied_to_discussion_notification, class: "User::Notifications::MentorRepliedToDiscussionNotification" do
+    user
+    params do
+      {
+        discussion_post: create(:mentor_discussion_post)
+      }
+    end
+  end
+end

--- a/test/flows/notifications_test.rb
+++ b/test/flows/notifications_test.rb
@@ -11,13 +11,16 @@ class NotificationsFlowsTest < ActiveSupport::TestCase
     content_markdown = "This\nis some sort of\nreply"
 
     discussion = Mentor::Discussion::Create.(mentor, request, iteration.idx, content_markdown)
+    User::Notification.last.update(status: :unread)
     assert_equal 1, user.notifications.count
 
     Mentor::Discussion::ReplyByStudent.(discussion, iteration, "This is great")
+    User::Notification.last.update(status: :unread)
     assert_equal 1, mentor.notifications.count
     assert_equal 1, mentor.notifications.unread.count
 
     Mentor::Discussion::ReplyByMentor.(discussion, iteration, "This is great")
+    User::Notification.last.update(status: :unread)
     assert_equal 2, user.notifications.count
     assert_equal 2, user.notifications.unread.count
 

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
-  test "read, unread, read? and read!" do
+  test "statuses" do
+    user = create :user
+    pending = create :notification, user: user, status: :pending
+    unread = create :notification, user: user, status: :unread
+    read = create :notification, user: user, status: :read
+
+    assert pending.pending?
+    assert unread.unread?
+    assert read.read?
+
+    assert_equal [pending], User::Notification.pending
+    assert_equal [unread], User::Notification.unread
+    assert_equal [read], User::Notification.read
+    assert_equal [pending, unread], User::Notification.pending_or_unread
+  end
+
+  test "read!" do
     freeze_time do
       user = create :user
       notification = create :notification, user: user, status: :unread

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -4,7 +4,7 @@ class NotificationTest < ActiveSupport::TestCase
   test "read, unread, read? and read!" do
     freeze_time do
       user = create :user
-      notification = create :notification, user: user
+      notification = create :notification, user: user, status: :unread
       refute notification.read?
       assert_empty user.notifications.read
       assert_equal [notification], user.notifications.unread

--- a/test/models/user/notifications/mentor_replied_notification_test.rb
+++ b/test/models/user/notifications/mentor_replied_notification_test.rb
@@ -14,11 +14,13 @@ class User::Notifications::MentorRepliedToDiscussionNotificationTest < ActiveSup
       user: user,
       params: { discussion_post: discussion_post }
     )
-    assert_equal "#", notification.url
     assert_equal "#{user.id}|mentor_replied_to_discussion|DiscussionPost##{discussion_post.id}", notification.uniqueness_key
     assert_equal "#{mentor.handle} has added a new comment on your solution to #{track.title}:#{exercise.title}",
       notification.text
     assert_equal :avatar, notification.image_type
     assert_equal mentor.avatar_url, notification.image_url
+    assert_equal discussion_post.discussion.student_url, notification.url
+    assert_equal "/tracks/#{track.slug}/exercises/#{exercise.slug}/mentor_discussions/#{discussion_post.discussion.uuid}",
+      notification.path
   end
 end

--- a/test/models/user/notifications/mentor_started_discussion_notification_test.rb
+++ b/test/models/user/notifications/mentor_started_discussion_notification_test.rb
@@ -17,10 +17,11 @@ class User::Notifications::MentorStartedDiscussionNotificationTest < ActiveSuppo
         discussion_post: discussion_post
       }
     )
-    assert_equal "#", notification.url
     assert_equal "#{user.id}|mentor_started_discussion|Discussion##{discussion.id}", notification.uniqueness_key
     assert_equal "<strong>#{mentor.handle}</strong> has started mentoring your solution to <strong>#{exercise.title}</strong> in <strong>#{track.title}</strong>", notification.text # rubocop:disable Layout/LineLength
     assert_equal :avatar, notification.image_type
     assert_equal mentor.avatar_url, notification.image_url
+    assert_equal discussion.student_url, notification.url
+    assert_equal "/tracks/#{track.slug}/exercises/#{exercise.slug}/mentor_discussions/#{discussion.uuid}", notification.path
   end
 end

--- a/test/models/user/notifications/student_replied_to_discussion_test.rb
+++ b/test/models/user/notifications/student_replied_to_discussion_test.rb
@@ -18,10 +18,11 @@ class User::Notifications::StudentRepliedToDiscussionNotificationTest < ActiveSu
         discussion_post: discussion_post
       }
     )
-    assert_equal "#", notification.url
     assert_equal "#{user.id}|student_replied_to_discussion|DiscussionPost##{discussion_post.id}", notification.uniqueness_key
     assert_equal "#{student.handle} has added a new comment on the solution you are mentoring for #{track.title}:#{exercise.title}", notification.text  # rubocop:disable Layout/LineLength
     assert_equal :avatar, notification.image_type
     assert_equal student.avatar_url, notification.image_url
+    assert_equal discussion_post.discussion.mentor_url, notification.url
+    assert_equal "/mentoring/discussions/#{discussion_post.discussion.uuid}", notification.path
   end
 end

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -366,14 +366,18 @@ class UserTrackTest < ActiveSupport::TestCase
     discussion = create :mentor_discussion, solution: solution
 
     # Load of notifications that result in false
-    create :mentor_started_discussion_notification, user: user
-    create :mentor_started_discussion_notification, user: user, read_at: Time.current
-    create :mentor_started_discussion_notification, user: user, read_at: Time.current,
+    create :mentor_started_discussion_notification, user: user, status: :pending
+    create :mentor_started_discussion_notification, user: user, status: :unread
+    create :mentor_started_discussion_notification, user: user, status: :read
+    create :mentor_started_discussion_notification, user: user, status: :pending,
                                                     params: { discussion: create(:mentor_discussion, solution: solution) }
-    create :mentor_started_discussion_notification, params: { discussion: create(:mentor_discussion, solution: solution) }
+    create :mentor_started_discussion_notification, user: user, status: :read,
+                                                    params: { discussion: create(:mentor_discussion, solution: solution) }
+    create :mentor_started_discussion_notification, status: :unread,
+                                                    params: { discussion: create(:mentor_discussion, solution: solution) }
     refute UserTrack.find(ut_id).has_notifications?
 
-    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+    create :mentor_started_discussion_notification, status: :unread, user: user, params: { discussion: discussion }
     assert UserTrack.find(ut_id).has_notifications?
   end
 end

--- a/test/serializers/serialize_solution_test.rb
+++ b/test/serializers/serialize_solution_test.rb
@@ -57,7 +57,7 @@ class SerializeSolutionTest < ActiveSupport::TestCase
     assert solution_data[:has_notifications]
 
     # True if there is one
-    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
     solution_data = SerializeSolution.(solution, user_track: UserTrack.find(ut_id))
     assert solution_data[:has_notifications]
   end

--- a/test/serializers/serialize_solutions_test.rb
+++ b/test/serializers/serialize_solutions_test.rb
@@ -22,7 +22,7 @@ class SerializeSolutionsTest < ActiveSupport::TestCase
     solution_1 = create :practice_solution, exercise: exercise_1, user: user
     solution_2 = create :practice_solution, exercise: exercise_2, user: user
     discussion = create(:mentor_discussion, solution: solution_1)
-    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
 
     user_track = create :user_track, user: user, track: track
     assert user_track.exercise_has_notifications?(exercise_1)

--- a/test/serializers/serialize_track_test.rb
+++ b/test/serializers/serialize_track_test.rb
@@ -120,7 +120,7 @@ class SerializeTrackTest < ActiveSupport::TestCase
     assert track_data[:has_notifications]
 
     # True if there is one
-    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+    create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
     track_data = SerializeTrack.(track, UserTrack.find(ut_id))
     assert track_data[:has_notifications]
   end

--- a/test/serializers/serialize_tracks_test.rb
+++ b/test/serializers/serialize_tracks_test.rb
@@ -41,7 +41,7 @@ class SerializeTracksTest < ActiveSupport::TestCase
 
     # Create notification and check it matches this track
     # (which it does because of clever factories)
-    create :notification, user: user
+    create :notification, user: user, status: :unread
     assert user_track_1.has_notifications?
     refute user_track_2.has_notifications?
 

--- a/test/system/components/journey/reputation_test.rb
+++ b/test/system/components/journey/reputation_test.rb
@@ -36,7 +36,7 @@ module Components
       test "paginates contributions" do
         User::ReputationToken::Search.stubs(:default_per).returns(1)
         user = create :user
-        review_token = create :user_code_review_reputation_token, user: user
+        review_token = create :user_code_review_reputation_token, user: user, created_at: Time.current - 1.day
         contribution_token = create :user_code_contribution_reputation_token, user: user, level: :major
 
         use_capybara_host do

--- a/test/system/flows/user_loads_notifications_test.rb
+++ b/test/system/flows/user_loads_notifications_test.rb
@@ -11,7 +11,7 @@ module Flows
       user = create :user
       mentor = create :user, handle: "mr-mentor"
       discussion = create :mentor_discussion, mentor: mentor
-      create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+      create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
 
       use_capybara_host do
         sign_in!(user)
@@ -34,9 +34,9 @@ module Flows
         visit dashboard_path
         wait_for_websockets
 
-        create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
+        create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
 
-        NotificationsChannel.broadcast_changed(user)
+        NotificationsChannel.broadcast_changed!(user)
         within(".c-notification") { assert_text "1" }
         find(".c-notification").click
 
@@ -54,8 +54,8 @@ module Flows
         visit dashboard_path
         find(".c-notification").click
 
-        create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }
-        NotificationsChannel.broadcast_changed(user)
+        create :mentor_started_discussion_notification, user: user, params: { discussion: discussion }, status: :unread
+        NotificationsChannel.broadcast_changed!(user)
         wait_for_websockets
 
         assert_no_text "mrs-mentor has started mentoring your solution to Bob in Ruby"

--- a/test/system/flows/user_loads_reputation_test.rb
+++ b/test/system/flows/user_loads_reputation_test.rb
@@ -105,7 +105,7 @@ module Flows
             pr_number: 120,
             pr_title: "Something else"
           }
-        ReputationChannel.broadcast_changed(user)
+        ReputationChannel.broadcast_changed!(user)
         within(".c-primary-reputation") { assert_text "5" }
         assert_css ".--notification.unseen"
         find(".c-primary-reputation").click


### PR DESCRIPTION
This fundamentally does two things:
1. Adds a `path` to each notification. When a page is visited with that page, any outstanding notifications for it are cleared.
2. Adds a small delay between a notification being generated and it showing for the user.

The purpose of the delay is to avoid us showing notifications to someone about the page they are on. When we create the notification we send a websocket out with the path of the new notification on. React should watch for this and check to see if the page the user is viewing matches the path. If so, it should report this back, and the notification will be marked as read before it gets shown to a user. The React part of this is not yet done.

To see the value of this, imagine you're having a synchronous mentoring conversation with someone. Every time they write a message you don't want a notification icon to appear if you're in the conversation to then have to refresh to clear it. Or another example, imagine you're sitting on the iterations page waiting to see if your iteration has feedback or not. The website arrives with the feedback and you start reading it - you don't also want to get a notification about the same thing.

So by having a short window for those notifications to be cleared before they are shown allows for a much nicer experience.

(cc @ErikSchierboom @kntsoriano (and taiyab purely FYI))