### PR TITLE
Add guard to publishing/completing in solutions API

### DIFF
--- a/app/commands/solution/complete.rb
+++ b/app/commands/solution/complete.rb
@@ -5,6 +5,8 @@ class Solution
     initialize_with :solution, :user_track
 
     def call
+      raise SolutionHasNoIterationsError if solution.iterations.empty?
+
       solution.with_lock do
         return if solution.completed?
 

--- a/app/commands/solution/publish.rb
+++ b/app/commands/solution/publish.rb
@@ -2,10 +2,12 @@ class Solution
   class Publish
     include Mandate
 
-    initialize_with :solution, :iteration_idx
+    initialize_with :solution, :user_track, :iteration_idx
 
     def call
       solution.with_lock do
+        Solution::Complete.(solution, user_track) unless solution.completed?
+
         return if solution.published?
 
         ActiveRecord::Base.transaction do

--- a/app/commands/solution/publish.rb
+++ b/app/commands/solution/publish.rb
@@ -5,9 +5,9 @@ class Solution
     initialize_with :solution, :user_track, :iteration_idx
 
     def call
-      solution.with_lock do
-        Solution::Complete.(solution, user_track) unless solution.completed?
+      Solution::Complete.(solution, user_track) unless solution.completed?
 
+      solution.with_lock do
         return if solution.published?
 
         ActiveRecord::Base.transaction do

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -124,8 +124,6 @@ module API
         return render_solution_not_found
       end
 
-      # TODO: (Required): Add check if solution is not complete
-
       return render_solution_not_accessible unless solution.user_id == current_user.id
 
       user_track = UserTrack.for(current_user, solution.track)

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -85,14 +85,13 @@ module API
         return render_solution_not_found
       end
 
-      # TODO: (Required) Add check if solution is not complete
-
       return render_solution_not_accessible unless solution.user_id == current_user.id
       return render_400(:solution_without_iterations) if solution.iterations.empty?
 
       user_track = UserTrack.for(current_user, solution.track)
       return render_404(:track_not_joined) if user_track.external?
 
+      Solution::Complete.(solution, user_track) unless solution.completed?
       Solution::Publish.(solution, params[:iteration_idx])
 
       render json: {

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -43,6 +43,7 @@ module API
       end
 
       return render_solution_not_accessible unless solution.user_id == current_user.id
+      return render_400(:solution_without_iterations) if solution.iterations.empty?
 
       user_track = UserTrack.for(current_user, solution.track)
       return render_404(:track_not_joined) if user_track.external?
@@ -87,6 +88,7 @@ module API
       # TODO: (Required) Add check if solution is not complete
 
       return render_solution_not_accessible unless solution.user_id == current_user.id
+      return render_400(:solution_without_iterations) if solution.iterations.empty?
 
       user_track = UserTrack.for(current_user, solution.track)
       return render_404(:track_not_joined) if user_track.external?

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -50,7 +50,7 @@ module API
 
       changes = UserTrack::MonitorChanges.(user_track) do
         Solution::Complete.(solution, user_track)
-        Solution::Publish.(solution, params[:iteration_idx]) if params[:publish]
+        Solution::Publish.(solution, user_track, params[:iteration_idx]) if params[:publish]
       end
 
       output = {
@@ -91,8 +91,7 @@ module API
       user_track = UserTrack.for(current_user, solution.track)
       return render_404(:track_not_joined) if user_track.external?
 
-      Solution::Complete.(solution, user_track) unless solution.completed?
-      Solution::Publish.(solution, params[:iteration_idx])
+      Solution::Publish.(solution, user_track, params[:iteration_idx])
 
       render json: {
         solution: SerializeSolution.(solution)

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -17,6 +17,8 @@ class MissingTracksError < RuntimeError; end
 
 class SubmissionFileTooLargeError < RuntimeError; end
 
+class SolutionHasNoIterationsError < RuntimeError; end
+
 class SolutionLockedByAnotherMentorError < RuntimeError; end
 
 class StudentCannotMentorThemselvesError < RuntimeError; end

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -10,6 +10,7 @@ en:
       solution_not_found: "This solution could not be found"
       solution_not_accessible: "You do not have permission to view this solution"
       solution_not_unlocked: "You have not unlocked this exercise"
+      solution_without_iterations: "This solution does not have any iterations"
       submission_not_found: "This submission could not be found"
       submission_not_accessible: "You do not have permission to view this submission"
       team_not_found: "The team could not be found"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -130,7 +130,7 @@ submission.files.create!(
 Iteration::Create.(solution, submission)
 
 Solution::Complete.(solution, user_track)
-Solution::Publish.(solution, [])
+Solution::Publish.(solution, user_track, [])
 
 ## Create mentoring solutions
 UserTrack.create!(user: erik, track: ruby)

--- a/test/commands/solution/complete_test.rb
+++ b/test/commands/solution/complete_test.rb
@@ -27,7 +27,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
 
     Solution::Complete.(solution, user_track)
 
-    assert user_track.concept_learnt?(concept)
+    assert user_track.reload.concept_learnt?(concept)
   end
 
   test "sets practice exercise solution as completed" do
@@ -67,6 +67,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
       user = create :user
       user_track = create :user_track, user: user, track: exercise.track
       solution = create :concept_solution, user: user, exercise: exercise, completed_at: completed_at
+      create :iteration, solution: solution
 
       # Sanity check
       assert solution.completed?

--- a/test/commands/solution/complete_test.rb
+++ b/test/commands/solution/complete_test.rb
@@ -7,6 +7,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, user: user, track: exercise.track
     solution = create :concept_solution, user: user, exercise: exercise
+    create :iteration, solution: solution
 
     Solution::Complete.(solution, user_track)
 
@@ -22,6 +23,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, user: user, track: track
     solution = create :concept_solution, user: user, exercise: exercise
+    create :iteration, solution: solution
 
     Solution::Complete.(solution, user_track)
 
@@ -34,6 +36,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, user: user, track: exercise.track
     solution = create :practice_solution, user: user, exercise: exercise
+    create :iteration, solution: solution
 
     Solution::Complete.(solution, user_track)
 
@@ -46,6 +49,7 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, user: user, track: exercise.track
     solution = create :practice_solution, user: user, exercise: exercise
+    create :iteration, solution: solution
 
     Solution::Complete.(solution, user_track)
 
@@ -73,6 +77,18 @@ class Solution::CompleteTest < ActiveSupport::TestCase
       assert solution.completed?
       assert_equal completed_at, solution.completed_at
       refute User::Activities::CompletedExerciseActivity.exists?
+    end
+  end
+
+  test "raises when solution has no iterations" do
+    exercise = create :practice_exercise
+
+    user = create :user
+    user_track = create :user_track, user: user, track: exercise.track
+    solution = create :practice_solution, user: user, exercise: exercise
+
+    assert_raises SolutionHasNoIterationsError do
+      Solution::Complete.(solution, user_track)
     end
   end
 end

--- a/test/commands/solution/complete_test.rb
+++ b/test/commands/solution/complete_test.rb
@@ -23,11 +23,12 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     user = create :user
     user_track = create :user_track, user: user, track: track
     solution = create :concept_solution, user: user, exercise: exercise
-    create :iteration, solution: solution
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission
 
     Solution::Complete.(solution, user_track)
 
-    assert user_track.reload.concept_learnt?(concept)
+    assert user_track.concept_learnt?(concept)
   end
 
   test "sets practice exercise solution as completed" do

--- a/test/commands/user_track/monitor_changes_test.rb
+++ b/test/commands/user_track/monitor_changes_test.rb
@@ -27,6 +27,8 @@ class Solution::CompleteWithSummaryTest < ActiveSupport::TestCase
       user = create :user
       user_track = create :user_track, user: user, track: track
       solution = create :concept_solution, user: user, exercise: concept_exercise_1
+      submission = create :submission, solution: solution
+      create :iteration, submission: submission
 
       summary = UserTrack::MonitorChanges.(user_track) do
         Solution::Complete.(solution, user_track)

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -436,12 +436,12 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "publish renders 400 when solution has no iterations" do
+  test "publish renders 400 when solution not completed and has no iterations" do
     setup_user
 
     exercise = create :concept_exercise
     create :user_track, track: exercise.track, user: @current_user
-    solution = create :concept_solution, exercise: exercise, user: @current_user, completed_at: Time.current
+    solution = create :concept_solution, exercise: exercise, user: @current_user, completed_at: nil
 
     patch publish_api_solution_path(solution.uuid, publish: true),
       headers: @headers, as: :json

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -237,6 +237,8 @@ class API::SolutionsControllerTest < API::BaseTestCase
     setup_user
 
     solution = create :concept_solution, user: @current_user
+    create :iteration, solution: solution
+
     patch complete_api_solution_path(solution.uuid),
       headers: @headers, as: :json
 
@@ -252,6 +254,28 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
+  test "complete renders 400 when solution has no iterations" do
+    setup_user
+
+    exercise = create :concept_exercise
+    create :user_track, track: exercise.track, user: @current_user
+    solution = create :concept_solution, exercise: exercise, user: @current_user
+
+    patch complete_api_solution_path(solution.uuid),
+      headers: @headers, as: :json
+
+    assert_response 400
+    assert_equal(
+      {
+        "error" => {
+          "type" => "solution_without_iterations",
+          "message" => I18n.t("api.errors.solution_without_iterations")
+        }
+      },
+      JSON.parse(response.body)
+    )
+  end
+
   test "complete completes exercise" do
     freeze_time do
       setup_user
@@ -259,6 +283,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
       exercise = create :concept_exercise
       create :user_track, track: exercise.track, user: @current_user
       solution = create :concept_solution, exercise: exercise, user: @current_user
+      create :iteration, solution: solution
 
       patch complete_api_solution_path(solution.uuid),
         headers: @headers, as: :json
@@ -298,6 +323,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
       setup_user
 
       track = create :track
+
       concept_1 = create :concept, track: track
       concept_2 = create :concept, track: track
 
@@ -320,6 +346,8 @@ class API::SolutionsControllerTest < API::BaseTestCase
 
       user_track = create :user_track, track: track, user: @current_user
       solution = create :concept_solution, exercise: concept_exercise_1, user: @current_user
+      submission = create :submission, solution: solution
+      create :iteration, submission: submission
 
       patch complete_api_solution_path(solution.uuid),
         headers: @headers, as: :json
@@ -347,6 +375,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
           }
         ]
       }.to_json
+
       assert_equal expected, response.body
     end
   end
@@ -390,6 +419,8 @@ class API::SolutionsControllerTest < API::BaseTestCase
     setup_user
 
     solution = create :concept_solution, user: @current_user
+    create :iteration, solution: solution
+
     patch publish_api_solution_path(solution.uuid),
       headers: @headers, as: :json
 
@@ -399,6 +430,28 @@ class API::SolutionsControllerTest < API::BaseTestCase
         "error" => {
           "type" => "track_not_joined",
           "message" => I18n.t("api.errors.track_not_joined")
+        }
+      },
+      JSON.parse(response.body)
+    )
+  end
+
+  test "publish renders 400 when solution has no iterations" do
+    setup_user
+
+    exercise = create :concept_exercise
+    create :user_track, track: exercise.track, user: @current_user
+    solution = create :concept_solution, exercise: exercise, user: @current_user, completed_at: Time.current
+
+    patch publish_api_solution_path(solution.uuid, publish: true),
+      headers: @headers, as: :json
+
+    assert_response 400
+    assert_equal(
+      {
+        "error" => {
+          "type" => "solution_without_iterations",
+          "message" => I18n.t("api.errors.solution_without_iterations")
         }
       },
       JSON.parse(response.body)

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -458,6 +458,27 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
+  test "publish completes the solution if not already completed" do
+    freeze_time do
+      setup_user
+
+      exercise = create :concept_exercise
+      create :user_track, track: exercise.track, user: @current_user
+      solution = create :concept_solution, exercise: exercise, user: @current_user, completed_at: nil
+      create :iteration, solution: solution
+
+      patch publish_api_solution_path(solution.uuid, publish: true),
+        headers: @headers, as: :json
+
+      assert_response 200
+
+      solution.reload
+      assert_equal Time.current, solution.completed_at
+      assert_equal Time.current, solution.published_at
+      assert_equal :published, solution.status
+    end
+  end
+
   test "publish publishes the solution" do
     freeze_time do
       setup_user

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -350,4 +350,79 @@ class API::SolutionsControllerTest < API::BaseTestCase
       assert_equal expected, response.body
     end
   end
+
+  ############
+  # Publish #
+  ############
+  test "publish renders 404 when solution not found" do
+    setup_user
+
+    patch publish_api_solution_path("xxx"),
+      headers: @headers, as: :json
+
+    assert_response 404
+    assert_equal(
+      {
+        "error" => {
+          "type" => "solution_not_found",
+          "message" => I18n.t("api.errors.solution_not_found")
+        }
+      },
+      JSON.parse(response.body)
+    )
+  end
+
+  test "publish should 404 if the solution belongs to someone else" do
+    setup_user
+    solution = create :concept_solution
+    patch publish_api_solution_path(solution.uuid), headers: @headers, as: :json
+
+    assert_response 403
+    expected = { error: {
+      type: "solution_not_accessible",
+      message: I18n.t('api.errors.solution_not_accessible')
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+
+  test "publish renders 404 when track not joined" do
+    setup_user
+
+    solution = create :concept_solution, user: @current_user
+    patch publish_api_solution_path(solution.uuid),
+      headers: @headers, as: :json
+
+    assert_response 404
+    assert_equal(
+      {
+        "error" => {
+          "type" => "track_not_joined",
+          "message" => I18n.t("api.errors.track_not_joined")
+        }
+      },
+      JSON.parse(response.body)
+    )
+  end
+
+  test "publish publishes the solution" do
+    freeze_time do
+      setup_user
+
+      exercise = create :concept_exercise
+      create :user_track, track: exercise.track, user: @current_user
+      solution = create :concept_solution, exercise: exercise, user: @current_user, completed_at: Time.current
+      create :iteration, solution: solution
+
+      patch publish_api_solution_path(solution.uuid, publish: true),
+        headers: @headers, as: :json
+
+      assert_response 200
+
+      solution.reload
+      assert_equal Time.current, solution.completed_at
+      assert_equal Time.current, solution.published_at
+      assert_equal :published, solution.status
+    end
+  end
 end


### PR DESCRIPTION
- Add API tests for publishing
- Add API tests for unpublishing
- Return 400 when trying to complete/publish solution without iteration
- Complete solution when publishing uncompleted solution
- Remove redundant todo
