### PR TITLE
Rename "Concept Exercise" to "Learning Exercise"

### DIFF
--- a/app/javascript/components/contributing/tasks-list/ModuleSwitcher.tsx
+++ b/app/javascript/components/contributing/tasks-list/ModuleSwitcher.tsx
@@ -23,7 +23,7 @@ const ModuleOption = ({
         <React.Fragment>
           <ModuleTag module={module} />
           <div className="info">
-            <div className="title">Concept Exercise</div>
+            <div className="title">Learning Exercise</div>
           </div>
         </React.Fragment>
       )
@@ -84,7 +84,7 @@ const SelectedComponent = ({ value: action }: { value: TaskModule[] }) => {
     case 'generator':
       return <>Generator</>
     case 'concept-exercise':
-      return <>Concept Exercise</>
+      return <>Learning Exercise</>
     case 'practice-exercise':
       return <>Practice Exercise</>
     case 'concept':

--- a/app/javascript/components/contributing/tasks-list/task/ModuleTag.tsx
+++ b/app/javascript/components/contributing/tasks-list/task/ModuleTag.tsx
@@ -18,7 +18,7 @@ export const ModuleTag = ({ module }: { module?: TaskModule }): JSX.Element => {
       return (
         <Icon
           icon="concept-exercise"
-          alt="Concept Exercise"
+          alt="Learning Exercise"
           className="module"
         />
       )

--- a/test/javascript/components/contributing/tasks-list/task/ModuleTag.test.tsx
+++ b/test/javascript/components/contributing/tasks-list/task/ModuleTag.test.tsx
@@ -19,7 +19,7 @@ test('renders tag for module = concept-exercise', async () => {
   render(<ModuleTag module="concept-exercise" />)
 
   expect(
-    screen.getByRole('img', { name: 'Concept Exercise' })
+    screen.getByRole('img', { name: 'Learning Exercise' })
   ).toBeInTheDocument()
 })
 


### PR DESCRIPTION
https://github.com/exercism/v3-beta/issues/174

@iHiD I've only touched strings inside React. Inside the Github commands and labels, it's still labeled as "concept exercise".