### PR TITLE
Fix exercise widget incorrect rendering of tooltip

### DIFF
--- a/app/assemblers/assemble_exercise_widget.rb
+++ b/app/assemblers/assemble_exercise_widget.rb
@@ -1,0 +1,40 @@
+class AssembleExerciseWidget < Assembler
+  include Mandate
+
+  def initialize(exercise, user_track,
+                 with_tooltip:, render_as_link:, render_blurb:, render_track:, recommended:, skinny:, solution: nil)
+    super()
+
+    @exercise = exercise
+    @user_track = user_track
+    @solution = solution
+    @with_tooltip = with_tooltip
+    @render_as_link = render_as_link
+    @render_blurb = render_blurb
+    @render_track = render_track
+    @recommended = recommended
+    @skinny = skinny
+  end
+
+  def call
+    {
+      exercise: SerializeExercise.(exercise, user_track: user_track, recommended: recommended),
+      track: render_track ? SerializeTrack.(exercise.track, user_track) : nil,
+      solution: solution ? SerializeSolution.(solution, user_track: user_track) : nil,
+      links: links,
+      render_as_link: render_as_link,
+      render_blurb: render_blurb,
+      skinny: skinny
+    }
+  end
+
+  private
+  attr_reader :exercise, :user_track, :solution, :with_tooltip, :render_as_link, :render_blurb, :render_track,
+    :recommended, :skinny
+
+  def links
+    {
+      tooltip: with_tooltip ? Exercism::Routes.tooltip_track_exercise_path(exercise.track, exercise) : nil
+    }.compact
+  end
+end

--- a/app/helpers/react_components/common/exercise_widget.rb
+++ b/app/helpers/react_components/common/exercise_widget.rb
@@ -23,26 +23,24 @@ module ReactComponents
       end
 
       def to_s
-        super("common-exercise-widget", {
-          exercise: SerializeExercise.(exercise, user_track: user_track, recommended: recommended),
-          track: render_track ? SerializeTrack.(exercise.track, user_track) : nil,
-          solution: solution ? SerializeSolution.(solution, user_track: user_track) : nil,
-          links: links,
+        data = AssembleExerciseWidget.(
+          exercise,
+          user_track,
+          solution: solution,
+          with_tooltip: with_tooltip,
           render_as_link: render_as_link,
           render_blurb: render_blurb,
+          render_track: render_track,
+          recommended: recommended,
           skinny: skinny
-        })
+        )
+
+        super("common-exercise-widget", data)
       end
 
       private
       attr_reader :exercise, :user_track, :solution, :with_tooltip, :render_as_link, :render_blurb, :render_track,
         :recommended, :skinny
-
-      def links
-        {
-          tooltip: with_tooltip ? Exercism::Routes.tooltip_track_exercise_path(exercise.track, exercise) : nil
-        }.compact
-      end
     end
   end
 end

--- a/app/javascript/components/common/ExerciseWidget.tsx
+++ b/app/javascript/components/common/ExerciseWidget.tsx
@@ -32,7 +32,7 @@ export const ExerciseWidget = ({
   return (
     <ExercismTippy
       content={links ? <ExerciseTooltip endpoint={links.tooltip} /> : null}
-      disabled={links === undefined}
+      disabled={links === undefined || !links.tooltip}
     >
       <ReferenceElement
         exercise={exercise}

--- a/app/javascript/components/common/ExerciseWidget.tsx
+++ b/app/javascript/components/common/ExerciseWidget.tsx
@@ -7,7 +7,7 @@ import { ExerciseTooltip } from '../tooltips/ExerciseTooltip'
 import { ExercismTippy } from '../misc/ExercismTippy'
 
 type Links = {
-  tooltip: string
+  tooltip?: string
 }
 
 export type Props = {
@@ -24,15 +24,17 @@ export const ExerciseWidget = ({
   exercise,
   track,
   solution,
-  links,
+  links = {},
   renderAsLink,
   renderBlurb,
   isSkinny,
 }: Props): JSX.Element => {
   return (
     <ExercismTippy
-      content={links ? <ExerciseTooltip endpoint={links.tooltip} /> : null}
-      disabled={links === undefined || !links.tooltip}
+      content={
+        links.tooltip ? <ExerciseTooltip endpoint={links.tooltip} /> : null
+      }
+      disabled={!links.tooltip}
     >
       <ReferenceElement
         exercise={exercise}

--- a/app/serializers/serialize_site_updates.rb
+++ b/app/serializers/serialize_site_updates.rb
@@ -17,19 +17,24 @@ class SerializeSiteUpdates
 
     case update
     when SiteUpdates::NewExerciseUpdate
-      { exercise_widget: data_for_exercise(update) }
+      { exercise_widget: data_for_exercise_widget(update) }
     else
       {}
     end
   end
 
-  def data_for_exercise(update)
-    solution = solutions[update.exercise_id]
-
-    {
-      exercise: SerializeExercise.(update.exercise),
-      solution: solution ? SerializeSolution.(solution, user_track: user_tracks[update.track_id]) : nil
-    }
+  def data_for_exercise_widget(update)
+    AssembleExerciseWidget.(
+      update.exercise,
+      user_tracks[update.track_id],
+      solution: solutions[update.exercise_id],
+      with_tooltip: false,
+      render_as_link: true,
+      render_blurb: true,
+      render_track: true,
+      recommended: false,
+      skinny: false
+    )
   end
 
   private

--- a/test/serializers/serialize_site_updates_test.rb
+++ b/test/serializers/serialize_site_updates_test.rb
@@ -17,10 +17,17 @@ class SerializeSiteUpdatesTest < ActiveSupport::TestCase
 
     expected = [
       update.rendering_data.merge(
-        exercise_widget: {
-          exercise: SerializeExercise.(update.exercise),
-          solution: nil
-        }
+        exercise_widget: AssembleExerciseWidget.(
+          update.exercise,
+          nil,
+          solution: nil,
+          with_tooltip: false,
+          render_as_link: true,
+          render_blurb: true,
+          render_track: true,
+          recommended: false,
+          skinny: false
+        )
       )
     ]
 
@@ -37,10 +44,17 @@ class SerializeSiteUpdatesTest < ActiveSupport::TestCase
 
     expected = [
       update.rendering_data.merge(
-        exercise_widget: {
-          exercise: SerializeExercise.(update.exercise),
-          solution: SerializeSolution.(solution, user_track: user_track)
-        }
+        exercise_widget: AssembleExerciseWidget.(
+          update.exercise,
+          user_track,
+          solution: solution,
+          with_tooltip: false,
+          render_as_link: true,
+          render_blurb: true,
+          render_track: true,
+          recommended: false,
+          skinny: false
+        )
       )
     ]
     assert_equal expected, SerializeSiteUpdates.([update], user: user)


### PR DESCRIPTION
`links` can be `undefined` or `{}` [0]

Atm if its empty then things break. This guards against that. You might want to add a test.

---

[0] e.g. on the Concept page: 
<img width="171" alt="Screenshot 2021-07-24 at 14 46 03" src="https://user-images.githubusercontent.com/286476/126870400-1025700f-d587-4b30-a025-da323d7fcba9.png">

Closes https://github.com/exercism/website/issues/1307.