### PR TITLE
Don't award rep to exercism-bot and exercism-ghost

### DIFF
--- a/app/commands/user/reputation_token/award_for_pull_request_author.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_author.rb
@@ -28,7 +28,7 @@ class User
           external_url: params[:html_url],
           merged_at: params[:merged_at]
         )
-        token.update!(level: reputation_level)
+        token&.update!(level: reputation_level)
       end
 
       private

--- a/app/commands/user/reputation_token/award_for_pull_request_merger.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_merger.rb
@@ -28,7 +28,7 @@ class User
           external_url: params[:html_url],
           merged_at: params[:merged_at]
         )
-        token.update!(level: reputation_level)
+        token&.update!(level: reputation_level)
       end
 
       private

--- a/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
@@ -35,7 +35,7 @@ class User
             merged_at: params[:merged_at],
             closed_at: params[:closed_at]
           )
-          token.update!(level: reputation_level)
+          token&.update!(level: reputation_level)
         end
 
         # TODO: consider what to do with missing reviewers

--- a/app/commands/user/reputation_token/create.rb
+++ b/app/commands/user/reputation_token/create.rb
@@ -6,6 +6,8 @@ class User
       initialize_with :user, :type, :params
 
       def call
+        return if user.system? || user.ghost?
+
         klass = "user/reputation_tokens/#{type}_token".camelize.constantize
 
         klass.new(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,6 +167,14 @@ class User < ApplicationRecord
     became_mentor_at.present?
   end
 
+  def system?
+    id == SYSTEM_USER_ID
+  end
+
+  def ghost?
+    id == GHOST_USER_ID
+  end
+
   # TODO: Remove if not used by launch
   # def favorited_by?(mentor)
   #   relationship = Mentor::StudentRelationship.find_by(student: self, mentor: mentor)

--- a/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
@@ -74,6 +74,52 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     refute User::ReputationTokens::CodeContributionToken.exists?
   end
 
+  test "reputation not awarded to pull request author if author is exercism-bot" do
+    action = 'closed'
+    author = 'exercism-bot'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    merged = true
+    merged_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    html_url = 'https://github.com/exercism/v3/pull/1347'
+    labels = []
+
+    create :user, :system
+
+    User::ReputationToken::AwardForPullRequestAuthor.(
+      action: action, author_username: author, url: url, html_url: html_url, labels: labels,
+      repo: repo, node_id: node_id, number: number, title: title, merged: merged, merged_at: merged_at
+    )
+
+    refute User::ReputationTokens::CodeContributionToken.exists?
+  end
+
+  test "reputation not awarded to pull request author if author is exercism-ghost" do
+    action = 'closed'
+    author = 'exercism-ghost'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    merged = true
+    merged_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    html_url = 'https://github.com/exercism/v3/pull/1347'
+    labels = []
+
+    create :user, :ghost
+
+    User::ReputationToken::AwardForPullRequestAuthor.(
+      action: action, author_username: author, url: url, html_url: html_url, labels: labels,
+      repo: repo, node_id: node_id, number: number, title: title, merged: merged, merged_at: merged_at
+    )
+
+    refute User::ReputationTokens::CodeContributionToken.exists?
+  end
+
   test "reputation not awarded to pull request author if pull request is closed but not merged" do
     action = 'closed'
     author = 'user22'

--- a/test/commands/user/reputation_token/award_for_pull_request_merger_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_request_merger_test.rb
@@ -57,6 +57,56 @@ class User::ReputationToken::AwardForPullRequestMergerTest < ActiveSupport::Test
     assert_equal 1, User::ReputationTokens::CodeMergeToken.where(user: user).size
   end
 
+  test "reputation not awarded to pull request merger if merger is exercism-bot" do
+    action = 'closed'
+    author = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    merged = true
+    merged_at = Time.parse('2020-04-03T14:54:57Z').utc
+    merged_by = "exercism-bot"
+    url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    html_url = 'https://github.com/exercism/v3/pull/1347'
+    labels = []
+
+    create :user, :system
+
+    User::ReputationToken::AwardForPullRequestMerger.(
+      action: action, author_username: author, url: url, html_url: html_url, labels: labels,
+      repo: repo, node_id: node_id, number: number, title: title,
+      merged: merged, merged_at: merged_at, merged_by_username: merged_by
+    )
+
+    refute User::ReputationTokens::CodeMergeToken.exists?
+  end
+
+  test "reputation not awarded to pull request merger if merger is exercism-ghost" do
+    action = 'closed'
+    author = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    merged = true
+    merged_at = Time.parse('2020-04-03T14:54:57Z').utc
+    merged_by = "exercism-ghost"
+    url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    html_url = 'https://github.com/exercism/v3/pull/1347'
+    labels = []
+
+    create :user, :ghost
+
+    User::ReputationToken::AwardForPullRequestMerger.(
+      action: action, author_username: author, url: url, html_url: html_url, labels: labels,
+      repo: repo, node_id: node_id, number: number, title: title,
+      merged: merged, merged_at: merged_at, merged_by_username: merged_by
+    )
+
+    refute User::ReputationTokens::CodeMergeToken.exists?
+  end
+
   test "reputation not awarded to pull request merger if merger is not known" do
     action = 'closed'
     author = 'user22'

--- a/test/commands/user/reputation_token/create_test.rb
+++ b/test/commands/user/reputation_token/create_test.rb
@@ -17,6 +17,34 @@ class User::ReputationToken::CreateTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not create reputation token for system user" do
+    user = create :user, :system
+    contributorship = create :exercise_contributorship, contributor: user
+
+    User::ReputationToken::Create.(
+      user,
+      :exercise_contribution, {
+        contributorship: contributorship
+      }
+    )
+
+    refute User::ReputationToken.exists?
+  end
+
+  test "does not create reputation token for ghost user" do
+    user = create :user, :ghost
+    contributorship = create :exercise_contributorship, contributor: user
+
+    User::ReputationToken::Create.(
+      user,
+      :exercise_contribution, {
+        contributorship: contributorship
+      }
+    )
+
+    refute User::ReputationToken.exists?
+  end
+
   test "idempotent" do
     user = create :user, handle: "User22", github_username: "user22"
     contributorship = create :exercise_contributorship, contributor: user

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -29,10 +29,12 @@ FactoryBot.define do
 
     trait :system do
       id { User::SYSTEM_USER_ID }
+      github_username { 'exercism-bot' }
     end
 
     trait :ghost do
       id { User::GHOST_USER_ID }
+      github_username { 'exercism-ghost' }
     end
   end
 end


### PR DESCRIPTION
- Don't create reputation tokens for system or ghost user
- Don't award PR rep to exercism-ghost and exercism-bot users

Closes #109