### PR TITLE
Fix editor scroll position

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csp_meta_tag
     = action_cable_meta_tag
 
-    = javascript_packs_with_chunks_tag(*js_packs, 'data-turbolinks-track': 'reload')
+    = javascript_packs_with_chunks_tag(*js_packs)
     = stylesheet_packs_with_chunks_tag(*js_packs, media: 'all', 'data-turbolinks-track': 'reload')
 
     %meta{ name: "language-server-url", content: Exercism.config.language_server_url }


### PR DESCRIPTION
https://github.com/exercism/v3-beta/issues/143

This is a known error for Turbolinks, and I copied the solution here: https://github.com/turbolinks/turbolinks/issues/181#issuecomment-735246518

It seems to me that https://github.com/turbolinks/turbolinks/pull/420 is the PR for this fix, but it won't seem to get merged anytime soon. Should we look into using Hotwire now?

