### PR TITLE
Add a11y tab support to CodeMirror

### DIFF
--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -120,7 +120,7 @@ export function Editor({
     Keybindings.DEFAULT
   )
   const [wrap, setWrap] = useState<WrapSetting>('on')
-  const [tabBehavior, setTabBehavior] = useState<TabBehavior>('default')
+  const [tabBehavior, setTabBehavior] = useState<TabBehavior>('captured')
   const isMountedRef = useIsMounted()
   const [
     { submission, status: submissionStatus, apiError: submissionApiError },

--- a/app/javascript/components/editor/header/Settings.tsx
+++ b/app/javascript/components/editor/header/Settings.tsx
@@ -19,9 +19,9 @@ const WRAP = [
   { label: 'Off', value: 'off' },
 ]
 
-const TAB_ENABLED = [
-  { label: 'On', value: 'captured' },
-  { label: 'Off', value: 'default' },
+const TAB_MODE = [
+  { label: 'Editor', value: 'captured' },
+  { label: 'Accesibility', value: 'default' },
 ]
 
 const Setting = React.forwardRef<
@@ -175,9 +175,9 @@ export function Settings({
               {...itemAttributes(2)}
             />
             <Setting
-              title="Tab enabled"
+              title="Tab mode"
               value={tabBehavior}
-              options={TAB_ENABLED}
+              options={TAB_MODE}
               set={(tabBehavior) => setTabBehavior(tabBehavior as TabBehavior)}
               {...itemAttributes(3)}
             />

--- a/app/javascript/components/editor/types.ts
+++ b/app/javascript/components/editor/types.ts
@@ -68,7 +68,7 @@ export enum Themes {
   DARK = 'material-ocean',
 }
 
-export type TabBehavior = 'default' | 'captured'
+export type TabBehavior = 'captured' | 'default'
 
 export type Assignment = {
   overview: string

--- a/app/javascript/components/misc/CodeMirror.tsx
+++ b/app/javascript/components/misc/CodeMirror.tsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { EditorView, keymap, KeyBinding } from '@codemirror/view'
 import { basicSetup } from '@codemirror/basic-setup'
-import { defaultTabBinding } from '@codemirror/commands'
 import { EditorState, Compartment } from '@codemirror/state'
+import { showPanel } from '@codemirror/panel'
 import { indentUnit } from '@codemirror/language'
 import { Themes } from '../editor/types'
 import { languageCompartment } from './CodeMirror/languageCompartment'
+import {
+  a11yTabBinding,
+  a11yTabBindingPanel,
+  a11yTabBindingPanelTheme,
+} from './CodeMirror/a11yTabBinding'
 
 const wrapCompartment = new Compartment()
 const themeCompartment = new Compartment()
@@ -15,7 +20,6 @@ export type Handler = {
   setValue: (value: string) => void
   getValue: () => string
 }
-
 export const CodeMirror = ({
   hidden,
   value,
@@ -76,10 +80,11 @@ export const CodeMirror = ({
         doc: value,
         extensions: [
           basicSetup,
+          showPanel.of(a11yTabBindingPanel),
+          a11yTabBindingPanelTheme,
           languageCompartment(language),
-          //javascript(),
           tabCaptureCompartment.of(
-            keymap.of(isTabCaptured ? [defaultTabBinding] : [])
+            keymap.of(isTabCaptured ? [a11yTabBinding] : [])
           ),
           EditorState.tabSize.of(tabSize),
           indentUnit.of(useSoftTabs ? '  ' : '	'),
@@ -127,7 +132,7 @@ export const CodeMirror = ({
 
     viewRef.current.dispatch({
       effects: tabCaptureCompartment.reconfigure(
-        keymap.of(isTabCaptured ? [defaultTabBinding] : [])
+        keymap.of(isTabCaptured ? [a11yTabBinding] : [])
       ),
     })
   }, [isTabCaptured])

--- a/app/javascript/components/misc/CodeMirror.tsx
+++ b/app/javascript/components/misc/CodeMirror.tsx
@@ -2,15 +2,11 @@ import React, { useState, useEffect, useRef } from 'react'
 import { EditorView, keymap, KeyBinding } from '@codemirror/view'
 import { basicSetup } from '@codemirror/basic-setup'
 import { EditorState, Compartment } from '@codemirror/state'
-import { showPanel } from '@codemirror/panel'
 import { indentUnit } from '@codemirror/language'
 import { Themes } from '../editor/types'
 import { languageCompartment } from './CodeMirror/languageCompartment'
-import {
-  a11yTabBinding,
-  a11yTabBindingPanel,
-  a11yTabBindingPanelTheme,
-} from './CodeMirror/a11yTabBinding'
+import { a11yTabBindingPanel } from './CodeMirror/a11yTabBinding'
+import { defaultTabBinding } from '@codemirror/commands'
 
 const wrapCompartment = new Compartment()
 const themeCompartment = new Compartment()
@@ -80,12 +76,11 @@ export const CodeMirror = ({
         doc: value,
         extensions: [
           basicSetup,
-          showPanel.of(a11yTabBindingPanel),
-          a11yTabBindingPanelTheme,
-          languageCompartment(language),
+          a11yTabBindingPanel(),
           tabCaptureCompartment.of(
-            keymap.of(isTabCaptured ? [a11yTabBinding] : [])
+            keymap.of(isTabCaptured ? [defaultTabBinding] : [])
           ),
+          languageCompartment(language),
           EditorState.tabSize.of(tabSize),
           indentUnit.of(useSoftTabs ? '  ' : '	'),
           wrapCompartment.of(wrap ? EditorView.lineWrapping : []),
@@ -132,7 +127,7 @@ export const CodeMirror = ({
 
     viewRef.current.dispatch({
       effects: tabCaptureCompartment.reconfigure(
-        keymap.of(isTabCaptured ? [a11yTabBinding] : [])
+        keymap.of(isTabCaptured ? [defaultTabBinding] : [])
       ),
     })
   }, [isTabCaptured])

--- a/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
+++ b/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
@@ -1,0 +1,55 @@
+import { Text } from '@codemirror/text'
+import { EditorView, KeyBinding } from '@codemirror/view'
+import { Panel } from '@codemirror/panel'
+import { insertTab, indentSelection } from '@codemirror/commands'
+import { StateCommand } from '@codemirror/state'
+
+export const a11yTabBindingPanelTheme = EditorView.baseTheme({
+  '.cm-a11y-panel': {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: '0',
+  },
+})
+
+export function a11yTabBindingPanel(view: EditorView): Panel {
+  let dom = document.createElement('div')
+  dom.textContent = ''
+  console.log(dom)
+  // @ts-ignore */
+  dom.ariaLive = 'assertive'
+  dom.className = 'cm-a11y-panel'
+
+  return {
+    top: true,
+    dom,
+    update(update) {
+      if (!update.docChanged) {
+        return
+      }
+      // @ts-ignore */
+      if (update.changes.inserted.some((insert) => insert.text == '\t')) {
+        dom.textContent = 'Press ESC then Tab to exit the editor'
+        setTimeout(() => {
+          dom.textContent = ''
+        }, 5000)
+      }
+    },
+  }
+}
+
+export const customInsertTab: StateCommand = ({ state, dispatch }) => {
+  return insertTab({ state, dispatch })
+}
+
+export const a11yTabBinding: KeyBinding = {
+  key: 'Tab',
+  run: customInsertTab,
+  shift: indentSelection,
+}

--- a/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
+++ b/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
@@ -1,9 +1,15 @@
-import { Text } from '@codemirror/text'
-import { EditorView, KeyBinding } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 import { Panel } from '@codemirror/panel'
-import { insertTab, indentSelection } from '@codemirror/commands'
-import { StateCommand } from '@codemirror/state'
+import { StateField } from '@codemirror/state'
+import { showPanel } from '@codemirror/panel'
 
+// See the note on this near the bottom of the file
+// import { insertTab, indentSelection } from '@codemirror/commands'
+// import { KeyBinding } from '@codemirror/view'
+// import { StateCommand } from '@codemirror/state'
+
+// This is taken from Tailwind's `sr-only` class.
+// It hides the panel from view on visual devices
 export const a11yTabBindingPanelTheme = EditorView.baseTheme({
   '.cm-a11y-panel': {
     position: 'absolute',
@@ -18,38 +24,97 @@ export const a11yTabBindingPanelTheme = EditorView.baseTheme({
   },
 })
 
-export function a11yTabBindingPanel(view: EditorView): Panel {
+// The typing for this seems to be wrong in CodeMirror.
+// Changes doesn't have `inserted` defined on it
+function tabPressed(changes: any): boolean {
+  // @ts-ignore */
+  return changes.inserted.some((insert) => insert.text == '\t')
+}
+
+// This changes the desired value every time tab is pressed.
+// This is useful for ensuring that screen-readers don't just
+// think the text is the same as it previously was and ignore it.
+const text1 = 'Press Escape then Tab to exit the editor'
+const text2 = 'To exit the editor, press Escape then tab'
+const a11yTabBindingState = StateField.define<string>({
+  create: () => text1,
+  update(value, tr) {
+    if (tabPressed(tr.changes)) {
+      if (value == text1) {
+        value = text2
+      } else {
+        value = text1
+      }
+    }
+    return value
+  },
+})
+
+// This creates a CodeMirror Panel, adds its classes and sets it
+// to be an assertive ariaLive area. It is assertive as it only
+// changes in direct response to a user pressing the tab key.
+function createA11yTabBindingPanel(view: EditorView): Panel {
   let dom = document.createElement('div')
   dom.textContent = ''
-  console.log(dom)
+  dom.className = 'cm-a11y-panel'
+
   // @ts-ignore */
   dom.ariaLive = 'assertive'
-  dom.className = 'cm-a11y-panel'
+  // @ts-ignore */
+  dom.ariaAtomic = 'true'
 
   return {
     top: true,
     dom,
     update(update) {
-      if (!update.docChanged) {
+      // Only announce things if the user has pressed a tab
+      if (!update.docChanged || !tabPressed(update.changes)) {
         return
       }
-      // @ts-ignore */
-      if (update.changes.inserted.some((insert) => insert.text == '\t')) {
-        dom.textContent = 'Press ESC then Tab to exit the editor'
-        setTimeout(() => {
-          dom.textContent = ''
-        }, 5000)
+
+      // Only announce things if the aria-live area has been reset
+      if (dom.textContent != '') {
+        return
       }
+
+      // Set the text content, which announces via the aria-live functionality.
+      dom.textContent = view.state.field(a11yTabBindingState)
+
+      // Reset the text content five seconds later.
+      setTimeout(() => {
+        dom.textContent = ''
+      }, 5000)
     },
   }
 }
 
-export const customInsertTab: StateCommand = ({ state, dispatch }) => {
-  return insertTab({ state, dispatch })
-}
+// We may want to add an update manually here so that we are relying
+// on the fact someone has pressed the tab key, not somehow inserted
+// a tab a different way. However, that's one step too far for this
+// initial version as it would involve dispatching custom events.
+//
+// const customInsertTab: StateCommand = ({ state, dispatch }) => {
+//   return insertTab({ state, dispatch })
+// }
+// const customIntendSelection: Command = (target) => {
+//   return indentSelection(target)
+// }
+// const a11yTabBinding: KeyBinding = {
+//   key: 'Tab',
+//   run: customInsertTab,
+//   shift: indentSelection,
+// }
 
-export const a11yTabBinding: KeyBinding = {
-  key: 'Tab',
-  run: customInsertTab,
-  shift: indentSelection,
+// Add all the parts together in one function that is exported
+// and added to the CodeMirror configuration
+export function a11yTabBindingPanel() {
+  return [
+    a11yTabBindingState,
+    showPanel.of(createA11yTabBindingPanel),
+    a11yTabBindingPanelTheme,
+
+    // We'll ideally add this here too, but currently its needed
+    // for when the editor gets reconfigured downstream of this.
+    // tabCaptureCompartment.of( keymap.of(isTabCaptured ? [a11yTabBinding] : [])),
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "exercism",
   "private": true,
   "dependencies": {
-    "@codemirror/basic-setup": "^0.18.1",
+    "@codemirror/basic-setup": "^0.18.2",
     "@codemirror/lang-cpp": "^0.18.0",
     "@codemirror/lang-java": "^0.18.0",
     "@codemirror/lang-javascript": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "exercism",
   "private": true,
   "dependencies": {
+    "@codemirror/view": "^0.18.13",
     "@codemirror/basic-setup": "^0.18.2",
     "@codemirror/lang-cpp": "^0.18.0",
     "@codemirror/lang-java": "^0.18.0",

--- a/test/javascript/components/Editor/features/settings.test.js
+++ b/test/javascript/components/Editor/features/settings.test.js
@@ -58,7 +58,7 @@ test('change wrapping', async () => {
   })
 })
 
-test('change "Enable tab"', async () => {
+test('change "Tab mode"', async () => {
   render(
     <Editor
       files={[{ filename: 'lasagna.rb', content: 'class Lasagna' }]}
@@ -67,9 +67,9 @@ test('change "Enable tab"', async () => {
   )
 
   fireEvent.click(screen.getByAltText('Settings'))
-  fireEvent.click(screen.getAllByLabelText('Off')[1])
+  fireEvent.click(screen.getAllByLabelText('Editor')[0])
 
   await waitFor(() => {
-    expect(screen.queryByText('Tab behavior: default')).toBeInTheDocument()
+    expect(screen.queryByText('Tab behavior: captured')).toBeInTheDocument()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,10 +2081,10 @@
     "@codemirror/state" "^0.18.0"
     "@codemirror/view" "^0.18.0"
 
-"@codemirror/view@^0.18.0":
-  version "0.18.12"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.18.12.tgz#28d6fdefd7362481bff3b05ab893c10710311e13"
-  integrity sha512-8PLqxl136aRiNO9dIKuB4CIMP6pgHAMXIbM0HxYMdFiLKaAH+nnvVFJVKCY3DUqaEWBB9R+OvUPVa0Rx/LpqLw==
+"@codemirror/view@^0.18.0", "@codemirror/view@^0.18.13":
+  version "0.18.13"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.18.13.tgz#34c268895f2b1b3b9907abe9ecfee0136b2a91fe"
+  integrity sha512-3aFEh9UB3JyYXG0GTneC8q6KQ87obftwHtis8FI/7NeiLfT+miuVj1By1IteRDpTQQ+7FbFnjDw4WFYhEHBcaw==
   dependencies:
     "@codemirror/rangeset" "^0.18.0"
     "@codemirror/state" "^0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,17 +1832,17 @@
     "@codemirror/view" "^0.18.0"
     lezer-tree "^0.13.0"
 
-"@codemirror/basic-setup@^0.18.1":
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.18.1.tgz#3be5a5b5cc922eaef7f2c0009ea02b598f5a5831"
-  integrity sha512-ItDjFVGtVzAlIHWFWoLEf+CL28CplNpiXpzFKVVfnJaJivWRx7jRYo8HbglpA445tUc1LF2OsRaP5jXn86/mgA==
+"@codemirror/basic-setup@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.18.2.tgz#a766b7e8898ce5d4cd4782c1ebf87d15a0f1965f"
+  integrity sha512-4UNFQ4jhU7wKxJH23AJcZW6Ho54VXUpmbtFnN5amIdtGci4ZLvci4M7JKgKFraHmKfDIYQnSzN8d8ohXR7CRhw==
   dependencies:
     "@codemirror/autocomplete" "^0.18.0"
     "@codemirror/closebrackets" "^0.18.0"
     "@codemirror/commands" "^0.18.0"
     "@codemirror/comment" "^0.18.0"
     "@codemirror/fold" "^0.18.0"
-    "@codemirror/gutter" "^0.18.0"
+    "@codemirror/gutter" "^0.18.3"
     "@codemirror/highlight" "^0.18.0"
     "@codemirror/history" "^0.18.0"
     "@codemirror/language" "^0.18.0"
@@ -1896,7 +1896,7 @@
     "@codemirror/state" "^0.18.0"
     "@codemirror/view" "^0.18.0"
 
-"@codemirror/gutter@^0.18.0":
+"@codemirror/gutter@^0.18.0", "@codemirror/gutter@^0.18.3":
   version "0.18.3"
   resolved "https://registry.yarnpkg.com/@codemirror/gutter/-/gutter-0.18.3.tgz#d195e2f69c6bdba037ec9c4d97eee0b46b1f02b7"
   integrity sha512-9ZLpR3s3MCPtB5fpRAy8af89GjO763XB4GE4HLBnESS7E1CHAuHFSTyd/ZqKHZogueF1mJhv9IQnCamEYcNMQw==


### PR DESCRIPTION
@kntsoriano @ErikSchierboom @SleeplessByte Pls give this a look over.

My aim with this PR is:
- Enable us to have tab as a whitespace inserter by default
- Clearly communicate to a user without a pointing-device that there is an escape hatch.
- Continue to enable support for a user to disable the tab as a whitespace-inserter.

To achieve this, this PR adds an assertive aria-live area that announces to the user that they can press ESC and then tab to leave the editor.

I initially wrote this using the built-in CodeMirror announce functionality (I'll include this in a comment for reference). This uses `aria-live=polite`. However, due to the way things get read out (by VoiceOver at least), the "polite" aria-live region is often ignored or comes after VoiceOver has read **all** the code in the editor twice(?!). If you've tabbed into the editor and want to get out, this is incredibly annoying and effectively means we trap the user for at least 10 seconds. I considered the downsides of having assertive, and I can't really think of any as it only happens in direct response to a user pressing tab (rather than something in the background interrupting the user). It currently only makes the announcement at most every 5 seconds. I'm not sure what the correct frequency is - I wonder if a backoff is good (so 5s between the first, 20s between the second, then every minute or so after that).

I've also changed the tab mode option to be this:

<img width="471" alt="Screenshot 2021-05-25 at 23 51 56" src="https://user-images.githubusercontent.com/286476/119578324-3243d000-bdb4-11eb-8272-e79b7123cb3d.png">

I suggest that we add a third option `Editor (Silent)` so that the tab can work a whitespace-inserter and not have this announcement at all, for those who are happy to remember the ESC-tab and don't want the constant announcements.

With regards to the code, I've commented it as CodeMirror isn't particularly intuitive without reading all the docs (but that complexity means it's also very modular, which is nice). There's a couple of TS-ignore bits (aria and one typing bit that seems wrong). Help on that would be appreciated. Then any other general advice too. This is the first TypeScript I've written that's not just editing @kntsoriano's existing work.

If we're all happy with this, we can extract it into an npm package that others can use, and I'll inform the CodeMirror team about it.

---

~Also, the escape hatch doesn't actually work. It's fixed in the latest version but all the types break if I install that because different things seem to rely on different types, so I'll wait until `@codemirror/basic-setup` is updated to install that (or we'll fix it if we get to launch and it's still broken)~ **Update:** I worked this out.