### PR TITLE
Render backtrace as separate lines

### DIFF
--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -23,7 +23,7 @@ module Github
           ```
           #{error.message}
 
-          #{error.backtrace}
+          #{error.backtrace.join("\n")}
           ```
 
           Please tag @iHiD if you require more information.


### PR DESCRIPTION
See https://github.com/exercism/csharp/issues/1548 for an example of how the backtrace will now be rendered.

Closes https://github.com/exercism/v3-beta/issues/99
