### PR TITLE
Update progress graph line algorithm

### DIFF
--- a/app/javascript/components/common/svg-graph-util.ts
+++ b/app/javascript/components/common/svg-graph-util.ts
@@ -7,119 +7,221 @@ export type Line = {
   length: number
   angle: number
 }
-
-const SMOOTHING_RATIO = 0.2
+const SIMILAR_THRESHOLD_DELTA = 0.01
+const SMOOTHING_THRESHOLD_DELTA = 0.2
+const INTERPOLATION_STEPS = 3
+const SEGMENT_PARTS = INTERPOLATION_STEPS + 1
 
 export const minMaxNormalize = (data: Array<number>): Array<number> => {
   const min = Math.min(0, ...data)
   const max = Math.max(...data)
+
+  if (max === 0 && min === 0) {
+    return data
+  }
+
   return data.map((n) => (n - min) / (max - min))
 }
 
-export const drawSegmentPath = (dataPoints: Array<DataPoint>): string => {
+export const mapToSvgDimensions = (
+  data: number[],
+  height: number,
+  width: number
+): DataPoint[] => {
+  // due to the nature of bezier splines, some curves can go outside the boundaries without this buffer
+  const vBuffer = height * 0.05
+  const step = width / (data.length - 1)
+
+  return data.map((normalizedHeight: number, index: number) => {
+    if (normalizedHeight < 0 || normalizedHeight > 1) {
+      throw new Error('Normalized height must be between 0 and 1')
+    }
+
+    return {
+      x: index * step,
+      y: height - vBuffer - (height - 2 * vBuffer) * normalizedHeight, // SVG coordinates start from the upper left corner
+    } as DataPoint
+  })
+}
+
+/**
+ * With splines (bezier or catmull-rom) when there are large differences in values, in order to
+ * keep the curve smooth, it often will vary above or below the baseline since they must touch all
+ * of the points.  This function examines the list of data points, and if there is an extreme difference
+ * attempts to prevent the dipping above or below the baseline by interpolating points to guide the curve
+ */
+export const smoothDataPoints = (
+  dataPoints: DataPoint[],
+  height: number
+): DataPoint[] => {
   return dataPoints.reduce(
     (
-      path: string,
+      acc: DataPoint[],
       dataPoint: DataPoint,
-      idx: number,
-      dataPoints: Array<DataPoint>
+      index: number,
+      dataPoints: readonly DataPoint[]
     ) => {
-      switch (idx) {
-        case 0:
-          return `${drawM(dataPoint)}`
-        case 1:
-          return `${path} ${drawC(dataPoints, idx)}`
-        default:
-          return `${path} ${drawS(dataPoints, idx)}`
+      const prevPoint = dataPoints[index - 1]
+      const nextPoint = dataPoints[index + 1]
+      const nextNextPoint = dataPoints[index + 2]
+
+      const isLastPoint = index === dataPoints.length - 1
+      const isFlatLineSegmentFromPrevToCurrent = prevPoint
+        ? areDataPointsWithinPercentDelta(
+            prevPoint,
+            dataPoint,
+            height,
+            SIMILAR_THRESHOLD_DELTA
+          )
+        : false
+      const isFlatLineSegmentFromNextToNextNext =
+        nextPoint && nextNextPoint
+          ? areDataPointsWithinPercentDelta(
+              nextPoint,
+              nextNextPoint,
+              height,
+              SIMILAR_THRESHOLD_DELTA
+            )
+          : false
+
+      if (
+        isLastPoint ||
+        (!isFlatLineSegmentFromPrevToCurrent &&
+          !isFlatLineSegmentFromNextToNextNext)
+      ) {
+        acc.push(dataPoint)
+        return acc
       }
+
+      if (
+        areDataPointsWithinPercentDelta(
+          dataPoint,
+          nextPoint,
+          height,
+          SMOOTHING_THRESHOLD_DELTA
+        )
+      ) {
+        acc.push(dataPoint)
+        return acc
+      }
+
+      const easingFunction =
+        dataPoint.y > nextPoint.y ? quartEaseInFunction : quartEaseOutFunction
+
+      /**
+       * At this point, has been determined that the curve will be arbitrarily "sharp",
+       * so will interpolate some points to smooth the spline towards the next point.
+       * Method:
+       *  - Find the slope of the line between the two points
+       *  - find the y intercepts when x = 0
+       *  - use `y = mx + c` to create points between the two points with an easing
+       *    function
+       */
+      const slope = (nextPoint.y - dataPoint.y) / (nextPoint.x - dataPoint.x)
+      const yIntercept = dataPoint.y - slope * dataPoint.x
+      const dx = nextPoint.x - dataPoint.x
+
+      const interpolatedPoints = new Array(INTERPOLATION_STEPS)
+        .fill(null)
+        .map((_, step) => getTimeAtStep(step))
+        .map((t) => easingFunction(t))
+        .map(
+          (easedT, i): DataPoint => {
+            return {
+              x: dataPoint.x + getTimeAtStep(i) * dx,
+              y: slope * (dataPoint.x + easedT * dx) + yIntercept, // y = mx + c
+            }
+          }
+        )
+
+      acc.push(dataPoint, ...interpolatedPoints)
+
+      return acc
     },
-    ''
+    []
   )
 }
 
-export const drawSmoothPath = (dataPoints: Array<DataPoint>): string => {
-  return dataPoints.reduce(
-    (acc: string, point: DataPoint, i: number, points: Array<DataPoint>) =>
-      i === 0 ? drawM(point) : `${acc} ${drawSmoothC(point, i, points)}`,
-    ''
-  )
+const areDataPointsWithinPercentDelta = (
+  a: DataPoint | null | undefined,
+  b: DataPoint | null | undefined,
+  height: number,
+  delta: number
+) => {
+  if (!a || !b) {
+    return false
+  }
+
+  const aHeightPercent = a.y / height
+  const bHeightPercent = b.y / height
+
+  return Math.abs(aHeightPercent - bHeightPercent) < delta
 }
 
-export const drawM = ({ x, y }: DataPoint): string => `M ${x} ${y}`
+const getTimeAtStep = (step: number): number => (1 / SEGMENT_PARTS) * (step + 1)
 
-export const drawS = (
-  dataPoints: readonly DataPoint[],
-  idx: number
-): string => {
-  const { x, y } = dataPoints[idx]
-  const { x: xPrev } = dataPoints[idx - 1]
+const quartEaseInFunction = (t: number): number => t * t * t * t
+const quartEaseOutFunction = (t: number): number => 1 - --t * t * t * t
 
-  const x2 = x - (x - xPrev) / 2
-  const y2 = y
-
-  return `S ${x2} ${y2}, ${x} ${y}`
-}
-
-export const drawC = (
-  dataPoints: readonly DataPoint[],
-  idx: number
-): string => {
-  const { x, y } = dataPoints[idx]
-  const { x: xPrev, y: yPrev } = dataPoints[idx - 1]
-
-  const x1 = xPrev + (x - xPrev) / 2
-  const y1 = yPrev
-  const x2 = x - (x - xPrev) / 2
-  const y2 = y
-
-  return `C ${x1} ${y1}, ${x2} ${y2}, ${x} ${y}`
-}
-
-export const drawSmoothC = (
-  current: DataPoint,
-  i: number,
+/**
+ * Takes a sequence of CatmullRom Spline points and returns a smooth SVG Bezier
+ * Curve draw command. Adapted under the MIT license from:
+ * http://schepers.cc/svg/path/catmullrom2bezier.js
+ */
+export const transformCatmullRomSplineToBezierCurve = (
   dataPoints: Array<DataPoint>
 ): string => {
-  const { x: x1, y: y1 } = controlPointPosition(
-    dataPoints[i - 1],
-    dataPoints[i - 2],
-    current
-  )
-  const { x: x2, y: y2 } = controlPointPosition(
-    current,
-    dataPoints[i - 1],
-    dataPoints[i + 1],
-    true
-  )
+  if (dataPoints.length < 3) {
+    throw new Error('Graph requires at least 3 data points')
+  }
 
-  return `C ${x1} ${y1}, ${x2} ${y2}, ${current.x} ${current.y}`
+  let path = drawM(dataPoints[0])
+
+  for (let index = 0; index < dataPoints.length - 1; index += 1) {
+    const points: Array<DataPoint> = []
+    if (index === 0) {
+      points.push(dataPoints[index])
+      points.push(dataPoints[index])
+      points.push(dataPoints[index + 1])
+      points.push(dataPoints[index + 2])
+    } else if (index === dataPoints.length - 2) {
+      points.push(dataPoints[index - 1])
+      points.push(dataPoints[index])
+      points.push(dataPoints[index + 1])
+      points.push(dataPoints[index + 1])
+    } else {
+      points.push(dataPoints[index - 1])
+      points.push(dataPoints[index])
+      points.push(dataPoints[index + 1])
+      points.push(dataPoints[index + 2])
+    }
+
+    path += ' ' + drawC(points[0], points[1], points[2], points[3])
+  }
+
+  return path
 }
 
-export const line = (a: DataPoint, b: DataPoint): Line => {
-  const lengthX = b.x - a.x
-  const lengthY = b.y - a.y
+/**
+ * Draw point as SVG Move command
+ */
+const drawM = ({ x, y }: DataPoint): string => `M ${x} ${y}`
 
-  return {
-    length: Math.sqrt(lengthX ** 2 + lengthY ** 2),
-    angle: Math.atan2(lengthY, lengthX),
-  }
-}
+/**
+ * Translates 4 points from a CatmullRom Spline into an SVG Bezier Curve command
+ */
+const drawC = (
+  p0: DataPoint,
+  p1: DataPoint,
+  p2: DataPoint,
+  p3: DataPoint
+): string => {
+  const x1 = (-p0.x + 6 * p1.x + p2.x) / 6
+  const y1 = (-p0.y + 6 * p1.y + p2.y) / 6
+  const x2 = (p1.x + 6 * p2.x - p3.x) / 6
+  const y2 = (p1.y + 6 * p2.y - p3.y) / 6
+  const x = p2.x
+  const y = p2.y
 
-export const controlPointPosition = (
-  current: DataPoint,
-  previous: DataPoint | undefined,
-  next: DataPoint | undefined,
-  reverse = false
-): DataPoint => {
-  previous = previous ?? current
-  next = next ?? current
-
-  const opposingLine = line(previous, next)
-  const angle = opposingLine.angle + (reverse ? Math.PI : 0)
-  const length = opposingLine.length * SMOOTHING_RATIO
-
-  return {
-    x: current.x + Math.cos(angle) * length,
-    y: current.y + Math.sin(angle) * length,
-  }
+  return `C ${x1} ${y1}, ${x2} ${y2}, ${x} ${y}`
 }

--- a/app/javascript/components/journey/overview/learning-section/TrackSummary.tsx
+++ b/app/javascript/components/journey/overview/learning-section/TrackSummary.tsx
@@ -21,7 +21,6 @@ export const TrackSummary = ({
             data={track.progressChart.data}
             height={120}
             width={300}
-            smooth
           />
           <div className="info">
             <h4>{track.progressChart.period}</h4>

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -694,7 +694,6 @@ initReact({
       data={data.values}
       height={data.height}
       width={data.width}
-      smooth
     />
   ),
   'settings-profile-form': (data: any) => (

--- a/test/javascript/components/progress-graph/progress-graph-util.test.ts
+++ b/test/javascript/components/progress-graph/progress-graph-util.test.ts
@@ -1,12 +1,9 @@
 import { number } from 'prop-types'
 import {
   minMaxNormalize,
-  drawM,
-  drawS,
-  drawSmoothC,
-  drawC,
-  line,
-  controlPointPosition,
+  mapToSvgDimensions,
+  smoothDataPoints,
+  transformCatmullRomSplineToBezierCurve,
   DataPoint,
 } from '../../../../app/javascript/components/common/svg-graph-util'
 
@@ -30,123 +27,285 @@ describe('minMaxNormalize', () => {
     expect(actual[3]).toEqual(0.8)
     expect(actual[4]).toEqual(1)
   })
-})
 
-describe('drawM', () => {
-  it('returns a string with a svg M line command', () => {
-    const dataPoint = mockDataPoint()
-    const actual = drawM(dataPoint)
-
-    expect(actual).toEqual('M 1 1')
+  it('should handle a list of 0s', () => {
+    const values = [0, 0, 0, 0, 0]
+    const actual = minMaxNormalize(values)
+    expect(actual).toStrictEqual([0, 0, 0, 0, 0])
   })
 })
 
-describe('drawS', () => {
-  it('returns a string with a svg S line command', () => {
-    const dataPoints = [mockDataPoint(), mockDataPoint(2, 2)]
-    const actual = drawS(dataPoints, 1)
+describe('mapToSvgDimensions', () => {
+  it('should map an array of normalized values to data points', () => {
+    const data = [0, 0.5, 1]
+    const height = 100
+    const width = 200
 
-    expect(actual).toEqual('S 1.5 2, 2 2')
+    const result = mapToSvgDimensions(data, height, width)
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result.length).toEqual(3)
+    expect(result[0]).toStrictEqual({ x: 0, y: 95 })
+    expect(result[1]).toStrictEqual({ x: 100, y: 50 })
+    expect(result[2]).toStrictEqual({ x: 200, y: 5 })
   })
-})
 
-describe('drawC', () => {
-  it('returns a string with a svg S line command with smoothing math', () => {
-    const dataPoints = [mockDataPoint(), mockDataPoint(2, 2)]
-    const actual = drawC(dataPoints, 1)
-
-    expect(actual).toEqual('C 1.5 1, 1.5 2, 2 2')
-  })
-})
-
-describe('line', () => {
-  it('returns an object describing a line segment', () => {
-    const a = mockDataPoint(0, 0)
-    const b = mockDataPoint(1, 1)
-    const actual = line(a, b)
-
-    expect(actual).toStrictEqual({
-      length: Math.sqrt(2),
-      angle: 0.7853981633974483,
-    })
-  })
-})
-
-type ControlPointTestCaseArgs = {
-  current: DataPoint
-  previous?: DataPoint
-  next?: DataPoint
-  reverse: boolean
-  expected: DataPoint
-}
-
-type ControlPointTestCase = [string, ControlPointTestCaseArgs]
-
-describe('controlPointPosition', () => {
-  const testCases: ControlPointTestCase[] = [
+  test.each([
     [
-      'returns a DataPoint for the control point',
+      'less than 0',
       {
-        current: mockDataPoint(2, 2),
-        previous: mockDataPoint(1, 1),
-        next: mockDataPoint(3, 3),
-        reverse: false,
-        expected: { x: 2.4, y: 2.4 },
+        data: [-1],
       },
     ],
     [
-      'returns a DataPoint for the control point if previous does not exist',
+      'greater than 1',
       {
-        current: mockDataPoint(2, 2),
-        next: mockDataPoint(3, 3),
-        reverse: false,
-        expected: { x: 2.2, y: 2.2 },
+        data: [2],
       },
     ],
-    [
-      'returns a DataPoint for the control point if next does not exist',
-      {
-        current: mockDataPoint(2, 2),
-        previous: mockDataPoint(1, 1),
-        reverse: false,
-        expected: { x: 2.2, y: 2.2 },
-      },
-    ],
-    [
-      'returns a DataPoint for the control point if next does not exist and reversed',
-      {
-        current: mockDataPoint(2, 2),
-        previous: mockDataPoint(1, 1),
-        reverse: true,
-        expected: { x: 1.7999999999999998, y: 1.8 },
-      },
-    ],
-  ]
-
-  test.each<ControlPointTestCase>(testCases)(
-    '%s',
-    (name, { current, previous, next, reverse, expected }) => {
-      const actual = controlPointPosition(current, previous, next, reverse)
-
-      expect(actual).toStrictEqual(expected)
-    }
-  )
-})
-
-describe('drawSmoothC', () => {
-  it('returns a string with a svg S line command with smoothing math', () => {
-    const dataPoints = [
-      mockDataPoint(0, 0),
-      mockDataPoint(1, 1),
-      mockDataPoint(2, 2),
-      mockDataPoint(3, 3),
-    ]
-    const actual = drawSmoothC(dataPoints[2], 2, dataPoints)
-
-    expect(actual).toEqual(
-      'C 1.4000000000000001 1.4, 1.5999999999999999 1.6, 2 2'
+  ])('throws error for height %s', (_, { data }) => {
+    expect(() => mapToSvgDimensions(data, 100, 100)).toThrow(
+      'Normalized height must be between 0 and 1'
     )
   })
+})
+
+describe('smoothDataPoints', () => {
+  test.each([
+    [
+      'should not smooth single datapoint',
+      {
+        dataPoints: [{ x: 50, y: 50 }],
+        expected: [{ x: 50, y: 50 }],
+        height: 100,
+      },
+    ],
+    [
+      'should not smooth two datapoints',
+      {
+        dataPoints: [
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+        ],
+        expected: [
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should not smooth datapoints that are always increasing',
+      {
+        dataPoints: [
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+          { x: 70, y: 70 },
+        ],
+        expected: [
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+          { x: 70, y: 70 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should not smooth datapoints that are always decreasing',
+      {
+        dataPoints: [
+          { x: 50, y: 70 },
+          { x: 60, y: 60 },
+          { x: 70, y: 50 },
+        ],
+        expected: [
+          { x: 50, y: 70 },
+          { x: 60, y: 60 },
+          { x: 70, y: 50 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should not smooth datapoints that are always different',
+      {
+        dataPoints: [
+          { x: 70, y: 70 },
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+        ],
+        expected: [
+          { x: 70, y: 70 },
+          { x: 50, y: 50 },
+          { x: 60, y: 60 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should not smooth datapoints when two are equal, but within "extremeness" threshold',
+      {
+        dataPoints: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 20, y: 9 },
+        ],
+        expected: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 20, y: 9 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should smooth when two are equal low, but next high greater "extremeness" threshold',
+      {
+        dataPoints: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 20, y: 20 },
+        ],
+        expected: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          {
+            x: 12.5,
+            y: 13.671875,
+          },
+          {
+            x: 15,
+            y: 18.75,
+          },
+          {
+            x: 17.5,
+            y: 19.921875,
+          },
+          { x: 20, y: 20 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should smooth when two are equal high, but next low greater "extremeness" threshold',
+      {
+        dataPoints: [
+          { x: 0, y: 20 },
+          { x: 10, y: 20 },
+          { x: 20, y: 0 },
+        ],
+        expected: [
+          { x: 0, y: 20 },
+          { x: 10, y: 20 },
+          {
+            x: 12.5,
+            y: 19.921875,
+          },
+          {
+            x: 15,
+            y: 18.75,
+          },
+          {
+            x: 17.5,
+            y: 13.671875,
+          },
+          { x: 20, y: 0 },
+        ],
+        height: 100,
+      },
+    ],
+    [
+      'should smooth when first is high, but next low greater "extremeness" threshold',
+      {
+        dataPoints: [
+          { x: 0, y: 20 },
+          { x: 10, y: 0 },
+          { x: 20, y: 0 },
+        ],
+        expected: [
+          {
+            x: 0,
+            y: 20,
+          },
+          {
+            x: 2.5,
+            y: 19.921875,
+          },
+          {
+            x: 5,
+            y: 18.75,
+          },
+          {
+            x: 7.5,
+            y: 13.671875,
+          },
+          {
+            x: 10,
+            y: 0,
+          },
+          {
+            x: 20,
+            y: 0,
+          },
+        ],
+        height: 100,
+      },
+    ],
+  ])('%s', (_, { expected, dataPoints, height }) => {
+    const result = smoothDataPoints(dataPoints, height)
+    expect(result).toStrictEqual(expected)
+  })
+})
+
+describe('transformCatmullRomSplineToBezierCurve', () => {
+  it('should throw error when less than 3 datapoints supplied', () => {
+    const data = [mockDataPoint(1, 1), mockDataPoint(2, 2)]
+
+    expect(() => transformCatmullRomSplineToBezierCurve(data)).toThrow(
+      'Graph requires at least 3 data points'
+    )
+  })
+
+  test.each([
+    [
+      'inline',
+      {
+        data: [mockDataPoint(0, 0), mockDataPoint(1, 0), mockDataPoint(2, 0)],
+        expected:
+          'M 0 0 C 0.16666666666666666 0, 0.6666666666666666 0, 1 0 C 1.3333333333333333 0, 1.8333333333333333 0, 2 0',
+      },
+    ],
+    [
+      'hump',
+      {
+        data: [mockDataPoint(0, 0), mockDataPoint(), mockDataPoint(2, 0)],
+        expected:
+          'M 0 0 C 0.16666666666666666 0.16666666666666666, 0.6666666666666666 1, 1 1 C 1.3333333333333333 1, 1.8333333333333333 0.16666666666666666, 2 0',
+      },
+    ],
+    [
+      'increasing',
+      {
+        data: [mockDataPoint(0, 0), mockDataPoint(1, 1), mockDataPoint(2, 2)],
+        expected:
+          'M 0 0 C 0.16666666666666666 0.16666666666666666, 0.6666666666666666 0.6666666666666666, 1 1 C 1.3333333333333333 1.3333333333333333, 1.8333333333333333 1.8333333333333333, 2 2',
+      },
+    ],
+    [
+      'decreasing',
+      {
+        data: [mockDataPoint(0, 2), mockDataPoint(1, 1), mockDataPoint(2, 0)],
+        expected:
+          'M 0 2 C 0.16666666666666666 1.8333333333333333, 0.6666666666666666 1.3333333333333333, 1 1 C 1.3333333333333333 0.6666666666666666, 1.8333333333333333 0.16666666666666666, 2 0',
+      },
+    ],
+  ])(
+    'should draw a bezier spline from catmullrom spline data points - %s',
+    (_, { data, expected }) => {
+      const result = transformCatmullRomSplineToBezierCurve(data)
+      expect(result).toEqual(expected)
+    }
+  )
 })
 
 function mockDataPoint(x = 1, y = 1): DataPoint {


### PR DESCRIPTION
previously a sliding window algorithm was being used which found the line connect the prev/next points and used as parallel line to create the bezier control points.  This was leading to a "dipping" behaviour when there were extreme changes in the datapoints.  This is because in order for the bezier line to curve to accomodate all of the point, it sometimes must curve the opposite way to accomodate the extremeness of a curve.

![Screenshot from 2021-07-11 20-58-51](https://user-images.githubusercontent.com/8953691/125224459-e927dc80-e28a-11eb-8aa1-677d0e4f38bf.png)

> Example of the "Dip"

Now using a catmullrom spline to bezier curve algorithm (http://schepers.cc/svg/path/catmullrom2bezier.js) to produce a more predictable curve, and then when there is an extreme curve, points are being interpolated to ease it in.  There is a chance that this causes the same "dipping" after the curve rather than preceed it, but this is the limitation of using a spline to graph datapoints rather than computing a best-fit line.

![Screenshot from 2021-07-06 00-33-12](https://user-images.githubusercontent.com/8953691/125224511-052b7e00-e28b-11eb-985b-d1402341c16b.png)
> Using catmullrom spline (translated to bezier) with interpolated points

I think if there are further aesthetic concerns, probably would be good consider creating a high-resolution (many many data points) poly-line so that it appears smooth, but is more reflective of the true data. 