### PR TITLE
Set stale time to 30 seconds

### DIFF
--- a/app/helpers/react_components/mentoring/inbox.rb
+++ b/app/helpers/react_components/mentoring/inbox.rb
@@ -35,14 +35,16 @@ module ReactComponents
             criteria: params[:criteria],
             page: params[:page] ? params[:page].to_i : 1,
             track: params[:track]
-          }.compact
+          }.compact,
+          options: { stale_time: 0 }
         }
       end
 
       def tracks_request
         {
           endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
-          query: { status: params[:status] || DEFAULT_STATUS }
+          query: { status: params[:status] || DEFAULT_STATUS },
+          options: { stale_time: 0 }
         }
       end
     end

--- a/app/helpers/react_components/mentoring/queue.rb
+++ b/app/helpers/react_components/mentoring/queue.rb
@@ -42,7 +42,8 @@ module ReactComponents
           options: {
             initial_data: {
               tracks: tracks_data
-            }
+            },
+            stale_time: 0
           }
         }
       end
@@ -73,7 +74,8 @@ module ReactComponents
             exercise_slug: default_exercise.try(:[], :slug)
           }.compact,
           options: {
-            initial_data: AssembleMentorRequests.(params, mentor)
+            initial_data: AssembleMentorRequests.(params, mentor),
+            stale_time: 0
           }
         }
       end

--- a/app/javascript/components/mentoring/queue/useExerciseList.tsx
+++ b/app/javascript/components/mentoring/queue/useExerciseList.tsx
@@ -26,6 +26,7 @@ export const useExerciseList = ({
       endpoint: track?.links.exercises,
       options: {
         enabled: !!track,
+        staleTime: 0,
         initialData: track?.exercises ? track.exercises : undefined,
       },
     },

--- a/app/javascript/hooks/request-query.ts
+++ b/app/javascript/hooks/request-query.ts
@@ -53,7 +53,11 @@ export function usePaginatedRequestQuery<TResult = unknown, TError = unknown>(
     () => {
       return handleFetch(request, isMountedRef)
     },
-    { refetchOnWindowFocus: false, ...camelizeKeys(request.options) }
+    {
+      refetchOnWindowFocus: false,
+      staleTime: 1000 * 30,
+      ...camelizeKeys(request.options),
+    }
   )
 }
 
@@ -64,7 +68,11 @@ export function useRequestQuery<TResult = unknown, TError = unknown>(
 ): QueryResult<TResult, TError> {
   return useQuery<TResult, TError>(
     key,
-    () => (handleFetch(request, isMountedRef)),
-    { refetchOnWindowFocus: false, ...camelizeKeys(request.options) }
+    () => handleFetch(request, isMountedRef),
+    {
+      refetchOnWindowFocus: false,
+      staleTime: 1000 * 30,
+      ...camelizeKeys(request.options),
+    }
   )
 }

--- a/test/helpers/react_components/mentoring/inbox_test.rb
+++ b/test/helpers/react_components/mentoring/inbox_test.rb
@@ -11,11 +11,13 @@ class MentoringInboxTest < ReactComponentTestCase
       {
         discussions_request: {
           endpoint: Exercism::Routes.api_mentoring_discussions_path(sideload: [:all_discussion_counts]),
-          query: { status: "awaiting_mentor", criteria: "Ruby", page: 1 }
+          query: { status: "awaiting_mentor", criteria: "Ruby", page: 1 },
+          options: { stale_time: 0 }
         },
         tracks_request: {
           endpoint: Exercism::Routes.tracks_api_mentoring_discussions_path,
-          query: { status: "awaiting_mentor" }
+          query: { status: "awaiting_mentor" },
+          options: { stale_time: 0 }
         },
         sort_options: [
           { value: '', label: 'Sort by oldest first' },

--- a/test/helpers/react_components/mentoring/queue_helper_test.rb
+++ b/test/helpers/react_components/mentoring/queue_helper_test.rb
@@ -47,7 +47,8 @@ class MentoringQueueTest < ReactComponentTestCase
             exercise_slug: "bob"
           },
           options: {
-            initial_data: AssembleMentorRequests.(params, user)
+            initial_data: AssembleMentorRequests.(params, user),
+            stale_time: 0
           }
         },
         tracks_request: {
@@ -86,7 +87,8 @@ class MentoringQueueTest < ReactComponentTestCase
                   }
                 }
               ]
-            }
+            },
+            stale_time: 0
           }
         },
         default_track: {


### PR DESCRIPTION
Closes https://github.com/exercism/v3-project-management/issues/256.

Currently, `react-query` refetches the data every time the query mounts because the stale time is set to 0. I've set it to 30 seconds for now. I'm unsure of what a good value is

A stale time of 30 seconds means that `react-query` won't refetch if the query mounts again, in the case of the video above, when toggling through pages, if we have the data in our cache. After 30 seconds, `react-query` will refetch if ever the query mounts again.