### PR TITLE
Do not use JSON columns

### DIFF
--- a/app/models/concerns/is_paramaterised_sti.rb
+++ b/app/models/concerns/is_paramaterised_sti.rb
@@ -63,6 +63,9 @@ module IsParamaterisedSTI
   extend Mandate::Memoize
 
   included do
+    serialize :params, JSON
+    serialize :rendering_data_cache, JSON
+
     cattr_accessor :class_suffix, :i18n_category
 
     belongs_to :user

--- a/app/models/exercise/representation.rb
+++ b/app/models/exercise/representation.rb
@@ -1,4 +1,5 @@
 class Exercise::Representation < ApplicationRecord
+  serialize :mapping, JSON
   has_markdown_field :feedback
 
   belongs_to :exercise

--- a/app/models/github/pull_request.rb
+++ b/app/models/github/pull_request.rb
@@ -1,6 +1,8 @@
 class Github::PullRequest < ApplicationRecord
   extend Mandate::Memoize
 
+  serialize :data, JSON
+
   has_many :reviews,
     dependent: :destroy,
     inverse_of: :pull_request,

--- a/app/models/submission/analysis.rb
+++ b/app/models/submission/analysis.rb
@@ -1,6 +1,8 @@
 class Submission::Analysis < ApplicationRecord
   extend Mandate::Memoize
 
+  serialize :data, JSON
+
   belongs_to :submission
 
   scope :ops_successful, -> { where(ops_status: 200) }

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -1,6 +1,8 @@
 class Submission::TestRun < ApplicationRecord
   extend Mandate::Memoize
 
+  serialize :raw_results, JSON
+
   belongs_to :submission
 
   scope :ops_successful, -> { where(ops_status: 200) }

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -2,6 +2,8 @@ class UserTrack < ApplicationRecord
   extend Mandate::Memoize
   include UserTrack::MentoringSlots
 
+  serialize :summary_data, JSON
+
   belongs_to :user
   belongs_to :track
   has_many :user_track_learnt_concepts, class_name: "UserTrack::LearntConcept", dependent: :destroy

--- a/db/migrate/20210504224212_change_json_to_text.rb
+++ b/db/migrate/20210504224212_change_json_to_text.rb
@@ -1,0 +1,23 @@
+class ChangeJsonToText < ActiveRecord::Migration[6.1]
+  def up
+    %w{
+      exercise_representations mapping
+      github_pull_requests data
+      submission_analyses data
+      submission_test_runs raw_results
+      user_activities params
+      user_activities rendering_data_cache
+      user_notifications params
+      user_notifications rendering_data_cache
+      user_reputation_tokens params
+      user_reputation_tokens rendering_data_cache
+      user_tracks summary_data
+
+    }.each_slice(2) do |table, column|
+      change_column table, column, :text
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_174645) do
+ActiveRecord::Schema.define(version: 2021_05_04_224212) do
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.bigint "source_submission_id", null: false
     t.text "ast", null: false
     t.string "ast_digest", null: false
-    t.json "mapping"
+    t.text "mapping"
     t.integer "feedback_type", limit: 1
     t.text "feedback_markdown"
     t.text "feedback_html"
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.string "author_username"
     t.string "merged_by_username"
     t.string "title"
-    t.json "data", null: false
+    t.text "data", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["node_id"], name: "index_github_pull_requests_on_node_id", unique: true
@@ -337,7 +337,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
   create_table "submission_analyses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
     t.integer "ops_status", limit: 2, null: false
-    t.json "data"
+    t.text "data"
     t.string "tooling_job_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -371,7 +371,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.string "status", null: false
     t.text "message"
     t.integer "ops_status", limit: 2, null: false
-    t.json "raw_results", null: false
+    t.text "raw_results", null: false
     t.integer "version", limit: 1, default: 0, null: false
     t.text "output"
     t.datetime "created_at", precision: 6, null: false
@@ -441,11 +441,11 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.bigint "track_id"
     t.bigint "exercise_id"
     t.bigint "solution_id"
-    t.json "params", null: false
+    t.text "params", null: false
     t.datetime "occurred_at", null: false
     t.string "uniqueness_key", null: false
     t.integer "version", null: false
-    t.json "rendering_data_cache", null: false
+    t.text "rendering_data_cache", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exercise_id"], name: "index_user_activities_on_exercise_id"
@@ -474,10 +474,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.string "path", null: false
     t.string "type", null: false
     t.integer "version", null: false
-    t.json "params", null: false
+    t.text "params", null: false
     t.integer "email_status", limit: 1, default: 0, null: false
     t.string "uniqueness_key", null: false
-    t.json "rendering_data_cache", null: false
+    t.text "rendering_data_cache", null: false
     t.datetime "read_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -510,10 +510,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
     t.integer "value", null: false
     t.string "reason", null: false
     t.string "category", null: false
-    t.json "params", null: false
+    t.text "params", null: false
     t.string "level"
     t.integer "version", null: false
-    t.json "rendering_data_cache", null: false
+    t.text "rendering_data_cache", null: false
     t.string "external_url"
     t.boolean "seen", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -547,7 +547,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_174645) do
   create_table "user_tracks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "track_id", null: false
-    t.json "summary_data", null: false
+    t.text "summary_data", null: false
     t.string "summary_key"
     t.boolean "anonymous_during_mentoring", default: false, null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
It became apparent during ETL that using JSON columns is extremely inefficient. As we're not actually using MySQL's JSON functionality in most places (and I have no plans to), we're losing performance for no gain.

In the one place where we do use MySQL JSON functionality, I've left it in, and I've left one other where we might use it too.