### PR TITLE
Fix bug where sendRequest returns undefined when component unmounts

### DIFF
--- a/app/javascript/components/common/Introducer.tsx
+++ b/app/javascript/components/common/Introducer.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useState } from 'react'
 import { GraphicalIcon, Icon } from './'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { FormButton } from './FormButton'
 import { ErrorBoundary, ErrorMessage } from '../ErrorBoundary'
 
@@ -26,15 +25,15 @@ export const Introducer = ({
 }>): JSX.Element | null => {
   const [hidden, setHidden] = useState(defaultHidden)
   const ref = useRef<HTMLDivElement | null>(null)
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: () => {

--- a/app/javascript/components/common/SearchableList.tsx
+++ b/app/javascript/components/common/SearchableList.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { GraphicalIcon, Loading, Pagination } from '../common'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../hooks/use-list'
 import { FilterPanel } from './searchable-list/FilterPanel'
 import { ErrorBoundary, useErrorHandler } from '../ErrorBoundary'
@@ -52,7 +51,6 @@ export const SearchableList = ({
   ResultsComponent: React.ComponentType<ResultsType>
   isEnabled?: boolean
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const {
     request,
     setPage,
@@ -72,15 +70,11 @@ export const SearchableList = ({
     latestData,
     isFetching,
     error,
-  } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
-    cacheKey,
-    {
-      ...request,
-      query: removeEmpty(request.query),
-      options: { ...request.options, enabled: isEnabled },
-    },
-    isMountedRef
-  )
+  } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(cacheKey, {
+    ...request,
+    query: removeEmpty(request.query),
+    options: { ...request.options, enabled: isEnabled },
+  })
 
   const setFilter = useCallback(
     (filter) => {

--- a/app/javascript/components/common/SolutionView.tsx
+++ b/app/javascript/components/common/SolutionView.tsx
@@ -5,7 +5,6 @@ import { ResultsZone } from '../ResultsZone'
 import { IterationsList } from '../mentoring/session/IterationsList'
 import { FilePanel } from '../mentoring/session/FilePanel'
 import { IterationSummaryWithWebsockets } from '../track/IterationSummary'
-import { useIsMounted } from 'use-is-mounted'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
 import { PublishSettings } from '../student/published-solution/PublishSettings'
 
@@ -34,14 +33,12 @@ export const SolutionView = ({
   const [currentIteration, setCurrentIteration] = useState(
     iterations[iterations.length - 1]
   )
-  const isMountedRef = useIsMounted()
   const { resolvedData, error, status, isFetching } = usePaginatedRequestQuery<{
     files: File[]
-  }>(
-    currentIteration.links.files,
-    { endpoint: currentIteration.links.files, options: {} },
-    isMountedRef
-  )
+  }>(currentIteration.links.files, {
+    endpoint: currentIteration.links.files,
+    options: {},
+  })
 
   return (
     <div className="c-solution-iterations">

--- a/app/javascript/components/community-solutions/StarButton.tsx
+++ b/app/javascript/components/community-solutions/StarButton.tsx
@@ -3,7 +3,6 @@ import { FormButton, Icon } from '../common'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
 import { typecheck } from '../../utils/typecheck'
-import { useIsMounted } from 'use-is-mounted'
 import { ErrorBoundary, ErrorMessage } from '../ErrorBoundary'
 
 type Links = {
@@ -26,32 +25,22 @@ export const StarButton = ({
   defaultIsStarred: boolean
   links: Links
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [state, setState] = useState({
     numStars: defaultNumStars,
     isStarred: defaultIsStarred,
   })
-  const [mutation, { status, error }] = useMutation(
+  const [mutation, { status, error }] = useMutation<APIResponse>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: links.star,
         method: state.isStarred ? 'DELETE' : 'POST',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<APIResponse>(json, 'star')
       })
+
+      return fetch.then((json) => typecheck<APIResponse>(json, 'star'))
     },
     {
       onSuccess: (response) => {
-        if (!response) {
-          return
-        }
-
         setState(response)
       },
     }

--- a/app/javascript/components/contributing/ContributorsList.tsx
+++ b/app/javascript/components/contributing/ContributorsList.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react'
 import { PaginatedResult, Contributor, Track } from '../types'
 import { ContributorRow } from './contributors-list/ContributorRow'
 import { PeriodButton } from './contributors-list/PeriodButton'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../hooks/use-list'
 import { usePaginatedRequestQuery, Request } from '../../hooks/request-query'
 import { ResultsZone } from '../ResultsZone'
@@ -30,7 +29,6 @@ export const ContributorsList = ({
   request: Request
   tracks: readonly Track[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setPage, setQuery } = useList(initialRequest)
   const {
     status,
@@ -43,8 +41,7 @@ export const ContributorsList = ({
     {
       ...request,
       options: { ...request.options },
-    },
-    isMountedRef
+    }
   )
 
   const setPeriod = useCallback(

--- a/app/javascript/components/contributing/TasksList.tsx
+++ b/app/javascript/components/contributing/TasksList.tsx
@@ -5,7 +5,6 @@ import {
   usePaginatedRequestQuery,
   Request as BaseRequest,
 } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import {
   Task as TaskProps,
   Track,
@@ -63,7 +62,6 @@ export const TasksList = ({
   request: Request
   tracks: readonly Track[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setPage, setQuery, setOrder } = useList(initialRequest)
   const {
     status,
@@ -73,8 +71,7 @@ export const TasksList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     ['contributing-tasks', request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
   const track =
     tracks.find((t) => t.slug === request.query.trackSlug) || tracks[0]

--- a/app/javascript/components/dropdowns/Notifications.tsx
+++ b/app/javascript/components/dropdowns/Notifications.tsx
@@ -7,7 +7,6 @@ import { Notification } from './notifications/types'
 import { useNotificationDropdown } from './notifications/useNotificationDropdown'
 import { DropdownAttributes } from './useDropdown'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { useErrorHandler, ErrorBoundary } from '../ErrorBoundary'
 import { Loading } from '../common/Loading'
 import { QueryStatus } from 'react-query'
@@ -86,19 +85,14 @@ export const Notifications = ({
 }: {
   endpoint: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [isStale, setIsStale] = useState(false)
   const { resolvedData, error, status, refetch } = usePaginatedRequestQuery<
     APIResponse
-  >(
-    CACHE_KEY,
-    {
-      endpoint: endpoint,
-      query: { per: MAX_NOTIFICATIONS },
-      options: {},
-    },
-    isMountedRef
-  )
+  >(CACHE_KEY, {
+    endpoint: endpoint,
+    query: { per: MAX_NOTIFICATIONS },
+    options: {},
+  })
   const {
     buttonAttributes,
     panelAttributes,

--- a/app/javascript/components/dropdowns/Reputation.tsx
+++ b/app/javascript/components/dropdowns/Reputation.tsx
@@ -3,7 +3,6 @@ import { ReputationIcon } from './reputation/ReputationIcon'
 import { ReputationMenu } from './reputation/ReputationMenu'
 import { ReputationChannel } from '../../channels/reputationChannel'
 import { useDropdown, DropdownAttributes } from './useDropdown'
-import { useIsMounted } from 'use-is-mounted'
 import { QueryStatus } from 'react-query'
 import { useErrorHandler, ErrorBoundary } from '../ErrorBoundary'
 import { Loading } from '../common/Loading'
@@ -98,22 +97,17 @@ export const Reputation = ({
   defaultIsSeen: boolean
   endpoint: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [isStale, setIsStale] = useState(false)
   const [reputation, setReputation] = useState(defaultReputation)
   const [isSeen, setIsSeen] = useState(defaultIsSeen)
   const cacheKey = 'reputations'
   const { resolvedData, error, status, refetch } = usePaginatedRequestQuery<
     APIResponse
-  >(
-    cacheKey,
-    {
-      endpoint: endpoint,
-      query: { per: MAX_TOKENS },
-      options: {},
-    },
-    isMountedRef
-  )
+  >(cacheKey, {
+    endpoint: endpoint,
+    query: { per: MAX_TOKENS },
+    options: {},
+  })
   const {
     buttonAttributes,
     panelAttributes,

--- a/app/javascript/components/editor/TestRunSummaryContainer.tsx
+++ b/app/javascript/components/editor/TestRunSummaryContainer.tsx
@@ -3,7 +3,6 @@ import { TestRun, TestRunStatus } from './types'
 import { TestRunChannel } from '../../channels/testRunChannel'
 import { fetchJSON } from '../../utils/fetch-json'
 import { useRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { TestRunSummary } from './TestRunSummary'
 
 const REFETCH_INTERVAL = 2000
@@ -25,7 +24,6 @@ export const TestRunSummaryContainer = ({
   cancelLink: string
   averageTestDuration: number
 }): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const { data } = useRequestQuery<{ testRun: TestRun }>(
     `test-run-${testRun.submissionUuid}`,
     {
@@ -35,8 +33,7 @@ export const TestRunSummaryContainer = ({
         refetchInterval:
           testRun.status === TestRunStatus.QUEUED ? REFETCH_INTERVAL : false,
       },
-    },
-    isMountedRef
+    }
   )
   const setTestRun = useCallback(
     (testRun) => {

--- a/app/javascript/components/journey/Overview.tsx
+++ b/app/javascript/components/journey/Overview.tsx
@@ -15,7 +15,6 @@ import {
   BadgesSection,
   Props as BadgesSectionProps,
 } from './overview/BadgesSection'
-import { useIsMounted } from 'use-is-mounted'
 import { usePaginatedRequestQuery, Request } from '../../hooks/request-query'
 import { ResultsZone } from '../ResultsZone'
 import { FetchingBoundary } from '../FetchingBoundary'
@@ -84,17 +83,12 @@ export const Overview = ({
   request: Request
   isEnabled: boolean
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { status, resolvedData, isFetching, error } = usePaginatedRequestQuery<{
     overview: JourneyOverview
-  }>(
-    'journey-overview',
-    {
-      ...request,
-      options: { ...request.options, enabled: isEnabled },
-    },
-    isMountedRef
-  )
+  }>('journey-overview', {
+    ...request,
+    options: { ...request.options, enabled: isEnabled },
+  })
   const formattedData = resolvedData ? formatData(resolvedData) : null
 
   return (

--- a/app/javascript/components/journey/UnrevealedBadge.tsx
+++ b/app/javascript/components/journey/UnrevealedBadge.tsx
@@ -20,29 +20,18 @@ export const UnrevealedBadge = ({
 }): JSX.Element => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [revealedBadge, setRevealedBadge] = useState<BadgeProps | null>(null)
-
-  const isMountedRef = useIsMounted()
-  const [mutation, { status, error }] = useMutation<BadgeProps | undefined>(
+  const [mutation, { status, error }] = useMutation<BadgeProps>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: badge.links.reveal,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<BadgeProps>(json, 'badge')
       })
+
+      return fetch.then((json) => typecheck<BadgeProps>(json, 'badge'))
     },
     {
       onSuccess: (badge) => {
-        if (!badge) {
-          return
-        }
-
         setRevealedBadge(badge)
         setIsModalOpen(true)
       },

--- a/app/javascript/components/mentoring/Inbox.tsx
+++ b/app/javascript/components/mentoring/Inbox.tsx
@@ -9,7 +9,6 @@ import {
   usePaginatedRequestQuery,
   Request as BaseRequest,
 } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { ResultsZone } from '../ResultsZone'
 import { useHistory, removeEmpty } from '../../hooks/use-history'
 import { MentorDiscussion, DiscussionStatus } from '../types'
@@ -57,7 +56,6 @@ export const Inbox = ({
     setPage,
     setQuery,
   } = useList(discussionsRequest)
-  const isMountedRef = useIsMounted()
   const {
     status,
     resolvedData,
@@ -66,8 +64,7 @@ export const Inbox = ({
     refetch,
   } = usePaginatedRequestQuery<APIResponse>(
     ['mentor-discussion-list', request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   useEffect(() => {

--- a/app/javascript/components/mentoring/TestimonialsList.tsx
+++ b/app/javascript/components/mentoring/TestimonialsList.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState, useEffect } from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import {
   Request as BaseRequest,
   usePaginatedRequestQuery,
@@ -49,7 +48,6 @@ export const TestimonialsList = ({
   request: Request
   tracks: readonly Track[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const {
     request,
     setQuery,
@@ -69,14 +67,10 @@ export const TestimonialsList = ({
     latestData,
     isFetching,
     error,
-  } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
-    cacheKey,
-    {
-      ...request,
-      query: removeEmpty(request.query),
-    },
-    isMountedRef
-  )
+  } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(cacheKey, {
+    ...request,
+    query: removeEmpty(request.query),
+  })
 
   const setTrack = useCallback(
     (trackSlug) => {

--- a/app/javascript/components/mentoring/TrackSelector.tsx
+++ b/app/javascript/components/mentoring/TrackSelector.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { TracksList } from './track-selector/TracksList'
 import { SelectedTracksMessage } from './track-selector/SelectedTracksMessage'
 import { ContinueButton } from './track-selector/ContinueButton'
@@ -31,14 +30,13 @@ export const TrackSelector = ({
   setSelected: (selected: string[]) => void
   onContinue: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setCriteria } = useList({
     endpoint: tracksEndpoint,
     options: {},
   })
   const { status, resolvedData, isFetching, error } = usePaginatedRequestQuery<
     APIResponse
-  >(['tracks', request.endpoint, request.query], request, isMountedRef)
+  >(['tracks', request.endpoint, request.query], request)
 
   const handleContinue = useCallback(() => {
     onContinue()

--- a/app/javascript/components/mentoring/discussion/AddDiscussionPostForm.tsx
+++ b/app/javascript/components/mentoring/discussion/AddDiscussionPostForm.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import { sendRequest } from '../../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation, queryCache } from 'react-query'
 import { PostsContext } from './PostsContext'
 import { DiscussionPostProps } from './DiscussionPost'
@@ -22,28 +21,20 @@ export const AddDiscussionPostForm = ({
     expanded: false,
     value: localStorage.getItem(`smde_${contextId}`) || '',
   })
-  const isMountedRef = useIsMounted()
   const { cacheKey } = useContext(PostsContext)
   const handleSuccess = useCallback(() => {
     setState({ value: '', expanded: false })
     onSuccess()
   }, [onSuccess])
-  const [mutation, { status, error }] = useMutation<
-    DiscussionPostProps | undefined
-  >(
+  const [mutation, { status, error }] = useMutation<DiscussionPostProps>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: discussion.links.posts,
         method: 'POST',
         body: JSON.stringify({ content: state.value }),
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<DiscussionPostProps>(json, 'post')
       })
+
+      return fetch.then((json) => typecheck<DiscussionPostProps>(json, 'post'))
     },
     {
       onSettled: () => queryCache.invalidateQueries(cacheKey),

--- a/app/javascript/components/mentoring/discussion/FinishButton.tsx
+++ b/app/javascript/components/mentoring/discussion/FinishButton.tsx
@@ -3,7 +3,6 @@ import { FinishMentorDiscussionModal } from '../../modals/mentor/FinishMentorDis
 import { ModalProps } from '../../modals/Modal'
 import { MentorDiscussion as Discussion } from '../../types'
 import Mousetrap from 'mousetrap'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../utils/send-request'
 import { typecheck } from '../../../utils/typecheck'
@@ -18,30 +17,18 @@ export const FinishButton = ({
   onSuccess: (discussion: Discussion) => void
 }): JSX.Element => {
   const [open, setOpen] = useState(false)
-  const isMountedRef = useIsMounted()
-  const [mutation, { status, error }] = useMutation(
+  const [mutation, { status, error }] = useMutation<Discussion>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Discussion>(json, 'discussion')
       })
+
+      return fetch.then((json) => typecheck<Discussion>(json, 'discussion'))
     },
     {
-      onSuccess: (discussion) => {
-        if (!discussion) {
-          return
-        }
-
-        onSuccess(discussion)
-      },
+      onSuccess: (discussion) => onSuccess(discussion),
     }
   )
 

--- a/app/javascript/components/mentoring/discussion/MarkAsNothingToDoButton.tsx
+++ b/app/javascript/components/mentoring/discussion/MarkAsNothingToDoButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation } from 'react-query'
 import { Loading } from '../../common'
 import { ErrorBoundary, useErrorHandler } from '../../ErrorBoundary'
@@ -20,14 +19,14 @@ export const MarkAsNothingToDoButton = (props: ComponentProps): JSX.Element => {
 const DEFAULT_ERROR = new Error('Unable to mark discussion as nothing to do')
 
 const Component = ({ endpoint }: ComponentProps): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation(() => {
-    return sendRequest({
+    const { fetch } = sendRequest({
       endpoint: endpoint,
       method: 'PATCH',
       body: null,
-      isMountedRef: isMountedRef,
     })
+
+    return fetch
   })
 
   useErrorHandler(error, { defaultError: DEFAULT_ERROR })

--- a/app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.tsx
+++ b/app/javascript/components/mentoring/discussion/finished-wizard/FavoriteStep.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { typecheck } from '../../../../utils/typecheck'
 import { Loading } from '../../../common'
 import { GraphicalIcon } from '../../../common/GraphicalIcon'
@@ -25,31 +24,23 @@ export const FavoriteStep = ({
   onFavorite: (student: Student) => void
   onSkip: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-  const [handleFavorite, { status, error }] = useMutation(
+  const [handleFavorite, { status, error }] = useMutation<Student>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: student.links.favorite,
         method: 'POST',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Student>(json, 'student')
       })
+
+      return fetch.then((json) => typecheck<Student>(json, 'student'))
     },
     {
       onSuccess: (student) => {
-        if (!student) {
+        if (!onFavorite) {
           return
         }
 
-        if (onFavorite) {
-          onFavorite(student)
-        }
+        onFavorite(student)
       },
     }
   )

--- a/app/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.tsx
+++ b/app/javascript/components/mentoring/discussion/finished-wizard/MentorAgainStep.tsx
@@ -28,31 +28,21 @@ export const MentorAgainStep = ({
   onYes: SuccessFn
   onNo: SuccessFn
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [choice, setChoice] = useState<Choice | null>(null)
-  const [mutate, { status, error }] = useMutation(
+  const [mutate, { status, error }] = useMutation<Student>(
     () => {
       const method = choice === 'yes' ? 'DELETE' : 'POST'
 
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: student.links.block,
         method: method,
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Student>(json, 'student')
       })
+
+      return fetch.then((json) => typecheck<Student>(json, 'student'))
     },
     {
       onSuccess: (student) => {
-        if (!student) {
-          return
-        }
-
         choice === 'yes' ? onYes(student) : onNo(student)
       },
     }

--- a/app/javascript/components/mentoring/discussion/use-discussion-iterations.tsx
+++ b/app/javascript/components/mentoring/discussion/use-discussion-iterations.tsx
@@ -1,4 +1,3 @@
-import { useIsMounted } from 'use-is-mounted'
 import { useRequestQuery } from '../../../hooks/request-query'
 import { DiscussionPostProps } from './DiscussionPost'
 import { MentorDiscussion, Iteration } from '../../types'
@@ -29,11 +28,9 @@ export const useDiscussionIterations = ({
   discussion?: MentorDiscussion
   iterations: readonly Iteration[]
 }): { iterations: readonly Iteration[]; status: QueryStatus } => {
-  const isMountedRef = useIsMounted()
   const { data, status } = useRequestQuery<{ posts: DiscussionPostProps[] }>(
     `posts-discussion-${discussion?.uuid}`,
-    { endpoint: discussion?.links.posts, options: { enabled: !!discussion } },
-    isMountedRef
+    { endpoint: discussion?.links.posts, options: { enabled: !!discussion } }
   )
 
   return {

--- a/app/javascript/components/mentoring/inbox/TrackFilter.tsx
+++ b/app/javascript/components/mentoring/inbox/TrackFilter.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { useRequestQuery, Request } from '../../../hooks/request-query'
 import { Loading } from '../../common/Loading'
 import { TrackList, Track } from './TrackList'
@@ -13,11 +12,9 @@ export const TrackFilter = ({
   value: string | null
   setTrack: (track: string | null) => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { isLoading, isError, data: tracks } = useRequestQuery<Track[]>(
     ['track-filter', request.query],
-    request,
-    isMountedRef
+    request
   )
 
   return (

--- a/app/javascript/components/mentoring/queue/useExerciseList.tsx
+++ b/app/javascript/components/mentoring/queue/useExerciseList.tsx
@@ -1,5 +1,4 @@
 import { QueryStatus } from 'react-query'
-import { useIsMounted } from 'use-is-mounted'
 import { MentoredTrack, MentoredTrackExercise } from '../../types'
 import { usePaginatedRequestQuery } from '../../../hooks/request-query'
 
@@ -13,8 +12,6 @@ export const useExerciseList = ({
   isFetching: boolean
   error: unknown
 } => {
-  const isMountedRef = useIsMounted()
-
   const {
     resolvedData: exercises,
     status,
@@ -29,8 +26,7 @@ export const useExerciseList = ({
         staleTime: 0,
         initialData: track?.exercises ? track.exercises : undefined,
       },
-    },
-    isMountedRef
+    }
   )
 
   return {

--- a/app/javascript/components/mentoring/queue/useMentoringQueue.tsx
+++ b/app/javascript/components/mentoring/queue/useMentoringQueue.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { usePaginatedRequestQuery, Request } from '../../../hooks/request-query'
 import { useList } from '../../../hooks/use-list'
-import { useIsMounted } from 'use-is-mounted'
 import { MentoredTrack, MentoredTrackExercise } from '../../types'
 import { QueryStatus } from 'react-query'
 import { useDebounce } from '../../../hooks/use-debounce'
@@ -54,7 +53,6 @@ export const useMentoringQueue = ({
   status: QueryStatus
   error: unknown
 } => {
-  const isMountedRef = useIsMounted()
   const { request, setCriteria, setOrder, setPage } = useList(initialRequest)
   const trackSlug = track?.slug
   const exerciseSlug = exercise?.slug
@@ -81,8 +79,7 @@ export const useMentoringQueue = ({
         ...request.options,
         enabled: !!track,
       },
-    },
-    isMountedRef
+    }
   )
 
   useHistory({ pushOn: debouncedQuery })

--- a/app/javascript/components/mentoring/queue/useTrackList.tsx
+++ b/app/javascript/components/mentoring/queue/useTrackList.tsx
@@ -1,5 +1,4 @@
 import { Request, usePaginatedRequestQuery } from '../../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { MentoredTrack } from '../../types'
 import { QueryStatus } from 'react-query'
 
@@ -19,11 +18,9 @@ export const useTrackList = ({
   error: unknown
   isFetching: boolean
 } => {
-  const isMountedRef = useIsMounted()
-
   const { resolvedData, isFetching, status, error } = usePaginatedRequestQuery<
     APIResponse
-  >(cacheKey, request, isMountedRef)
+  >(cacheKey, request)
 
   return {
     tracks: resolvedData ? resolvedData.tracks : [],

--- a/app/javascript/components/mentoring/request/StartDiscussionPanel.tsx
+++ b/app/javascript/components/mentoring/request/StartDiscussionPanel.tsx
@@ -4,7 +4,6 @@ import {
   Iteration,
   MentorSessionRequest as Request,
 } from '../../types'
-import { useIsMounted } from 'use-is-mounted'
 import { sendRequest } from '../../../utils/send-request'
 import { typecheck } from '../../../utils/typecheck'
 import { useMutation } from 'react-query'
@@ -27,11 +26,10 @@ export const StartDiscussionPanel = ({
     value: localStorage.getItem(`smde_${contextId}`) || '',
   })
   const lastIteration = iterations[iterations.length - 1]
-  const isMountedRef = useIsMounted()
 
-  const [mutation, { status, error }] = useMutation<Discussion | undefined>(
+  const [mutation, { status, error }] = useMutation<Discussion>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: request.links.discussion,
         method: 'POST',
         body: JSON.stringify({
@@ -39,23 +37,12 @@ export const StartDiscussionPanel = ({
           content: state.value,
           iteration_idx: lastIteration.idx,
         }),
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Discussion>(json, 'discussion')
       })
+
+      return fetch.then((json) => typecheck<Discussion>(json, 'discussion'))
     },
     {
-      onSuccess: (discussion) => {
-        if (!discussion) {
-          return
-        }
-
-        setDiscussion(discussion)
-      },
+      onSuccess: (discussion) => setDiscussion(discussion),
     }
   )
 

--- a/app/javascript/components/mentoring/request/StartMentoringPanel.tsx
+++ b/app/javascript/components/mentoring/request/StartMentoringPanel.tsx
@@ -3,7 +3,6 @@ import { useMutation } from 'react-query'
 import { sendRequest } from '../../../utils/send-request'
 import { typecheck } from '../../../utils/typecheck'
 import { MentorSessionRequest as Request } from '../../types'
-import { useIsMounted } from 'use-is-mounted'
 import { Loading } from '../../common'
 import { ErrorBoundary, useErrorHandler } from '../../ErrorBoundary'
 
@@ -26,30 +25,18 @@ export const StartMentoringPanel = ({
   request: Request
   setRequest: (request: Request) => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-  const [lock, { status, error }] = useMutation<Request | undefined>(
+  const [lock, { status, error }] = useMutation<Request>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: request.links.lock,
         body: null,
         method: 'PATCH',
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Request>(json, 'request')
       })
+
+      return fetch.then((json) => typecheck<Request>(json, 'request'))
     },
     {
-      onSuccess: (request) => {
-        if (!request) {
-          return
-        }
-
-        setRequest(request)
-      },
+      onSuccess: (request) => setRequest(request),
     }
   )
 

--- a/app/javascript/components/mentoring/session/AddFavoriteButton.tsx
+++ b/app/javascript/components/mentoring/session/AddFavoriteButton.tsx
@@ -1,19 +1,15 @@
 import React from 'react'
 import { useMutation } from 'react-query'
-import { useIsMounted } from 'use-is-mounted'
-import { sendPostRequest } from '../../../utils/send-request'
+import { sendRequest } from '../../../utils/send-request'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { ErrorBoundary, useErrorHandler } from '../../ErrorBoundary'
 import { Student } from '../../types'
 import { FormButton } from '../../common'
+import { typecheck } from '../../../utils/typecheck'
 
 type ComponentProps = {
   endpoint: string
   onSuccess: (student: Student) => void
-}
-
-type APIResponse = {
-  student: Student
 }
 
 export const AddFavoriteButton = (props: ComponentProps): JSX.Element => {
@@ -30,17 +26,18 @@ const Component = ({
   endpoint,
   onSuccess,
 }: ComponentProps): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
-  const [mutation, { status, error }] = useMutation<APIResponse>(
+  const [mutation, { status, error }] = useMutation<Student>(
     () => {
-      return sendPostRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
+        method: 'POST',
         body: null,
-        isMountedRef: isMountedRef,
       })
+
+      return fetch.then((json) => typecheck<Student>(json, 'student'))
     },
     {
-      onSuccess: (response) => onSuccess(response.student),
+      onSuccess: (student) => onSuccess(student),
     }
   )
 

--- a/app/javascript/components/mentoring/session/IterationFiles.tsx
+++ b/app/javascript/components/mentoring/session/IterationFiles.tsx
@@ -5,7 +5,6 @@ import { useRequestQuery } from '../../../hooks/request-query'
 import { File } from '../../types'
 import { Loading } from '../../common'
 import { ErrorBoundary, useErrorHandler } from '../../ErrorBoundary'
-import { useIsMounted } from 'use-is-mounted'
 
 const TabsContext = createContext<TabContext>({
   current: '',
@@ -39,11 +38,10 @@ const Component = ({
   language,
   indentSize,
 }: ComponentProps): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const { data, error, status } = useRequestQuery<
     { files: File[] },
     Error | Response
-  >(endpoint, { endpoint: endpoint, options: {} }, isMountedRef)
+  >(endpoint, { endpoint: endpoint, options: {} })
   const [tab, setTab] = useState<string | null>(null)
 
   useErrorHandler(error, { defaultError: DEFAULT_ERROR })

--- a/app/javascript/components/mentoring/session/IterationView.tsx
+++ b/app/javascript/components/mentoring/session/IterationView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { Iteration } from '../../types'
 import { IterationsList } from './IterationsList'
 import { FilePanel } from './FilePanel'
@@ -32,14 +32,12 @@ export const IterationView = ({
   settings: Settings
   setSettings: (settings: Settings) => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { resolvedData, error, status, isFetching } = usePaginatedRequestQuery<{
     files: File[]
-  }>(
-    currentIteration.links.files,
-    { endpoint: currentIteration.links.files, options: {} },
-    isMountedRef
-  )
+  }>(currentIteration.links.files, {
+    endpoint: currentIteration.links.files,
+    options: {},
+  })
 
   return (
     <React.Fragment>

--- a/app/javascript/components/mentoring/session/RemoveFavoriteButton.tsx
+++ b/app/javascript/components/mentoring/session/RemoveFavoriteButton.tsx
@@ -3,17 +3,13 @@ import { FormButton } from '../../common'
 import { GraphicalIcon } from '../../common/GraphicalIcon'
 import { useMutation } from 'react-query'
 import { ErrorBoundary, useErrorHandler } from '../../ErrorBoundary'
-import { useIsMounted } from 'use-is-mounted'
 import { sendRequest } from '../../../utils/send-request'
 import { Student } from '../../types'
+import { typecheck } from '../../../utils/typecheck'
 
 type ComponentProps = {
   endpoint: string
   onSuccess: (student: Student) => void
-}
-
-type APIResponse = {
-  student: Student
 }
 
 export const RemoveFavoriteButton = (props: ComponentProps): JSX.Element => {
@@ -31,20 +27,20 @@ const Component = ({
   onSuccess,
   ...props
 }: ComponentProps): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const [isHovering, setIsHovering] = useState(false)
 
-  const [mutation, { status, error }] = useMutation<APIResponse>(
+  const [mutation, { status, error }] = useMutation<Student>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'DELETE',
         body: null,
-        isMountedRef: isMountedRef,
       })
+
+      return fetch.then((json) => typecheck<Student>('student', json))
     },
     {
-      onSuccess: (response) => onSuccess(response.student),
+      onSuccess: (student) => onSuccess(student),
     }
   )
 

--- a/app/javascript/components/modals/ChangePublishedIterationModal.tsx
+++ b/app/javascript/components/modals/ChangePublishedIterationModal.tsx
@@ -25,20 +25,20 @@ export const ChangePublishedIterationModal = ({
   defaultIterationIdx: number | null
   iterations: readonly Iteration[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [iterationIdx, setIterationIdx] = useState<number | null>(
     defaultIterationIdx
   )
   const [mutation, { status, error }] = useMutation<SolutionForStudent>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: JSON.stringify({ published_iteration_idx: iterationIdx }),
-        isMountedRef: isMountedRef,
-      }).then((response) => {
-        return typecheck<SolutionForStudent>(response, 'solution')
       })
+
+      return fetch.then((response) =>
+        typecheck<SolutionForStudent>(response, 'solution')
+      )
     },
     {
       onSuccess: (solution) => {

--- a/app/javascript/components/modals/ConceptMakersModal.tsx
+++ b/app/javascript/components/modals/ConceptMakersModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { FetchingBoundary } from '../FetchingBoundary'
 import { ResultsZone } from '../ResultsZone'
 import { ModalProps, Modal } from './Modal'
@@ -99,15 +98,12 @@ export const ConceptMakersModal = ({
   endpoint,
   ...props
 }: { endpoint: string } & Omit<ModalProps, 'className'>): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { status, resolvedData, isFetching, error } = usePaginatedRequestQuery<
     APIResponse
-  >(
-    ['concept-makers', endpoint],
-    { endpoint: endpoint, options: { enabled: props.open } },
-    isMountedRef
-  )
+  >(['concept-makers', endpoint], {
+    endpoint: endpoint,
+    options: { enabled: props.open },
+  })
 
   return (
     <Modal {...props} className="m-makers">

--- a/app/javascript/components/modals/DeleteAccountModal.tsx
+++ b/app/javascript/components/modals/DeleteAccountModal.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react'
 import { Modal, ModalProps } from './Modal'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { FormButton } from '../common'
 import { ErrorBoundary, ErrorMessage } from '../ErrorBoundary'
 import { useConfirmation } from '../../hooks/use-confirmation'
@@ -24,15 +23,15 @@ export const DeleteAccountModal = ({
   handle: string
   endpoint: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<APIResponse>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'DELETE',
         body: JSON.stringify({ handle: handle }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (response) => {

--- a/app/javascript/components/modals/ExerciseMakersModal.tsx
+++ b/app/javascript/components/modals/ExerciseMakersModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { FetchingBoundary } from '../FetchingBoundary'
 import { ResultsZone } from '../ResultsZone'
 import { ModalProps, Modal } from './Modal'
@@ -99,15 +98,12 @@ export const ExerciseMakersModal = ({
   endpoint,
   ...props
 }: { endpoint: string } & Omit<ModalProps, 'className'>): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { status, resolvedData, isFetching, error } = usePaginatedRequestQuery<
     APIResponse
-  >(
-    ['exercise-makers', endpoint],
-    { endpoint: endpoint, options: { enabled: props.open } },
-    isMountedRef
-  )
+  >(['exercise-makers', endpoint], {
+    endpoint: endpoint,
+    options: { enabled: props.open },
+  })
 
   return (
     <Modal {...props} className="m-makers">

--- a/app/javascript/components/modals/ExerciseUpdateModal.tsx
+++ b/app/javascript/components/modals/ExerciseUpdateModal.tsx
@@ -3,7 +3,6 @@ import { FetchingBoundary } from '../FetchingBoundary'
 import { Modal, ModalProps } from './Modal'
 import { Icon } from '../common'
 import { useRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { ExerciseUpdateForm } from './exercise-update-modal/ExerciseUpdateForm'
 import { Exercise } from '../types'
 
@@ -25,12 +24,9 @@ export const ExerciseUpdateModal = ({
   endpoint,
   ...props
 }: Omit<ModalProps, 'className'> & { endpoint: string }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { data, status, error } = useRequestQuery<{ diff: ExerciseDiff }>(
     ['exercise-update', endpoint],
-    { endpoint: endpoint, options: {} },
-    isMountedRef
+    { endpoint: endpoint, options: {} }
   )
   return (
     <Modal {...props} className="m-update-exercise">

--- a/app/javascript/components/modals/MentorChangeTracksModal.tsx
+++ b/app/javascript/components/modals/MentorChangeTracksModal.tsx
@@ -26,17 +26,17 @@ export const MentorChangeTracksModal = ({
   cacheKey: string
   onSuccess: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [selected, setSelected] = useState<string[]>(tracks.map((t) => t.slug))
 
   const [mutation] = useMutation<TrackListAPIResponse>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: links.updateTracks,
         method: 'PATCH',
         body: JSON.stringify({ track_slugs: selected }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (response) => {

--- a/app/javascript/components/modals/PreviousMentoringSessionsModal.tsx
+++ b/app/javascript/components/modals/PreviousMentoringSessionsModal.tsx
@@ -11,7 +11,6 @@ import { Modal, ModalProps } from './Modal'
 import pluralize from 'pluralize'
 import { FavoriteButton } from '../mentoring/session/FavoriteButton'
 import { useList } from '../../hooks/use-list'
-import { useIsMounted } from 'use-is-mounted'
 import { PaginatedResult, MentorDiscussion, Student } from '../types'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
 import { FetchingBoundary } from '../FetchingBoundary'
@@ -28,7 +27,6 @@ export const PreviousMentoringSessionsModal = ({
   student: Student
   setStudent: (student: Student) => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setPage } = useList({
     endpoint: student.links.previousSessions,
   })
@@ -41,7 +39,7 @@ export const PreviousMentoringSessionsModal = ({
   } = usePaginatedRequestQuery<
     PaginatedResult<readonly MentorDiscussion[]>,
     Error | Response
-  >([request.endpoint, request.query], request, isMountedRef)
+  >([request.endpoint, request.query], request)
 
   const numPrevious = student.numDiscussionsWithMentor - 1
 

--- a/app/javascript/components/modals/PublishSolutionModal.tsx
+++ b/app/javascript/components/modals/PublishSolutionModal.tsx
@@ -4,7 +4,6 @@ import { Iteration, SolutionForStudent } from '../types'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
 import { typecheck } from '../../utils/typecheck'
-import { useIsMounted } from 'use-is-mounted'
 import { FormButton } from '../common'
 import { ErrorMessage, ErrorBoundary } from '../ErrorBoundary'
 import { IterationSelector } from './student/IterationSelector'
@@ -20,18 +19,18 @@ export const PublishSolutionModal = ({
   endpoint: string
   iterations: readonly Iteration[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [iterationIdx, setIterationIdx] = useState<number | null>(null)
   const [mutation, { status, error }] = useMutation<SolutionForStudent>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: JSON.stringify({ iteration_idx: iterationIdx }),
-        isMountedRef: isMountedRef,
-      }).then((response) => {
-        return typecheck<SolutionForStudent>(response, 'solution')
       })
+
+      return fetch.then((json) =>
+        typecheck<SolutionForStudent>(json, 'solution')
+      )
     },
     {
       onSuccess: (solution) => {

--- a/app/javascript/components/modals/RequestMentoringModal.tsx
+++ b/app/javascript/components/modals/RequestMentoringModal.tsx
@@ -10,7 +10,6 @@ import {
 import { Modal, ModalProps } from './Modal'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
 import { useList } from '../../hooks/use-list'
-import { useIsMounted } from 'use-is-mounted'
 import { SolutionForStudent } from '../types'
 import { FetchingBoundary } from '../FetchingBoundary'
 import { ResultsZone } from '../ResultsZone'
@@ -35,7 +34,6 @@ export const RequestMentoringModal = ({
   request: Request
   links: Links
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setPage, setCriteria } = useList(initialRequest)
   const {
     status,
@@ -45,8 +43,7 @@ export const RequestMentoringModal = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     ['exercises-for-mentoring', request.query],
-    request,
-    isMountedRef
+    request
   )
 
   return (

--- a/app/javascript/components/modals/ResetAccountModal.tsx
+++ b/app/javascript/components/modals/ResetAccountModal.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react'
 import { Modal, ModalProps } from './Modal'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { FormButton } from '../common'
 import { ErrorBoundary, ErrorMessage } from '../ErrorBoundary'
 import { useConfirmation } from '../../hooks/use-confirmation'
@@ -24,15 +23,15 @@ export const ResetAccountModal = ({
   handle: string
   endpoint: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<APIResponse>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: JSON.stringify({ handle: handle }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (response) => {

--- a/app/javascript/components/modals/TestRunModal.tsx
+++ b/app/javascript/components/modals/TestRunModal.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { TestRunSummary } from '../editor/TestRunSummary'
 import { FetchingBoundary } from '../FetchingBoundary'
 import { Modal, ModalProps } from './Modal'
-import { useIsMounted } from 'use-is-mounted'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
 import { TestRun } from '../editor/types'
 import { ResultsZone } from '../ResultsZone'
@@ -17,14 +16,12 @@ export const TestRunModal = ({
   endpoint,
   ...props
 }: Omit<ModalProps, 'className'> & { endpoint: string }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { resolvedData, status, error, isFetching } = usePaginatedRequestQuery<
     APIResponse
-  >(
-    ['test-run', endpoint],
-    { endpoint: endpoint, options: { enabled: props.open } },
-    isMountedRef
-  )
+  >(['test-run', endpoint], {
+    endpoint: endpoint,
+    options: { enabled: props.open },
+  })
 
   return (
     <Modal className="m-test-run" {...props}>

--- a/app/javascript/components/modals/UnpublishSolutionModal.tsx
+++ b/app/javascript/components/modals/UnpublishSolutionModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Modal, ModalProps } from './Modal'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../utils/send-request'
 import { typecheck } from '../../utils/typecheck'
@@ -15,17 +14,17 @@ export const UnpublishSolutionModal = ({
   endpoint,
   ...props
 }: ModalProps & { endpoint: string }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<SolutionForStudent>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        return typecheck<SolutionForStudent>(json, 'solution')
       })
+
+      return fetch.then((json) =>
+        typecheck<SolutionForStudent>(json, 'solution')
+      )
     },
     {
       onSuccess: (solution) => {

--- a/app/javascript/components/modals/complete-exercise-modal/PublishSolutionForm.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/PublishSolutionForm.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react'
 import { QueryStatus, useMutation } from 'react-query'
-import { useIsMounted } from 'use-is-mounted'
 import { sendRequest } from '../../../utils/send-request'
 import { Loading } from '../../common'
 import { ExerciseCompletion } from '../CompleteExerciseModal'
@@ -44,27 +43,21 @@ export const PublishSolutionForm = ({
   const [iterationIdxToPublish, setIterationIdxToPublish] = useState<
     number | null
   >(null)
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<ExerciseCompletion>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: JSON.stringify({
           publish: toPublish,
           iteration_idx: iterationIdxToPublish,
         }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
-      onSuccess: (data) => {
-        if (!data) {
-          return
-        }
-
-        onSuccess(data)
-      },
+      onSuccess: onSuccess,
     }
   )
 

--- a/app/javascript/components/modals/exercise-update-modal/ExerciseUpdateForm.tsx
+++ b/app/javascript/components/modals/exercise-update-modal/ExerciseUpdateForm.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useState } from 'react'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../utils/send-request'
 import { ExerciseDiff } from '../ExerciseUpdateModal'
-import { useIsMounted } from 'use-is-mounted'
 import { GraphicalIcon, ExerciseIcon, FormButton } from '../../common'
 import { ErrorBoundary, ErrorMessage } from '../../ErrorBoundary'
 import { SolutionForStudent } from '../../types'
@@ -25,19 +24,19 @@ export const ExerciseUpdateForm = ({
   diff: ExerciseDiff
   onCancel: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [tab, setTab] = useState(diff.files[0].filename)
 
   const [mutation, { status, error }] = useMutation<SolutionForStudent>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: diff.links.update,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        return typecheck<SolutionForStudent>(json, 'solution')
       })
+
+      return fetch.then((json) =>
+        typecheck<SolutionForStudent>(json, 'solution')
+      )
     },
     {
       onSuccess: (solution) => {

--- a/app/javascript/components/modals/mentor-registration-modal/CommitStep.tsx
+++ b/app/javascript/components/modals/mentor-registration-modal/CommitStep.tsx
@@ -4,7 +4,6 @@ import { ReputationInfo } from './commit-step/ReputationInfo'
 import { Checkbox } from './commit-step/Checkbox'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { ErrorMessage, ErrorBoundary } from '../../ErrorBoundary'
 
 export type Links = {
@@ -27,18 +26,18 @@ export const CommitStep = ({
   onContinue: () => void
   onBack: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: links.registration,
         method: 'POST',
         body: JSON.stringify({
           track_slugs: selected,
           accept_terms: true,
         }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: () => {

--- a/app/javascript/components/modals/student/finish-mentor-discussion-modal/AddTestimonialStep.tsx
+++ b/app/javascript/components/modals/student/finish-mentor-discussion-modal/AddTestimonialStep.tsx
@@ -3,7 +3,6 @@ import { MentorDiscussion } from '../../../types'
 import { Avatar, GraphicalIcon } from '../../../common'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../../utils/send-request'
-import { useIsMounted } from 'use-is-mounted'
 import { FormButton } from '../../../common'
 import { FetchingBoundary } from '../../../FetchingBoundary'
 import { TestimonialField } from './TestimonialField'
@@ -20,18 +19,18 @@ export const AddTestimonialStep = ({
   discussion: MentorDiscussion
 }): JSX.Element => {
   const [value, setValue] = useState('')
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: discussion.links.finish,
         method: 'PATCH',
         body: JSON.stringify({
           rating: 5,
           testimonial: value,
         }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: onSubmit,

--- a/app/javascript/components/modals/student/finish-mentor-discussion-modal/ReportStep.tsx
+++ b/app/javascript/components/modals/student/finish-mentor-discussion-modal/ReportStep.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState, useRef } from 'react'
 import { MentorDiscussion } from '../../../types'
 import { Avatar, GraphicalIcon } from '../../../common'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../../utils/send-request'
 import { FormButton } from '../../../common'
@@ -26,10 +25,9 @@ export const ReportStep = ({
     reason: 'coc',
   })
   const messageRef = useRef<HTMLTextAreaElement>(null)
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: discussion.links.finish,
         method: 'PATCH',
         body: JSON.stringify({
@@ -39,8 +37,9 @@ export const ReportStep = ({
           report_reason: state.reason,
           report_message: messageRef.current?.value,
         }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: () => {

--- a/app/javascript/components/modals/student/finish-mentor-discussion-modal/SatisfiedStep.tsx
+++ b/app/javascript/components/modals/student/finish-mentor-discussion-modal/SatisfiedStep.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../../utils/send-request'
 import { FormButton } from '../../../common'
@@ -19,15 +18,15 @@ export const SatisfiedStep = ({
   onNotRequeued: () => void
   onBack: () => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [finish, { status, error }] = useMutation(
     (requeue: boolean) => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: discussion.links.finish,
         method: 'PATCH',
         body: JSON.stringify({ rating: 3, requeue: requeue }),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (data, requeue) => {

--- a/app/javascript/components/profile/CommunitySolutionsList.tsx
+++ b/app/javascript/components/profile/CommunitySolutionsList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../hooks/use-list'
 import { useHistory, removeEmpty } from '../../hooks/use-history'
 import { CommunitySolution as CommunitySolutionProps } from '../types'
@@ -40,7 +39,6 @@ export const CommunitySolutionsList = ({
   request: Request
   tracks: TrackData[]
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const {
     request,
     setCriteria: setRequestCriteria,
@@ -57,8 +55,7 @@ export const CommunitySolutionsList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     ['profile-community-solution-list', request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   const setTrack = useCallback(

--- a/app/javascript/components/profile/contributions-list/AuthoringContributionsList.tsx
+++ b/app/javascript/components/profile/contributions-list/AuthoringContributionsList.tsx
@@ -3,7 +3,6 @@ import { ExerciseWidget, Pagination } from '../../common'
 import { ExerciseAuthorship } from '../../types'
 import { FetchingBoundary } from '../../FetchingBoundary'
 import { ResultsZone } from '../../ResultsZone'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../../hooks/use-list'
 import { usePaginatedRequestQuery, Request } from '../../../hooks/request-query'
 
@@ -23,8 +22,6 @@ export const AuthoringContributionsList = ({
 }: {
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { request, setPage } = useList(initialRequest)
   const {
     status,
@@ -34,8 +31,7 @@ export const AuthoringContributionsList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     [request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   return (

--- a/app/javascript/components/profile/contributions-list/BuildingContributionsList.tsx
+++ b/app/javascript/components/profile/contributions-list/BuildingContributionsList.tsx
@@ -4,7 +4,6 @@ import { TrackIcon, Reputation, GraphicalIcon, Pagination } from '../../common'
 import { fromNow } from '../../../utils/date'
 import { FetchingBoundary } from '../../FetchingBoundary'
 import { ResultsZone } from '../../ResultsZone'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../../hooks/use-list'
 import { usePaginatedRequestQuery, Request } from '../../../hooks/request-query'
 
@@ -24,8 +23,6 @@ export const BuildingContributionsList = ({
 }: {
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { request, setPage } = useList(initialRequest)
   const {
     status,
@@ -35,8 +32,7 @@ export const BuildingContributionsList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     [request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   return (

--- a/app/javascript/components/profile/contributions-list/MaintainingContributionsList.tsx
+++ b/app/javascript/components/profile/contributions-list/MaintainingContributionsList.tsx
@@ -4,7 +4,6 @@ import { TrackIcon, Reputation, GraphicalIcon, Pagination } from '../../common'
 import { fromNow } from '../../../utils/date'
 import { FetchingBoundary } from '../../FetchingBoundary'
 import { ResultsZone } from '../../ResultsZone'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../../hooks/use-list'
 import { usePaginatedRequestQuery, Request } from '../../../hooks/request-query'
 
@@ -24,8 +23,6 @@ export const MaintainingContributionsList = ({
 }: {
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-
   const { request, setPage } = useList(initialRequest)
   const {
     status,
@@ -35,8 +32,7 @@ export const MaintainingContributionsList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     [request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   return (

--- a/app/javascript/components/settings/useSettingsMutation.tsx
+++ b/app/javascript/components/settings/useSettingsMutation.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useCallback } from 'react'
-import { useIsMounted } from 'use-is-mounted'
 import { sendRequest } from '../../utils/send-request'
 import { useMutation } from 'react-query'
 
@@ -19,15 +18,15 @@ export const useSettingsMutation = <
   timeout?: number
   onSuccess?: (params: U) => void
 }) => {
-  const isMountedRef = useIsMounted()
   const [baseMutation, { status, error, reset }] = useMutation<U>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: method,
         body: JSON.stringify(body),
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: onSuccess,

--- a/app/javascript/components/student/ExerciseList.tsx
+++ b/app/javascript/components/student/ExerciseList.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { ExerciseWidget } from '../common'
 import { usePaginatedRequestQuery, Request } from '../../hooks/request-query'
 import { Exercise, SolutionForStudent } from '../types'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../hooks/use-list'
 import { FetchingBoundary } from '../FetchingBoundary'
 import { ResultsZone } from '../ResultsZone'
@@ -98,7 +97,6 @@ export const ExerciseList = ({
   request: Request
   defaultStatus?: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setCriteria: setRequestCriteria } = useList(initialRequest)
   const [criteria, setCriteria] = useState(request.query?.criteria || '')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(
@@ -108,7 +106,7 @@ export const ExerciseList = ({
   const { status, resolvedData, isFetching, error } = usePaginatedRequestQuery<
     { solutions: SolutionForStudent[]; exercises: Exercise[] },
     Error | Response
-  >(['exercise-list', request.endpoint, request.query], request, isMountedRef)
+  >(['exercise-list', request.endpoint, request.query], request)
 
   const results = resolvedData?.exercises.map((exercise) => {
     const solution = resolvedData.solutions.find(

--- a/app/javascript/components/student/IterationPage.tsx
+++ b/app/javascript/components/student/IterationPage.tsx
@@ -3,7 +3,6 @@ import { Loading } from '../common'
 import { Iteration } from '../types'
 import { IterationReport } from './iteration-page/IterationReport'
 import { EmptyIterations } from './iteration-page/EmptyIterations'
-import { useIsMounted } from 'use-is-mounted'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
 import { SolutionChannel } from '../../channels/solutionChannel'
 import { queryCache } from 'react-query'
@@ -50,11 +49,10 @@ export const IterationPage = ({
   links: Links
 }): JSX.Element => {
   const [isOpen, setIsOpen] = useState<boolean[]>([])
-  const isMountedRef = useIsMounted()
   const CACHE_KEY = `iterations-${track.title}-${exercise.title}`
   const { resolvedData } = usePaginatedRequestQuery<{
     iterations: readonly Iteration[]
-  }>(CACHE_KEY, request, isMountedRef)
+  }>(CACHE_KEY, request)
 
   useEffect(() => {
     const solutionChannel = new SolutionChannel(

--- a/app/javascript/components/student/Nudge.tsx
+++ b/app/javascript/components/student/Nudge.tsx
@@ -16,7 +16,6 @@ import {
 import { LatestIterationStatusChannel } from '../../channels/latestIterationStatusChannel'
 import { usePaginatedRequestQuery, Request } from '../../hooks/request-query'
 import pluralize from 'pluralize'
-import { useIsMounted } from 'use-is-mounted'
 import { queryCache } from 'react-query'
 
 export type Track = {
@@ -61,22 +60,17 @@ export const Nudge = ({
   iterations,
   track,
 }: Props): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const CACHE_KEY = `nudge-${solution.uuid}`
   const [queryEnabled, setQueryEnabled] = useState(true)
   const { resolvedData } = usePaginatedRequestQuery<{
     status: IterationStatus
-  }>(
-    CACHE_KEY,
-    {
-      ...request,
-      options: {
-        ...request.options,
-        refetchInterval: queryEnabled ? REFETCH_INTERVAL : false,
-      },
+  }>(CACHE_KEY, {
+    ...request,
+    options: {
+      ...request.options,
+      refetchInterval: queryEnabled ? REFETCH_INTERVAL : false,
     },
-    isMountedRef
-  )
+  })
 
   const iterationStatus = resolvedData?.status
 

--- a/app/javascript/components/student/SolutionSummary.tsx
+++ b/app/javascript/components/student/SolutionSummary.tsx
@@ -6,7 +6,6 @@ import { Mentoring } from './solution-summary/Mentoring'
 import { Loading, ProminentLink } from '../common'
 import { SolutionChannel } from '../../channels/solutionChannel'
 import { usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { queryCache } from 'react-query'
 import {
   Iteration,
@@ -60,22 +59,17 @@ export const SolutionSummary = ({
   exerciseType: ExerciseType
   links: SolutionSummaryLinks
 }): JSX.Element | null => {
-  const isMountedRef = useIsMounted()
   const CACHE_KEY = `solution-${solution.uuid}-summary`
   const [queryEnabled, setQueryEnabled] = useState(true)
   const { resolvedData } = usePaginatedRequestQuery<{
     iterations: Iteration[]
-  }>(
-    CACHE_KEY,
-    {
-      ...request,
-      options: {
-        ...request.options,
-        refetchInterval: queryEnabled ? REFETCH_INTERVAL : false,
-      },
+  }>(CACHE_KEY, {
+    ...request,
+    options: {
+      ...request.options,
+      refetchInterval: queryEnabled ? REFETCH_INTERVAL : false,
     },
-    isMountedRef
-  )
+  })
 
   useEffect(() => {
     const solutionChannel = new SolutionChannel(

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
 import { TagsFilter } from './tracks-list/TagsFilter'
 import { List } from './tracks-list/List'
-import { useIsMounted } from 'use-is-mounted'
 import { ResultsZone } from '../ResultsZone'
 import { useList } from '../../hooks/use-list'
 import { StudentTrack } from '../types'
@@ -30,7 +29,6 @@ export const TracksList = ({
   tagOptions: readonly TagOption[]
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setCriteria: setRequestCriteria, setQuery } = useList(
     initialRequest
   )
@@ -38,7 +36,7 @@ export const TracksList = ({
   const CACHE_KEY = ['track-list', request.endpoint, request.query]
   const { resolvedData, isError, isFetching } = usePaginatedRequestQuery<
     APIResponse
-  >(CACHE_KEY, request, isMountedRef)
+  >(CACHE_KEY, request)
 
   const setTags = useCallback(
     (tags) => {

--- a/app/javascript/components/student/iteration-page/EmptyIterations.tsx
+++ b/app/javascript/components/student/iteration-page/EmptyIterations.tsx
@@ -34,12 +34,13 @@ export const EmptyIterations = ({
   const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<Solution>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: links.startExercise,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (solution) => {

--- a/app/javascript/components/student/iteration-page/TestsInformation.tsx
+++ b/app/javascript/components/student/iteration-page/TestsInformation.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Request, usePaginatedRequestQuery } from '../../../hooks/request-query'
 import { FetchingBoundary } from '../../FetchingBoundary'
 import { ResultsZone } from '../../ResultsZone'
-import { useIsMounted } from 'use-is-mounted'
 import { TestRunSummary } from '../../editor/TestRunSummary'
 import { TestRun } from '../../editor/types'
 
@@ -17,10 +16,9 @@ export const TestsInformation = ({
 }: {
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { resolvedData, status, error, isFetching } = usePaginatedRequestQuery<
     APIResponse
-  >(['test-run', request.endpoint], request, isMountedRef)
+  >(['test-run', request.endpoint], request)
 
   return (
     <ResultsZone isFetching={isFetching}>

--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
@@ -11,7 +11,6 @@ import {
 import { useMutation } from 'react-query'
 import { sendRequest } from '../../../../utils/send-request'
 import { typecheck } from '../../../../utils/typecheck'
-import { useIsMounted } from 'use-is-mounted'
 import { MentorSessionRequest as Request } from '../../../types'
 import { FetchingBoundary } from '../../../FetchingBoundary'
 
@@ -37,33 +36,21 @@ export const MentoringRequestForm = ({
   links: Links
   onSuccess: (mentorRequest: Request) => void
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
-  const [mutation, { status, error }] = useMutation<Request | undefined>(
+  const [mutation, { status, error }] = useMutation<Request>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: links.createMentorRequest,
         method: 'POST',
         body: JSON.stringify({
           comment: solutionCommentRef.current?.value,
           track_objectives: trackObjectivesRef.current?.value,
         }),
-        isMountedRef: isMountedRef,
-      }).then((json) => {
-        if (!json) {
-          return
-        }
-
-        return typecheck<Request>(json, 'mentorRequest')
       })
+
+      return fetch.then((json) => typecheck<Request>(json, 'mentorRequest'))
     },
     {
-      onSuccess: (mentorRequest) => {
-        if (!mentorRequest) {
-          return
-        }
-
-        onSuccess(mentorRequest)
-      },
+      onSuccess: onSuccess,
     }
   )
 

--- a/app/javascript/components/student/open-editor-button/StartExerciseButton.tsx
+++ b/app/javascript/components/student/open-editor-button/StartExerciseButton.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 import { useMutation } from 'react-query'
-import { useIsMounted } from 'use-is-mounted'
 import { sendRequest } from '../../../utils/send-request'
 import { FormButton } from '../../common'
 import { FetchingBoundary } from '../../FetchingBoundary'
@@ -15,17 +14,17 @@ export const StartExerciseButton = ({
   endpoint: string
   className?: string
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const [mutation, { status, error }] = useMutation<{
     links: { exercise: string }
   }>(
     () => {
-      return sendRequest({
+      const { fetch } = sendRequest({
         endpoint: endpoint,
         method: 'PATCH',
         body: null,
-        isMountedRef: isMountedRef,
       })
+
+      return fetch
     },
     {
       onSuccess: (data) => {

--- a/app/javascript/components/tooltips/ExerciseTooltip.tsx
+++ b/app/javascript/components/tooltips/ExerciseTooltip.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { Exercise, Track, SolutionForStudent } from '../types'
 import { Icon, ExerciseWidget } from '../common'
 import { useRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { FetchingBoundary } from '../FetchingBoundary'
 
 const DEFAULT_ERROR = new Error('Unable to load information')
@@ -27,16 +26,11 @@ export const ExerciseTooltip = React.forwardRef<
   HTMLDivElement,
   React.HTMLProps<HTMLDivElement> & { endpoint: string; slug: string }
 >(({ endpoint, slug, ...props }, ref) => {
-  const isMountedRef = useIsMounted()
   const { data, error, status } = useRequestQuery<{
     track: Track
     exercise: Exercise
     solution: SolutionForStudent
-  }>(
-    `exercise-tooltip-${slug}`,
-    { endpoint: endpoint, options: { staleTime: 0 } },
-    isMountedRef
-  )
+  }>(`exercise-tooltip-${slug}`, { endpoint: endpoint, options: {} })
 
   return (
     <div className="c-exercise-tooltip" {...props} ref={ref}>

--- a/app/javascript/components/tooltips/StudentTooltip.tsx
+++ b/app/javascript/components/tooltips/StudentTooltip.tsx
@@ -31,13 +31,9 @@ export const StudentTooltip = React.forwardRef<
   HTMLDivElement,
   React.HTMLProps<HTMLDivElement> & { endpoint: string; requestId: string }
 >(({ endpoint, requestId, ...props }, ref) => {
-  const isMountedRef = useIsMounted()
-  const { data, error, status } = useRequestQuery<{
-    student: Student
-  }>(
+  const { data, error, status } = useRequestQuery<{ student: Student }>(
     `student-tooltip-${requestId}`,
-    { endpoint: endpoint, options: {} },
-    isMountedRef
+    { endpoint: endpoint, options: {} }
   )
 
   return (

--- a/app/javascript/components/track/ExerciseCommunitySolutionsList.tsx
+++ b/app/javascript/components/track/ExerciseCommunitySolutionsList.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 import { useList } from '../../hooks/use-list'
 import { useHistory, removeEmpty } from '../../hooks/use-history'
 import { CommunitySolution as CommunitySolutionProps } from '../types'
@@ -27,7 +26,6 @@ export const ExerciseCommunitySolutionsList = ({
 }: {
   request: Request
 }): JSX.Element => {
-  const isMountedRef = useIsMounted()
   const { request, setPage, setCriteria: setRequestCriteria } = useList(
     initialRequest
   )
@@ -40,8 +38,7 @@ export const ExerciseCommunitySolutionsList = ({
     error,
   } = usePaginatedRequestQuery<PaginatedResult, Error | Response>(
     ['exercise-community-solution-list', request.endpoint, request.query],
-    request,
-    isMountedRef
+    request
   )
 
   useEffect(() => {

--- a/app/javascript/hooks/use-content-query.ts
+++ b/app/javascript/hooks/use-content-query.ts
@@ -1,5 +1,4 @@
 import { useRequestQuery } from '../hooks/request-query'
-import { useIsMounted } from 'use-is-mounted'
 
 export function useContentQuery(
   id: string,
@@ -10,10 +9,9 @@ export function useContentQuery(
   isError: boolean
   htmlContent: { html: string } | undefined
 } {
-  const isMountedRef = useIsMounted()
   const { isLoading, isError, data: htmlContent } = useRequestQuery<{
     html: string
-  }>(id, { endpoint: endpoint, options: { enabled } }, isMountedRef)
+  }>(id, { endpoint: endpoint, options: { enabled } })
 
   return { isLoading, isError, htmlContent }
 }

--- a/app/javascript/utils/fetch-json.ts
+++ b/app/javascript/utils/fetch-json.ts
@@ -1,12 +1,15 @@
 import { camelizeKeys } from 'humps'
 
-export function fetchJSON(endpoint: string, options: any) {
+export const fetchJSON = <T extends any>(
+  input: RequestInfo,
+  options: RequestInit
+): Promise<T> => {
   const headers = {
     'content-type': 'application/json',
     accept: 'application/json',
   }
 
-  return fetch(endpoint, Object.assign(options, { headers: headers }))
+  return fetch(input, Object.assign(options, { headers: headers }))
     .then((response) => {
       if (!response.ok) {
         throw response
@@ -27,6 +30,6 @@ export function fetchJSON(endpoint: string, options: any) {
       return response.json()
     })
     .then((json) => {
-      return camelizeKeys(json)
+      return camelizeKeys(json) as T
     })
 }

--- a/test/system/flows/edit_solution_test.rb
+++ b/test/system/flows/edit_solution_test.rb
@@ -18,7 +18,6 @@ module Components
 
           sign_in!(user)
           visit edit_track_exercise_path(solution.track, solution.exercise)
-          fill_in_editor "test"
           click_on "Run Tests"
           wait_for_submission
           2.times { wait_for_websockets }
@@ -47,7 +46,6 @@ module Components
 
           sign_in!(user)
           visit edit_track_exercise_path(solution.track, solution.exercise)
-          fill_in_editor "test"
           click_on "Run Tests"
           wait_for_submission
           2.times { wait_for_websockets }


### PR DESCRIPTION
https://github.com/exercism/v3-beta/issues/82
https://github.com/exercism/v3-beta/issues/112

I just found out that when a component unmounts, our `sendRequest` function returns `undefined`. This is why tooltips don't load on hovering out of them quickly. Also, I think this is why the notification dropdown doesn't work, since we've unmounted the component when we change pages.

There are some things that might break from this, and these might at the top of my head:

1. Cancelling a test run.

I will handle this case at the same time as this issue: https://github.com/exercism/v3-beta/issues/123

2. Scratchpad 

When I was looking at the scratchpad code, I noticed that we weren't using `useRequestQuery`. I will make a separate issue for this.