### PR TITLE
Don't create/open issue for deadlock error

### DIFF
--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -3,7 +3,7 @@ module Github
     class OpenForSyncFailure
       include Mandate
 
-      initialize_with :track, :error, :git_sha
+      initialize_with :track, :exception, :git_sha
 
       def call
         if missing?
@@ -21,9 +21,9 @@ module Github
 
           The error was:
           ```
-          #{error.message}
+          #{exception.message}
 
-          #{error.backtrace.join("\n")}
+          #{exception.backtrace.join("\n")}
           ```
 
           Please tag @exercism/maintainers-admin if you require more information.

--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -26,7 +26,7 @@ module Github
           #{error.backtrace.join("\n")}
           ```
 
-          Please tag @iHiD if you require more information.
+          Please tag @exercism/maintainers-admin if you require more information.
         BODY
 
         Exercism.octokit_client.create_issue(repo, title, body)

--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -6,6 +6,8 @@ module Github
       initialize_with :track, :exception, :git_sha
 
       def call
+        return if deadlock_exception?
+
         if missing?
           create_issue
         elsif closed?
@@ -54,6 +56,10 @@ module Github
         # TODO: Elevate this into exercism-config gem
         author = "exercism-bot"
         Exercism.octokit_client.search_issues("#{git_sha} is:issue in:body repo:#{repo} author:#{author}")[:items]&.first
+      end
+
+      def deadlock_exception?
+        exception.is_a?(Mysql2::Error) && exception.message.include?("Deadlock found when trying to get lock")
       end
     end
   end

--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -59,7 +59,7 @@ module Github
       end
 
       def deadlock_exception?
-        exception.is_a?(Mysql2::Error) && exception.message.include?("Deadlock found when trying to get lock")
+        exception.is_a?(ActiveRecord::Deadlocked)
       end
     end
   end

--- a/test/commands/github/issue/open_for_sync_failure_test.rb
+++ b/test/commands/github/issue/open_for_sync_failure_test.rb
@@ -99,7 +99,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
   test "does nothing when exception is deadlock" do
     track = create :track
 
-    exception = Mysql2::Error.new "Deadlock found when trying to get lock; try restarting transaction"
+    exception = ActiveRecord::Deadlocked.new
 
     Github::Issue::OpenForSyncFailure.(track, exception, track.git_head_sha)
 

--- a/test/commands/github/issue/open_for_sync_failure_test.rb
+++ b/test/commands/github/issue/open_for_sync_failure_test.rb
@@ -32,7 +32,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
         json["labels"].empty? &&
           json["title"] == "🤖 Sync error for commit 2e25f7" &&
           json["body"].include?("We hit an error trying to sync the latest commit (2e25f799c1830b93a8ad65a2bbbb1c50f381e639) to the website.") && # rubocop:disable Layout/LineLength
-          json["body"].include?("Please tag @iHiD if you require more information.") &&
+          json["body"].include?("Please tag @exercism/maintainers-admin if you require more information.") &&
           json["body"].match?(/open_for_sync_failure_test\.rb:\d+:in `block in <class:OpenForSyncFailureTest>/)
       end.
       to_return(status: 200, body: "", headers: {}).


### PR DESCRIPTION
- Ping @exercism/maintainers-admin for sync failure
- Rename error to exception
- Don't sync deadlock issues
