### PR TITLE
Fix custom font rendering in editor (again)

### DIFF
--- a/app/javascript/components/editor/FileEditor.tsx
+++ b/app/javascript/components/editor/FileEditor.tsx
@@ -118,13 +118,11 @@ export function FileEditor({
 
     editor.setModel(filesRef.current[0].model)
 
-    editorDidMount({ getFiles, setFiles, openPalette })
+    // Fix a custom code font rendering bug
+    // See https://github.com/exercism/website/issues/742#issuecomment-816806513
+    document.fonts.ready.then(() => monacoEditor.editor.remeasureFonts())
 
-    setTimeout(() => {
-      // This fixes a Windows-only issue with the custom code font resulting in the cursor rendering being off
-      // See https://github.com/exercism/website/issues/742#issuecomment-816806513
-      monacoEditor.editor.remeasureFonts()
-    }, 0)
+    editorDidMount({ getFiles, setFiles, openPalette })
   }
 
   const handleEditorWillMount = () => {

--- a/app/javascript/declarations.d.ts
+++ b/app/javascript/declarations.d.ts
@@ -47,3 +47,11 @@ declare module '*.jpg'
 declare module '*.png'
 declare module '*.svg'
 declare module '*.gif'
+
+interface Fonts {
+  ready: Promise<void>
+}
+
+interface Document {
+  fonts: Fonts
+}


### PR DESCRIPTION
This tries to fix the font rendering bug (again). This time, I've taken a different approach: waiting for the font loading to be done. There is a CSS font loading API that we can use, as suggested in this issue: https://github.com/microsoft/monaco-editor/issues/392#issuecomment-383284917 This API is not supported in all browsers, but it looks like it is supported in all the browsers we care about: https://caniuse.com/font-loading

This fix works for me on my machine, but that was also the case with the previous one :shrug:
