### PR TITLE
Allow student to cancel mentoring request

### DIFF
--- a/app/commands/mentor/request/cancel.rb
+++ b/app/commands/mentor/request/cancel.rb
@@ -1,0 +1,17 @@
+module Mentor
+  class Request
+    class Cancel
+      include Mandate
+
+      initialize_with :request
+
+      # TODO: Temporary implementation
+      def call
+        ActiveRecord::Base.transaction do
+          request.solution.update!(mentoring_status: :none)
+          request.destroy
+        end
+      end
+    end
+  end
+end

--- a/app/commands/mentor/request/cancel.rb
+++ b/app/commands/mentor/request/cancel.rb
@@ -5,12 +5,8 @@ module Mentor
 
       initialize_with :request
 
-      # TODO: Temporary implementation
       def call
-        ActiveRecord::Base.transaction do
-          request.solution.update!(mentoring_status: :none)
-          request.destroy
-        end
+        request.cancelled!
       end
     end
   end

--- a/app/controllers/api/mentoring/requests_controller.rb
+++ b/app/controllers/api/mentoring/requests_controller.rb
@@ -31,5 +31,20 @@ module API
         request: SerializeMentorSessionRequest.(mentor_request, current_user)
       }
     end
+
+    # TODO: Temporary implementation
+    def cancel
+      mentor_request = current_user.solution_mentor_requests.find_by(uuid: params[:uuid])
+
+      return render_404(:mentor_request_not_found) unless mentor_request
+
+      Mentor::Request::Cancel.(mentor_request)
+
+      render json: {
+        links: {
+          home: Exercism::Routes.track_exercise_mentor_discussions_path(mentor_request.track, mentor_request.exercise)
+        }
+      }
+    end
   end
 end

--- a/app/controllers/api/mentoring/requests_controller.rb
+++ b/app/controllers/api/mentoring/requests_controller.rb
@@ -32,10 +32,8 @@ module API
       }
     end
 
-    # TODO: Temporary implementation
     def cancel
       mentor_request = current_user.solution_mentor_requests.find_by(uuid: params[:uuid])
-
       return render_404(:mentor_request_not_found) unless mentor_request
 
       Mentor::Request::Cancel.(mentor_request)

--- a/app/css/components/mentor/discussion.css
+++ b/app/css/components/mentor/discussion.css
@@ -627,7 +627,7 @@
                         @apply font-medium text-textColor6 leading-150;
                     }
                 }
-                & a {
+                & button {
                     @apply text-lightBlue font-semibold;
                 }
             }

--- a/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestButton.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestButton.tsx
@@ -1,0 +1,32 @@
+import React, { useState, useCallback } from 'react'
+import { MentorSessionRequest } from '../../../types'
+import { CancelRequestModal } from './CancelRequestModal'
+
+export const CancelRequestButton = ({
+  request,
+}: {
+  request: MentorSessionRequest
+}): JSX.Element => {
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const handleModalOpen = useCallback(() => {
+    setModalOpen(true)
+  }, [])
+
+  const handleModalClose = useCallback(() => {
+    setModalOpen(false)
+  }, [])
+
+  return (
+    <React.Fragment>
+      <button type="button" onClick={handleModalOpen}>
+        Cancel Request
+      </button>
+      <CancelRequestModal
+        open={modalOpen}
+        request={request}
+        onClose={handleModalClose}
+      />
+    </React.Fragment>
+  )
+}

--- a/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestModal.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestModal.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback } from 'react'
+import { Modal, ModalProps } from '../../../modals/Modal'
+import { FormButton } from '../../../common'
+import { ErrorBoundary, ErrorMessage } from '../../../ErrorBoundary'
+import { MentorSessionRequest } from '../../../types'
+import { useMutation } from 'react-query'
+import { sendRequest } from '../../../../utils/send-request'
+import { redirectTo } from '../../../../utils/redirect-to'
+
+const DEFAULT_ERROR = new Error('Unable to cancel request')
+
+type APIResponse = {
+  links: {
+    home: string
+  }
+}
+
+export const CancelRequestModal = ({
+  open,
+  onClose,
+  request,
+  ...props
+}: Omit<ModalProps, 'className'> & {
+  request: MentorSessionRequest
+}): JSX.Element => {
+  const [mutation, { status, error }] = useMutation<APIResponse>(
+    () => {
+      const { fetch } = sendRequest({
+        endpoint: request.links.cancel,
+        method: 'PATCH',
+        body: null,
+      })
+
+      return fetch
+    },
+    {
+      onSuccess: (response) => {
+        redirectTo(response.links.home)
+      },
+    }
+  )
+
+  const handleSubmit = useCallback(
+    (e) => {
+      e.preventDefault()
+
+      mutation()
+    },
+    [mutation]
+  )
+
+  const handleClose = useCallback(() => {
+    if (status === 'loading') {
+      return
+    }
+
+    onClose()
+  }, [status, onClose])
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      className="m-generic-confirmation"
+      {...props}
+    >
+      <h3>Cancel request?</h3>
+      <p>Are you sure you want to cancel this request?</p>
+      <form data-turbo="false" onSubmit={handleSubmit} className="buttons">
+        <FormButton status={status} type="submit" className="btn-warning btn-s">
+          Cancel request
+        </FormButton>
+        <FormButton
+          status={status}
+          type="button"
+          className="btn-enhanced btn-s"
+          onClick={handleClose}
+        >
+          Cancel
+        </FormButton>
+      </form>
+      <ErrorBoundary resetKeys={[status]}>
+        <ErrorMessage error={error} defaultError={DEFAULT_ERROR} />
+      </ErrorBoundary>
+    </Modal>
+  )
+}

--- a/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestModal.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/CancelRequestModal.tsx
@@ -64,11 +64,15 @@ export const CancelRequestModal = ({
       className="m-generic-confirmation"
       {...props}
     >
-      <h3>Cancel request?</h3>
-      <p>Are you sure you want to cancel this request?</p>
+      <h3>Cancel mentoring request?</h3>
+      <p>
+        Are you sure you want to cancel this mentoring request? Please note that
+        if someone has started giving feedback in the last few minutes, the
+        session may continue regardless of this cancellation.
+      </p>
       <form data-turbo="false" onSubmit={handleSubmit} className="buttons">
-        <FormButton status={status} type="submit" className="btn-warning btn-s">
-          Cancel request
+        <FormButton status={status} type="submit" className="btn-primary btn-s">
+          Cancel mentoring request
         </FormButton>
         <FormButton
           status={status}
@@ -76,7 +80,7 @@ export const CancelRequestModal = ({
           className="btn-enhanced btn-s"
           onClick={handleClose}
         >
-          Cancel
+          Close
         </FormButton>
       </form>
       <ErrorBoundary resetKeys={[status]}>

--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
@@ -10,6 +10,7 @@ import {
   DiscussionPostProps,
   DiscussionPostAction,
 } from '../../../mentoring/discussion/DiscussionPost'
+import { CancelRequestButton } from './CancelRequestButton'
 
 type Links = {
   privateMentoring: string
@@ -59,7 +60,7 @@ export const MentoringRequestInfo = ({
             <h3>Waiting on a mentor...</h3>
             <p>Recent median waiting time: ~{track.medianWaitTime}</p>
           </div>
-          <a href="#">Cancel Request</a>
+          <CancelRequestButton request={request} />
         </div>
         <div className="placeholder">
           <div className="info">

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -215,6 +215,7 @@ export type MentorSessionRequest = {
   links: {
     lock: string
     discussion: string
+    cancel: string
   }
 }
 export type MentorSessionTrack = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   has_many :iterations, through: :solutions
 
   has_many :solution_mentor_discussions, through: :solutions, source: :mentor_discussions
+  has_many :solution_mentor_requests, through: :solutions, source: :mentor_requests
 
   has_many :activities, class_name: "User::Activity", dependent: :destroy
   has_many :notifications, dependent: :destroy

--- a/app/serializers/serialize_mentor_session_request.rb
+++ b/app/serializers/serialize_mentor_session_request.rb
@@ -19,6 +19,7 @@ class SerializeMentorSessionRequest
       },
       links: {
         lock: Exercism::Routes.lock_api_mentoring_request_path(request),
+        cancel: Exercism::Routes.cancel_api_mentoring_request_path(request),
         discussion: Exercism::Routes.api_mentoring_discussions_path
       }
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,7 @@ Rails.application.routes.draw do
           end
           member do
             patch :lock
+            patch :cancel
           end
         end
 

--- a/test/commands/mentor/request/cancel_test.rb
+++ b/test/commands/mentor/request/cancel_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Mentor::Request::CancelTest < ActiveSupport::TestCase
+  test "cancels request" do
+    solution = create :practice_solution
+    request = create :mentor_request, solution: solution
+
+    Mentor::Request::Cancel.(request)
+
+    assert request.cancelled?
+    assert :none, solution.mentoring_status
+  end
+end

--- a/test/controllers/api/mentoring/requests_controller_test.rb
+++ b/test/controllers/api/mentoring/requests_controller_test.rb
@@ -3,6 +3,7 @@ require_relative '../base_test_case'
 class API::Mentoring::RequestsControllerTest < API::BaseTestCase
   guard_incorrect_token! :api_mentoring_requests_path
   guard_incorrect_token! :lock_api_mentoring_request_path, args: 1, method: :patch
+  guard_incorrect_token! :cancel_api_mentoring_request_path, args: 1, method: :patch
 
   ###
   # Index
@@ -103,6 +104,38 @@ class API::Mentoring::RequestsControllerTest < API::BaseTestCase
 
     assert request.reload.locked?
     assert_equal user, request.reload.locks.last.locked_by
+  end
+
+  ###
+  # Cancel
+  ###
+  test "cancel should 404 if the request doesn't exist" do
+    setup_user
+    patch cancel_api_mentoring_request_path('xxx'), headers: @headers, as: :json
+    assert_response 404
+  end
+
+  test "cancel should 404 if the request belongs to someone else" do
+    setup_user
+    solution = create :concept_solution
+    request = create :mentor_request, solution: solution
+
+    patch cancel_api_mentoring_request_path(request.uuid), headers: @headers, as: :json
+
+    assert_response 404
+  end
+
+  test "cancel should succeed" do
+    user = create :user
+    setup_user(user)
+    solution = create :concept_solution, user: user
+    request = create :mentor_request, solution: solution
+
+    patch cancel_api_mentoring_request_path(request.uuid), headers: @headers, as: :json
+
+    assert_response :success
+
+    assert request.reload.cancelled?
   end
 
   ###

--- a/test/serializers/serialize_mentor_session_request_test.rb
+++ b/test/serializers/serialize_mentor_session_request_test.rb
@@ -20,6 +20,7 @@ class SerializeMentorSessionRequestTest < ActiveSupport::TestCase
       },
       links: {
         lock: Exercism::Routes.lock_api_mentoring_request_path(request),
+        cancel: Exercism::Routes.cancel_api_mentoring_request_path(request),
         discussion: Exercism::Routes.api_mentoring_discussions_path
       }
     }

--- a/test/system/flows/student_cancels_mentor_request_test.rb
+++ b/test/system/flows/student_cancels_mentor_request_test.rb
@@ -1,0 +1,28 @@
+require "application_system_test_case"
+require_relative "../../support/capybara_helpers"
+require_relative "../../support/redirect_helpers"
+
+module Flows
+  class StudentCancelsMentorRequestTest < ApplicationSystemTestCase
+    include CapybaraHelpers
+    include RedirectHelpers
+
+    test "student cancels mentor request" do
+      user = create :user
+      solution = create :concept_solution, user: user
+      request = create :mentor_request, solution: solution
+      submission = create :submission, solution: solution
+      create :iteration, solution: solution, submission: submission
+
+      use_capybara_host do
+        sign_in!(user)
+        visit track_exercise_mentor_request_path(solution.track, solution.exercise, request)
+        click_on "Cancel Request"
+        within(".m-generic-confirmation") { click_on "Cancel request" }
+
+        wait_for_redirect
+        assert_link "Request mentoring"
+      end
+    end
+  end
+end

--- a/test/system/flows/student_cancels_mentor_request_test.rb
+++ b/test/system/flows/student_cancels_mentor_request_test.rb
@@ -18,7 +18,7 @@ module Flows
         sign_in!(user)
         visit track_exercise_mentor_request_path(solution.track, solution.exercise, request)
         click_on "Cancel Request"
-        within(".m-generic-confirmation") { click_on "Cancel request" }
+        within(".m-generic-confirmation") { click_on "Cancel mentoring request" }
 
         wait_for_redirect
         assert_link "Request mentoring"


### PR DESCRIPTION
@iHiD This works fine. Could you check the following please?

1. Confirmation modal copy
2. Backend implementation (API endpoint, `Mentor::Request::Cancel` command)