### PR TITLE
Add Site Updates

### DIFF
--- a/app/controllers/maintaining/site_updates_controller.rb
+++ b/app/controllers/maintaining/site_updates_controller.rb
@@ -1,0 +1,23 @@
+class Maintaining::SiteUpdatesController < ApplicationController
+  def index
+    @updates = SiteUpdate.order(published_at: :desc).page(params[:page]).per(20)
+  end
+
+  def edit
+    @update = SiteUpdate.find(params[:id])
+  end
+
+  def update
+    @update = SiteUpdate.find(params[:id])
+
+    if @update.editable_by?(current_user)
+      @update.update!(
+        params.require(:site_update).permit(
+          :title, :description, :pull_request_number
+        ).merge(author: current_user)
+      )
+    end
+
+    redirect_to action: :index
+  end
+end

--- a/app/controllers/maintaining/site_updates_controller.rb
+++ b/app/controllers/maintaining/site_updates_controller.rb
@@ -1,6 +1,6 @@
 class Maintaining::SiteUpdatesController < ApplicationController
   def index
-    @updates = SiteUpdate.order(published_at: :desc).page(params[:page]).per(20)
+    @updates = SiteUpdate.sorted.page(params[:page]).per(20)
   end
 
   def edit

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -31,6 +31,7 @@ class TracksController < ApplicationController
       end
 
       @recent_solutions = UserTrack::RetrieveRecentlyActiveSolutions.(@user_track)
+      @updates = SiteUpdate.published.where(track: @track).order(published_at: :desc).limit(10)
 
       render "tracks/show/joined"
     else

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -31,7 +31,7 @@ class TracksController < ApplicationController
       end
 
       @recent_solutions = UserTrack::RetrieveRecentlyActiveSolutions.(@user_track)
-      @updates = SiteUpdate.published.where(track: @track).order(published_at: :desc).limit(10)
+      @updates = SiteUpdate.published.for_track(@track).sorted.limit(10)
 
       render "tracks/show/joined"
     else

--- a/app/css/components/faces.css
+++ b/app/css/components/faces.css
@@ -4,7 +4,9 @@
     padding-left: 16px;
 
     & .face {
-        margin-left: -16px;
+        &:not(:first-child) {
+            margin-left: -16px;
+        }
         transition: margin 0.2s ease-out;
         cursor: pointer;
 

--- a/app/css/pages/track-show-joined.css
+++ b/app/css/pages/track-show-joined.css
@@ -461,38 +461,138 @@
                 @apply text-h2 mb-20;
             }
             & hr.c-divider {
-                @apply mb-28;
+                @apply mb-40;
             }
 
             & .updates {
                 & .update {
-                    @apply grid gap-20 mb-12;
-                    grid-template-columns: 32px auto 72px;
-
-                    & .icon {
-                        & .c-icon {
-                            height: 32px;
-                            width: 32px;
+                    @apply flex relative;
+                    @apply mb-24;
+                    &:before {
+                        content: "";
+                        @apply absolute bg-borderColor7;
+                        width: 2px;
+                        top: -32px;
+                        left: 24px;
+                        bottom: -32px;
+                    }
+                    &:first-child {
+                        &:before {
+                            top: 43px;
+                        }
+                    }
+                    &:last-child {
+                        &:before {
+                            display: none;
                         }
                     }
 
-                    & .info {
-                        & .desc {
-                            @apply text-16 leading-paragraph;
-                            & strong {
-                                @apply font-medium;
+                    & > .c-icon {
+                        height: 50px;
+                        width: 50px;
+                        @apply mr-24;
+                    }
+
+                    & .content {
+                        @apply flex-grow;
+                    }
+                    & .standard {
+                        @apply flex items-center flex-grow;
+                        & .info {
+                            @apply mr-16;
+                            & .desc {
+                                @apply text-18 leading-150;
+                                & em {
+                                    @apply not-italic font-medium;
+                                }
+                                & a {
+                                    @apply font-semibold;
+                                    @apply border-b-1 border-textColor6;
+                                    &:hover {
+                                        @apply text-lightBlue border-lightBlue;
+                                    }
+                                }
+                            }
+
+                            & time {
+                                @apply text-14 leading-160 text-textColor6;
                             }
                         }
 
-                        & time {
-                            @apply text-label-timestamp;
+                        & .c-faces {
+                            @apply flex-shrink-0 ml-auto;
+                            & .c-avatar {
+                                height: 32px;
+                                width: 32px;
+                            }
                         }
                     }
 
-                    & .faces {
-                        & .c-avatar {
-                            height: 32px;
-                            width: 32px;
+                    & .expanded {
+                        @apply mt-20;
+                        @apply shadow-base rounded-8;
+                        @apply py-16 px-24;
+
+                        & .header {
+                            @apply flex items-center;
+                            @apply mb-12;
+                            & .c-icon {
+                                height: 48px;
+                                width: 48px;
+                                @apply mr-16;
+                            }
+
+                            & .title {
+                                @apply text-h4;
+                            }
+                            & .byline {
+                                @apply text-16 leading-180 text-textColor6;
+                                @apply flex items-center;
+                                & .c-avatar {
+                                    height: 24px;
+                                    width: 24px;
+                                    @apply mr-12;
+                                }
+                                & strong {
+                                    @apply font-medium text-textColor2;
+                                }
+                            }
+                        }
+                        & .description {
+                            @apply text-p-base mb-20;
+                        }
+                        & .pull-request {
+                            @apply flex items-center;
+                            @apply border-1 border-borderColor6;
+                            @apply py-16 px-32 mb-16;
+                            @apply rounded-8;
+
+                            & .c-icon {
+                                height: 42px;
+                                width: 42px;
+                                @apply mr-32;
+                            }
+                            & .pr-title {
+                                @apply text-h5 mb-4;
+                            }
+                            & .pr-details {
+                                @apply text-p-small text-textColor6;
+                                @apply mr-24;
+                            }
+                            & .merged {
+                                @apply ml-auto;
+                                & .c-icon {
+                                    height: 24px;
+                                    width: 24px;
+                                    @apply mr-12;
+                                }
+                                @apply flex items-center;
+                                @apply font-semibold text-darkSuccessGreen;
+                            }
+                        }
+                        & .c-exercise-widget {
+                            @apply border-1 border-borderColor6;
+                            @apply shadow-none;
                         }
                     }
                 }

--- a/app/css/pages/track-show-joined.css
+++ b/app/css/pages/track-show-joined.css
@@ -487,10 +487,15 @@
                         }
                     }
 
-                    & > .c-icon {
+                    & > .c-icon,
+                    & > .c-concept-icon {
+                        @apply relative mr-24;
+                        @apply z-1;
                         height: 50px;
                         width: 50px;
-                        @apply mr-24;
+                    }
+                    & > .c-concept-icon {
+                        @apply bg-backgroundColorA;
                     }
 
                     & .content {

--- a/app/css/pages/track-show-joined.css
+++ b/app/css/pages/track-show-joined.css
@@ -446,15 +446,10 @@
         @apply pt-64 pb-40;
 
         & header {
-            @apply mb-28;
-
             & .c-icon.graphical-icon {
                 width: 80px;
                 height: 80px;
                 @apply mb-16;
-            }
-            & h2 {
-                @apply text-h2 mb-20;
             }
         }
         & .container {
@@ -462,6 +457,12 @@
         }
         & section.updates-section {
             @apply flex-grow;
+            & h2 {
+                @apply text-h2 mb-20;
+            }
+            & hr.c-divider {
+                @apply mb-28;
+            }
 
             & .updates {
                 & .update {

--- a/app/models/concerns/is_paramaterised_sti.rb
+++ b/app/models/concerns/is_paramaterised_sti.rb
@@ -68,12 +68,11 @@ module IsParamaterisedSTI
 
     cattr_accessor :class_suffix, :i18n_category
 
-    belongs_to :user
     belongs_to :track, optional: true
     belongs_to :exercise, optional: true
 
     before_create do
-      self.uniqueness_key = "#{user_id}|#{type_key}|#{guard_params}"
+      self.uniqueness_key = generate_uniqueness_key!
       self.params = {} if self.params.blank?
       self.version = latest_i18n_version
       self.rendering_data_cache = cacheable_rendering_data
@@ -181,5 +180,13 @@ module IsParamaterisedSTI
 
   def i18n_params
     {}
+  end
+
+  def generate_uniqueness_key!
+    k = [type_key, guard_params]
+    # If we have a user_id column, include it in the key.
+    # If not, don't bother.
+    k.unshift(user_id) if respond_to?(:user_id)
+    k.join("|")
   end
 end

--- a/app/models/site_update.rb
+++ b/app/models/site_update.rb
@@ -5,16 +5,43 @@ class SiteUpdate < ApplicationRecord
   self.class_suffix = :update
   self.i18n_category = :site_updates
 
-  scope :posted, -> { where('posted_at < ?', Time.current) }
+  scope :published, -> { where('published_at < ?', Time.current) }
 
-  before_create do
+  before_validation only: :create do
     self.published_at = Time.current + 3.hours unless published_at
   end
 
   def cacheable_rendering_data
-    {
+    d = {
       text: text,
-      icon_url: icon_url
+      icon_url: icon_url,
+      published_at: published_at.iso8601
     }
+
+    if expanded?
+      d[:expanded] = {
+        author_handle: author.handle,
+        author_avatar_url: author.avatar_url,
+        title: title,
+        description: description
+      }
+    end
+
+    if pull_request
+      d[:pull_request] = {
+        title: pull_request.title,
+        number: pull_request.number,
+        url: "https://github.com/#{pull_request.repo}/pull/#{pull_request.number}",
+        merged_by: pull_request.merged_by_username,
+        merged_at: pull_request.updated_at.iso8601 # TODO: Use merged_at?
+      }
+    end
+
+    d
+  end
+
+  private
+  def expanded?
+    [author, title, description].all?(&:present?)
   end
 end

--- a/app/models/site_update.rb
+++ b/app/models/site_update.rb
@@ -6,6 +6,8 @@ class SiteUpdate < ApplicationRecord
   self.i18n_category = :site_updates
 
   scope :published, -> { where('published_at < ?', Time.current) }
+  scope :for_track, ->(track) { where(track: track) }
+  scope :sorted, -> { order(published_at: :desc) }
 
   belongs_to :author, optional: true, class_name: "User"
   belongs_to :pull_request, optional: true, class_name: "Github::PullRequest"
@@ -37,6 +39,7 @@ class SiteUpdate < ApplicationRecord
     d = {
       text: text,
       icon_url: icon_url,
+      track_icon_url: track&.icon_url,
       published_at: published_at.iso8601
     }
 

--- a/app/models/site_update.rb
+++ b/app/models/site_update.rb
@@ -1,0 +1,20 @@
+class SiteUpdate < ApplicationRecord
+  include IsParamaterisedSTI
+  include Mandate
+
+  self.class_suffix = :update
+  self.i18n_category = :site_updates
+
+  scope :posted, -> { where('posted_at < ?', Time.current) }
+
+  before_create do
+    self.published_at = Time.current + 3.hours unless published_at
+  end
+
+  def cacheable_rendering_data
+    {
+      text: text,
+      icon_url: icon_url
+    }
+  end
+end

--- a/app/models/site_update.rb
+++ b/app/models/site_update.rb
@@ -38,6 +38,7 @@ class SiteUpdate < ApplicationRecord
   def cacheable_rendering_data
     d = {
       text: text,
+      icon_type: icon_type,
       icon_url: icon_url,
       track_icon_url: track&.icon_url,
       published_at: published_at.iso8601
@@ -67,5 +68,10 @@ class SiteUpdate < ApplicationRecord
 
   def expanded?
     [author, title, description].all?(&:present?)
+  end
+
+  # Should be overriden in children
+  def icon_url
+    nil
   end
 end

--- a/app/models/site_updates/new_concept_update.rb
+++ b/app/models/site_updates/new_concept_update.rb
@@ -1,12 +1,14 @@
-class SiteUpdates::NewExerciseUpdate < SiteUpdate
+class SiteUpdates::NewConceptUpdate < SiteUpdate
+  params :concept
+
   def guard_params
-    "Exercise##{exercise_id}"
+    "Concept##{concept.id}"
   end
 
   def i18n_params
     {
-      exercise_title: exercise.title,
-      exercise_url: Exercism::Routes.track_exercise_url(track, exercise),
+      concept_name: concept.name,
+      concept_url: Exercism::Routes.track_concept_url(track, concept),
       maker_handles: maker_handles
     }
   end
@@ -17,10 +19,13 @@ class SiteUpdates::NewExerciseUpdate < SiteUpdate
     )
   end
 
-  delegate :icon_url, to: :exercise
-
   def icon_type
-    :image
+    :concept
+  end
+
+  # TODO: This is pretty gross
+  def icon_url
+    concept.name[0, 2]
   end
 
   def maker_handles
@@ -32,6 +37,8 @@ class SiteUpdates::NewExerciseUpdate < SiteUpdate
 
   memoize
   def makers
-    exercise.authors + exercise.contributors
+    # TODO: Readd once we have contributors
+    # concept.authors + concept.contributors
+    []
   end
 end

--- a/app/models/site_updates/new_exercise_update.rb
+++ b/app/models/site_updates/new_exercise_update.rb
@@ -1,0 +1,32 @@
+class SiteUpdates::NewExerciseUpdate < SiteUpdate
+  def guard_params
+    "Exercise##{exercise_id}"
+  end
+
+  def i18n_params
+    {
+      exercise_title: exercise.title,
+      maker_handles: maker_handles
+    }
+  end
+
+  def cacheable_rendering_data
+    super.merge(
+      maker_avatar_urls: makers.map(&:avatar_url)
+    )
+  end
+
+  delegate :icon_url, to: :exercise
+
+  def maker_handles
+    return "We" if makers.empty?
+    return makers[0, 3].map(&:handle).to_sentence if makers.size <= 3
+
+    "#{makers[0].handle}, #{makers[1].handle}, and #{makers.size - 2} others"
+  end
+
+  memoize
+  def makers
+    exercise.authors + exercise.contributors
+  end
+end

--- a/app/models/site_updates/new_exercise_update.rb
+++ b/app/models/site_updates/new_exercise_update.rb
@@ -1,4 +1,6 @@
 class SiteUpdates::NewExerciseUpdate < SiteUpdate
+  params :author, :title, :description, :pull_request
+
   def guard_params
     "Exercise##{exercise_id}"
   end
@@ -6,6 +8,7 @@ class SiteUpdates::NewExerciseUpdate < SiteUpdate
   def i18n_params
     {
       exercise_title: exercise.title,
+      exercise_url: Exercism::Routes.track_exercise_url(track, exercise),
       maker_handles: maker_handles
     }
   end

--- a/app/models/site_updates/new_exercise_update.rb
+++ b/app/models/site_updates/new_exercise_update.rb
@@ -1,6 +1,4 @@
 class SiteUpdates::NewExerciseUpdate < SiteUpdate
-  params :author, :title, :description, :pull_request
-
   def guard_params
     "Exercise##{exercise_id}"
   end

--- a/app/models/user/activity.rb
+++ b/app/models/user/activity.rb
@@ -10,6 +10,7 @@ class User::Activity < ApplicationRecord
   self.class_suffix = :activity
   self.i18n_category = :user_activities
 
+  belongs_to :user
   belongs_to :solution, optional: true
 
   def cacheable_rendering_data

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -3,6 +3,8 @@ class User::Notification < ApplicationRecord
   self.class_suffix = :notification
   self.i18n_category = :notifications
 
+  belongs_to :user
+
   # If track or exercise is set, it means that this is a
   # notification *about* that track and/or exercise and that
   # the blue notification dot should propogate everywhere

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -5,6 +5,8 @@ class User::ReputationToken < ApplicationRecord
   self.class_suffix = :token
   self.i18n_category = :user_reputation_tokens
 
+  belongs_to :user
+
   scope :unseen, -> { where(seen: false) }
 
   # Reason, category and value can be set statically in

--- a/app/views/maintaining/site_updates/edit.html.haml
+++ b/app/views/maintaining/site_updates/edit.html.haml
@@ -1,0 +1,42 @@
+:css
+  #maintaining-site-update-form {
+    padding:25px 5%;
+    font-size: 16px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-bottom: 16px;
+  }
+  input, textarea {
+    width:400px;
+    border:1px solid #aaa;
+  }
+  textarea {
+    padding:20px;
+    height:100px;
+  }
+  .field {
+    margin-bottom:20px;
+  }
+  label {
+    display:block;
+  }
+
+#maintaining-site-update-form
+  %h2.text-h3 Edit Update
+  = form_for @update, url: maintaining_site_update_path(@update), as: :site_update do |f|
+    .field
+      = f.label :title, "Title"
+      = f.text_field :title
+
+    .field
+      = f.label :title, "Description"
+      = f.text_area :description
+
+    .field
+      = f.label :pull_request_number, "Pull Request ID (#{@update.track.repo_url}/pull/xxx)"
+      = f.text_field :pull_request_number
+
+    = f.button "Update Post", class: "btn-primary btn-m"
+
+

--- a/app/views/maintaining/site_updates/index.html.haml
+++ b/app/views/maintaining/site_updates/index.html.haml
@@ -1,0 +1,26 @@
+.lg-container
+  %table
+    %thead
+      %tr
+        %th About
+        %th Published At
+        %th Expanded Details
+        %th Pull Request
+        %th
+    %tbody
+      - @updates.each do |update|
+        %tr
+          %td
+            = update.track&.title
+            \/
+            = update.exercise&.title
+          %td= update.published_at
+          %td
+            - if update.expanded?
+              .title= update.title
+              .handle= update.author.handle
+              %p= update.description
+          %td= update.pull_request&.title
+          %td
+            - if update.editable_by?(current_user)
+              = link_to "Edit", edit_maintaining_site_update_path(update)

--- a/app/views/tracks/show/joined.html.haml
+++ b/app/views/tracks/show/joined.html.haml
@@ -12,4 +12,4 @@
 
   = render "tracks/show/joined/summary_article", track: @track, user_track: @user_track, exercise_statuses: @exercise_statuses, recent_solutions: @recent_solutions, sample_completed_exercises: @sample_completed_exercises, sample_learnt_concepts: @sample_learnt_concepts, sample_mastered_concepts: @sample_mastered_concepts, sample_in_progress_exercises: @sample_in_progress_exercises, sample_available_exercises: @sample_available_exercises
   = render "tracks/show/joined/mentoring_article", track: @track, user_track: @user_track
-  = render "tracks/show/joined/updates_article", track: @track
+  = render "tracks/show/joined/updates_article", track: @track, updates: @updates

--- a/app/views/tracks/show/joined/_updates_article.html.haml
+++ b/app/views/tracks/show/joined/_updates_article.html.haml
@@ -5,5 +5,5 @@
       = graphical_icon(:updates, hex: true, css_class: "graphical-icon")
 
   .lg-container.container
-    = render "tracks/show/joined/updates_section", track: track
+    = render "tracks/show/joined/updates_section", track: track, updates: updates
     = render "tracks/show/joined/contributors_section", track: track, contributors: track.top_contributors, num_contributors: track.num_contributors

--- a/app/views/tracks/show/joined/_updates_article.html.haml
+++ b/app/views/tracks/show/joined/_updates_article.html.haml
@@ -3,8 +3,6 @@
   .lg-container
     %header
       = graphical_icon(:updates, hex: true, css_class: "graphical-icon")
-      %h2 What's going on with #{track.title}
-      %hr.c-divider
 
   .lg-container.container
     = render "tracks/show/joined/updates_section", track: track

--- a/app/views/tracks/show/joined/_updates_section.html.haml
+++ b/app/views/tracks/show/joined/_updates_section.html.haml
@@ -6,7 +6,11 @@
     - updates.each do |update|
       - data = update.rendering_data
       .update
-        = image_tag data[:icon_url], class: 'c-icon'
+        - if data[:icon_type] == "image"
+          = image_tag data[:icon_url], class: 'c-icon'
+        - elsif data[:icon_type] == "concept"
+          .c-concept-icon.c--large= data[:icon_url]
+
         .content
           .standard
             .info
@@ -19,7 +23,11 @@
           - if data[:expanded]
             .expanded
               .header
-                = image_tag data[:icon_url], class: 'c-icon'
+                - if data[:icon_type] == "image"
+                  = image_tag data[:icon_url], class: 'c-icon'
+                - elsif data[:icon_type] == "concept"
+                  .c-concept-icon.c--medium= data[:icon_url]
+
                 .info
                   .title= data[:expanded][:title]
                   .byline

--- a/app/views/tracks/show/joined/_updates_section.html.haml
+++ b/app/views/tracks/show/joined/_updates_section.html.haml
@@ -3,43 +3,51 @@
   %hr.c-divider
 
   .updates
-    .update
-      .icon
-        .c-concept-icon.c--medium St
-      .info
-        .desc
-          %strong erikschierboom
-          published a new concept
-          %strong Structs
-        %time 2 days ago
-      .faces
-        = avatar(User.first)
-
-    - exercise = track.exercises.first
-    - if exercise
+    - updates.each do |update|
+      - data = update.rendering_data
       .update
-        .icon
-          = exercise_icon(exercise)
-        .info
-          .desc
-            %strong thelostlambda, WDNeumann and 3 others
-            published a new exercise
-            %strong= exercise.title
-          %time 3 days ago
-        .faces
-          = avatar(User.first)
+        = image_tag data[:icon_url], class: 'c-icon'
+        .content
+          .standard
+            .info
+              .desc= raw data[:text]
+              %time #{time_ago_in_words(data[:published_at])} ago
+            .c-faces
+              - data[:maker_avatar_urls].each do |avatar_url|
+                = image_tag avatar_url, class: 'face c-avatar'
 
-    .update
-      .icon
-        .c-concept-icon.c--medium Bo
-      .info
-        .desc
-          %strong bobahop
-          updated the concept
-          %strong Booleans
-        %time 5 days ago
-      .faces
-        = avatar(User.first)
+          - if data[:expanded]
+            .expanded
+              .header
+                = image_tag data[:icon_url], class: 'c-icon'
+                .info
+                  .title= data[:expanded][:title]
+                  .byline
+                    = image_tag data[:expanded][:author_avatar_url], class: 'c-avatar'
+                    .by
+                      by
+                      %strong= data[:expanded][:author_handle]
+              .description= data[:expanded][:description]
+
+              - if data[:pull_request]
+                = link_to data[:pull_request][:url], class: "pull-request", target: "_blank", rel: 'noopener' do
+                  = icon "pull-request-merge", "Pull Request", category: :graphics
+                  .details
+                    .pr-title= data[:pull_request][:title]
+                    .pr-info
+                      \##{data[:pull_request][:number]} merged
+                      = time_ago_in_words(data[:pull_request][:merged_at])
+                      ago by
+                      = data[:pull_request][:merged_by]
+
+                  .merged
+                    = graphical_icon "completed-check-circle"
+                    Merged
+
+
+              / TODO: How to do this efficiently?
+              - user_track = UserTrack.for(current_user, track)
+              - solution = Solution.for(current_user, track, update.exercise)
+              = ReactComponents::Common::ExerciseWidget.new(update.exercise, user_track, solution: solution, render_track: false, render_blurb: false)
 
   = render ViewComponents::ProminentLink.new("See all #{track.title} updates", "#")
-

--- a/app/views/tracks/show/joined/_updates_section.html.haml
+++ b/app/views/tracks/show/joined/_updates_section.html.haml
@@ -1,4 +1,7 @@
 %section.updates-section
+  %h2 What's going on with #{track.title}
+  %hr.c-divider
+
   .updates
     .update
       .icon

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -4,6 +4,7 @@
   notifications
   user_activities
   user_reputation_tokens
+  site_updates
 ].each do |category|
   I18n.load_path += Dir[Rails.root.join('config', 'locales', category, '*.{rb,yml}')]
 end

--- a/config/locales/site_updates/en.yml
+++ b/config/locales/site_updates/en.yml
@@ -2,4 +2,4 @@ en:
   site_updates:
     new_exercise:
       1: >
-        <em>%{maker_handles}</em> published a new exercise: <strong>%{exercise_title}</strong>
+        <em>%{maker_handles}</em> published a new exercise: <a href="%{exercise_url}">%{exercise_title}</a>

--- a/config/locales/site_updates/en.yml
+++ b/config/locales/site_updates/en.yml
@@ -1,0 +1,5 @@
+en:
+  site_updates:
+    new_exercise:
+      1: >
+        <em>%{maker_handles}</em> published a new exercise: <strong>%{exercise_title}</strong>

--- a/config/locales/site_updates/en.yml
+++ b/config/locales/site_updates/en.yml
@@ -2,4 +2,8 @@ en:
   site_updates:
     new_exercise:
       1: >
-        <em>%{maker_handles}</em> published a new exercise: <a href="%{exercise_url}">%{exercise_title}</a>
+        <em>%{maker_handles}</em> published a new Exercise: <a href="%{exercise_url}">%{exercise_title}</a>
+
+    new_concept:
+      1: >
+        <em>%{maker_handles}</em> published a new Concept: <a href="%{concept_url}">%{concept_name}</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,7 @@ Rails.application.routes.draw do
     resources :submissions, only: [:index]
     resources :exercise_representations
     resources :tracks, only: [:show]
+    resources :site_updates, except: [:destroy]
   end
 
   namespace :contributing do

--- a/db/migrate/20210614114503_create_site_updates.rb
+++ b/db/migrate/20210614114503_create_site_updates.rb
@@ -1,0 +1,25 @@
+class CreateSiteUpdates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :site_updates do |t|
+      t.string :type, null: false
+      t.string :uniqueness_key, null: false
+      t.text :params, null: false
+      t.integer :version, null: false
+      t.text :rendering_data_cache, null: false
+      t.belongs_to :track, optional: true, foreign_key: true
+      t.belongs_to :exercise, optional: true, foreign_key: true
+
+      t.datetime :published_at, null: false
+
+      # t.belongs_to :poster, foreign_key: {to_table: "users"}
+
+      # t.belongs_to :track, optional: true
+      # t.belongs_to :about, polymorphic: true, optional: true
+      # t.belongs_to :pull_request, optional: true, foreign_key: {to_table: "github_pull_requests"}
+
+      # t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210614114503_create_site_updates.rb
+++ b/db/migrate/20210614114503_create_site_updates.rb
@@ -9,15 +9,12 @@ class CreateSiteUpdates < ActiveRecord::Migration[6.1]
       t.belongs_to :track, optional: true, foreign_key: true
       t.belongs_to :exercise, optional: true, foreign_key: true
 
+      t.belongs_to :author, optional: true, foreign_key: { to_table: :users }
+      t.belongs_to :pull_request, optional: true, foreign_key: { to_table: "github_pull_requests" }
       t.datetime :published_at, null: false
 
-      # t.belongs_to :poster, foreign_key: {to_table: "users"}
-
-      # t.belongs_to :track, optional: true
-      # t.belongs_to :about, polymorphic: true, optional: true
-      # t.belongs_to :pull_request, optional: true, foreign_key: {to_table: "github_pull_requests"}
-
-      # t.string :title, null: false
+      t.string :title, null: true
+      t.text :description, null: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -386,10 +386,16 @@ ActiveRecord::Schema.define(version: 2021_06_14_114503) do
     t.text "rendering_data_cache", null: false
     t.bigint "track_id"
     t.bigint "exercise_id"
+    t.bigint "author_id"
+    t.bigint "pull_request_id"
     t.datetime "published_at", null: false
+    t.string "title"
+    t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["author_id"], name: "index_site_updates_on_author_id"
     t.index ["exercise_id"], name: "index_site_updates_on_exercise_id"
+    t.index ["pull_request_id"], name: "index_site_updates_on_pull_request_id"
     t.index ["track_id"], name: "index_site_updates_on_track_id"
   end
 
@@ -750,7 +756,9 @@ ActiveRecord::Schema.define(version: 2021_06_14_114503) do
   add_foreign_key "problem_reports", "users"
   add_foreign_key "scratchpad_pages", "users"
   add_foreign_key "site_updates", "exercises"
+  add_foreign_key "site_updates", "github_pull_requests", column: "pull_request_id"
   add_foreign_key "site_updates", "tracks"
+  add_foreign_key "site_updates", "users", column: "author_id"
   add_foreign_key "solution_stars", "solutions"
   add_foreign_key "solution_stars", "users"
   add_foreign_key "solutions", "exercises"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_212112) do
+ActiveRecord::Schema.define(version: 2021_06_14_114503) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -378,6 +378,21 @@ ActiveRecord::Schema.define(version: 2021_06_03_212112) do
     t.index ["user_id"], name: "index_scratchpad_pages_on_user_id"
   end
 
+  create_table "site_updates", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "uniqueness_key", null: false
+    t.text "params", null: false
+    t.integer "version", null: false
+    t.text "rendering_data_cache", null: false
+    t.bigint "track_id"
+    t.bigint "exercise_id"
+    t.datetime "published_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["exercise_id"], name: "index_site_updates_on_exercise_id"
+    t.index ["track_id"], name: "index_site_updates_on_track_id"
+  end
+
   create_table "solution_stars", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "solution_id", null: false
     t.bigint "user_id", null: false
@@ -548,6 +563,14 @@ ActiveRecord::Schema.define(version: 2021_06_03_212112) do
     t.index ["user_id"], name: "index_user_auth_tokens_on_user_id"
   end
 
+  create_table "user_communication_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.boolean "email_on_mentor_started_discussion_notification", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_communication_preferences_on_user_id"
+  end
+
   create_table "user_notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "user_id", null: false
@@ -623,6 +646,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_212112) do
     t.index ["exercise_id"], name: "index_user_reputation_tokens_on_exercise_id"
     t.index ["track_id"], name: "index_user_reputation_tokens_on_track_id"
     t.index ["uniqueness_key", "user_id"], name: "index_user_reputation_tokens_on_uniqueness_key_and_user_id", unique: true
+    t.index ["user_id", "type"], name: "index_user_reputation_tokens_on_user_id_and_type"
     t.index ["user_id"], name: "index_user_reputation_tokens_on_user_id"
     t.index ["uuid"], name: "index_user_reputation_tokens_on_uuid", unique: true
   end
@@ -725,6 +749,8 @@ ActiveRecord::Schema.define(version: 2021_06_03_212112) do
   add_foreign_key "problem_reports", "tracks"
   add_foreign_key "problem_reports", "users"
   add_foreign_key "scratchpad_pages", "users"
+  add_foreign_key "site_updates", "exercises"
+  add_foreign_key "site_updates", "tracks"
   add_foreign_key "solution_stars", "solutions"
   add_foreign_key "solution_stars", "users"
   add_foreign_key "solutions", "exercises"
@@ -743,6 +769,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_212112) do
   add_foreign_key "user_activities", "tracks"
   add_foreign_key "user_activities", "users"
   add_foreign_key "user_auth_tokens", "users"
+  add_foreign_key "user_communication_preferences", "users"
   add_foreign_key "user_notifications", "exercises"
   add_foreign_key "user_notifications", "tracks"
   add_foreign_key "user_notifications", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -254,6 +254,17 @@ Exercise.all.each do |exercise|
   )
 end
 
+Track::Concept.all.each do |concept|
+  SiteUpdates::NewConceptUpdate.create!(
+    track: concept.track,
+    published_at: concept.created_at,
+    params: {
+      concept: concept
+    }
+  )
+end
+
+
 update = SiteUpdate.where(track: ruby).order(published_at: :desc).first
 update.update!(
   author: User.first,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -255,10 +255,10 @@ Exercise.all.each do |exercise|
 end
 
 update = SiteUpdate.where(track: ruby).order(published_at: :desc).first
-update.update!(params: {
+update.update!(
   author: User.first,
   title: "New exercise for OCaml! 🚀",
   description: "Of course, it is likely enough, my friends,' he said slowly, 'likely enough that we are going to our doom: the last march of the Ents. But if we stayed home and did nothing, doom would find us anyway, sooner or later. That thought has long been growing in our hearts; and that is why we are marching now."
-})
-update.update(params: update.params.merge({pull_request: Github::PullRequest.first}))
+)
+update.update(pull_request: Github::PullRequest.first)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -242,5 +242,23 @@ exercises.each do |exercise|
     exercise: exercise
   )
 end
+
 User::ReputationPeriod::Sweep.()
+
+SiteUpdates::NewExerciseUpdate.destroy_all
+Exercise.all.each do |exercise|
+  SiteUpdates::NewExerciseUpdate.create!(
+    exercise: exercise, 
+    track: exercise.track,
+    published_at: exercise.created_at
+  )
+end
+
+update = SiteUpdate.where(track: ruby).order(published_at: :desc).first
+update.update!(params: {
+  author: User.first,
+  title: "New exercise for OCaml! 🚀",
+  description: "Of course, it is likely enough, my friends,' he said slowly, 'likely enough that we are going to our doom: the last march of the Ents. But if we stayed home and did nothing, doom would find us anyway, sooner or later. That thought has long been growing in our hearts; and that is why we are marching now."
+})
+update.update(params: update.params.merge({pull_request: Github::PullRequest.first}))
 

--- a/test/controllers/maintaining/site_updates_controller_test.rb
+++ b/test/controllers/maintaining/site_updates_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Maintaining::SiteUpdatesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/factories/site_updates.rb
+++ b/test/factories/site_updates.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :site_update, class: "SiteUpdates::NewExerciseUpdate" do
     exercise { create :practice_exercise }
+    track { exercise.track }
   end
 end

--- a/test/factories/site_updates.rb
+++ b/test/factories/site_updates.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :site_update, class: "SiteUpdates::NewExerciseUpdate" do
+    exercise { create :practice_exercise }
+  end
+end

--- a/test/factories/site_updates.rb
+++ b/test/factories/site_updates.rb
@@ -3,4 +3,18 @@ FactoryBot.define do
     exercise { create :practice_exercise }
     track { exercise.track }
   end
+
+  factory :new_exercise_site_update, class: "SiteUpdates::NewExerciseUpdate" do
+    exercise { create :practice_exercise }
+    track { exercise.track }
+  end
+
+  factory :new_concept_site_update, class: "SiteUpdates::NewConceptUpdate" do
+    track { concept.track }
+    params do
+      {
+        concept: create(:track_concept)
+      }
+    end
+  end
 end

--- a/test/factories/site_updates.rb
+++ b/test/factories/site_updates.rb
@@ -10,11 +10,11 @@ FactoryBot.define do
   end
 
   factory :new_concept_site_update, class: "SiteUpdates::NewConceptUpdate" do
-    track { concept.track }
     params do
       {
         concept: create(:track_concept)
       }
     end
+    track { concept.track }
   end
 end

--- a/test/models/site_update_test.rb
+++ b/test/models/site_update_test.rb
@@ -15,85 +15,6 @@ class SiteUpdateTest < ActiveSupport::TestCase
     update.text
   end
 
-  test "rendering_data with no contributors" do
-    freeze_time do
-      track = create :track
-      exercise = create :concept_exercise, track: track
-      update = create :site_update, exercise: exercise, track: track
-
-      expected = {
-        text: "<em>We</em> published a new exercise: #{i18n_exercise(exercise)}",
-        icon_url: exercise.icon_url,
-        track_icon_url: track.icon_url,
-        published_at: (Time.current + 3.hours).iso8601,
-        maker_avatar_urls: []
-      }.with_indifferent_access
-
-      assert_equal expected, update.rendering_data
-    end
-  end
-
-  test "rendering_data with 1 contributors" do
-    track = create :track
-    author = create :user
-    exercise = create :concept_exercise, track: track
-    create :exercise_authorship, exercise: exercise, author: author
-    update = create :site_update, exercise: exercise, track: track
-
-    text = "<em>#{author.handle}</em> published a new exercise: #{i18n_exercise(exercise)}"
-    assert_equal text, update.rendering_data[:text]
-    assert_equal [author.avatar_url], update.rendering_data[:maker_avatar_urls]
-  end
-
-  test "rendering_data with 2 contributors" do
-    track = create :track
-    contributor = create :user
-    author = create :user
-    exercise = create :concept_exercise, track: track
-    create :exercise_contributorship, exercise: exercise, contributor: contributor
-    create :exercise_authorship, exercise: exercise, author: author
-    update = create :site_update, exercise: exercise, track: track
-
-    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new exercise: #{i18n_exercise(exercise)}"
-    assert_equal text, update.rendering_data[:text]
-    assert_equal [author, contributor].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
-  end
-
-  test "rendering_data with 3 contributors" do
-    track = create :track
-    contributor_1 = create :user
-    author = create :user
-    contributor_2 = create :user
-    exercise = create :concept_exercise, track: track
-    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
-    create :exercise_authorship, exercise: exercise, author: author
-    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
-    update = create :site_update, exercise: exercise, track: track
-
-    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
-    assert_equal text, update.rendering_data[:text]
-    assert_equal [author, contributor_1, contributor_2].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
-  end
-
-  test "rendering_data with 4 contributors" do
-    track = create :track
-    contributor_1 = create :user
-    author = create :user
-    contributor_2 = create :user
-    contributor_3 = create :user
-    exercise = create :concept_exercise, track: track
-    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
-    create :exercise_authorship, exercise: exercise, author: author
-    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
-    create :exercise_contributorship, exercise: exercise, contributor: contributor_3
-    update = create :site_update, exercise: exercise, track: track
-
-    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
-    assert_equal text, update.rendering_data[:text]
-    assert_equal [author, contributor_1, contributor_2, contributor_3].map(&:avatar_url),
-      update.rendering_data[:maker_avatar_urls]
-  end
-
   test "rendering expanded data" do
     track = create :track
     exercise = create :concept_exercise, track: track
@@ -160,9 +81,5 @@ class SiteUpdateTest < ActiveSupport::TestCase
 
     assert_equal [ruby_update, js_update], SiteUpdate.all # Sanity
     assert_equal [js_update], SiteUpdate.for_track(js)
-  end
-
-  def i18n_exercise(exercise)
-    %(<a href="#{Exercism::Routes.track_exercise_url(exercise.track, exercise)}">#{exercise.title}</a>)
   end
 end

--- a/test/models/site_update_test.rb
+++ b/test/models/site_update_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class SiteUpdateTest < ActiveSupport::TestCase
+  test "text is sanitized" do
+    update = SiteUpdates::NewExerciseUpdate.new
+    update.define_singleton_method(:i18n_params) do
+      { user: "<foo>d</foo>angerous" }
+    end
+
+    I18n.expects(:t).with(
+      "site_updates.new_exercise.",
+      { user: "dangerous" }
+    ).returns("")
+
+    update.text
+  end
+
+  test "rendering_data with no contributors" do
+    track = create :track
+    exercise = create :concept_exercise, track: track
+    update = create :site_update, exercise: exercise, track: track
+
+    expected = {
+      text: "<em>We</em> published a new exercise: <strong>#{exercise.title}</strong>",
+      icon_url: exercise.icon_url,
+      maker_avatar_urls: []
+    }.with_indifferent_access
+
+    assert_equal expected, update.rendering_data
+  end
+
+  test "rendering_data with 1 contributors" do
+    track = create :track
+    author = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_authorship, exercise: exercise, author: author
+    update = create :site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author.avatar_url], update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 2 contributors" do
+    track = create :track
+    contributor = create :user
+    author = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor
+    create :exercise_authorship, exercise: exercise, author: author
+    update = create :site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 3 contributors" do
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
+    create :exercise_authorship, exercise: exercise, author: author
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
+    update = create :site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 4 contributors" do
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    contributor_3 = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
+    create :exercise_authorship, exercise: exercise, author: author
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_3
+    update = create :site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new exercise: <strong>#{exercise.title}</strong>" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2, contributor_3].map(&:avatar_url),
+      update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "published_at is set to now + 3.hours" do
+    freeze_time do
+      update = create :site_update
+      assert_equal Time.current + 3.hours, update.published_at
+    end
+  end
+end

--- a/test/models/site_update_test.rb
+++ b/test/models/site_update_test.rb
@@ -24,6 +24,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
       expected = {
         text: "<em>We</em> published a new exercise: #{i18n_exercise(exercise)}",
         icon_url: exercise.icon_url,
+        track_icon_url: track.icon_url,
         published_at: (Time.current + 3.hours).iso8601,
         maker_avatar_urls: []
       }.with_indifferent_access
@@ -133,6 +134,32 @@ class SiteUpdateTest < ActiveSupport::TestCase
       update = create :site_update
       assert_equal Time.current + 3.hours, update.published_at
     end
+  end
+
+  test "published scope" do
+    published = create :site_update, published_at: Time.current - 1.minute
+    unpublished = create :site_update, published_at: Time.current + 1.minute
+
+    assert_equal [published, unpublished], SiteUpdate.all # Sanity
+    assert_equal [published], SiteUpdate.published
+  end
+
+  test "sorted scope" do
+    first = create :site_update, published_at: Time.current - 1.minute
+    third = create :site_update, published_at: Time.current + 2.minutes
+    second = create :site_update, published_at: Time.current
+
+    assert_equal [third, second, first], SiteUpdate.sorted
+  end
+
+  test "for track scope" do
+    ruby = create :track, slug: 'ruby'
+    js = create :track, slug: 'js'
+    ruby_update = create :site_update, track: ruby
+    js_update = create :site_update, track: js
+
+    assert_equal [ruby_update, js_update], SiteUpdate.all # Sanity
+    assert_equal [js_update], SiteUpdate.for_track(js)
   end
 
   def i18n_exercise(exercise)

--- a/test/models/site_update_test.rb
+++ b/test/models/site_update_test.rb
@@ -100,9 +100,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
     author = create :user
     title = "Check this out!!"
     description = "I did something really cool :)"
-    update = create :site_update, exercise: exercise, track: track, params: {
-      author: author, title: title, description: description
-    }
+    update = create :site_update, exercise: exercise, track: track, author: author, title: title, description: description
 
     expected = {
       author_handle: author.handle,
@@ -118,9 +116,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
     exercise = create :concept_exercise, track: track
 
     pull_request = create :github_pull_request
-    update = create :site_update, exercise: exercise, track: track, params: {
-      pull_request: pull_request
-    }
+    update = create :site_update, exercise: exercise, track: track, pull_request: pull_request
 
     expected = {
       title: pull_request.title,

--- a/test/models/site_update_test.rb
+++ b/test/models/site_update_test.rb
@@ -16,17 +16,20 @@ class SiteUpdateTest < ActiveSupport::TestCase
   end
 
   test "rendering_data with no contributors" do
-    track = create :track
-    exercise = create :concept_exercise, track: track
-    update = create :site_update, exercise: exercise, track: track
+    freeze_time do
+      track = create :track
+      exercise = create :concept_exercise, track: track
+      update = create :site_update, exercise: exercise, track: track
 
-    expected = {
-      text: "<em>We</em> published a new exercise: <strong>#{exercise.title}</strong>",
-      icon_url: exercise.icon_url,
-      maker_avatar_urls: []
-    }.with_indifferent_access
+      expected = {
+        text: "<em>We</em> published a new exercise: #{i18n_exercise(exercise)}",
+        icon_url: exercise.icon_url,
+        published_at: (Time.current + 3.hours).iso8601,
+        maker_avatar_urls: []
+      }.with_indifferent_access
 
-    assert_equal expected, update.rendering_data
+      assert_equal expected, update.rendering_data
+    end
   end
 
   test "rendering_data with 1 contributors" do
@@ -36,7 +39,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
     create :exercise_authorship, exercise: exercise, author: author
     update = create :site_update, exercise: exercise, track: track
 
-    text = "<em>#{author.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>"
+    text = "<em>#{author.handle}</em> published a new exercise: #{i18n_exercise(exercise)}"
     assert_equal text, update.rendering_data[:text]
     assert_equal [author.avatar_url], update.rendering_data[:maker_avatar_urls]
   end
@@ -50,7 +53,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
     create :exercise_authorship, exercise: exercise, author: author
     update = create :site_update, exercise: exercise, track: track
 
-    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>"
+    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new exercise: #{i18n_exercise(exercise)}"
     assert_equal text, update.rendering_data[:text]
     assert_equal [author, contributor].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
   end
@@ -66,7 +69,7 @@ class SiteUpdateTest < ActiveSupport::TestCase
     create :exercise_contributorship, exercise: exercise, contributor: contributor_2
     update = create :site_update, exercise: exercise, track: track
 
-    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new exercise: <strong>#{exercise.title}</strong>" # rubocop:disable Layout/LineLength
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
     assert_equal text, update.rendering_data[:text]
     assert_equal [author, contributor_1, contributor_2].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
   end
@@ -84,10 +87,49 @@ class SiteUpdateTest < ActiveSupport::TestCase
     create :exercise_contributorship, exercise: exercise, contributor: contributor_3
     update = create :site_update, exercise: exercise, track: track
 
-    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new exercise: <strong>#{exercise.title}</strong>" # rubocop:disable Layout/LineLength
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
     assert_equal text, update.rendering_data[:text]
     assert_equal [author, contributor_1, contributor_2, contributor_3].map(&:avatar_url),
       update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering expanded data" do
+    track = create :track
+    exercise = create :concept_exercise, track: track
+
+    author = create :user
+    title = "Check this out!!"
+    description = "I did something really cool :)"
+    update = create :site_update, exercise: exercise, track: track, params: {
+      author: author, title: title, description: description
+    }
+
+    expected = {
+      author_handle: author.handle,
+      author_avatar_url: author.avatar_url,
+      title: title,
+      description: description
+    }.stringify_keys
+    assert_equal expected, update.rendering_data[:expanded]
+  end
+
+  test "rendering pull request" do
+    track = create :track
+    exercise = create :concept_exercise, track: track
+
+    pull_request = create :github_pull_request
+    update = create :site_update, exercise: exercise, track: track, params: {
+      pull_request: pull_request
+    }
+
+    expected = {
+      title: pull_request.title,
+      number: pull_request.number,
+      url: "https://github.com/#{pull_request.repo}/pull/#{pull_request.number}",
+      merged_by: pull_request.merged_by_username,
+      merged_at: pull_request.updated_at.iso8601
+    }.stringify_keys
+    assert_equal expected, update.rendering_data[:pull_request]
   end
 
   test "published_at is set to now + 3.hours" do
@@ -95,5 +137,9 @@ class SiteUpdateTest < ActiveSupport::TestCase
       update = create :site_update
       assert_equal Time.current + 3.hours, update.published_at
     end
+  end
+
+  def i18n_exercise(exercise)
+    %(<a href="#{Exercism::Routes.track_exercise_url(exercise.track, exercise)}">#{exercise.title}</a>)
   end
 end

--- a/test/models/site_updates/new_concept_update_test.rb
+++ b/test/models/site_updates/new_concept_update_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+
+class SiteUpdates::NewConceptUpdateTest < ActiveSupport::TestCase
+  test "rendering_data with no contributors" do
+    freeze_time do
+      track = create :track
+      concept = create :track_concept, track: track
+      update = create :new_concept_site_update, track: track, params: { concept: concept }
+
+      expected = {
+        text: "<em>We</em> published a new Concept: #{i18n_concept(concept)}",
+        icon_type: 'concept',
+        icon_url: nil,
+        track_icon_url: track.icon_url,
+        published_at: (Time.current + 3.hours).iso8601,
+        maker_avatar_urls: []
+      }.with_indifferent_access
+
+      assert_equal expected, update.rendering_data
+    end
+  end
+
+  test "rendering_data with 1 contributors" do
+    # TODO: Readd once we have contributors
+    skip
+    track = create :track
+    author = create :user
+    concept = create :track_concept, track: track
+    create :concept_authorship, concept: concept, author: author
+    update = create :new_concept_site_update, track: track, params: { concept: concept }
+
+    text = "<em>#{author.handle}</em> published a new Concept: #{i18n_concept(concept)}"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author.avatar_url], update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 2 contributors" do
+    # TODO: Readd once we have contributors
+    skip
+    track = create :track
+    contributor = create :user
+    author = create :user
+    concept = create :track_concept, track: track
+    create :concept_contributorship, concept: concept, contributor: contributor
+    create :concept_authorship, concept: concept, author: author
+    update = create :new_concept_site_update, track: track, params: { concept: concept }
+
+    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new Concept: #{i18n_concept(concept)}"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 3 contributors" do
+    # TODO: Readd once we have contributors
+    skip
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    concept = create :track_concept, track: track
+    create :concept_contributorship, concept: concept, contributor: contributor_1
+    create :concept_authorship, concept: concept, author: author
+    create :concept_contributorship, concept: concept, contributor: contributor_2
+    update = create :new_concept_site_update, track: track, params: { concept: concept }
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new Concept: #{i18n_concept(concept)}" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 4 contributors" do
+    # TODO: Readd once we have contributors
+    skip
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    contributor_3 = create :user
+    concept = create :track_concept, track: track
+    create :concept_contributorship, concept: concept, contributor: contributor_1
+    create :concept_authorship, concept: concept, author: author
+    create :concept_contributorship, concept: concept, contributor: contributor_2
+    create :concept_contributorship, concept: concept, contributor: contributor_3
+    update = create :new_concept_site_update, track: track, params: { concept: concept }
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new Concept: #{i18n_concept(concept)}" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2, contributor_3].map(&:avatar_url),
+      update.rendering_data[:maker_avatar_urls]
+  end
+
+  def i18n_concept(concept)
+    %(<a href="#{Exercism::Routes.track_concept_url(concept.track, concept)}">#{concept.name}</a>)
+  end
+end

--- a/test/models/site_updates/new_concept_update_test.rb
+++ b/test/models/site_updates/new_concept_update_test.rb
@@ -10,7 +10,7 @@ class SiteUpdates::NewConceptUpdateTest < ActiveSupport::TestCase
       expected = {
         text: "<em>We</em> published a new Concept: #{i18n_concept(concept)}",
         icon_type: 'concept',
-        icon_url: nil,
+        icon_url: "Co",
         track_icon_url: track.icon_url,
         published_at: (Time.current + 3.hours).iso8601,
         maker_avatar_urls: []

--- a/test/models/site_updates/new_exercise_update_test.rb
+++ b/test/models/site_updates/new_exercise_update_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class SiteUpdates::NewExerciseUpdateTest < ActiveSupport::TestCase
+  test "rendering_data with no contributors" do
+    freeze_time do
+      track = create :track
+      exercise = create :concept_exercise, track: track
+      update = create :new_exercise_site_update, exercise: exercise, track: track
+
+      expected = {
+        text: "<em>We</em> published a new Exercise: #{i18n_exercise(exercise)}",
+        icon_type: 'image',
+        icon_url: exercise.icon_url,
+        track_icon_url: track.icon_url,
+        published_at: (Time.current + 3.hours).iso8601,
+        maker_avatar_urls: []
+      }.with_indifferent_access
+
+      assert_equal expected, update.rendering_data
+    end
+  end
+
+  test "rendering_data with 1 contributors" do
+    track = create :track
+    author = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_authorship, exercise: exercise, author: author
+    update = create :new_exercise_site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}</em> published a new Exercise: #{i18n_exercise(exercise)}"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author.avatar_url], update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 2 contributors" do
+    track = create :track
+    contributor = create :user
+    author = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor
+    create :exercise_authorship, exercise: exercise, author: author
+    update = create :new_exercise_site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle} and #{contributor.handle}</em> published a new Exercise: #{i18n_exercise(exercise)}"
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 3 contributors" do
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
+    create :exercise_authorship, exercise: exercise, author: author
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
+    update = create :new_exercise_site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and #{contributor_2.handle}</em> published a new Exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2].map(&:avatar_url), update.rendering_data[:maker_avatar_urls]
+  end
+
+  test "rendering_data with 4 contributors" do
+    track = create :track
+    contributor_1 = create :user
+    author = create :user
+    contributor_2 = create :user
+    contributor_3 = create :user
+    exercise = create :concept_exercise, track: track
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_1
+    create :exercise_authorship, exercise: exercise, author: author
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_2
+    create :exercise_contributorship, exercise: exercise, contributor: contributor_3
+    update = create :new_exercise_site_update, exercise: exercise, track: track
+
+    text = "<em>#{author.handle}, #{contributor_1.handle}, and 2 others</em> published a new Exercise: #{i18n_exercise(exercise)}" # rubocop:disable Layout/LineLength
+    assert_equal text, update.rendering_data[:text]
+    assert_equal [author, contributor_1, contributor_2, contributor_3].map(&:avatar_url),
+      update.rendering_data[:maker_avatar_urls]
+  end
+
+  def i18n_exercise(exercise)
+    %(<a href="#{Exercism::Routes.track_exercise_url(exercise.track, exercise)}">#{exercise.title}</a>)
+  end
+end


### PR DESCRIPTION
This adds site updates, renders them on tracks, and adds a very basic admin page for them. The admin UI is really temporary (thus no tests) and the HAML will end up as React eventually, but the rest should be solid.

This currently only has support for New Exercises and New Concepts, but there will be other types too.

They look like this:

<img width="841" alt="Screenshot 2021-06-14 at 21 21 11" src="https://user-images.githubusercontent.com/286476/121954266-793f3880-cd56-11eb-82e1-078bfac554cd.png">
