### PR TITLE
Simplify rep descriptions

### DIFF
--- a/app/javascript/components/profile/contributions-list/BuildingContributionsList.tsx
+++ b/app/javascript/components/profile/contributions-list/BuildingContributionsList.tsx
@@ -36,6 +36,11 @@ const Contribution = ({
   const url = internalUrl || externalUrl
   const linkIcon = url === internalUrl ? 'chevron-right' : 'external-link'
 
+  const parsedText = text
+    .replace(/^You created/, 'Created')
+    .replace(/^You contributed/, 'Contributed')
+    .replace(/^You authored/, 'Authored')
+
   return (
     <a href={url} className="reputation-token">
       <img
@@ -48,7 +53,7 @@ const Contribution = ({
         <div
           className="title"
           dangerouslySetInnerHTML={{
-            __html: text.replace('You ', `${userHandle} `),
+            __html: parsedText,
           }}
         />
         <div className="extra">

--- a/app/javascript/components/profile/contributions-list/MaintainingContributionsList.tsx
+++ b/app/javascript/components/profile/contributions-list/MaintainingContributionsList.tsx
@@ -35,6 +35,9 @@ const Contribution = ({
 }: ContributionProps & { userHandle: string }): JSX.Element => {
   const url = internalUrl || externalUrl
   const linkIcon = url === internalUrl ? 'chevron-right' : 'external-link'
+  const parsedText = text
+    .replace(/^You reviewed/, 'Reviewed')
+    .replace(/^You merged/, 'Merged')
 
   return (
     <a href={url} className="reputation-token">
@@ -48,7 +51,7 @@ const Contribution = ({
         <div
           className="title"
           dangerouslySetInnerHTML={{
-            __html: text.replace('You ', `${userHandle} `),
+            __html: parsedText,
           }}
         />
         <div className="extra">

--- a/test/system/flows/user_views_contributions_test.rb
+++ b/test/system/flows/user_views_contributions_test.rb
@@ -22,7 +22,7 @@ module Flows
         visit contributions_profile_url(user.handle)
       end
 
-      assert_text "author created PR#12 on ruby: Fix bugs"
+      assert_text "Created PR#12 on ruby: Fix bugs"
     end
 
     test "shows maintaining contributions for a user" do
@@ -42,7 +42,7 @@ module Flows
         visit contributions_profile_url(user.handle)
       end
 
-      assert_text "maintainer merged PR#12 on ruby: Fix bugs"
+      assert_text "Merged PR#12 on ruby: Fix bugs"
     end
 
     test "shows authorship contributions for a user" do


### PR DESCRIPTION
TODO:
- [ ] Revert the change (its needed in the dropdown)
- [ ] Remove "You" on profile ones (instead of subbing)
- [ ] Remove the "Created" on the profile ones too.