### PR TITLE
Switch sidekiq-cron for sidekiq-scheduler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'image_processing', '~> 1.2'
 gem 'friendly_id', '~> 5.4.0'
 gem 'sidekiq', '~> 6.1'
 gem 'sidekiq-failures'
-gem "sidekiq-cron", "~> 1.1"
+gem "sidekiq-scheduler"
 
 # View-level Dependencies
 gem 'webpacker', '~> 5.x'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,8 @@ GEM
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
     rubyzip (2.3.0)
+    rufus-scheduler (3.7.0)
+      fugit (~> 1.1, >= 1.1.6)
     rugged (1.1.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
@@ -391,11 +393,15 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-cron (1.2.0)
-      fugit (~> 1.1)
-      sidekiq (>= 4.2.1)
     sidekiq-failures (1.0.0)
       sidekiq (>= 4.0.0)
+    sidekiq-scheduler (3.1.0)
+      e2mmap
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      thwait
+      tilt (>= 1.4.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -426,6 +432,8 @@ GEM
     sysexits (1.2.0)
     temple (0.8.2)
     thor (1.1.0)
+    thwait (0.2.0)
+      e2mmap
     tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -515,8 +523,8 @@ DEPENDENCIES
   selenium-webdriver
   show_me_the_cookies
   sidekiq (~> 6.1)
-  sidekiq-cron (~> 1.1)
   sidekiq-failures
+  sidekiq-scheduler
   simplecov (~> 0.17.0)
   solargraph
   spring

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,15 @@
+require 'sidekiq'
+require 'sidekiq-scheduler'
+
 Sidekiq.configure_server do |config|
   config.redis = { url: Exercism.config.sidekiq_redis_url }
+
+  config.on(:startup) do
+    Sidekiq.schedule = YAML.load_file(Rails.root.join('config', 'sidekiq-schedule.yml'))
+    SidekiqScheduler::Scheduler.instance.reload_schedule!
+  end
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: Exercism.config.sidekiq_redis_url }
-end
-
-if Sidekiq.server?
-  data = YAML.load_file(Rails.root.join("config", "sidekiq-schedule.yml"))
-  Sidekiq::Cron::Job.load_from_hash(data)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 require 'sidekiq/web'
-require 'sidekiq/cron/web'
+require 'sidekiq-scheduler/web'
 
 Rails.application.routes.draw do
   mount ActionCable.server => '/cable'

--- a/config/sidekiq-schedule.yml
+++ b/config/sidekiq-schedule.yml
@@ -1,12 +1,12 @@
 # Every minute
 clear_mentor_request_locks:
-  cron: "* * * * *"
+  interval: "1m"
   class: "ClearMentorRequestLocksJob"
   queue: cron
 
 # Every minute
 sweep_reputation_periods:
-  cron: "* * * * *"
+  interval: "1m"
   class: "SweepReputationPeriodsJob"
   queue: reputation
 


### PR DESCRIPTION
`sidekiq-cron` has sporadic errors about `jids` not being found, so switching to `sidekiq-scheduler` which also seems better maintained.