### PR TITLE
Split concepts and their exercises so both are clickable

### DIFF
--- a/app/commands/user_track/generate_exercise_status_mapping.rb
+++ b/app/commands/user_track/generate_exercise_status_mapping.rb
@@ -41,6 +41,7 @@ class UserTrack
         # in local testing).
         exercise_slugs.map do |slug|
           {
+            url: Exercism::Routes.track_exercise_path(track.slug, slug),
             status: (user_track.external? ? "available" : user_track.exercise_status(slug)),
             type: user_track.exercise_type(slug)
           }

--- a/app/css/components/track/concept-map.css
+++ b/app/css/components/track/concept-map.css
@@ -30,7 +30,7 @@
             @apply flex justify-evenly items-center flex-wrap;
 
             & .card {
-                @apply rounded-8 py-16 px-24;
+                @apply rounded-8;
                 @apply box-border pointer-events-auto;
                 @apply relative;
                 @apply flex flex-col justify-between m-40;
@@ -96,6 +96,7 @@
 
                 & .display {
                     @apply flex items-center justify-center;
+                    @apply py-16 px-24;
 
                     & .name {
                         @apply text-18 font-semibold leading-150;
@@ -107,13 +108,17 @@
                         width: 16px;
                         height: 16px;
                     }
+
+                    &:hover {
+                        @apply bg-backgroundColorE;
+                    }
                 }
             }
 
             & .exercise-status-bar {
+                @apply py-10 px-24;
                 @apply flex justify-center align-middle;
-                @apply mt-16 pt-10 border-t-1 border-borderColor7;
-                margin-bottom: -6px;
+                @apply border-t-1 border-borderColor7;
 
                 & .c-ed {
                     @apply m-6;

--- a/app/javascript/components/concept-map/Concept.tsx
+++ b/app/javascript/components/concept-map/Concept.tsx
@@ -68,26 +68,28 @@ export const Concept = ({
 
   return (
     <div role="presentation">
-      <a
+      <div
         ref={conceptRef}
-        href={webUrl}
         id={conceptSlugToId(slug)}
         className={classes.join(' ')}
         data-concept-slug={slug}
         data-concept-status={status}
-        onFocus={() => setHasFocus(true)}
-        onBlur={() => setHasFocus(false)}
-        onMouseEnter={wrapAnimationFrame(handleEnter)}
-        onMouseLeave={wrapAnimationFrame(handleLeave)}
       >
-        <div className="display">
+        <a
+          className="display"
+          href={webUrl}
+          onMouseEnter={wrapAnimationFrame(handleEnter)}
+          onMouseLeave={wrapAnimationFrame(handleLeave)}
+          onFocus={() => setHasFocus(true)}
+          onBlur={() => setHasFocus(false)}
+        >
           <ConceptIcon name={name} size="medium" />
           <span className="name" aria-label={getAriaLabel(status)}>
             {name}
           </span>
-        </div>
+        </a>
         {!isLocked && <PureExerciseStatusBar exercisesData={exercisesData} />}
-      </a>
+      </div>
       <ConceptTooltip
         contentEndpoint={tooltipUrl}
         hoverRequestToShow={isActiveHover}

--- a/app/javascript/components/concept-map/ExerciseStatusBar.tsx
+++ b/app/javascript/components/concept-map/ExerciseStatusBar.tsx
@@ -21,9 +21,10 @@ export const PureExerciseStatusBar = React.memo(ExerciseStatusBar)
 
 const statusMapper = (data: ExerciseData, key: number): JSX.Element => {
   return (
-    <div
+    <a
+      href={data.url}
       key={key}
-      className={`c-ed --${data.status} --${data.type} disabled`}
+      className={`c-ed --${data.status} --${data.type}`}
     />
   )
 }

--- a/app/javascript/components/concept-map/concept-map-types.ts
+++ b/app/javascript/components/concept-map/concept-map-types.ts
@@ -64,6 +64,8 @@ export interface IConceptMap {
 export type ConceptLayer = string[]
 
 export type ExerciseData = {
+  url: string
+  tooltipUrl: string
   status: ExerciseStatus[]
   type: string
 }


### PR DESCRIPTION
We want to allow both concepts and their exercises to be hoverable and clickable, and both have tooltips. It's quite hard to get a feel for how this works without making it, so this is a spike to test it. Here's a loom I made for @taiyab that demonstrates it: https://www.loom.com/share/278bc7d80e3b4f83bd9731bf87b11fdc