### PR TITLE
Add Legacy files

### DIFF
--- a/app/controllers/api/solutions/last_iteration_files_controller.rb
+++ b/app/controllers/api/solutions/last_iteration_files_controller.rb
@@ -9,6 +9,7 @@ module API
         end
 
         return render_403(:solution_not_accessible) unless current_user.may_view_solution?(solution)
+        return render_400(:no_iterations_submitted_yet) if solution.latest_iteration.blank?
 
         files = solution.latest_iteration.files.map do |file|
           {

--- a/app/css/components/iteration-pane.css
+++ b/app/css/components/iteration-pane.css
@@ -3,12 +3,14 @@
     @apply bg-backgroundColorB;
 
     & .tabs {
+        @apply flex items-center;
         @apply bg-backgroundColorB;
         @apply border-b-1 border-borderColor7;
+
         & .c-tab {
             @apply grid place-items-center;
             @apply bg-backgroundColorB;
-            @apply px-16 py-8;
+            @apply px-16 py-8 mr-0;
             @apply text-13 text-textColor6 leading-paragraph;
             @apply border-r-1 border-borderColor7;
             @apply rounded-none;

--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -200,6 +200,17 @@
                 }
             }
 
+            & .legacy-file-banner {
+                @apply mt-16 mb-24 mx-16;
+                @apply py-12 px-24;
+                @apply shadow-smZ1 rounded-8 bg-backgroundColorA;
+                @apply flex items-center;
+
+                & .c-prominent-link {
+                    @apply text-14;
+                }
+            }
+
             & .c-iteration-pane {
                 overflow: hidden;
             }

--- a/app/helpers/react_components/editor.rb
+++ b/app/helpers/react_components/editor.rb
@@ -72,9 +72,15 @@ module ReactComponents
 
     # TODO: (Required) remove this before launch
     def example_files
-      return solution.exercise.send(:git).exemplar_files if solution.exercise.concept_exercise?
+      if solution.exercise.concept_exercise?
+        return solution.exercise.send(:git).exemplar_files.transform_values do |content|
+          { content: content }
+        end
+      end
 
-      solution.exercise.send(:git).example_files
+      solution.exercise.send(:git).example_files.transform_values do |content|
+        { content: content }
+      end
     end
 
     memoize

--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -215,7 +215,7 @@ export function Editor({
 
   const handleRevertToLastIteration = useCallback(() => {
     if (!submission) {
-      return
+      return setFiles(defaultFiles)
     }
 
     dispatch({ status: EditorStatus.REVERTING })
@@ -257,7 +257,7 @@ export function Editor({
 
   const handleRevertToExerciseStart = useCallback(() => {
     if (!submission) {
-      return
+      return setFiles(defaultFiles)
     }
 
     dispatch({ status: EditorStatus.REVERTING })

--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -9,6 +9,7 @@ import { File } from '../types'
 import { CodeMirror, Handler } from '../misc/CodeMirror'
 import { Tab, TabContext } from '../common/Tab'
 import { EditorSettings } from '../editor/types'
+import { LegacyFileBanner } from './LegacyFileBanner'
 
 export type FileEditorHandle = {
   getFiles: () => File[]
@@ -38,24 +39,50 @@ export function FileEditorCodeMirror({
 }): JSX.Element {
   const [tab, setTab] = useState(files[0].filename)
   const containerRef = useRef<HTMLDivElement>(null)
-  const editorRefs = useRef<Handler[]>([])
+  const editorRefs = useRef<Record<string, Handler>>({})
 
   const setFiles = useCallback((files: File[]) => {
-    editorRefs.current?.forEach((editor, i) => {
-      editor.setValue(files[i].content)
+    const editors: Record<string, Handler> = {}
+
+    files.forEach((file) => {
+      const editor = editorRefs.current[file.filename]
+      editor.setValue(file.content)
+
+      editors[file.filename] = editor
     })
+
+    editorRefs.current = editors
   }, [])
 
   const getFiles = useCallback(() => {
-    return editorRefs.current?.map((editor, i) => {
-      return {
-        filename: files[i].filename,
-        content: editor.getValue() || '',
-      }
-    })
+    return Object.keys(editorRefs.current)
+      .map((filename) => {
+        const editor = editorRefs.current[filename]
+        const file = files.find((f) => f.filename === filename)
+
+        if (!file) {
+          return
+        }
+
+        return {
+          filename: file.filename,
+          content: editor.getValue() || '',
+          type: file.type,
+        }
+      })
+      .filter((f) => f !== undefined)
   }, [files])
 
   const openPalette = useCallback(() => null, [])
+
+  const handleDelete = useCallback(
+    (fileToDelete: File) => {
+      return () => {
+        setFiles(files.filter((f) => f.filename !== fileToDelete.filename))
+      }
+    },
+    [files, setFiles]
+  )
 
   useEffect(() => {
     editorDidMount({ getFiles, setFiles, openPalette })
@@ -82,13 +109,16 @@ export function FileEditorCodeMirror({
             key={file.filename}
             id={file.filename}
           >
+            {file.type === 'legacy' ? (
+              <LegacyFileBanner onDelete={handleDelete(file)} />
+            ) : null}
             <CodeMirror
               key={file.filename}
               value={file.content}
               editorDidMount={(editor) => {
-                const oldEditors = [...editorRefs.current]
+                const oldEditors = editorRefs.current
 
-                oldEditors[index] = editor
+                oldEditors[file.filename] = editor
 
                 editorRefs.current = oldEditors
               }}

--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -128,6 +128,7 @@ export function FileEditorCodeMirror({
               wrap={settings.wrap !== 'off'}
               isTabCaptured={settings.tabBehavior === 'captured'}
               theme={settings.theme}
+              readonly={file.type === 'legacy'}
               commands={[
                 {
                   key: 'F2',

--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -70,7 +70,7 @@ export function FileEditorCodeMirror({
           type: file.type,
         }
       })
-      .filter((f) => f !== undefined)
+      .filter((f): f is File => f !== undefined)
   }, [files])
 
   const openPalette = useCallback(() => null, [])

--- a/app/javascript/components/editor/LegacyFileBanner.tsx
+++ b/app/javascript/components/editor/LegacyFileBanner.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useCallback } from 'react'
+import { DeleteFileModal } from './legacy-file-banner/DeleteFileModal'
+
+export const LegacyFileBanner = ({
+  onDelete,
+}: {
+  onDelete: () => void
+}): JSX.Element => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  return (
+    <React.Fragment>
+      <div>
+        <button onClick={handleOpen}>Delete file</button>
+      </div>
+      <DeleteFileModal
+        open={isOpen}
+        onClose={handleClose}
+        onDelete={onDelete}
+      />
+    </React.Fragment>
+  )
+}

--- a/app/javascript/components/editor/LegacyFileBanner.tsx
+++ b/app/javascript/components/editor/LegacyFileBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { DeleteFileModal } from './legacy-file-banner/DeleteFileModal'
+import { ProminentLink, GraphicalIcon } from '../common'
 
 export const LegacyFileBanner = ({
   onDelete,
@@ -18,8 +19,18 @@ export const LegacyFileBanner = ({
 
   return (
     <React.Fragment>
-      <div>
-        <button onClick={handleOpen}>Delete file</button>
+      <div className="legacy-file-banner">
+        <h3 className="text-15 leading-150 font-semibold">
+          This file is unexpected. Did you upload it via the CLI by accident?
+        </h3>
+        <button
+          onClick={handleOpen}
+          className="btn-xs btn-secondary mr-24 ml-auto"
+        >
+          <GraphicalIcon icon="trash" />
+          <span>Delete file...</span>
+        </button>
+        <ProminentLink link="#" text="Learn More" external={true} />
       </div>
       <DeleteFileModal
         open={isOpen}

--- a/app/javascript/components/editor/legacy-file-banner/DeleteFileModal.tsx
+++ b/app/javascript/components/editor/legacy-file-banner/DeleteFileModal.tsx
@@ -22,9 +22,22 @@ export const DeleteFileModal = ({
 
   return (
     <Modal className="m-generic-confirmation" onClose={handleClose} {...props}>
+      <h3>Are you sure you want to delete this file?</h3>
+      <p>
+        Deleting this file will mean it is not submitted as part of your next
+        iteration. However, it will remain visible in your previous iteration.
+        If you change your mind before submitting, you can use the "Reset to
+        last iteration" button (top-right) to undo this change.
+      </p>
       <form onSubmit={handleSubmit} className="buttons">
-        <button type="submit">Delete file</button>
-        <button type="button" onClick={handleClose}>
+        <button type="submit" className="btn-warning btn-s">
+          Delete file
+        </button>
+        <button
+          type="button"
+          className="btn-enhanced btn-s"
+          onClick={handleClose}
+        >
           Cancel
         </button>
       </form>

--- a/app/javascript/components/editor/legacy-file-banner/DeleteFileModal.tsx
+++ b/app/javascript/components/editor/legacy-file-banner/DeleteFileModal.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback } from 'react'
+import { Modal, ModalProps } from '../../modals/Modal'
+
+export const DeleteFileModal = ({
+  onDelete,
+  onClose,
+  ...props
+}: Omit<ModalProps, 'className'> & {
+  onDelete: () => void
+}): JSX.Element => {
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  const handleSubmit = useCallback(
+    (e) => {
+      e.preventDefault()
+      onDelete()
+    },
+    [onDelete]
+  )
+
+  return (
+    <Modal className="m-generic-confirmation" onClose={handleClose} {...props}>
+      <form onSubmit={handleSubmit} className="buttons">
+        <button type="submit">Delete file</button>
+        <button type="button" onClick={handleClose}>
+          Cancel
+        </button>
+      </form>
+    </Modal>
+  )
+}

--- a/app/javascript/components/misc/CodeMirror.tsx
+++ b/app/javascript/components/misc/CodeMirror.tsx
@@ -14,6 +14,7 @@ const wrapCompartment = new Compartment()
 const themeCompartment = new Compartment()
 const tabCaptureCompartment = new Compartment()
 const keymapCompartment = new Compartment()
+const readonlyCompartment = new Compartment()
 
 export type Handler = {
   setValue: (value: string) => void
@@ -29,6 +30,7 @@ export const CodeMirror = ({
   tabSize,
   isTabCaptured,
   editorDidMount,
+  readonly = false,
 }: {
   value: string
   language: string
@@ -39,6 +41,7 @@ export const CodeMirror = ({
   isTabCaptured: boolean
   tabSize: number
   editorDidMount: (handler: Handler) => void
+  readonly?: boolean
 }): JSX.Element => {
   const [textarea, setTextarea] = useState<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
@@ -92,6 +95,7 @@ export const CodeMirror = ({
               ? [defaultHighlightStyle]
               : [oneDarkTheme, oneDarkHighlightStyle]
           ),
+          readonlyCompartment.of(EditorView.editable.of(!readonly)),
         ],
       }),
       parent: textarea,
@@ -155,6 +159,18 @@ export const CodeMirror = ({
       effects: keymapCompartment.reconfigure(keymap.of(commands)),
     })
   }, [commands])
+
+  useEffect(() => {
+    if (!viewRef.current) {
+      return
+    }
+
+    viewRef.current.dispatch({
+      effects: readonlyCompartment.reconfigure(
+        EditorView.editable.of(!readonly)
+      ),
+    })
+  }, [readonly])
 
   return <div className="editor" ref={setTextarea} />
 }

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -191,7 +191,10 @@ export type File = {
   filename: string
   content: string
   digest?: string
+  type: FileType
 }
+
+type FileType = 'exercise' | 'solution' | 'legacy'
 
 export type APIError = {
   type: string

--- a/app/javascript/images/icons/trash.svg
+++ b/app/javascript/images/icons/trash.svg
@@ -1,0 +1,8 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.875 2.625H13.125" stroke="#604FCD" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.3125 0.875H5.6875C5.20425 0.875 4.8125 1.26675 4.8125 1.75V2.625H9.1875V1.75C9.1875 1.26675 8.79575 0.875 8.3125 0.875Z" stroke="#604FCD" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.6875 10.0625V5.6875" stroke="#604FCD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.3125 10.0625V5.6875" stroke="#604FCD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.0046 12.3223C10.967 12.776 10.5877 13.125 10.1325 13.125H3.86808C3.41285 13.125 3.03363 12.776 2.996 12.3223L2.1875 2.625H11.8125L11.0046 12.3223Z" stroke="#604FCD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+

--- a/app/serializers/serialize_files.rb
+++ b/app/serializers/serialize_files.rb
@@ -4,10 +4,11 @@ class SerializeFiles
   initialize_with :files
 
   def call
-    files.map do |filename, content|
+    files.map do |filename, data|
       {
         filename: filename,
-        content: content
+        type: data[:type],
+        content: data[:content]
       }
     end
   end

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -36,3 +36,4 @@ en:
       scratchpad_page_not_found: "The scratchpad page could not be found"
       incorrect_password: "Incorrect password"
       passwords_dont_match: "Passwords don't match"
+      no_iterations_submitted_yet: "You haven't submitted an iteration yet."

--- a/test/controllers/api/solutions/last_iteration_files_controller_test.rb
+++ b/test/controllers/api/solutions/last_iteration_files_controller_test.rb
@@ -1,0 +1,22 @@
+require_relative '../base_test_case'
+
+class API::Solutions::LastIterationFilesControllerTest < API::BaseTestCase
+  ###
+  # Index
+  ###
+  test "index should return 400 when there are no iterations submitted yet" do
+    user = create :user
+    setup_user(user)
+    solution = create :concept_solution, user: user
+
+    get api_solution_last_iteration_files_path(solution.uuid), headers: @headers, as: :json
+
+    assert_response 400
+    expected = { error: {
+      type: "no_iterations_submitted_yet",
+      message: I18n.t('api.errors.no_iterations_submitted_yet')
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
+end

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -154,9 +154,38 @@ class SolutionTest < ActiveSupport::TestCase
     exercise = create :concept_exercise
     solution = create :concept_solution, exercise: exercise
 
-    expected_files = ["log_line_parser.rb"]
-    assert_equal expected_files, solution.exercise_solution_files.keys
-    assert solution.exercise_solution_files["log_line_parser.rb"].start_with?("module LogLineParser")
+    expected_filenames = ["log_line_parser.rb"]
+    assert_equal expected_filenames, solution.exercise_solution_files.keys
+    file = solution.exercise_solution_files["log_line_parser.rb"]
+    assert file[:content].start_with?("module LogLineParser")
+    assert_equal :exercise, file[:type]
+  end
+
+  test "#solution_files returns solution files" do
+    exercise = create :concept_exercise
+    solution = create :concept_solution, exercise: exercise
+
+    expected_filenames = ["log_line_parser.rb"]
+    assert_equal expected_filenames, solution.solution_files.keys
+    file = solution.solution_files["log_line_parser.rb"]
+    assert file[:content].start_with?("module LogLineParser")
+    assert_equal :exercise, file[:type]
+
+    # Add a submission to override them
+    submission = create :submission, solution: solution
+    create :submission_file, submission: submission, filename: "log_line_parser.rb", content: "foobar1"
+    create :submission_file, submission: submission, filename: "something_else.rb", content: "foobar2"
+
+    expected_filenames = ["log_line_parser.rb", "something_else.rb"]
+    assert_equal expected_filenames, solution.solution_files.keys
+
+    file_1 = solution.solution_files["log_line_parser.rb"]
+    assert "foobar1", file_1[:content]
+    assert_equal :solution, file_1[:type]
+
+    file_2 = solution.solution_files["something_else.rb"]
+    assert "foobar2", file_2[:content]
+    assert_equal :legacy, file_2[:type]
   end
 
   test "read_file for concept exercise returns exercise file" do

--- a/test/serializers/serialize_files_test.rb
+++ b/test/serializers/serialize_files_test.rb
@@ -2,8 +2,13 @@ require 'test_helper'
 
 class SerializeFilesTest < ActiveSupport::TestCase
   test "serializes files" do
-    files = { "bob.rb" => "content" }
+    files = {
+      "bob.rb" => {
+        type: :exercise,
+        content: "content"
+      }
+    }
 
-    assert_equal [{ filename: "bob.rb", content: "content" }], SerializeFiles.(files)
+    assert_equal [{ filename: "bob.rb", type: :exercise, content: "content" }], SerializeFiles.(files)
   end
 end

--- a/test/system/components/editor_test.rb
+++ b/test/system/components/editor_test.rb
@@ -438,6 +438,7 @@ module Components
         within(".m-generic-confirmation") { click_on "Delete file" }
 
         assert_no_text "something_else.rb"
+        assert_text "foobar1"
       end
     end
 

--- a/test/system/components/editor_test.rb
+++ b/test/system/components/editor_test.rb
@@ -422,6 +422,25 @@ module Components
       end
     end
 
+    test "user deletes legacy files" do
+      user = create :user
+      strings = create :concept_exercise
+      solution = create :concept_solution, user: user, exercise: strings
+      submission = create :submission, solution: solution
+      create :submission_file, submission: submission, filename: "log_line_parser.rb", content: "foobar1"
+      create :submission_file, submission: submission, filename: "something_else.rb", content: "foobar2"
+
+      use_capybara_host do
+        sign_in!(user)
+        visit test_components_editor_path(solution_id: solution.id)
+        click_on "something_else.rb"
+        click_on "Delete file"
+        within(".m-generic-confirmation") { click_on "Delete file" }
+
+        assert_no_text "something_else.rb"
+      end
+    end
+
     private
     def wait_for_submission
       assert_text "Running tests..."


### PR DESCRIPTION
@kntsoriano So, this is for readonly files in the editor.

There are files that a student might have submitted via the CLI, which they need to **see** in the editor, but should **not be able to edit**. This might happen because:
- You can upload anything in the CLI and they uploaded supporting files
- They uploaded a solution and the exercise has since had the expected filename renamed, so they have a new file and an old stub.

There's various possibilities here we need to work with but for now I want to handle the basic one, which is:
- Files get a ` type` key. It can currently be `exercise`, `solution`, `legacy`. (This is done in this PR on the Ruby side)
- Files with `exercise` or `solution` behave as normal.
- Files with `legacy` are readonly. They cannot be edited.
- Files with `legacy` have an extra banner when they open. [1]
- Files with `legacy` can be deleted within the editor. This doesn't do anything outside of the editor, but means in the editor that file no longer exists and when the next submission is made it is without that file (and we should persist this fact in local storage).

Also, we also need to have support for multiple files in the editor, which I'm not sure we do atm. It doesn't seem to work for me. You should be able to submit an iteration then do `Submission.last.files.create(filename: "foobar.rb", content: "# something")` and it should appear in the editor.

Also, you might want to consider https://github.com/exercism/v3-beta/issues/145 at the same time as doing this. I think it's a good idea, but, depending on how "readonly" works it might have a different codepath entirely, as we might not want to lose the cursor position while the tests run maybe 🤷 See what you come up with 🙂 

---

[1]
<img width="782" alt="Screenshot 2021-08-02 at 15 12 35" src="https://user-images.githubusercontent.com/286476/127875357-0d53871c-aea6-4a6d-94dd-191e161c6b91.png">
<img width="424" alt="Screenshot 2021-08-02 at 15 12 37" src="https://user-images.githubusercontent.com/286476/127875366-905d5f68-0df8-4f0b-b06e-ff742a03b67d.png">
