### PR TITLE
Add hydrated and hide removed explainers

### DIFF
--- a/app/css/components/introducer.css
+++ b/app/css/components/introducer.css
@@ -3,6 +3,10 @@
 .c-react-wrapper-common-introducer {
     min-height: 130px;
     @apply mt-8 mb-40;
+
+    &.--hydrated:empty {
+        display: none;
+    }
 }
 
 .c-introducer {

--- a/app/javascript/packs/react-bootloader.jsx
+++ b/app/javascript/packs/react-bootloader.jsx
@@ -25,6 +25,7 @@ const renderComponents = (mappings) => {
     document.querySelectorAll(selector).forEach((elem) => {
       const data = JSON.parse(elem.dataset.reactData)
       render(elem, generator(data, elem))
+      elem.classList.add('--hydrated')
     })
   }
 }

--- a/app/javascript/packs/react-bootloader.jsx
+++ b/app/javascript/packs/react-bootloader.jsx
@@ -11,6 +11,7 @@ export const initReact = (mappings) => {
 
 const render = (elem, component) => {
   ReactDOM.render(<React.StrictMode>{component}</React.StrictMode>, elem)
+  elem.classList.add('--hydrated')
 
   const unloadOnce = () => {
     ReactDOM.unmountComponentAtNode(elem)
@@ -25,7 +26,6 @@ const renderComponents = (mappings) => {
     document.querySelectorAll(selector).forEach((elem) => {
       const data = JSON.parse(elem.dataset.reactData)
       render(elem, generator(data, elem))
-      elem.classList.add('--hydrated')
     })
   }
 }


### PR DESCRIPTION
This:
- Adds a `--hydrated` class to all React components once they are hydrated
- For the introducer, hides the (outer) react component once it's (inner) introducer has been removed.