### PR TITLE
Read git sha in production

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -2,3 +2,9 @@ authentication: <%= Exercism.secrets.skylight_key %>
 enable_sidekiq: true
 ignored_endpoints:
   - PagesController#health_check
+
+git_sha: <%=
+  ref = File.read(Rails.root.join(".git", "HEAD")) # This gives `ref: refs/heads/main`
+  path = ref.split(':').last.strip # This extracts `refs/heads/main`
+  File.read(Rails.root.join(".git", path)) 
+%>


### PR DESCRIPTION
Not ideal but it'll work. I could just hardcode the `main` path, but this insulates us if we ever use a deploy branch, etc.