### PR TITLE
Add statues to mentoring

### DIFF
--- a/app/commands/mentor/discussion/create.rb
+++ b/app/commands/mentor/discussion/create.rb
@@ -23,7 +23,7 @@ module Mentor
           discussion = Mentor::Discussion.create!(
             mentor: mentor,
             request: request,
-            requires_student_action_since: Time.current
+            awaiting_student_since: Time.current
           )
 
           discussion_post = Mentor::DiscussionPost.create!(

--- a/app/commands/mentor/discussion/reply_by_mentor.rb
+++ b/app/commands/mentor/discussion/reply_by_mentor.rb
@@ -14,7 +14,7 @@ module Mentor
           seen_by_mentor: true
         )
 
-        discussion.student_action_required!
+        discussion.awaiting_student!
 
         User::Notification::Create.(
           iteration.solution.user,

--- a/app/commands/mentor/discussion/reply_by_student.rb
+++ b/app/commands/mentor/discussion/reply_by_student.rb
@@ -14,7 +14,7 @@ module Mentor
           seen_by_student: true
         )
 
-        discussion.mentor_action_required!
+        discussion.awaiting_mentor!
 
         User::Notification::Create.(
           discussion.mentor,

--- a/app/commands/mentor/discussion/retrieve.rb
+++ b/app/commands/mentor/discussion/retrieve.rb
@@ -9,7 +9,7 @@ module Mentor
         REQUESTS_PER_PAGE
       end
 
-      def initialize(user,
+      def initialize(mentor,
                      status,
                      page: nil,
                      criteria: nil, order: nil,
@@ -18,7 +18,7 @@ module Mentor
 
         # TODO: Guard valid status
 
-        @user = user
+        @mentor = mentor
         @status = status.to_sym
         @page = page || 1
         @track_slug = track_slug
@@ -41,7 +41,7 @@ module Mentor
       end
 
       private
-      attr_reader :user, :status, :page, :track_slug, :criteria, :order
+      attr_reader :mentor, :status, :page, :track_slug, :criteria, :order
 
       %i[sorted paginated].each do |attr|
         define_method("#{attr}?") { instance_variable_get("@#{attr}") }
@@ -51,17 +51,17 @@ module Mentor
         @discussions = Mentor::Discussion.
           joins(solution: :exercise).
           includes(solution: [:user, { exercise: :track }]).
-          where(mentor: user)
+          where(mentor: mentor)
       end
 
       def filter_status!
         case status
-        when :requires_mentor_action
-          @discussions = @discussions.requires_mentor_action
-        when :requires_student_action
-          @discussions = @discussions.requires_student_action
+        when :awaiting_mentor
+          @discussions = @discussions.awaiting_mentor
+        when :awaiting_student
+          @discussions = @discussions.awaiting_student
         when :finished
-          @discussions = @discussions.finished
+          @discussions = @discussions.finished_for_mentor
         end
       end
 
@@ -81,7 +81,7 @@ module Mentor
         when "exercise"
           @discussions = @discussions.order("exercises.title")
         else
-          @discussions = @discussions.order(requires_mentor_action_since: :asc)
+          @discussions = @discussions.order(awaiting_mentor_since: :asc)
         end
       end
 

--- a/app/controllers/api/mentoring/discussions_controller.rb
+++ b/app/controllers/api/mentoring/discussions_controller.rb
@@ -19,9 +19,9 @@ module API
         discussions,
         serializer: SerializeMentorDiscussions,
         meta: {
-          requires_mentor_action_total: all_discussions.requires_mentor_action.count,
-          requires_student_action_total: all_discussions.requires_student_action.count,
-          finished_total: all_discussions.finished.count
+          awaiting_mentor_total: all_discussions.awaiting_mentor.count,
+          awaiting_student_total: all_discussions.awaiting_student.count,
+          finished_total: all_discussions.finished_for_mentor.count
         }
       )
     end
@@ -72,7 +72,7 @@ module API
       render json: {
         discussion: {
           id: discussion.uuid,
-          is_finished: discussion.finished?,
+          is_finished: discussion.finished_for_mentor?,
           links: {
             posts: Exercism::Routes.api_mentoring_discussion_posts_url(discussion),
             mark_as_nothing_to_do: Exercism::Routes.mark_as_nothing_to_do_api_mentoring_discussion_url(discussion),
@@ -89,7 +89,7 @@ module API
       return render_403(:mentor_discussion_not_accessible) unless discussion.viewable_by?(current_user)
       return render_403(:mentor_discussion_not_accessible) unless current_user == discussion.mentor
 
-      discussion.student_action_required!
+      discussion.awaiting_student!
 
       render json: {}
     end

--- a/app/controllers/api/mentoring/discussions_controller.rb
+++ b/app/controllers/api/mentoring/discussions_controller.rb
@@ -98,7 +98,7 @@ module API
     # The JSON response below is what I expect for the React component.
     def finish
       discussion = current_user.mentor_discussions.find_by(uuid: params[:id])
-      discussion.update!(finished_at: Time.current)
+      discussion.mentor_finished!
       relationship = Mentor::StudentRelationship.find_or_create_by!(mentor: discussion.mentor, student: discussion.student)
 
       render json: {

--- a/app/helpers/react_components/mentoring/inbox.rb
+++ b/app/helpers/react_components/mentoring/inbox.rb
@@ -19,7 +19,7 @@ module ReactComponents
       ].freeze
       private_constant :SORT_OPTIONS
 
-      DEFAULT_STATUS = "requires_mentor_action".freeze
+      DEFAULT_STATUS = "awaiting_mentor".freeze
       private_constant :DEFAULT_STATUS
 
       private

--- a/app/helpers/react_components/student/solution_summary.rb
+++ b/app/helpers/react_components/student/solution_summary.rb
@@ -50,11 +50,14 @@ module ReactComponents
           request_mentoring: Exercism::Routes.new_track_exercise_mentor_request_path(solution.track, solution.exercise),
           pending_mentor_request: Exercism::Routes.track_exercise_mentor_request_path(solution.track, solution.exercise)
         }.tap do |links|
-          in_progress_discussion = solution.mentor_discussions.in_progress.first
+          in_progress_discussion = solution.mentor_discussions.in_progress_for_student.first
           if in_progress_discussion
             links[:in_progress_discussion] =
-              Exercism::Routes.track_exercise_mentor_discussion_path(solution.track, solution.exercise,
-                in_progress_discussion)
+              Exercism::Routes.track_exercise_mentor_discussion_path(
+                solution.track,
+                solution.exercise,
+                in_progress_discussion
+              )
           end
         end
       end
@@ -71,7 +74,7 @@ module ReactComponents
               avatar_url: discussion.student.avatar_url,
               handle: discussion.student.handle
             },
-            is_finished: discussion.finished?,
+            is_finished: discussion.finished_for_student?,
             is_unread: discussion.posts.where(seen_by_student: false).exists?,
             posts_count: discussion.posts.count,
             created_at: discussion.created_at.iso8601,

--- a/app/helpers/view_components/mentor/header.rb
+++ b/app/helpers/view_components/mentor/header.rb
@@ -93,7 +93,7 @@ module ViewComponents
       def inbox_size
         ::Mentor::Discussion.joins(solution: :exercise).
           where(mentor: current_user).
-          requires_mentor_action.
+          awaiting_mentor.
           count
       end
 

--- a/app/javascript/components/mentoring/Inbox.jsx
+++ b/app/javascript/components/mentoring/Inbox.jsx
@@ -38,26 +38,24 @@ export function Inbox({ tracksRequest, sortOptions, ...props }) {
     <div className="c-mentor-inbox">
       <div className="tabs">
         <StatusTab
-          status="requires_mentor_action"
+          status="awaiting_mentor"
           currentStatus={request.query.status}
           setStatus={setStatus}
         >
           Inbox
           {resolvedData ? (
-            <div className="count">
-              {resolvedData.meta.requiresMentorActionTotal}
-            </div>
+            <div className="count">{resolvedData.meta.awaitingMentorTotal}</div>
           ) : null}
         </StatusTab>
         <StatusTab
-          status="requires_student_action"
+          status="awaiting_student"
           currentStatus={request.query.status}
           setStatus={setStatus}
         >
           Awaiting student
           {resolvedData ? (
             <div className="count">
-              {resolvedData.meta.requiresStudentActionTotal}
+              {resolvedData.meta.awaitingStudentTotal}
             </div>
           ) : null}
         </StatusTab>

--- a/app/javascript/components/student/solution-summary/Nudge.tsx
+++ b/app/javascript/components/student/solution-summary/Nudge.tsx
@@ -324,7 +324,8 @@ const InProgressMentoringNudge = ({
           You&apos;re being mentored by
           <strong>{discussion.mentor.handle}</strong>
         </h3>
-        {/* TODO: Add who's turn it is to respond tag */}
+        {/* TODO: Add discussion.status to serializer */}
+        {/* TOOD: If status is awating_student show a tag here for "Your turn to respond"*/}
         <div className="comments">
           <GraphicalIcon icon="comment" />
           {discussion.postsCount} {pluralize('comments', discussion.postsCount)}

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -80,8 +80,8 @@ export type SolutionMentoringStatus =
   | 'finished'
 
 export type DiscussionStatus =
-  | 'requires_mentor_action'
-  | 'requires_student_action'
+  | 'awaiting_mentor'
+  | 'awaiting_student'
   | 'finished'
 
 export type CommunitySolution = {

--- a/app/models/mentor/discussion.rb
+++ b/app/models/mentor/discussion.rb
@@ -79,6 +79,15 @@ class Mentor::Discussion < ApplicationRecord
     [mentor, student].include?(user)
   end
 
+  def mentor_finished!
+    update_columns(
+      status: :mentor_finished,
+      mentor_finished_at: Time.current,
+      awaiting_mentor_since: nil,
+      awaiting_student_since: awaiting_student_since || Time.current
+    )
+  end
+
   def awaiting_student!
     update_columns(
       status: :awaiting_student,

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -110,8 +110,9 @@ class Solution < ApplicationRecord
     mentor_requests.pending.locked.exists?
   end
 
+  memoize
   def in_progress_mentor_discussion
-    mentor_discussions.in_progress.first
+    mentor_discussions.in_progress_for_student.first
   end
 
   def update_status!
@@ -205,9 +206,9 @@ class Solution < ApplicationRecord
   end
 
   def determine_mentoring_status
-    return :in_progress if mentor_discussions.in_progress.exists?
+    return :in_progress if mentor_discussions.in_progress_for_student.exists?
     return :requested if mentor_requests.pending.exists?
-    return :finished if mentor_discussions.finished.exists?
+    return :finished if mentor_discussions.finished_for_student.exists?
 
     :none
   end

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -58,7 +58,7 @@ class UserTrack < ApplicationRecord
 
   memoize
   def active_mentoring_discussions
-    Mentor::Discussion.where(solution: solutions).in_progress
+    Mentor::Discussion.where(solution: solutions).in_progress_for_student
   end
 
   memoize

--- a/app/serializers/serialize_mentor_session_discussion.rb
+++ b/app/serializers/serialize_mentor_session_discussion.rb
@@ -8,7 +8,7 @@ class SerializeMentorSessionDiscussion
 
     {
       id: discussion.uuid,
-      is_finished: discussion.finished?,
+      is_finished: finished?,
       links: links
     }
   end
@@ -16,12 +16,20 @@ class SerializeMentorSessionDiscussion
   private
   delegate :mentor, to: :discussion
 
+  def finished?
+    if user == mentor
+      discussion.finished_for_mentor?
+    else
+      discussion.finished_for_student?
+    end
+  end
+
   def links
     if user == mentor
       {
         posts: Exercism::Routes.api_mentoring_discussion_posts_url(discussion)
       }.tap do |links|
-        links[:finish] = Exercism::Routes.finish_api_mentoring_discussion_path(discussion) unless discussion.finished?
+        links[:finish] = Exercism::Routes.finish_api_mentoring_discussion_path(discussion) unless finished?
 
         links[:mark_as_nothing_to_do] = Exercism::Routes.mark_as_nothing_to_do_api_mentoring_discussion_path(discussion)
       end

--- a/app/views/tracks/show/joined/_mentoring_article.html.haml
+++ b/app/views/tracks/show/joined/_mentoring_article.html.haml
@@ -45,8 +45,8 @@
             = avatar(discussion.mentor)
             .name= discussion.mentor.name
 
-          -# -if discussion.requires_student_action
-          .turn Your turn to respond
+          - if discussion.awaiting_student
+            .turn Your turn to respond
 
           .comments
             = graphical_icon :comment

--- a/db/migrate/20210420155220_add_status_to_mentor_discussions.rb
+++ b/db/migrate/20210420155220_add_status_to_mentor_discussions.rb
@@ -1,0 +1,7 @@
+class AddStatusToMentorDiscussions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :mentor_discussions, :status, :tinyint, null: false, default: 0
+    add_column :mentor_discussions, :mentor_finished_at, :datetime, null: true
+    rename_column :mentor_discussions, :finished_at, :student_finished_at
+  end
+end

--- a/db/migrate/20210420162905_rename_mentor_discussion_fields.rb
+++ b/db/migrate/20210420162905_rename_mentor_discussion_fields.rb
@@ -1,0 +1,6 @@
+class RenameMentorDiscussionFields < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :mentor_discussions, :requires_student_action_since, :awaiting_student_since
+    rename_column :mentor_discussions, :requires_mentor_action_since, :awaiting_mentor_since
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_111409) do
+ActiveRecord::Schema.define(version: 2021_04_20_162905) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
@@ -214,11 +214,13 @@ ActiveRecord::Schema.define(version: 2021_03_24_111409) do
     t.bigint "solution_id", null: false
     t.bigint "mentor_id", null: false
     t.bigint "request_id"
-    t.datetime "requires_mentor_action_since"
-    t.datetime "requires_student_action_since"
-    t.datetime "finished_at"
+    t.datetime "awaiting_mentor_since"
+    t.datetime "awaiting_student_since"
+    t.datetime "student_finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", limit: 1, default: 0, null: false
+    t.datetime "mentor_finished_at"
     t.index ["mentor_id"], name: "index_mentor_discussions_on_mentor_id"
     t.index ["request_id"], name: "index_mentor_discussions_on_request_id"
     t.index ["solution_id"], name: "index_mentor_discussions_on_solution_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -138,7 +138,7 @@ ruby.practice_exercises.limit(10).each do |exercise|
   req = Mentor::Request.create!(solution: solution, comment_markdown: "Could you please look at my code?")
   discussion = Mentor::Discussion.create!(
     request: req, solution: solution, mentor: iHiD,
-    requires_mentor_action_since: Time.current
+    awaiting_mentor_since: Time.current
   )
   p "Discussion: #{discussion.uuid}"
 

--- a/test/commands/mentor/discussion/create_test.rb
+++ b/test/commands/mentor/discussion/create_test.rb
@@ -18,8 +18,8 @@ class Mentor::Discussion::CreateTest < ActiveSupport::TestCase
       assert_equal mentor, discussion.mentor
       assert_equal request, discussion.request
       assert_equal request.solution, discussion.solution
-      assert_equal Time.current, discussion.requires_student_action_since
-      assert_nil discussion.requires_mentor_action_since
+      assert_equal Time.current, discussion.awaiting_student_since
+      assert_nil discussion.awaiting_mentor_since
 
       assert_equal 1, discussion.posts.count
       assert_equal content_markdown, discussion.posts.first.content_markdown

--- a/test/commands/mentor/discussion/reply_by_mentor_test.rb
+++ b/test/commands/mentor/discussion/reply_by_mentor_test.rb
@@ -21,8 +21,8 @@ class Mentor::Discussion::ReplyByMentorTest < ActiveSupport::TestCase
       assert discussion_post.seen_by_mentor?
       refute discussion_post.seen_by_student?
 
-      assert_nil discussion.requires_mentor_action_since
-      assert_equal Time.current, discussion.requires_student_action_since
+      assert_nil discussion.awaiting_mentor_since
+      assert_equal Time.current, discussion.awaiting_student_since
     end
   end
 

--- a/test/commands/mentor/discussion/reply_by_student_test.rb
+++ b/test/commands/mentor/discussion/reply_by_student_test.rb
@@ -20,8 +20,8 @@ class Mentor::Discussion::ReplyByStudentTest < ActiveSupport::TestCase
       assert discussion_post.seen_by_student?
       refute discussion_post.seen_by_mentor?
 
-      assert_equal Time.current, discussion.requires_mentor_action_since
-      assert_nil discussion.requires_student_action_since
+      assert_equal Time.current, discussion.awaiting_mentor_since
+      assert_nil discussion.awaiting_student_since
     end
   end
 

--- a/test/commands/mentor/discussion/retrieve_test.rb
+++ b/test/commands/mentor/discussion/retrieve_test.rb
@@ -4,38 +4,40 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
   test "only retrieves user's solutions" do
     user = create :user
 
-    valid = create :mentor_discussion, :requires_mentor_action, mentor: user
-    create :mentor_discussion, :requires_mentor_action
+    valid = create :mentor_discussion, :awaiting_mentor, mentor: user
+    create :mentor_discussion, :awaiting_mentor
 
-    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :requires_mentor_action, page: 1)
+    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, page: 1)
   end
 
-  test "status: requires_mentor_action" do
+  test "status: awaiting_mentor" do
     user = create :user
 
-    valid = create :mentor_discussion, :requires_mentor_action, mentor: user
+    valid = create :mentor_discussion, :awaiting_mentor, mentor: user
     create :mentor_discussion, mentor: user
 
-    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :requires_mentor_action, page: 1)
+    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, page: 1)
   end
 
-  test "status: requires_student_action" do
+  test "status: awaiting_student" do
     user = create :user
 
-    valid = create :mentor_discussion, :requires_student_action, mentor: user
+    valid = create :mentor_discussion, :awaiting_student, mentor: user
     create :mentor_discussion, mentor: user
 
-    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :requires_student_action, page: 1)
+    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :awaiting_student, page: 1)
   end
 
   test "status: finished" do
     user = create :user
 
-    valid = create :mentor_discussion, :finished, mentor: user
-    create :mentor_discussion, :requires_mentor_action, mentor: user
-    create :mentor_discussion, :requires_student_action, mentor: user
+    valid_1 = create :mentor_discussion, :mentor_finished, mentor: user
+    valid_2 = create :mentor_discussion, :student_finished, mentor: user
+    valid_3 = create :mentor_discussion, :both_finished, mentor: user
+    create :mentor_discussion, :awaiting_mentor, mentor: user
+    create :mentor_discussion, :awaiting_student, mentor: user
 
-    assert_equal [valid], Mentor::Discussion::Retrieve.(user, :finished, page: 1)
+    assert_equal [valid_1, valid_2, valid_3], Mentor::Discussion::Retrieve.(user, :finished, page: 1)
   end
 
   test "only retrieves relevant tracks" do
@@ -44,32 +46,32 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
     js = create :track, slug: :js
     elixir = create :track, slug: :elixir
 
-    create :mentor_discussion, :requires_mentor_action, track: ruby, mentor: user
-    create :mentor_discussion, :requires_mentor_action, track: elixir, mentor: user
-    create :mentor_discussion, :requires_mentor_action, track: js
+    create :mentor_discussion, :awaiting_mentor, track: ruby, mentor: user
+    create :mentor_discussion, :awaiting_mentor, track: elixir, mentor: user
+    create :mentor_discussion, :awaiting_mentor, track: js
 
-    assert_equal [ruby, elixir], Mentor::Discussion::Retrieve.(user, :requires_mentor_action).map(&:track)
-    assert_equal [ruby, elixir], Mentor::Discussion::Retrieve.(user, :requires_mentor_action, track_slug: '').map(&:track)
-    assert_equal [ruby], Mentor::Discussion::Retrieve.(user, :requires_mentor_action, track_slug: 'ruby').map(&:track)
+    assert_equal [ruby, elixir], Mentor::Discussion::Retrieve.(user, :awaiting_mentor).map(&:track)
+    assert_equal [ruby, elixir], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, track_slug: '').map(&:track)
+    assert_equal [ruby], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, track_slug: 'ruby').map(&:track)
   end
 
-  test "orders by requires_mentor_action_since" do
+  test "orders by awaiting_mentor_since" do
     user = create :user
 
-    second = create :mentor_discussion, requires_mentor_action_since: Time.current - 2.minutes, mentor: user
-    first = create :mentor_discussion, requires_mentor_action_since: Time.current - 3.minutes, mentor: user
-    third = create :mentor_discussion, requires_mentor_action_since: Time.current - 1.minute, mentor: user
+    second = create :mentor_discussion, awaiting_mentor_since: Time.current - 2.minutes, mentor: user
+    first = create :mentor_discussion, awaiting_mentor_since: Time.current - 3.minutes, mentor: user
+    third = create :mentor_discussion, awaiting_mentor_since: Time.current - 1.minute, mentor: user
 
-    assert_equal [first, second, third], Mentor::Discussion::Retrieve.(user, :requires_mentor_action)
-    assert_equal [second, first, third], Mentor::Discussion::Retrieve.(user, :requires_mentor_action, sorted: false)
+    assert_equal [first, second, third], Mentor::Discussion::Retrieve.(user, :awaiting_mentor)
+    assert_equal [second, first, third], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, sorted: false)
   end
 
   test "pagination works" do
     user = create :user
 
-    25.times { create :mentor_discussion, :requires_mentor_action, mentor: user }
+    25.times { create :mentor_discussion, :awaiting_mentor, mentor: user }
 
-    requests = Mentor::Discussion::Retrieve.(user, :requires_mentor_action, page: 2)
+    requests = Mentor::Discussion::Retrieve.(user, :awaiting_mentor, page: 2)
     assert_equal 2, requests.current_page
     assert_equal 3, requests.total_pages
     assert_equal 10, requests.limit_value
@@ -84,7 +86,7 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
 
     create :mentor_request, solution: solution
 
-    requests = Mentor::Discussion::Retrieve.(user, :requires_mentor_action, paginated: false)
+    requests = Mentor::Discussion::Retrieve.(user, :awaiting_mentor, paginated: false)
     assert requests.is_a?(ActiveRecord::Relation)
     refute_respond_to requests, :current_page
   end

--- a/test/commands/mentor/discussion/retrieve_test.rb
+++ b/test/commands/mentor/discussion/retrieve_test.rb
@@ -23,7 +23,7 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
     user = create :user
 
     valid = create :mentor_discussion, :awaiting_student, mentor: user
-    create :mentor_discussion, mentor: user
+    create :mentor_discussion, :awaiting_mentor, mentor: user
 
     assert_equal [valid], Mentor::Discussion::Retrieve.(user, :awaiting_student, page: 1)
   end
@@ -32,12 +32,12 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
     user = create :user
 
     valid_1 = create :mentor_discussion, :mentor_finished, mentor: user
-    valid_2 = create :mentor_discussion, :student_finished, mentor: user
-    valid_3 = create :mentor_discussion, :both_finished, mentor: user
+    valid_2 = create :mentor_discussion, :both_finished, mentor: user
+    create :mentor_discussion, :student_finished, mentor: user
     create :mentor_discussion, :awaiting_mentor, mentor: user
     create :mentor_discussion, :awaiting_student, mentor: user
 
-    assert_equal [valid_1, valid_2, valid_3], Mentor::Discussion::Retrieve.(user, :finished, page: 1)
+    assert_equal [valid_1, valid_2], Mentor::Discussion::Retrieve.(user, :finished, page: 1)
   end
 
   test "only retrieves relevant tracks" do
@@ -58,9 +58,9 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
   test "orders by awaiting_mentor_since" do
     user = create :user
 
-    second = create :mentor_discussion, awaiting_mentor_since: Time.current - 2.minutes, mentor: user
-    first = create :mentor_discussion, awaiting_mentor_since: Time.current - 3.minutes, mentor: user
-    third = create :mentor_discussion, awaiting_mentor_since: Time.current - 1.minute, mentor: user
+    second = create :mentor_discussion, :awaiting_mentor, awaiting_mentor_since: Time.current - 2.minutes, mentor: user
+    first = create :mentor_discussion, :awaiting_mentor, awaiting_mentor_since: Time.current - 3.minutes, mentor: user
+    third = create :mentor_discussion, :awaiting_mentor, awaiting_mentor_since: Time.current - 1.minute, mentor: user
 
     assert_equal [first, second, third], Mentor::Discussion::Retrieve.(user, :awaiting_mentor)
     assert_equal [second, first, third], Mentor::Discussion::Retrieve.(user, :awaiting_mentor, sorted: false)

--- a/test/controllers/api/mentoring/discussions_controller_test.rb
+++ b/test/controllers/api/mentoring/discussions_controller_test.rb
@@ -13,9 +13,9 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
     user = create :user
     setup_user(user)
 
-    discussion = create :mentor_discussion, :requires_mentor_action, mentor: user
+    discussion = create :mentor_discussion, :awaiting_mentor, mentor: user
 
-    get api_mentoring_discussions_path(status: :requires_mentor_action),
+    get api_mentoring_discussions_path(status: :awaiting_mentor),
       headers: @headers, as: :json
     assert_response 200
 
@@ -36,14 +36,14 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
 
     series = create :concept_exercise, title: "Series", track: ruby
     series_solution = create :concept_solution, exercise: series
-    create :mentor_discussion, :requires_mentor_action, solution: series_solution, mentor: @current_user
+    create :mentor_discussion, :awaiting_mentor, solution: series_solution, mentor: @current_user
 
     tournament = create :concept_exercise, title: "Tournament", track: go
     tournament_solution = create :concept_solution, exercise: tournament
-    create :mentor_discussion, :requires_mentor_action, solution: tournament_solution, mentor: @current_user
-    create :mentor_discussion, :requires_mentor_action, solution: tournament_solution, mentor: @current_user
+    create :mentor_discussion, :awaiting_mentor, solution: tournament_solution, mentor: @current_user
+    create :mentor_discussion, :awaiting_mentor, solution: tournament_solution, mentor: @current_user
 
-    get tracks_api_mentoring_discussions_path(per: 1, status: :requires_mentor_action), headers: @headers, as: :json
+    get tracks_api_mentoring_discussions_path(per: 1, status: :awaiting_mentor), headers: @headers, as: :json
     assert_response 200
 
     expected = [
@@ -172,6 +172,6 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
 
     assert_response 200
     discussion.reload
-    refute discussion.requires_mentor_action?
+    refute discussion.awaiting_mentor?
   end
 end

--- a/test/factories/mentor/discussions.rb
+++ b/test/factories/mentor/discussions.rb
@@ -10,16 +10,30 @@ FactoryBot.define do
       end
     end
 
-    trait :requires_mentor_action do
-      requires_mentor_action_since { Time.current }
+    trait :awaiting_student do
+      status { :awaiting_student }
+      awaiting_student_since { Time.current }
     end
 
-    trait :requires_student_action do
-      requires_student_action_since { Time.current }
+    trait :awaiting_mentor do
+      status { :awaiting_mentor }
+      awaiting_mentor_since { Time.current }
     end
 
-    trait :finished do
-      finished_at { Time.current }
+    trait :mentor_finished do
+      status { :mentor_finished }
+      mentor_finished_at { Time.current }
+    end
+
+    trait :student_finished do
+      status { :student_finished }
+      student_finished_at { Time.current }
+    end
+
+    trait :both_finished do
+      status { :both_finished }
+      student_finished_at { Time.current }
+      mentor_finished_at { Time.current }
     end
   end
 end

--- a/test/factories/mentor/requests.rb
+++ b/test/factories/mentor/requests.rb
@@ -3,6 +3,18 @@ FactoryBot.define do
     solution { create :practice_solution }
     comment_markdown { "I could do with some help here" }
 
+    trait :pending do
+      status { :pending }
+    end
+
+    trait :fulfilled do
+      status { :fulfilled }
+    end
+
+    trait :cancelled do
+      status { :cancelled }
+    end
+
     trait :locked do
       locked_until { Time.current + 30.minutes }
       locked_by { create :user }

--- a/test/flows/mentor_action_required_test.rb
+++ b/test/flows/mentor_action_required_test.rb
@@ -12,27 +12,27 @@ class MentorActionRequiredTest < ActiveSupport::TestCase
 
     discussion = Mentor::Discussion::Create.(mentor, request, iteration.idx, "I'd love to help")
     discussion.reload
-    assert_nil discussion.requires_mentor_action_since
-    assert discussion.requires_student_action_since
+    assert_nil discussion.awaiting_mentor_since
+    assert discussion.awaiting_student_since
 
     Mentor::Discussion::ReplyByMentor.(discussion, iteration, "Oh btw...")
     discussion.reload
-    assert_nil discussion.requires_mentor_action_since
-    assert discussion.requires_student_action_since
+    assert_nil discussion.awaiting_mentor_since
+    assert discussion.awaiting_student_since
 
     Mentor::Discussion::ReplyByStudent.(discussion, iteration, "Great. That's helpful.")
     discussion.reload
-    assert discussion.requires_mentor_action_since
-    assert_nil discussion.requires_student_action_since
+    assert discussion.awaiting_mentor_since
+    assert_nil discussion.awaiting_student_since
 
     Mentor::Discussion::ReplyByMentor.(discussion, iteration, "No probs. How about ...")
     discussion.reload
-    assert_nil discussion.requires_mentor_action_since
-    assert discussion.requires_student_action_since
+    assert_nil discussion.awaiting_mentor_since
+    assert discussion.awaiting_student_since
 
     Mentor::Discussion::ReplyByStudent.(discussion, iteration, "Sure, I'll try that now.")
-    discussion.student_action_required!
-    assert_nil discussion.requires_mentor_action_since
-    assert discussion.requires_student_action_since
+    discussion.awaiting_student!
+    assert_nil discussion.awaiting_mentor_since
+    assert discussion.awaiting_student_since
   end
 end

--- a/test/helpers/react_components/mentoring/inbox_test.rb
+++ b/test/helpers/react_components/mentoring/inbox_test.rb
@@ -9,11 +9,11 @@ class MentoringInboxTest < ReactComponentTestCase
       {
         discussions_request: {
           endpoint: Exercism::Routes.api_mentoring_discussions_path,
-          query: { status: "requires_mentor_action" }
+          query: { status: "awaiting_mentor" }
         },
         tracks_request: {
           endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
-          query: { status: "requires_mentor_action" }
+          query: { status: "awaiting_mentor" }
         },
         sort_options: [
           { value: 'recent', label: 'Sort by Most Recent' },

--- a/test/models/mentor/discussion_test.rb
+++ b/test/models/mentor/discussion_test.rb
@@ -73,6 +73,38 @@ class Mentor::DiscussionTest < ActiveSupport::TestCase
     assert discussion.finished?
   end
 
+  test "mentor_finished!" do
+    freeze_time do
+      discussion = create :mentor_discussion,
+        awaiting_mentor_since: Time.current,
+        awaiting_student_since: nil,
+        status: :awaiting_mentor
+
+      discussion.mentor_finished!
+
+      assert :mentor_finished, discussion.status
+      assert_nil discussion.awaiting_mentor_since
+      assert_equal Time.current, discussion.mentor_finished_at
+      assert_equal Time.current, discussion.awaiting_student_since
+    end
+  end
+
+  test "mentor_finished! doesn't modernise existing time" do
+    freeze_time do
+      original = Time.current - 2.weeks
+
+      discussion = create :mentor_discussion,
+        awaiting_mentor_since: Time.current - 1.week,
+        awaiting_student_since: original,
+        status: :awaiting_mentor
+
+      discussion.mentor_finished!
+
+      assert_nil discussion.awaiting_mentor_since
+      assert_equal original, discussion.awaiting_student_since
+    end
+  end
+
   test "awaiting_student!" do
     freeze_time do
       discussion = create :mentor_discussion,
@@ -88,7 +120,7 @@ class Mentor::DiscussionTest < ActiveSupport::TestCase
     end
   end
 
-  test "awaiting_student doesn't modernise existing time" do
+  test "awaiting_student! doesn't modernise existing time" do
     freeze_time do
       original = Time.current - 2.weeks
 

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -212,12 +212,12 @@ class SolutionTest < ActiveSupport::TestCase
     assert_nil solution.reload.in_progress_mentor_discussion
 
     # In progress discussion
-    discussion = create :mentor_discussion, solution: solution, finished_at: nil
-    assert_equal discussion, solution.reload.in_progress_mentor_discussion
+    discussion = create :mentor_discussion, solution: solution
+    assert_equal discussion, Solution.find(solution.id).in_progress_mentor_discussion
 
     # Finished discussion
-    discussion.update!(finished_at: Time.current)
-    assert_nil solution.reload.in_progress_mentor_discussion
+    discussion.update!(status: :student_finished)
+    assert_nil Solution.find(solution.id).in_progress_mentor_discussion
   end
 
   test "has_pending_mentoring_requests" do
@@ -266,7 +266,19 @@ class SolutionTest < ActiveSupport::TestCase
     request.fulfilled!
     assert_equal :in_progress, solution.mentoring_status
 
-    discussion.update(finished_at: Time.current)
+    discussion.update(status: :awaiting_student)
+    assert_equal :in_progress, solution.mentoring_status
+
+    discussion.update(status: :awaiting_mentor)
+    assert_equal :in_progress, solution.mentoring_status
+
+    discussion.update(status: :mentor_finished)
+    assert_equal :in_progress, solution.mentoring_status
+
+    discussion.update(status: :student_finished)
+    assert_equal :finished, solution.mentoring_status
+
+    discussion.update(status: :both_finished)
     assert_equal :finished, solution.mentoring_status
 
     discussion.destroy

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -380,4 +380,27 @@ class UserTrackTest < ActiveSupport::TestCase
     create :mentor_started_discussion_notification, status: :unread, user: user, params: { discussion: discussion }
     assert UserTrack.find(ut_id).has_notifications?
   end
+
+  test "active_mentoring_discussions" do
+    ut = create :user_track
+    assert_empty ut.active_mentoring_discussions
+
+    disc_1 = create :mentor_discussion, :awaiting_mentor, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    disc_2 = create :mentor_discussion, :awaiting_student,
+      solution: create(:concept_solution, track: ut.track, user: ut.user)
+    disc_3 = create :mentor_discussion, :mentor_finished, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    create :mentor_discussion, :student_finished, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    create :mentor_discussion, :both_finished, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    assert_equal [disc_1, disc_2, disc_3], UserTrack.find(ut.id).active_mentoring_discussions
+  end
+
+  test "pending_mentoring_requests" do
+    ut = create :user_track
+    assert_empty ut.pending_mentoring_requests
+
+    req = create :mentor_request, :pending, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    create :mentor_request, :fulfilled, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    create :mentor_request, :cancelled, solution: create(:concept_solution, track: ut.track, user: ut.user)
+    assert_equal [req], UserTrack.find(ut.id).pending_mentoring_requests
+  end
 end

--- a/test/serializers/serialize_mentor_discussions_test.rb
+++ b/test/serializers/serialize_mentor_discussions_test.rb
@@ -8,11 +8,11 @@ class SerializeMentorDiscussionsTest < ActiveSupport::TestCase
     exercise = create :concept_exercise, track: track
     solution = create :concept_solution, exercise: exercise, user: student
     discussion = create :mentor_discussion,
-      :requires_mentor_action,
+      :awaiting_mentor,
       solution: solution,
       mentor: mentor
 
-    discussions = Mentor::Discussion::Retrieve.(mentor, :requires_mentor_action, page: 1)
+    discussions = Mentor::Discussion::Retrieve.(mentor, :awaiting_mentor, page: 1)
 
     expected = [
       {

--- a/test/system/components/mentoring/discussion_test.rb
+++ b/test/system/components/mentoring/discussion_test.rb
@@ -359,7 +359,7 @@ module Components
         discussion = create :mentor_discussion,
           solution: solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
         create :iteration, solution: solution
         create :scratchpad_page, content_markdown: "# Some notes", author: mentor, about: exercise
 
@@ -380,7 +380,7 @@ module Components
         discussion = create :mentor_discussion,
           solution: solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
         create :iteration, solution: solution
 
         use_capybara_host do
@@ -401,7 +401,7 @@ module Components
         discussion = create :mentor_discussion,
           solution: solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
         create :iteration, solution: solution
         create :scratchpad_page, content_markdown: "# Some notes", author: mentor, about: exercise
 

--- a/test/system/components/mentoring/inbox_test.rb
+++ b/test/system/components/mentoring/inbox_test.rb
@@ -15,7 +15,7 @@ module Components
         discussion = create :mentor_discussion,
           solution: solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago,
+          awaiting_mentor_since: 1.day.ago,
           created_at: 1.year.ago
 
         use_capybara_host do
@@ -41,13 +41,13 @@ module Components
         create :mentor_discussion,
           solution: series_solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
         tournament = create :concept_exercise, title: "Tournament"
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
           solution: tournament_solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
 
         use_capybara_host do
           sign_in!(mentor)
@@ -72,11 +72,11 @@ module Components
 
         series = create :concept_exercise, title: "Series", track: ruby
         series_solution = create :concept_solution, exercise: series
-        create :mentor_discussion, :requires_mentor_action, solution: series_solution, mentor: mentor
+        create :mentor_discussion, :awaiting_mentor, solution: series_solution, mentor: mentor
 
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
-        create :mentor_discussion, :requires_mentor_action, solution: tournament_solution, mentor: mentor
+        create :mentor_discussion, :awaiting_mentor, solution: tournament_solution, mentor: mentor
 
         use_capybara_host do
           sign_in!(mentor)
@@ -98,13 +98,13 @@ module Components
         create :mentor_discussion,
           solution: series_solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
           solution: tournament_solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
 
         use_capybara_host do
           sign_in!(mentor)
@@ -125,13 +125,13 @@ module Components
         create :mentor_discussion,
           solution: series_solution,
           mentor: mentor,
-          requires_mentor_action_since: 2.days.ago
+          awaiting_mentor_since: 2.days.ago
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
           solution: tournament_solution,
           mentor: mentor,
-          requires_mentor_action_since: 1.day.ago
+          awaiting_mentor_since: 1.day.ago
 
         use_capybara_host do
           sign_in!(mentor)
@@ -152,14 +152,14 @@ module Components
         create :mentor_discussion,
           solution: series_solution,
           mentor: mentor,
-          requires_mentor_action_since: 2.days.ago
+          awaiting_mentor_since: 2.days.ago
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
           solution: tournament_solution,
           mentor: mentor,
-          requires_mentor_action_since: nil,
-          requires_student_action_since: 1.day.ago
+          awaiting_mentor_since: nil,
+          awaiting_student_since: 1.day.ago
 
         use_capybara_host do
           sign_in!(mentor)

--- a/test/system/components/mentoring/inbox_test.rb
+++ b/test/system/components/mentoring/inbox_test.rb
@@ -13,9 +13,9 @@ module Components
         series = create :concept_exercise, title: "Series", track: ruby
         solution = create :concept_solution, exercise: series, user: student
         discussion = create :mentor_discussion,
+          :awaiting_mentor,
           solution: solution,
           mentor: mentor,
-          awaiting_mentor_since: 1.day.ago,
           created_at: 1.year.ago
 
         use_capybara_host do
@@ -39,15 +39,15 @@ module Components
         series = create :concept_exercise, title: "Series"
         series_solution = create :concept_solution, exercise: series
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: series_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 1.day.ago
+          mentor: mentor
         tournament = create :concept_exercise, title: "Tournament"
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: tournament_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 1.day.ago
+          mentor: mentor
 
         use_capybara_host do
           sign_in!(mentor)
@@ -96,15 +96,15 @@ module Components
         series = create :concept_exercise, title: "Series", track: ruby
         series_solution = create :concept_solution, exercise: series
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: series_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 1.day.ago
+          mentor: mentor
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: tournament_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 1.day.ago
+          mentor: mentor
 
         use_capybara_host do
           sign_in!(mentor)
@@ -123,15 +123,15 @@ module Components
         series = create :concept_exercise, title: "Series", track: ruby
         series_solution = create :concept_solution, exercise: series
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: series_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 2.days.ago
+          mentor: mentor
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: tournament_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 1.day.ago
+          mentor: mentor
 
         use_capybara_host do
           sign_in!(mentor)
@@ -150,16 +150,15 @@ module Components
         series = create :concept_exercise, title: "Series", track: ruby
         series_solution = create :concept_solution, exercise: series
         create :mentor_discussion,
+          :awaiting_mentor,
           solution: series_solution,
-          mentor: mentor,
-          awaiting_mentor_since: 2.days.ago
+          mentor: mentor
         tournament = create :concept_exercise, title: "Tournament", track: go
         tournament_solution = create :concept_solution, exercise: tournament
         create :mentor_discussion,
+          :awaiting_student,
           solution: tournament_solution,
-          mentor: mentor,
-          awaiting_mentor_since: nil,
-          awaiting_student_since: 1.day.ago
+          mentor: mentor
 
         use_capybara_host do
           sign_in!(mentor)

--- a/test/system/components/student/solution_summary/nudge_test.rb
+++ b/test/system/components/student/solution_summary/nudge_test.rb
@@ -46,7 +46,7 @@ module Components::Student
         submission = create :submission, solution: solution, tests_status: :failed
         create :iteration, idx: 1, solution: solution, submission: submission
         request = create :mentor_request, solution: solution, status: :fulfilled
-        discussion = create :mentor_discussion, solution: solution, mentor: mentor, request: request, finished_at: nil
+        discussion = create :mentor_discussion, solution: solution, mentor: mentor, request: request
         solution.update_mentoring_status!
 
         use_capybara_host do

--- a/test/system/flows/finish_mentor_discussion_test.rb
+++ b/test/system/flows/finish_mentor_discussion_test.rb
@@ -29,7 +29,7 @@ module Flows
       student = create :user, handle: "student-123"
       exercise = create :concept_exercise
       solution = create :concept_solution, exercise: exercise, user: student
-      discussion = create :mentor_discussion, solution: solution, mentor: mentor, finished_at: 1.day.ago
+      discussion = create :mentor_discussion, :mentor_finished, solution: solution, mentor: mentor
       create :iteration, solution: solution
       create :mentor_student_relationship, mentor: mentor, student: student
 
@@ -50,7 +50,7 @@ module Flows
       student = create :user, handle: "student-123"
       exercise = create :concept_exercise
       solution = create :concept_solution, exercise: exercise, user: student
-      discussion = create :mentor_discussion, solution: solution, mentor: mentor, finished_at: 1.day.ago
+      discussion = create :mentor_discussion, :mentor_finished, solution: solution, mentor: mentor
       create :iteration, solution: solution
       create :mentor_student_relationship, mentor: mentor, student: student
 


### PR DESCRIPTION
Both mentors and students can consider a discussion finished while the other still consider it in progress. (For example if a mentor has ended the discussion but the student hasn't yet reviewed them). We therefore need to monitor both of these differently. I've added a state-machine enum that handles this, and some helper methods for us to use publically.

(cc @kntsoriano and @ErikSchierboom as this is important to understand although no action is required)