### PR TITLE
Update concept map to use only concepts for node/edge generation

### DIFF
--- a/app/commands/track/determine_concept_map_layout.rb
+++ b/app/commands/track/determine_concept_map_layout.rb
@@ -26,15 +26,13 @@ class Track
 
     memoize
     def concepts
-      concepts = graph.nodes.flat_map do |exercise|
-        exercise.taught_concepts.map do |concept|
-          {
-            slug: concept.slug,
-            name: concept.name,
-            web_url: Exercism::Routes.track_concept_url(track, concept),
-            tooltip_url: Exercism::Routes.tooltip_track_concept_url(track, concept)
-          }
-        end
+      concepts = graph.nodes.flat_map do |concept|
+        {
+          slug: concept.slug,
+          name: concept.name,
+          web_url: Exercism::Routes.track_concept_url(track.slug, concept.slug),
+          tooltip_url: Exercism::Routes.tooltip_track_concept_url(track.slug, concept.slug)
+        }
       end
 
       concepts.sort_by { |concept| concept[:slug] }
@@ -42,47 +40,34 @@ class Track
 
     memoize
     def concept_levels
-      exercise_levels.map { |level| level.flat_map(&:taught_concepts).map(&:slug) }
+      node_levels.map { |level| level.map(&:slug) }
     end
 
     memoize
     def concept_connections
-      exercise_connections.flat_map do |connection|
-        from_concepts = connection[:from].taught_concepts
-        to_concepts = connection[:to].taught_concepts
-
-        from_concepts.product(to_concepts).map do |(from, to)|
-          { from: from.slug, to: to.slug }
+      node_levels.drop(1).flat_map.with_index do |level, level_idx|
+        level.flat_map do |node|
+          node.prerequisites.
+            map { |prerequisite| graph.node_for_concept(prerequisite.slug) }.
+            compact.
+            select { |prerequisite_node| prerequisite_node.level == level_idx }.
+            map { |prerequisite_node| { from: prerequisite_node.slug, to: node.slug } }
         end
       end
     end
 
     memoize
-    def exercise_levels
+    def node_levels
       return [] if graph.empty?
 
       raise TrackHasCyclicPrerequisiteError if graph.has_cycle?
 
-      Array.new(graph.exercise_levels.max + 1) { [] }.tap do |level|
-        graph.exercise_levels.each.with_index do |level_idx, node_idx|
+      Array.new(graph.concept_levels.max + 1) { [] }.tap do |level|
+        graph.concept_levels.each.with_index do |level_idx, node_idx|
           node = graph.node_for_index(node_idx)
           node.level = level_idx
 
           level[level_idx] << node
-        end
-      end
-    end
-
-    memoize
-    def exercise_connections
-      exercise_levels.drop(1).each.with_index.flat_map do |level, level_idx|
-        level.flat_map do |node|
-          node.prerequisites.
-            map { |prerequisite| graph.node_for_concept(prerequisite) }.
-            compact.
-            uniq.
-            select { |prerequisite_node| prerequisite_node.level == level_idx }.
-            map { |prerequisite_node| { from: prerequisite_node, to: node } }
         end
       end
     end
@@ -96,7 +81,7 @@ class Track
       Edge = Struct.new(:from, :to, keyword_init: true)
 
       # Node for representing an exercise within a track
-      Node = Struct.new(:index, :slug, :taught_concepts, :prerequisites, :level, keyword_init: true)
+      Node = Struct.new(:index, :slug, :name, :prerequisites, :level, keyword_init: true)
 
       def initialize(track)
         @track = track
@@ -123,7 +108,7 @@ class Track
       end
 
       memoize
-      def exercise_levels
+      def concept_levels
         GraphUtils.calculate_levels(adjacencies)
       end
 
@@ -143,20 +128,27 @@ class Track
       end
 
       def determine_nodes
-        track.concept_exercises.includes(:taught_concepts, :prerequisites).map.with_index do |exercise, idx|
-          Node.new(
-            index: idx,
-            slug: exercise.slug,
-            taught_concepts: exercise.taught_concepts.to_a,
-            prerequisites: exercise.prerequisites.to_a
-          )
-        end.freeze
+        nodes = track.concept_exercises.includes(:taught_concepts, :prerequisites).flat_map do |exercise|
+          exercise.taught_concepts.map do |concept|
+            Node.new(
+              index: nil,
+              slug: concept.slug,
+              name: concept.name,
+              prerequisites: exercise.prerequisites.to_a
+            )
+          end
+        end
+
+        nodes.map.with_index do |node, index|
+          node.index = index
+          node
+        end
       end
 
       def determine_edges
         nodes.flat_map do |node|
           node.prerequisites.map do |prereq|
-            prereq_node = node_for_concept(prereq)
+            prereq_node = node_for_concept(prereq.slug)
             prereq_node ? Edge.new(from: prereq_node, to: node) : nil
           end
         end.compact.freeze
@@ -164,9 +156,7 @@ class Track
 
       memoize
       def nodes_keyed_by_concept
-        nodes.flat_map do |node|
-          node.taught_concepts.map { |concept| [concept, node] }
-        end.to_h.freeze
+        nodes.index_by(&:slug).freeze
       end
 
       memoize

--- a/app/commands/track/determine_concept_map_layout.rb
+++ b/app/commands/track/determine_concept_map_layout.rb
@@ -48,7 +48,7 @@ class Track
       node_levels.drop(1).flat_map.with_index do |level, level_idx|
         level.flat_map do |node|
           node.prerequisites.
-            map { |prerequisite| graph.node_for_concept(prerequisite.slug) }.
+            map { |prerequisite| graph.node_for_concept(prerequisite) }.
             compact.
             select { |prerequisite_node| prerequisite_node.level == level_idx }.
             map { |prerequisite_node| { from: prerequisite_node.slug, to: node.slug } }
@@ -134,7 +134,7 @@ class Track
               index: nil,
               slug: concept.slug,
               name: concept.name,
-              prerequisites: exercise.prerequisites.to_a
+              prerequisites: exercise.prerequisites.pluck(:slug)
             )
           end
         end
@@ -148,7 +148,7 @@ class Track
       def determine_edges
         nodes.flat_map do |node|
           node.prerequisites.map do |prereq|
-            prereq_node = node_for_concept(prereq.slug)
+            prereq_node = node_for_concept(prereq)
             prereq_node ? Edge.new(from: prereq_node, to: node) : nil
           end
         end.compact.freeze

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.index ["type"], name: "index_badges_on_type", unique: true
   end
 
+  create_table "bug_reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "content_markdown", null: false
+    t.text "content_html", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_bug_reports_on_user_id"
+  end
+
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -118,11 +127,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.string "slug", null: false
     t.string "title", null: false
     t.string "blurb", limit: 350
-    t.integer "difficulty", limit: 1, default: 1, null: false
-    t.integer "status", limit: 1, default: 0, null: false
     t.string "git_sha", null: false
     t.string "synced_to_git_sha", null: false
     t.integer "position", null: false
+    t.boolean "deprecated", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["track_id", "uuid"], name: "index_exercises_on_track_id_and_uuid", unique: true
@@ -207,13 +215,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.bigint "mentor_id", null: false
     t.bigint "request_id"
     t.integer "status", limit: 1, default: 0, null: false
-    t.integer "rating", limit: 1
-    t.integer "num_posts", limit: 3, default: 0, null: false
-    t.boolean "anonymous_mode", default: false, null: false
     t.datetime "awaiting_student_since"
     t.datetime "awaiting_mentor_since"
-    t.datetime "finished_at"
-    t.integer "finished_by", limit: 1
+    t.datetime "mentor_finished_at"
+    t.datetime "student_finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["mentor_id"], name: "index_mentor_discussions_on_mentor_id"
@@ -232,30 +237,22 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
   create_table "mentor_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "solution_id", null: false
-    t.bigint "track_id", null: false
-    t.bigint "exercise_id", null: false
-    t.bigint "student_id", null: false
     t.integer "status", limit: 1, default: 0, null: false
     t.text "comment_markdown", null: false
     t.text "comment_html", null: false
+    t.bigint "locked_by_id"
+    t.datetime "locked_until"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["exercise_id", "status"], name: "index_mentor_requests_on_exercise_id_and_status"
-    t.index ["exercise_id"], name: "index_mentor_requests_on_exercise_id"
+    t.index ["locked_by_id"], name: "index_mentor_requests_on_locked_by_id"
     t.index ["solution_id"], name: "index_mentor_requests_on_solution_id"
-    t.index ["status", "exercise_id"], name: "index_mentor_requests_on_status_and_exercise_id"
-    t.index ["status", "track_id"], name: "index_mentor_requests_on_status_and_track_id"
-    t.index ["student_id"], name: "index_mentor_requests_on_student_id"
-    t.index ["track_id", "status"], name: "index_mentor_requests_on_track_id_and_status"
-    t.index ["track_id"], name: "index_mentor_requests_on_track_id"
   end
 
   create_table "mentor_student_relationships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "mentor_id", null: false
     t.bigint "student_id", null: false
     t.boolean "favorited", default: false, null: false
-    t.boolean "blocked_by_mentor", default: false, null: false
-    t.boolean "blocked_by_student", default: false, null: false
+    t.boolean "blocked", default: false, null: false
     t.integer "num_discussions", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -279,23 +276,6 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.index ["mentor_id"], name: "index_mentor_testimonials_on_mentor_id"
     t.index ["student_id"], name: "index_mentor_testimonials_on_student_id"
     t.index ["uuid"], name: "index_mentor_testimonials_on_uuid"
-  end
-
-  create_table "problem_reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "track_id"
-    t.bigint "exercise_id"
-    t.string "about_type"
-    t.bigint "about_id"
-    t.integer "type", limit: 1, default: 0, null: false
-    t.text "content_markdown", null: false
-    t.text "content_html", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["about_type", "about_id"], name: "index_problem_reports_on_about"
-    t.index ["exercise_id"], name: "index_problem_reports_on_exercise_id"
-    t.index ["track_id"], name: "index_problem_reports_on_track_id"
-    t.index ["user_id"], name: "index_problem_reports_on_user_id"
   end
 
   create_table "scratchpad_pages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -391,7 +371,6 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["solution_id"], name: "index_submissions_on_solution_id"
-    t.index ["uuid"], name: "index_submissions_on_uuid", unique: true
   end
 
   create_table "track_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -590,6 +569,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bug_reports", "users"
   add_foreign_key "documents", "tracks"
   add_foreign_key "exercise_authorships", "exercises"
   add_foreign_key "exercise_authorships", "users"
@@ -617,14 +597,12 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
   add_foreign_key "mentor_discussions", "users", column: "mentor_id"
   add_foreign_key "mentor_request_locks", "mentor_requests", column: "request_id"
   add_foreign_key "mentor_requests", "solutions"
+  add_foreign_key "mentor_requests", "users", column: "locked_by_id"
   add_foreign_key "mentor_student_relationships", "users", column: "mentor_id"
   add_foreign_key "mentor_student_relationships", "users", column: "student_id"
   add_foreign_key "mentor_testimonials", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_testimonials", "users", column: "mentor_id"
   add_foreign_key "mentor_testimonials", "users", column: "student_id"
-  add_foreign_key "problem_reports", "exercises"
-  add_foreign_key "problem_reports", "tracks"
-  add_foreign_key "problem_reports", "users"
   add_foreign_key "scratchpad_pages", "users"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "users"


### PR DESCRIPTION
A while ago the concept map connected concept exercises to concept
exercises. Then a shift was made to display individual concepts rather
than exercises. This is effectively created a subgraph (supergraph?),
but when exploding the exercise into individual taugh concepts, edges
were still being created with the exercise as the frame of reference,
potentially creating extra edges when a concept exercise taught multiple
concepts. This commit simplifies this logic to create nodes/edges using
only concepts. Determine concept map layout tests still pass.