### PR TITLE
Lazily calculate important files hash

### DIFF
--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -226,6 +226,15 @@ class Solution < ApplicationRecord
     Git::Exercise.for_solution(self)
   end
 
+  # TODO: (optional) Rather than doing this, we should recalculate all
+  # hashes for all solutions and make this column not null. But this is a
+  # good lazy way to do this for now.
+  def git_important_files_hash
+    super || exercise.git_important_files_hash.tap do |hash|
+      update(git_important_files_hash: hash) unless new_record?
+    end
+  end
+
   private
   def determine_status
     return :published if published?

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -541,6 +541,16 @@ class SolutionTest < ActiveSupport::TestCase
     assert_equal exercise.git_important_files_hash, solution.git_important_files_hash
   end
 
+  test "git_important_files_sha sets when called if nil" do
+    exercise = create :practice_exercise, slug: 'allergies', git_sha: '6f169b92d8500d9ec5f6e69d6927bf732ab5274a'
+    solution = create :practice_solution, exercise: exercise
+    solution.update_column(:git_important_files_hash, nil)
+    assert_nil solution.attributes['git_important_files_hash']
+
+    assert_equal exercise.git_important_files_hash, solution.git_important_files_hash
+    assert_equal exercise.git_important_files_hash, solution.attributes['git_important_files_hash']
+  end
+
   test "latest_submission and latest_valid_submission" do
     solution = create :practice_solution
     create :submission, solution: solution, tests_status: :failed


### PR DESCRIPTION
Closes https://github.com/exercism/website/issues/1209
Closes https://github.com/exercism/website/issues/1250

---

@kntsoriano This should fix the issue. We might also want to guard for it being empty, but for now I'm happy just to receive bugsnags if that happens, as its something that should never happen.