### PR TITLE
Add mentor finished state

### DIFF
--- a/app/css/components/mentor/discussion.css
+++ b/app/css/components/mentor/discussion.css
@@ -430,7 +430,8 @@
                     }
                 }
             }
-            & .finished-wizard.timeline-entry {
+            & .finished-wizard.timeline-entry,
+            & .student-review.timeline-entry {
                 @apply pt-24;
 
                 &:before {
@@ -444,17 +445,27 @@
                         @apply pb-12 mb-12;
                         @apply border-b-1 border-borderColor6;
                     }
-                    & > .--step {
-                        /* Leading-160 */
-                        & p {
-                            @apply text-16 leading-160 font-medium;
-                            @apply mb-12;
-                        }
-                        & .buttons {
-                            @apply flex items-center;
-                            & button {
-                                @apply mr-12;
-                            }
+                    & p {
+                        @apply text-p-base font-medium;
+                        @apply mb-12;
+                    }
+                }
+            }
+
+            & .student-review.timeline-entry {
+                & p {
+                    & strong {
+                        @apply block font-semibold text-textColor2;
+                    }
+                }
+            }
+            & .finished-wizard.timeline-entry {
+                & > .--step {
+                    /* Leading-160 */
+                    & .buttons {
+                        @apply flex items-center;
+                        & button {
+                            @apply mr-12;
                         }
                     }
                 }
@@ -735,8 +746,4 @@
             }
         }
     }
-}
-.hello {
-    padding: 20px;
-    background: red;
 }

--- a/app/javascript/components/student/MentoringSession.tsx
+++ b/app/javascript/components/student/MentoringSession.tsx
@@ -111,6 +111,7 @@ export const MentoringSession = ({
             userId={userId}
             iterations={iterations}
             onIterationScroll={handleIterationScroll}
+            links={{ exercise: exercise.links.self }}
           />
         ) : (
           <MentoringRequest

--- a/app/javascript/components/student/mentoring-session/DiscussionActions.tsx
+++ b/app/javascript/components/student/mentoring-session/DiscussionActions.tsx
@@ -14,12 +14,19 @@ export const DiscussionActions = ({
   discussion: MentorDiscussion
   links: Links
 }): JSX.Element => {
-  return discussion.isFinished ? (
+  return discussion.isFinished || discussion.status === 'mentor_finished' ? (
     <div className="finished">
       <GraphicalIcon icon="completed-check-circle" />
       Ended
     </div>
   ) : (
-    <FinishButton discussion={discussion} links={links} />
+    <FinishButton
+      discussion={discussion}
+      links={links}
+      className="btn-keyboard-shortcut finish-button"
+    >
+      <div className="--hint">End discussion</div>
+      <div className="--kb">F3</div>
+    </FinishButton>
   )
 }

--- a/app/javascript/components/student/mentoring-session/DiscussionInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/DiscussionInfo.tsx
@@ -7,6 +7,11 @@ import { MentorInfo } from './MentorInfo'
 import { MentorDiscussion, Iteration } from '../../types'
 import { Mentor } from '../MentoringSession'
 import { GraphicalIcon } from '../../common'
+import { FinishButton } from './FinishButton'
+
+type Links = {
+  exercise: string
+}
 
 export const DiscussionInfo = ({
   discussion,
@@ -14,12 +19,14 @@ export const DiscussionInfo = ({
   userId,
   iterations,
   onIterationScroll,
+  links,
 }: {
   discussion: MentorDiscussion
   mentor: Mentor
   userId: number
   iterations: readonly Iteration[]
   onIterationScroll: (iteration: Iteration) => void
+  links: Links
 }): JSX.Element => {
   return (
     <PostsWrapper discussionId={discussion.id}>
@@ -34,23 +41,31 @@ export const DiscussionInfo = ({
             userId={userId}
             onIterationScroll={onIterationScroll}
           />
-          <div className="student-review timeline-entry">
-            <GraphicalIcon
-              icon="completed-check-circle"
-              className="timeline-marker"
-            />
-            <div className="--details timeline-content">
-              <h3>{mentor.handle} ended this discussion.</h3>
-              <p>
-                <strong>It's time to review {mentor.handle}'s mentoring</strong>
-                You’ll be able to leave feedback and share what you thought of
-                your experience.
-              </p>
-              <button className="btn-primary btn-s">
-                Review &amp; finish discussion
-              </button>
+          {discussion.status === 'mentor_finished' ? (
+            <div className="student-review timeline-entry">
+              <GraphicalIcon
+                icon="completed-check-circle"
+                className="timeline-marker"
+              />
+              <div className="--details timeline-content">
+                <h3>{mentor.handle} ended this discussion.</h3>
+                <p>
+                  <strong>
+                    It&apos;s time to review {mentor.handle}&apos;s mentoring
+                  </strong>
+                  You’ll be able to leave feedback and share what you thought of
+                  your experience.
+                </p>
+                <FinishButton
+                  discussion={discussion}
+                  links={links}
+                  className="btn-primary btn-s"
+                >
+                  Review &amp; finish discussion
+                </FinishButton>
+              </div>
             </div>
-          </div>
+          ) : null}
         </div>
       </div>
       <section className="comment-section --comment">

--- a/app/javascript/components/student/mentoring-session/DiscussionInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/DiscussionInfo.tsx
@@ -6,6 +6,7 @@ import { PostsWrapper } from '../../mentoring/discussion/PostsContext'
 import { MentorInfo } from './MentorInfo'
 import { MentorDiscussion, Iteration } from '../../types'
 import { Mentor } from '../MentoringSession'
+import { GraphicalIcon } from '../../common'
 
 export const DiscussionInfo = ({
   discussion,
@@ -33,6 +34,23 @@ export const DiscussionInfo = ({
             userId={userId}
             onIterationScroll={onIterationScroll}
           />
+          <div className="student-review timeline-entry">
+            <GraphicalIcon
+              icon="completed-check-circle"
+              className="timeline-marker"
+            />
+            <div className="--details timeline-content">
+              <h3>{mentor.handle} ended this discussion.</h3>
+              <p>
+                <strong>It's time to review {mentor.handle}'s mentoring</strong>
+                You’ll be able to leave feedback and share what you thought of
+                your experience.
+              </p>
+              <button className="btn-primary btn-s">
+                Review &amp; finish discussion
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <section className="comment-section --comment">

--- a/app/javascript/components/student/mentoring-session/FinishButton.tsx
+++ b/app/javascript/components/student/mentoring-session/FinishButton.tsx
@@ -12,11 +12,14 @@ type Status = 'initialized' | 'confirming' | 'finishing'
 
 export const FinishButton = ({
   discussion,
+  className,
+  children,
   links,
-}: {
+}: React.PropsWithChildren<{
+  className: string
   discussion: MentorDiscussion
   links: Links
-}): JSX.Element => {
+}>): JSX.Element => {
   const [status, setStatus] = useState<Status>('initialized')
 
   useEffect(() => {
@@ -44,13 +47,12 @@ export const FinishButton = ({
     <React.Fragment>
       <button
         type="button"
-        className="btn-keyboard-shortcut finish-button"
+        className={className}
         onClick={() => {
           setStatus('confirming')
         }}
       >
-        <div className="--hint">End discussion</div>
-        <div className="--kb">F3</div>
+        {children}
       </button>
       <ConfirmFinishMentorDiscussionModal
         open={status === 'confirming'}

--- a/app/views/tracks/mentor_discussions/_mentoring_in_progress.html.haml
+++ b/app/views/tracks/mentor_discussions/_mentoring_in_progress.html.haml
@@ -9,7 +9,10 @@
         %strong= discussion.mentor.handle
 
       .details
-        .--turn Your turn to respond
+        - if discussion.mentor_finished?
+          .--turn Review your mentor
+        - else
+          .--turn Your turn to respond
         .--comments
           = graphical_icon "comment"
           = pluralize discussion.num_posts, "comment"

--- a/app/views/tracks/show/joined/_mentoring_article.html.haml
+++ b/app/views/tracks/show/joined/_mentoring_article.html.haml
@@ -48,6 +48,9 @@
           - if discussion.awaiting_student?
             .--turn Your turn to respond
 
+          - if discussion.mentor_finished?
+            .--turn Review your mentor
+
           .--comments
             = graphical_icon :comment
             = pluralize discussion.posts.count, "comment"

--- a/test/system/flows/student/mentor_finished_discussion_test.rb
+++ b/test/system/flows/student/mentor_finished_discussion_test.rb
@@ -1,0 +1,57 @@
+require "application_system_test_case"
+require_relative "../../../support/capybara_helpers"
+
+module Flows
+  module Student
+    class MentorFinishedDiscussionTest < ApplicationSystemTestCase
+      include CapybaraHelpers
+
+      test "end discussion button does not show" do
+        student = create :user, handle: "student"
+        track = create :track
+        exercise = create :concept_exercise, track: track
+        solution = create :concept_solution, user: student, exercise: exercise
+        request = create :mentor_request, solution: solution
+        discussion = create :mentor_discussion,
+          status: :mentor_finished,
+          solution: solution,
+          request: request
+        submission = create :submission, solution: solution
+        create :iteration, idx: 1, solution: solution, submission: submission
+
+        use_capybara_host do
+          sign_in!(student)
+          visit track_exercise_mentor_discussion_path(track, exercise, discussion)
+        end
+
+        assert_text "Ended"
+      end
+
+      test "student reviews discussion" do
+        user = create :user
+        track = create :track
+        exercise = create :concept_exercise, track: track
+        solution = create :concept_solution, exercise: exercise, user: user
+        submission = create :submission, solution: solution,
+                                         tests_status: :passed,
+                                         representation_status: :generated,
+                                         analysis_status: :completed
+        create :iteration, idx: 1, solution: solution, submission: submission
+        discussion = create :mentor_discussion, solution: solution, status: :mentor_finished
+
+        use_capybara_host do
+          sign_in!(user)
+          visit track_exercise_mentor_discussion_path(solution.track, solution.exercise, discussion)
+          click_on "Review & finish discussion"
+          within(".m-confirm-finish-student-mentor-discussion") { click_on "Review and end discussion" }
+          click_on "It was good!"
+          fill_in "Leave #{discussion.mentor.handle} a testimonial (optional)", with: "Good mentor!"
+          click_on "Finish"
+          click_on "Back to the exercise"
+
+          assert_text "Nice, it looks like you’re done here!"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@kntsoriano This needs a few things adding. 

Everything here is true if the `discussion.status == "mentor_finished"`

- [ ] Don't show end discussion at the top [1]
- [ ] Show this new section (added to the React) [2]
- [ ] Wire the button so that it takes you to the review mentor state [3]
- [ ] Add some tests to ensure it all works

---

[1]
<img width="197" alt="Screenshot 2021-06-30 at 14 01 06" src="https://user-images.githubusercontent.com/286476/123964824-c43e8a00-d9ab-11eb-8185-0e5006ae020a.png">

[2] 
<img width="560" alt="Screenshot 2021-06-30 at 14 01 08" src="https://user-images.githubusercontent.com/286476/123964839-c7d21100-d9ab-11eb-910b-d9a105c2b311.png">

[3] 
<img width="1174" alt="Screenshot 2021-06-30 at 14 02 27" src="https://user-images.githubusercontent.com/286476/123964882-d1f40f80-d9ab-11eb-845c-8292802b914d.png">