### PR TITLE
Open issue for prerequisite cycles

### DIFF
--- a/app/commands/github/issue/open.rb
+++ b/app/commands/github/issue/open.rb
@@ -1,0 +1,41 @@
+module Github
+  class Issue
+    class Open
+      include Mandate
+
+      initialize_with :repo, :title, :body
+
+      def call
+        if missing?
+          create_issue
+        elsif closed?
+          reopen_issue
+        end
+      end
+
+      private
+      def missing?
+        issue.nil?
+      end
+
+      def closed?
+        issue.state == "closed"
+      end
+
+      def create_issue
+        Exercism.octokit_client.create_issue(repo, title, body)
+      end
+
+      def reopen_issue
+        Exercism.octokit_client.reopen_issue(repo, issue.number)
+      end
+
+      memoize
+      def issue
+        # TODO: Elevate this into exercism-config gem
+        author = "exercism-bot"
+        Exercism.octokit_client.search_issues("\"#{title}\" is:issue in:title repo:#{repo} author:#{author}")[:items]&.first
+      end
+    end
+  end
+end

--- a/app/commands/github/issue/open_for_dependency_cycle.rb
+++ b/app/commands/github/issue/open_for_dependency_cycle.rb
@@ -1,0 +1,34 @@
+module Github
+  class Issue
+    class OpenForDependencyCycle
+      include Mandate
+
+      initialize_with :track
+
+      def call
+        Github::Issue::Open.(repo, title, body)
+      end
+
+      private
+      def repo
+        "exercism/#{track.slug}"
+      end
+
+      def title
+        "🤖 Concept prerequisite cycle found in commit #{track.synced_to_git_sha[0..5]}"
+      end
+
+      def body
+        <<~BODY.strip
+                              We found a concept prerequisite cycle in the `config.json` file in commit #{track.synced_to_git_sha}.
+          #{'          '}
+                              Such a cycle occurs when Concept Exercise A teaches concept X and has concept Y as a prerequisite, whereas Concept Exercise B teaches concept Y and has concept X as a prerequisite. The cycle can also be indirect, in which case there are intermediate Concept Exercises involved.
+                    #{'          '}
+                              These prerequisite cycles should be removed to have the track work properly on the website.
+                    #{'          '}
+                              Please tag @exercism/maintainers-admin if you require more information.
+        BODY
+      end
+    end
+  end
+end

--- a/app/commands/github/issue/open_for_dependency_cycle.rb
+++ b/app/commands/github/issue/open_for_dependency_cycle.rb
@@ -20,13 +20,13 @@ module Github
 
       def body
         <<~BODY.strip
-                              We found a concept prerequisite cycle in the `config.json` file in commit #{track.synced_to_git_sha}.
-          #{'          '}
-                              Such a cycle occurs when Concept Exercise A teaches concept X and has concept Y as a prerequisite, whereas Concept Exercise B teaches concept Y and has concept X as a prerequisite. The cycle can also be indirect, in which case there are intermediate Concept Exercises involved.
-                    #{'          '}
-                              These prerequisite cycles should be removed to have the track work properly on the website.
-                    #{'          '}
-                              Please tag @exercism/maintainers-admin if you require more information.
+          We found a concept prerequisite cycle in the `config.json` file in commit #{track.synced_to_git_sha}.
+
+          Such a cycle occurs when Concept Exercise A teaches concept X and has concept Y as a prerequisite, whereas Concept Exercise B teaches concept Y and has concept X as a prerequisite. The cycle can also be indirect, in which case there are intermediate Concept Exercises involved.
+
+          These prerequisite cycles should be removed to have the track work properly on the website.
+
+          Please tag @exercism/maintainers-admin if you require more information.
         BODY
       end
     end

--- a/app/commands/github/issue/open_for_sync_failure.rb
+++ b/app/commands/github/issue/open_for_sync_failure.rb
@@ -16,9 +16,12 @@ module Github
       end
 
       private
-      def create_issue
-        title = "🤖 Sync error for commit #{git_sha[0..5]}"
-        body = <<~BODY.strip
+      def title
+        "🤖 Sync error for commit #{git_sha[0..5]}"
+      end
+
+      def body
+        <<~BODY.strip
           We hit an error trying to sync the latest commit (#{git_sha}) to the website.
 
           The error was:
@@ -30,7 +33,9 @@ module Github
 
           Please tag @exercism/maintainers-admin if you require more information.
         BODY
+      end
 
+      def create_issue
         Exercism.octokit_client.create_issue(repo, title, body)
       end
 
@@ -55,7 +60,7 @@ module Github
       def issue
         # TODO: Elevate this into exercism-config gem
         author = "exercism-bot"
-        Exercism.octokit_client.search_issues("#{git_sha} is:issue in:body repo:#{repo} author:#{author}")[:items]&.first
+        Exercism.octokit_client.search_issues("\"#{title}\" is:issue in:title repo:#{repo} author:#{author}")[:items]&.first
       end
 
       def deadlock_exception?

--- a/app/commands/track/determine_concept_map_layout.rb
+++ b/app/commands/track/determine_concept_map_layout.rb
@@ -19,6 +19,8 @@ class Track
         levels: concept_levels,
         connections: concept_connections
       }
+    rescue TrackHasCyclicPrerequisiteError
+      Github::Issue::OpenForDependencyCycle.(track)
     end
 
     private

--- a/app/commands/track/determine_concept_map_layout.rb
+++ b/app/commands/track/determine_concept_map_layout.rb
@@ -20,7 +20,8 @@ class Track
         connections: concept_connections
       }
     rescue TrackHasCyclicPrerequisiteError
-      Github::Issue::OpenForDependencyCycle.(track)
+      OpenIssueForDependencyCycleJob.perform_later(track)
+      raise
     end
 
     private

--- a/app/jobs/open_issue_for_dependency_cycle_job.rb
+++ b/app/jobs/open_issue_for_dependency_cycle_job.rb
@@ -1,0 +1,7 @@
+class OpenIssueForDependencyCycleJob < ApplicationJob
+  queue_as :default
+
+  def perform(track)
+    Github::Issue::OpenForDependencyCycle.(track)
+  end
+end

--- a/test/commands/github/issue/open_for_dependency_cycle_test.rb
+++ b/test/commands/github/issue/open_for_dependency_cycle_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class Github::Issue::OpenForDependencyCycleTest < ActiveSupport::TestCase
+  test "opens issue when issue was not yet created" do
+    track = create :track, slug: 'ruby', synced_to_git_sha: '2e25f799c1830b93a8ad65a2bbbb1c50f381e639'
+
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Concept%20prerequisite%20cycle%20found%20in%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 0,
+          incomplete_results: false,
+          items: []
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby/issues").
+      with do |request|
+        json = JSON.parse(request.body)
+        json["labels"].empty? &&
+          json["title"] == "🤖 Concept prerequisite cycle found in commit 2e25f7" &&
+          json["body"].include?("Such a cycle occurs when Concept Exercise A teaches concept X") &&
+          json["body"].include?("These prerequisite cycles should be removed to have the track work properly on the website") &&
+          json["body"].include?("Please tag @exercism/maintainers-admin if you require more information.")
+      end.
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::OpenForDependencyCycle.(track)
+  end
+
+  test "re-opens issue when issue was closed" do
+    track = create :track, slug: 'ruby', synced_to_git_sha: '2e25f799c1830b93a8ad65a2bbbb1c50f381e639'
+
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Concept%20prerequisite%20cycle%20found%20in%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 1,
+          incomplete_results: false,
+          items: [{
+            number: 22,
+            state: "closed"
+          }]
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    stub_request(:patch, "https://api.github.com/repos/exercism/ruby/issues/22").
+      with(body: { state: "open" }.to_json).
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::OpenForDependencyCycle.(track)
+  end
+
+  test "does nothing when issue already open" do
+    track = create :track, slug: 'ruby', synced_to_git_sha: '2e25f799c1830b93a8ad65a2bbbb1c50f381e639'
+
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Concept%20prerequisite%20cycle%20found%20in%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 1,
+          incomplete_results: false,
+          items: [{
+            number: 22,
+            state: "open"
+          }]
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    Github::Issue::OpenForDependencyCycle.(track)
+
+    # If the GitHub API would have been called, we would not have gotten to this point
+  end
+end

--- a/test/commands/github/issue/open_for_sync_failure_test.rb
+++ b/test/commands/github/issue/open_for_sync_failure_test.rb
@@ -15,7 +15,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
     track = create :track, slug: 'ruby'
     track.stubs(:git_head_sha).returns(head_git_sha)
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=2e25f799c1830b93a8ad65a2bbbb1c50f381e639%20is:issue%20in:body%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Sync%20error%20for%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
       to_return(
         status: 200,
         body: {
@@ -48,7 +48,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
     track = create :track, slug: 'ruby'
     track.stubs(:git_head_sha).returns(head_git_sha)
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=2e25f799c1830b93a8ad65a2bbbb1c50f381e639%20is:issue%20in:body%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Sync%20error%20for%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
       to_return(
         status: 200,
         body: {
@@ -77,7 +77,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
     track = create :track, slug: 'ruby'
     track.stubs(:git_head_sha).returns(head_git_sha)
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=2e25f799c1830b93a8ad65a2bbbb1c50f381e639%20is:issue%20in:body%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22%F0%9F%A4%96%20Sync%20error%20for%20commit%202e25f7%22%20is:issue%20in:title%20repo:exercism/ruby%20author:exercism-bot"). # rubocop:disable Layout/LineLength
       to_return(
         status: 200,
         body: {

--- a/test/commands/github/issue/open_for_sync_failure_test.rb
+++ b/test/commands/github/issue/open_for_sync_failure_test.rb
@@ -4,8 +4,7 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
   test "opens issue when issue was not yet created" do
     head_git_sha = "2e25f799c1830b93a8ad65a2bbbb1c50f381e639"
 
-    # We raise the error and then catch it to make sure that the
-    # error has a proper backtrace
+    # Raise the error and catch it to ensure a proper backtrace
     begin
       raise StandardError, "Could not find Concept X"
     rescue StandardError => e
@@ -43,7 +42,13 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
 
   test "re-opens issue when issue was closed" do
     head_git_sha = "2e25f799c1830b93a8ad65a2bbbb1c50f381e639"
-    exception = StandardError.new "Could not find Concept X"
+
+    # Raise the error and catch it to ensure a proper backtrace
+    begin
+      raise StandardError, "Could not find Concept X"
+    rescue StandardError => e
+      exception = e
+    end
 
     track = create :track, slug: 'ruby'
     track.stubs(:git_head_sha).returns(head_git_sha)
@@ -72,7 +77,13 @@ class Github::Issue::OpenForSyncFailureTest < ActiveSupport::TestCase
 
   test "does nothing when issue already open" do
     head_git_sha = "2e25f799c1830b93a8ad65a2bbbb1c50f381e639"
-    exception = StandardError.new "Could not find Concept X"
+
+    # Raise the error and catch it to ensure a proper backtrace
+    begin
+      raise StandardError, "Could not find Concept X"
+    rescue StandardError => e
+      exception = e
+    end
 
     track = create :track, slug: 'ruby'
     track.stubs(:git_head_sha).returns(head_git_sha)

--- a/test/commands/track/determine_concepts_layout_test.rb
+++ b/test/commands/track/determine_concepts_layout_test.rb
@@ -230,5 +230,24 @@ class Track
         Track::DetermineConceptMapLayout.(track)
       )
     end
+
+    def test_open_issue_when_prerequisite_cycle_found
+      track = create :track
+
+      numbers = create :concept, slug: 'numbers', track: track
+      booleans = create :concept, slug: 'booleans', track: track
+
+      pacman = create :concept_exercise, track: track
+      pacman.taught_concepts << booleans
+      pacman.prerequisites << numbers
+
+      logger = create :concept_exercise, track: track
+      logger.taught_concepts << numbers
+      logger.prerequisites << booleans
+
+      Github::Issue::OpenForDependencyCycle.expects(:call).with(track)
+
+      Track::DetermineConceptMapLayout.(track)
+    end
   end
 end

--- a/test/commands/track/determine_concepts_layout_test.rb
+++ b/test/commands/track/determine_concepts_layout_test.rb
@@ -245,9 +245,30 @@ class Track
       logger.taught_concepts << numbers
       logger.prerequisites << booleans
 
-      Github::Issue::OpenForDependencyCycle.expects(:call).with(track)
+      assert_enqueued_jobs 1, only: OpenIssueForDependencyCycleJob do
+        assert_raises TrackHasCyclicPrerequisiteError do
+          Track::DetermineConceptMapLayout.(track)
+        end
+      end
+    end
 
-      Track::DetermineConceptMapLayout.(track)
+    def test_raises_error_when_prerequisite_cycle_found
+      track = create :track
+
+      numbers = create :concept, slug: 'numbers', track: track
+      booleans = create :concept, slug: 'booleans', track: track
+
+      pacman = create :concept_exercise, track: track
+      pacman.taught_concepts << booleans
+      pacman.prerequisites << numbers
+
+      logger = create :concept_exercise, track: track
+      logger.taught_concepts << numbers
+      logger.prerequisites << booleans
+
+      assert_raises TrackHasCyclicPrerequisiteError do
+        Track::DetermineConceptMapLayout.(track)
+      end
     end
   end
 end

--- a/test/jobs/open_issue_for_dependency_cycle_job_test.rb
+++ b/test/jobs/open_issue_for_dependency_cycle_job_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class OpenIssueForDependencyCycleJobTest < ActiveJob::TestCase
+  test "opens issue" do
+    track = create :track
+
+    Github::Issue::OpenForDependencyCycle.expects(:call).with(track)
+
+    OpenIssueForDependencyCycleJob.perform_now(track)
+  end
+end


### PR DESCRIPTION
This PR adds functionality to automatically open an issue when a dependency cycle is found in a track's concept map.
For an example, see https://github.com/ErikSchierboom/go/issues/10. 

Let me know what you think of the issue body. I did not include the stacktrack because it wasn't really helpful. Once you're happy with the text, I'll create an issue on the Go repo (which was the repo with the cycles).

I've also refactored a bit to allow sharing the open/reopen issue on GitHub functionality between commands.

Closes https://github.com/exercism/website/issues/1210