### PR TITLE
Don't show learning/practice options for non-courses

### DIFF
--- a/app/helpers/react_components/dropdowns/track_menu.rb
+++ b/app/helpers/react_components/dropdowns/track_menu.rb
@@ -4,8 +4,6 @@ module ReactComponents
       initialize_with :track
 
       def to_s
-        # return if user_track.blank? || user_track.external?
-
         super("dropdowns-track-menu", {
           track: SerializeTrack.(track, user_track),
           links: links
@@ -25,12 +23,15 @@ module ReactComponents
         }
         return hash if user_track.external?
 
-        hash.merge(
-          activate_practice_mode: activate_practice_mode_url,
-          activate_learning_mode: activate_learning_mode_url,
-          reset: Exercism::Routes.reset_api_track_url(track),
-          leave: Exercism::Routes.leave_api_track_url(track)
-        )
+        if track.course?
+          hash[:activate_practice_mode] = activate_practice_mode_url
+          hash[:activate_learning_mode] = activate_learning_mode_url
+        end
+
+        hash[:reset] = Exercism::Routes.reset_api_track_url(track)
+        hash[:leave] = Exercism::Routes.leave_api_track_url(track)
+
+        hash
       end
 
       def activate_practice_mode_url

--- a/test/helpers/react_components/dropdowns/track_menu_test.rb
+++ b/test/helpers/react_components/dropdowns/track_menu_test.rb
@@ -1,0 +1,94 @@
+require_relative "../react_component_test_case"
+
+module ReactComponents::Dropdowns
+  class TrackMenuTest < ReactComponentTestCase
+    test "external course" do
+      track = create :track
+      track.expects(:course?).never
+
+      component = render(ReactComponents::Dropdowns::TrackMenu.new(track))
+      assert_component component,
+        "dropdowns-track-menu",
+        {
+          track: SerializeTrack.(track, UserTrack::External.new(track)),
+          links: {
+            repo: track.repo_url,
+            documentation: Exercism::Routes.track_docs_url(track)
+          }
+        }
+    end
+
+    test "joined course in learning mode" do
+      track = create :track
+      track.expects(course?: true)
+      user = create :user
+      user_track = create :user_track, track: track, user: user
+
+      component = ReactComponents::Dropdowns::TrackMenu.new(track)
+      component.stubs(current_user: user)
+
+      assert_component render(component),
+        "dropdowns-track-menu",
+        {
+          track: SerializeTrack.(track, user_track),
+          links: {
+            repo: track.repo_url,
+            documentation: Exercism::Routes.track_docs_url(track),
+            activate_practice_mode: Exercism::Routes.activate_practice_mode_api_track_url(track),
+            activate_learning_mode: nil,
+            reset: Exercism::Routes.reset_api_track_url(track),
+            leave: Exercism::Routes.leave_api_track_url(track)
+
+          }
+        }
+    end
+
+    test "joined course in practice mode" do
+      track = create :track
+      track.expects(course?: true)
+      user = create :user
+      user_track = create :user_track, track: track, user: user, practice_mode: true
+
+      component = ReactComponents::Dropdowns::TrackMenu.new(track)
+      component.stubs(current_user: user)
+
+      assert_component render(component),
+        "dropdowns-track-menu",
+        {
+          track: SerializeTrack.(track, user_track),
+          links: {
+            repo: track.repo_url,
+            documentation: Exercism::Routes.track_docs_url(track),
+            activate_practice_mode: nil,
+            activate_learning_mode: Exercism::Routes.activate_learning_mode_api_track_url(track),
+            reset: Exercism::Routes.reset_api_track_url(track),
+            leave: Exercism::Routes.leave_api_track_url(track)
+
+          }
+        }
+    end
+
+    test "joined non-course track" do
+      track = create :track
+      track.expects(course?: false)
+      user = create :user
+      user_track = create :user_track, track: track, user: user, practice_mode: true
+
+      component = ReactComponents::Dropdowns::TrackMenu.new(track)
+      component.stubs(current_user: user)
+
+      assert_component render(component),
+        "dropdowns-track-menu",
+        {
+          track: SerializeTrack.(track, user_track),
+          links: {
+            repo: track.repo_url,
+            documentation: Exercism::Routes.track_docs_url(track),
+            reset: Exercism::Routes.reset_api_track_url(track),
+            leave: Exercism::Routes.leave_api_track_url(track)
+
+          }
+        }
+    end
+  end
+end


### PR DESCRIPTION
This removes any user-facing distinction between learning + practice modes for tracks without concepts. I've opted **not** to have the "practice mode" tag for now.

(Fixes https://github.com/exercism/v3-beta/issues/250)