### PR TITLE
Bring assembler inline with the others

### DIFF
--- a/app/assemblers/assemble_mentor_requests.rb
+++ b/app/assemblers/assemble_mentor_requests.rb
@@ -1,13 +1,13 @@
 class AssembleMentorRequests
   include Mandate
 
-  initialize_with :params, :current_user
+  initialize_with :mentor, :params
 
   def call
     SerializePaginatedCollection.(
       requests,
       serializer: SerializeMentorRequests,
-      serializer_args: current_user,
+      serializer_args: mentor,
       meta: {
         unscoped_total: unscoped_total
       }
@@ -17,7 +17,7 @@ class AssembleMentorRequests
   memoize
   def unscoped_total
     ::Mentor::Request::Retrieve.(
-      mentor: current_user,
+      mentor: mentor,
       page: params[:page],
       track_slug: params[:track_slug],
       exercise_slug: params[:exercise_slug],
@@ -28,7 +28,7 @@ class AssembleMentorRequests
 
   def requests
     ::Mentor::Request::Retrieve.(
-      mentor: current_user,
+      mentor: mentor,
       page: params[:page],
       criteria: params[:criteria],
       order: params[:order],

--- a/app/commands/mentor/request/retrieve.rb
+++ b/app/commands/mentor/request/retrieve.rb
@@ -102,7 +102,7 @@ module Mentor
         when "recent"
           @requests = @requests.order("mentor_requests.id DESC")
         else
-          @requests = @requests.order("mentor_requests.id")
+          @requests = @requests.order("mentor_requests.id ASC")
         end
       end
 

--- a/app/commands/mentor/request/retrieve.rb
+++ b/app/commands/mentor/request/retrieve.rb
@@ -100,9 +100,9 @@ module Mentor
       def sort!
         case order
         when "recent"
-          @requests = @requests.order("mentor_requests.created_at DESC")
+          @requests = @requests.order("mentor_requests.id DESC")
         else
-          @requests = @requests.order("mentor_requests.created_at")
+          @requests = @requests.order("mentor_requests.id")
         end
       end
 

--- a/app/controllers/api/mentoring/requests_controller.rb
+++ b/app/controllers/api/mentoring/requests_controller.rb
@@ -10,7 +10,7 @@ module API
         # We can have an invalid track_slug here.
       end
 
-      render json: AssembleMentorRequests.(params, current_user)
+      render json: AssembleMentorRequests.(current_user, params)
     end
 
     def tracks

--- a/app/helpers/react_components/mentoring/queue.rb
+++ b/app/helpers/react_components/mentoring/queue.rb
@@ -73,7 +73,7 @@ module ReactComponents
           endpoint: Exercism::Routes.api_mentoring_requests_path,
           query: query,
           options: {
-            initial_data: AssembleMentorRequests.(query, mentor),
+            initial_data: AssembleMentorRequests.(mentor, query),
             stale_time: 0
           }
         }

--- a/test/assemblers/assemble_mentor_requests_test.rb
+++ b/test/assemblers/assemble_mentor_requests_test.rb
@@ -45,7 +45,7 @@ class AssembleMentorRequestsTest < ActiveSupport::TestCase
     15.times { create :mentor_request, solution: solution }
 
     assert_equal SerializePaginatedCollection.(
-      Mentor::Request.page(1).per(10),
+      Mentor::Request.page(1).per(25),
       serializer: SerializeMentorRequests,
       serializer_args: user,
       meta: {

--- a/test/assemblers/assemble_mentor_requests_test.rb
+++ b/test/assemblers/assemble_mentor_requests_test.rb
@@ -33,7 +33,7 @@ class AssembleMentorRequestsTest < ActiveSupport::TestCase
       exercise_slug: exercise_slug
     }
 
-    AssembleMentorRequests.(params, user)
+    AssembleMentorRequests.(user, params)
   end
 
   test "retrieves requests" do
@@ -42,15 +42,15 @@ class AssembleMentorRequestsTest < ActiveSupport::TestCase
     mentored_track = create :track
     create :user_track_mentorship, user: user, track: mentored_track
     solution = create :concept_solution, track: mentored_track
-    30.times { create :mentor_request, solution: solution }
+    15.times { create :mentor_request, solution: solution }
 
     assert_equal SerializePaginatedCollection.(
-      Mentor::Request.page(1).per(25),
+      Mentor::Request.page(1).per(10),
       serializer: SerializeMentorRequests,
       serializer_args: user,
       meta: {
-        unscoped_total: 30
+        unscoped_total: 15
       }
-    ), AssembleMentorRequests.({}, user)
+    ), AssembleMentorRequests.(user, {})
   end
 end

--- a/test/commands/mentor/request/retrieve_test.rb
+++ b/test/commands/mentor/request/retrieve_test.rb
@@ -131,12 +131,12 @@ class Mentor::Request::RetrieveTest < ActiveSupport::TestCase
 
     solution = create :concept_solution, track: mentored_track
 
-    second = create :mentor_request, created_at: Time.current - 2.minutes, solution: solution
-    first = create :mentor_request, created_at: Time.current - 3.minutes, solution: solution
-    third = create :mentor_request, created_at: Time.current - 1.minute, solution: solution
+    first = create :mentor_request, solution: solution
+    second = create :mentor_request, solution: solution
+    third = create :mentor_request, solution: solution
 
     assert_equal [first, second, third], Mentor::Request::Retrieve.(mentor: user)
-    assert_equal [second, first, third], Mentor::Request::Retrieve.(mentor: user, sorted: false)
+    assert_equal [first, second, third], Mentor::Request::Retrieve.(mentor: user, sorted: false)
   end
 
   test "pagination works" do

--- a/test/controllers/api/mentoring/requests_controller_test.rb
+++ b/test/controllers/api/mentoring/requests_controller_test.rb
@@ -20,9 +20,9 @@ class API::Mentoring::RequestsControllerTest < API::BaseTestCase
     }
     expected = { 'foo' => 'bar' }
 
-    AssembleMentorRequests.expects(:call).returns(expected).with do |actual_params, actual_user|
-      assert params, actual_params
+    AssembleMentorRequests.expects(:call).returns(expected).with do |actual_user, actual_params|
       assert_equal user, actual_user
+      assert params, actual_params
     end
 
     get api_mentoring_requests_path, params: params, headers: @headers, as: :json
@@ -39,7 +39,7 @@ class API::Mentoring::RequestsControllerTest < API::BaseTestCase
 
     get api_mentoring_requests_path, headers: @headers, as: :json
     assert_response 200
-    assert_includes AssembleMentorRequests.({}, user).to_json, response.body
+    assert_includes AssembleMentorRequests.(user, {}).to_json, response.body
   end
 
   test "index updates last_viewed" do

--- a/test/helpers/react_components/mentoring/queue_test.rb
+++ b/test/helpers/react_components/mentoring/queue_test.rb
@@ -47,7 +47,7 @@ class MentoringQueueTest < ReactComponentTestCase
             exercise_slug: "bob"
           },
           options: {
-            initial_data: AssembleMentorRequests.(params, user),
+            initial_data: AssembleMentorRequests.(user, params),
             stale_time: 0
           }
         },
@@ -178,7 +178,7 @@ class MentoringQueueTest < ReactComponentTestCase
           endpoint: Exercism::Routes.api_mentoring_requests_path,
           query: { track_slug: "csharp" },
           options: {
-            initial_data: AssembleMentorRequests.({ track_slug: "csharp" }, user),
+            initial_data: AssembleMentorRequests.(user, { track_slug: "csharp" }),
             stale_time: 0
           }
         },


### PR DESCRIPTION
The other assemblers are all this way round (user then params) so I've brought this one to be consistent.