### PR TITLE
Add generic tooltip

### DIFF
--- a/app/javascript/components/editor/RunTestsButton.tsx
+++ b/app/javascript/components/editor/RunTestsButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { GraphicalIcon } from '../common/GraphicalIcon'
-import { ExercismGenericTooltip } from '../misc/ExercismTippy'
+import { GenericTooltip } from '../misc/ExercismTippy'
 
 export const RunTestsButton = ({
   haveFilesChanged,
@@ -13,7 +13,7 @@ export const RunTestsButton = ({
   const isDisabled = !haveFilesChanged || isProcessing
 
   return (
-    <ExercismGenericTooltip
+    <GenericTooltip
       disabled={!isDisabled}
       content={'You have not made any changes since you last ran the tests'}
     >
@@ -29,6 +29,6 @@ export const RunTestsButton = ({
           <div className="kb-shortcut">F2</div>
         </button>
       </div>
-    </ExercismGenericTooltip>
+    </GenericTooltip>
   )
 }

--- a/app/javascript/components/editor/RunTestsButton.tsx
+++ b/app/javascript/components/editor/RunTestsButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { GraphicalIcon } from '../common/GraphicalIcon'
-import Tippy from '@tippyjs/react'
-import { roundArrow } from 'tippy.js'
+import { ExercismGenericTooltip } from '../misc/ExercismTippy'
 
 export const RunTestsButton = ({
   haveFilesChanged,
@@ -14,16 +13,9 @@ export const RunTestsButton = ({
   const isDisabled = !haveFilesChanged || isProcessing
 
   return (
-    <Tippy
-      animation="shift-away-subtle"
-      arrow={roundArrow}
-      maxWidth="none"
+    <ExercismGenericTooltip
       disabled={!isDisabled}
-      content={
-        <div className="c-generic-tooltip">
-          You have not made any changes since you last ran the tests
-        </div>
-      }
+      content={'You have not made any changes since you last ran the tests'}
     >
       <div className="run-tests-btn">
         <button
@@ -37,6 +29,6 @@ export const RunTestsButton = ({
           <div className="kb-shortcut">F2</div>
         </button>
       </div>
-    </Tippy>
+    </ExercismGenericTooltip>
   )
 }

--- a/app/javascript/components/editor/SubmitButton.tsx
+++ b/app/javascript/components/editor/SubmitButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ExercismGenericTooltip } from '../misc/ExercismTippy'
 
 export const SubmitButton = ({
   onClick,
@@ -7,13 +8,22 @@ export const SubmitButton = ({
   onClick: () => void
   disabled: boolean
 }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    disabled={disabled}
-    className="btn-primary btn-s"
+  <ExercismGenericTooltip
+    disabled={!disabled}
+    content={
+      'You need to get the tests passing before you can submit your solution'
+    }
   >
-    <span>Submit</span>
-    <div className="kb-shortcut">F3</div>
-  </button>
+    <div className="submit-btn">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="btn-primary btn-s"
+      >
+        <span>Submit</span>
+        <div className="kb-shortcut">F3</div>
+      </button>
+    </div>
+  </ExercismGenericTooltip>
 )

--- a/app/javascript/components/editor/SubmitButton.tsx
+++ b/app/javascript/components/editor/SubmitButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ExercismGenericTooltip } from '../misc/ExercismTippy'
+import { GenericTooltip } from '../misc/ExercismTippy'
 
 export const SubmitButton = ({
   onClick,
@@ -8,7 +8,7 @@ export const SubmitButton = ({
   onClick: () => void
   disabled: boolean
 }) => (
-  <ExercismGenericTooltip
+  <GenericTooltip
     disabled={!disabled}
     content={
       'You need to get the tests passing before you can submit your solution'
@@ -25,5 +25,5 @@ export const SubmitButton = ({
         <div className="kb-shortcut">F3</div>
       </button>
     </div>
-  </ExercismGenericTooltip>
+  </GenericTooltip>
 )

--- a/app/javascript/components/misc/ExercismTippy.tsx
+++ b/app/javascript/components/misc/ExercismTippy.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LazyTippy, LazyTippyProps } from './LazyTippy'
-import { followCursor } from 'tippy.js'
+import { followCursor, roundArrow } from 'tippy.js'
 
 export type ExercismTippyProps = LazyTippyProps
 
@@ -12,6 +12,18 @@ export const ExercismTippy = (props: ExercismTippyProps): JSX.Element => {
       maxWidth="none"
       plugins={[followCursor]}
       {...props}
+    />
+  )
+}
+
+export const ExercismGenericTooltip = (
+  props: ExercismTippyProps
+): JSX.Element => {
+  return (
+    <ExercismTippy
+      arrow={roundArrow}
+      {...props}
+      content={<div className="c-generic-tooltip">{props.content}</div>}
     />
   )
 }

--- a/app/javascript/components/misc/ExercismTippy.tsx
+++ b/app/javascript/components/misc/ExercismTippy.tsx
@@ -16,9 +16,7 @@ export const ExercismTippy = (props: ExercismTippyProps): JSX.Element => {
   )
 }
 
-export const ExercismGenericTooltip = (
-  props: ExercismTippyProps
-): JSX.Element => {
+export const GenericTooltip = (props: ExercismTippyProps): JSX.Element => {
   return (
     <ExercismTippy
       arrow={roundArrow}


### PR DESCRIPTION
@kntsoriano We are going to be using a consistent generic tooltip all over the place. I've added a component that wraps what you currently have, and used it in two places. `content` can either be a string or a JSX component. Let me know what you think! :) 