### PR TITLE
Use updated size labels for reputation

### DIFF
--- a/app/commands/user/reputation_token/award_for_pull_request_author.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_author.rb
@@ -40,10 +40,10 @@ class User
       end
 
       def reputation_level
-        return :major if params[:labels].include?('reputation/contributed_code/major')
-        return :minor if params[:labels].include?('reputation/contributed_code/minor')
-
-        :regular
+        # Sort descendingly to award greatest possible reputation
+        %i[massive large medium small tiny].find do |type|
+          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+        end || :medium
       end
     end
   end

--- a/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
@@ -51,10 +51,10 @@ class User
       end
 
       def reputation_level
-        return :major if params[:labels].include?('reputation/contributed_code/major')
-        return :minor if params[:labels].include?('reputation/contributed_code/minor')
-
-        :regular
+        # Sort descendingly to award greatest possible reputation
+        %i[massive large medium small tiny].find do |type|
+          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+        end || :medium
       end
     end
   end

--- a/app/models/user/reputation_tokens/code_contribution_token.rb
+++ b/app/models/user/reputation_tokens/code_contribution_token.rb
@@ -2,8 +2,8 @@ class User::ReputationTokens::CodeContributionToken < User::ReputationToken
   params :repo, :pr_node_id, :pr_number, :pr_title
   category :building
   reason :contributed_code
-  levels %i[minor regular major]
-  values({ minor: 5, regular: 12, major: 30 })
+  levels %i[tiny small medium large massive]
+  values({ tiny: 3, small: 5, medium: 12, large: 30, massive: 100 })
 
   before_validation on: :create do
     unless track

--- a/app/models/user/reputation_tokens/code_review_token.rb
+++ b/app/models/user/reputation_tokens/code_review_token.rb
@@ -2,8 +2,8 @@ class User::ReputationTokens::CodeReviewToken < User::ReputationToken
   params :repo, :pr_node_id, :pr_number, :pr_title
   category :maintaining
   reason :reviewed_code
-  levels %i[minor regular major]
-  values({ minor: 2, regular: 5, major: 10 })
+  levels %i[tiny small medium large massive]
+  values({ tiny: 1, small: 2, medium: 5, large: 10, massive: 20 })
 
   before_validation on: :create do
     unless track

--- a/test/factories/user/reputation_tokens.rb
+++ b/test/factories/user/reputation_tokens.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user_reputation_token, class: 'User::ReputationTokens::CodeContributionToken' do
     user
-    level { :regular }
+    level { :medium }
 
     params do
       {
@@ -15,7 +15,7 @@ FactoryBot.define do
 
   factory :user_code_contribution_reputation_token, class: 'User::ReputationTokens::CodeContributionToken' do
     user
-    level { :regular }
+    level { :medium }
 
     params do
       {
@@ -43,7 +43,7 @@ FactoryBot.define do
 
   factory :user_code_review_reputation_token, class: 'User::ReputationTokens::CodeReviewToken' do
     user
-    level { :regular }
+    level { :medium }
 
     params do
       {

--- a/test/models/user/reputation_tokens/code_contribution_token_test.rb
+++ b/test/models/user/reputation_tokens/code_contribution_token_test.rb
@@ -7,7 +7,7 @@ class User::ReputationTokens::CodeContributionTokenTest < ActiveSupport::TestCas
     pr_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
     pr_number = 1347
     pr_title = "The cat sat on the mat"
-    level = :major
+    level = :large
     user = create :user, handle: "User22", github_username: "user22"
 
     User::ReputationToken::Create.(
@@ -40,7 +40,7 @@ class User::ReputationTokens::CodeContributionTokenTest < ActiveSupport::TestCas
     pr_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
     pr_number = 1347
     pr_title = "The cat sat on the mat"
-    level = :regular
+    level = :medium
     user = create :user, handle: "User22", github_username: "user22"
 
     User::ReputationToken::Create.(
@@ -73,7 +73,7 @@ class User::ReputationTokens::CodeContributionTokenTest < ActiveSupport::TestCas
     pr_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
     pr_number = 1347
     pr_title = "The cat sat on the mat"
-    level = :minor
+    level = :small
     user = create :user, handle: "User22", github_username: "user22"
 
     User::ReputationToken::Create.(
@@ -114,7 +114,7 @@ class User::ReputationTokens::CodeContributionTokenTest < ActiveSupport::TestCas
       token = User::ReputationToken::Create.(
         user,
         :code_contribution,
-        level: :regular,
+        level: :medium,
         repo: repo,
         pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
         pr_number: 1347,
@@ -132,7 +132,7 @@ class User::ReputationTokens::CodeContributionTokenTest < ActiveSupport::TestCas
     token = User::ReputationToken::Create.(
       user,
       :code_contribution,
-      level: :regular,
+      level: :medium,
       repo: 'exercism/v3',
       pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
       pr_number: 1347,

--- a/test/models/user/reputation_tokens/code_review_token_test.rb
+++ b/test/models/user/reputation_tokens/code_review_token_test.rb
@@ -12,7 +12,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     User::ReputationToken::Create.(
       user,
       :code_review,
-      level: :minor,
+      level: :small,
       repo: repo,
       pr_node_id: pr_node_id,
       pr_number: pr_number,
@@ -29,7 +29,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     assert_equal "#{user.id}|code_review|PR#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
     assert_equal :maintaining, rt.category
     assert_equal :reviewed_code, rt.reason
-    assert_equal :minor, rt.level
+    assert_equal :small, rt.level
     assert_equal 2, rt.value
   end
 
@@ -44,7 +44,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     User::ReputationToken::Create.(
       user,
       :code_review,
-      level: :regular,
+      level: :medium,
       repo: repo,
       pr_node_id: pr_node_id,
       pr_number: pr_number,
@@ -61,7 +61,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     assert_equal "#{user.id}|code_review|PR#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
     assert_equal :maintaining, rt.category
     assert_equal :reviewed_code, rt.reason
-    assert_equal :regular, rt.level
+    assert_equal :medium, rt.level
     assert_equal 5, rt.value
   end
 
@@ -76,7 +76,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     User::ReputationToken::Create.(
       user,
       :code_review,
-      level: :major,
+      level: :large,
       repo: repo,
       pr_node_id: pr_node_id,
       pr_number: pr_number,
@@ -93,7 +93,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     assert_equal "#{user.id}|code_review|PR#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
     assert_equal :maintaining, rt.category
     assert_equal :reviewed_code, rt.reason
-    assert_equal :major, rt.level
+    assert_equal :large, rt.level
     assert_equal 10, rt.value
   end
 
@@ -111,7 +111,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
       token = User::ReputationToken::Create.(
         user,
         :code_review,
-        level: :minor,
+        level: :small,
         repo: repo,
         pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
         pr_number: 1347,
@@ -129,7 +129,7 @@ class User::ReputationTokens::CodeReviewTokenTest < ActiveSupport::TestCase
     token = User::ReputationToken::Create.(
       user,
       :code_review,
-      level: :minor,
+      level: :small,
       repo: 'exercism/v3',
       pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
       pr_number: 1347,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,8 +33,8 @@ class UserTest < ActiveSupport::TestCase
 
     create :user_exercise_contribution_reputation_token, user: user
     create :user_exercise_author_reputation_token, user: user
-    create :user_code_contribution_reputation_token, user: user, level: :major
-    create :user_code_contribution_reputation_token, user: user, level: :regular
+    create :user_code_contribution_reputation_token, user: user, level: :large
+    create :user_code_contribution_reputation_token, user: user, level: :medium
 
     assert_equal 72, user.reload.reputation
     # assert_equal 20, user.reputation(track_slug: :ruby)

--- a/test/system/components/journey/reputation_test.rb
+++ b/test/system/components/journey/reputation_test.rb
@@ -13,7 +13,7 @@ module Components
         exercise = create :concept_exercise, track: track
         token = create :user_code_contribution_reputation_token,
           user: user,
-          level: :major,
+          level: :large,
           track: track,
           exercise: exercise,
           created_at: 1.day.ago,
@@ -37,7 +37,7 @@ module Components
         User::ReputationToken::Search.stubs(:default_per).returns(1)
         user = create :user
         review_token = create :user_code_review_reputation_token, user: user, created_at: Time.current - 1.day
-        contribution_token = create :user_code_contribution_reputation_token, user: user, level: :major
+        contribution_token = create :user_code_contribution_reputation_token, user: user, level: :large
 
         use_capybara_host do
           sign_in!(user)
@@ -58,7 +58,7 @@ module Components
         user = create :user
         contribution_token = create :user_code_contribution_reputation_token,
           user: user,
-          level: :major,
+          level: :large,
           created_at: 2.days.ago
         review_token = create :user_code_review_reputation_token, user: user, created_at: 1.day.ago
 
@@ -79,7 +79,7 @@ module Components
         exercise = create :concept_exercise
         contribution_token = create :user_code_contribution_reputation_token,
           user: user,
-          level: :major,
+          level: :large,
           exercise: exercise
         review_token = create :user_code_review_reputation_token,
           user: user,


### PR DESCRIPTION
This PR changes the reputation awarding for PRs to not look at the `reputation/code_contribution/{major,minor}` labels, but to instead use the `x:size/{tiny/small/medium/large/massive}` labels.

The reputation for merging a PR is unaffected as we didn't use the existing size labels. We currently have `values({ janitorial: 1, reviewal: 5 })` there. Do we also want to differentiate between sizes for merges?

I've made this a draft as merging this will remove reputation temporarily, until I've run a script to convert the labels.