### PR TITLE
Add readonly editor files

### DIFF
--- a/app/controllers/api/solutions/initial_files_controller.rb
+++ b/app/controllers/api/solutions/initial_files_controller.rb
@@ -10,7 +10,7 @@ module API
 
         return render_403(:solution_not_accessible) unless current_user.may_view_solution?(solution)
 
-        files = SerializeFiles.(solution.exercise_solution_files)
+        files = SerializeFiles.(solution.exercise_files_for_editor)
 
         render json: { files: files }
       end

--- a/app/controllers/api/solutions/last_iteration_files_controller.rb
+++ b/app/controllers/api/solutions/last_iteration_files_controller.rb
@@ -11,7 +11,7 @@ module API
         return render_403(:solution_not_accessible) unless current_user.may_view_solution?(solution)
         return render_400(:no_iterations_submitted_yet) if solution.latest_iteration.blank?
 
-        files = solution.latest_iteration.solution_files
+        files = solution.latest_iteration.files_for_editor
 
         render json: { files: SerializeFiles.(files) }
       end

--- a/app/helpers/react_components/editor.rb
+++ b/app/helpers/react_components/editor.rb
@@ -7,7 +7,7 @@ module ReactComponents
         "editor",
         {
           default_submissions: submissions,
-          default_files: SerializeEditorFiles.(solution.solution_files),
+          default_files: SerializeEditorFiles.(solution.files_for_editor),
           default_settings: {
             tab_size: track.indent_size,
             use_soft_tabs: track.indent_style == :space

--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -152,7 +152,9 @@ export function FileEditorCodeMirror({
               wrap={settings.wrap !== 'off'}
               isTabCaptured={settings.tabBehavior === 'captured'}
               theme={settings.theme}
-              readonly={readonly || file.type === 'legacy'}
+              readonly={
+                readonly || file.type === 'legacy' || file.type === 'readonly'
+              }
               commands={[
                 {
                   key: 'F2',

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -194,7 +194,7 @@ export type File = {
   type: FileType
 }
 
-type FileType = 'exercise' | 'solution' | 'legacy'
+type FileType = 'exercise' | 'solution' | 'legacy' | 'readonly'
 
 export type APIError = {
   type: string

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -54,7 +54,7 @@ class Exercise < ApplicationRecord
     joins(:track).find_by('tracks.slug': track_slug, slug: exercise_slug)
   end
 
-  delegate :solution_files, :introduction, :instructions, :source, :source_url, to: :git
+  delegate :files_for_editor, :introduction, :instructions, :source, :source_url, to: :git
 
   before_create do
     self.synced_to_git_sha = git_sha unless self.synced_to_git_sha

--- a/app/models/git/exercise.rb
+++ b/app/models/git/exercise.rb
@@ -95,6 +95,11 @@ module Git
     end
 
     memoize
+    def editor_filepaths
+      config.dig(:files, :editor).to_a
+    end
+
+    memoize
     def exemplar_filepaths
       config.dig(:files, :exemplar).to_a
     end
@@ -129,10 +134,18 @@ module Git
     # Files that should be transported
     # to a user for use in the editor.
     memoize
-    def solution_files
-      solution_filepaths.index_with do |filepath|
-        read_file_blob(filepath)
+    def files_for_editor
+      files = {}
+
+      solution_filepaths.each do |filepath|
+        files[filepath] = { type: :exercise, content: read_file_blob(filepath) }
       end
+
+      editor_filepaths.each do |filepath|
+        files[filepath] = { type: :readonly, content: read_file_blob(filepath) }
+      end
+
+      files
     rescue StandardError
       {}
     end

--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -12,7 +12,7 @@ class Iteration < ApplicationRecord
   scope :not_deleted, -> { where(deleted_at: nil) }
 
   delegate :tests_status,
-    :solution_files,
+    :files_for_editor,
     :automated_feedback_pending,
     :representer_feedback,
     :analyzer_feedback, to: :submission

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -37,6 +37,8 @@ class Solution < ApplicationRecord
   scope :published, -> { where.not(published_at: nil) }
   scope :not_published, -> { where(published_at: nil) }
 
+  delegate :files_for_editor, to: :exercise, prefix: :exercise
+
   before_create do
     # Search engines derive meaning by using hyphens
     # as word-boundaries in URLs. Since we use the
@@ -184,26 +186,15 @@ class Solution < ApplicationRecord
     git_important_files_hash != exercise.git_important_files_hash
   end
 
-  def exercise_solution_files
-    exercise.solution_files.transform_values do |content|
-      {
-        type: :exercise,
-        content: content
-      }
-    end
-  end
-
   def external_mentoring_request_url
     Exercism::Routes.mentoring_external_request_url(public_uuid)
   end
 
-  def solution_files
-    files = exercise_solution_files
-
+  def files_for_editor
     submission = submissions.last
-    return files unless submission
+    return exercise.files_for_editor unless submission
 
-    submission.solution_files
+    submission.files_for_editor
   end
 
   def broadcast!

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -86,10 +86,10 @@ class Submission < ApplicationRecord
     iteration&.published?
   end
 
-  def solution_files
+  def files_for_editor
     # Merge the submission files into the exercise files. If we find a
     # file we don't expect, that it as type: :legacy
-    files.each_with_object(solution.exercise_solution_files) do |file, merged_files|
+    files.each_with_object(solution.exercise_files_for_editor) do |file, merged_files|
       type = merged_files.key?(file.filename) ? :solution : :legacy
 
       merged_files[file.filename] = {

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -8,7 +8,7 @@ module Git
 
       expected_files = ["log_line_parser.rb"]
       assert_equal expected_files, exercise.files_for_editor.keys
-      assert exercise.files_for_editor["log_line_parser.rb"].start_with?("module LogLineParser")
+      assert exercise.files_for_editor["log_line_parser.rb"][:content].start_with?("module LogLineParser")
     end
 
     test "read_file_blob" do

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 module Git
   class ExerciseTest < ActiveSupport::TestCase
-    test "solution_files" do
+    test "files_for_editor" do
       exercise = Git::Exercise.new(:strings, "concept", "HEAD",
         repo_url: TestHelpers.git_repo_url("track-with-exercises"))
 
       expected_files = ["log_line_parser.rb"]
-      assert_equal expected_files, exercise.solution_files.keys
-      assert exercise.solution_files["log_line_parser.rb"].start_with?("module LogLineParser")
+      assert_equal expected_files, exercise.files_for_editor.keys
+      assert exercise.files_for_editor["log_line_parser.rb"].start_with?("module LogLineParser")
     end
 
     test "read_file_blob" do

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -150,24 +150,24 @@ class SolutionTest < ActiveSupport::TestCase
     assert_equal instructions, solution.instructions
   end
 
-  test "#exercise_solution_files returns exercise files" do
+  test "#exercise_files_for_editor returns exercise files" do
     exercise = create :concept_exercise
     solution = create :concept_solution, exercise: exercise
 
     expected_filenames = ["log_line_parser.rb"]
-    assert_equal expected_filenames, solution.exercise_solution_files.keys
-    file = solution.exercise_solution_files["log_line_parser.rb"]
+    assert_equal expected_filenames, solution.exercise_files_for_editor.keys
+    file = solution.exercise_files_for_editor["log_line_parser.rb"]
     assert file[:content].start_with?("module LogLineParser")
     assert_equal :exercise, file[:type]
   end
 
-  test "#solution_files returns solution files" do
+  test "#files_for_editor returns solution files" do
     exercise = create :concept_exercise
     solution = create :concept_solution, exercise: exercise
 
     expected_filenames = ["log_line_parser.rb"]
-    assert_equal expected_filenames, solution.solution_files.keys
-    file = solution.solution_files["log_line_parser.rb"]
+    assert_equal expected_filenames, solution.files_for_editor.keys
+    file = solution.files_for_editor["log_line_parser.rb"]
     assert file[:content].start_with?("module LogLineParser")
     assert_equal :exercise, file[:type]
 
@@ -177,13 +177,13 @@ class SolutionTest < ActiveSupport::TestCase
     create :submission_file, submission: submission, filename: "something_else.rb", content: "foobar2"
 
     expected_filenames = ["log_line_parser.rb", "something_else.rb"]
-    assert_equal expected_filenames, solution.solution_files.keys
+    assert_equal expected_filenames, solution.files_for_editor.keys
 
-    file_1 = solution.solution_files["log_line_parser.rb"]
+    file_1 = solution.files_for_editor["log_line_parser.rb"]
     assert "foobar1", file_1[:content]
     assert_equal :solution, file_1[:type]
 
-    file_2 = solution.solution_files["something_else.rb"]
+    file_2 = solution.files_for_editor["something_else.rb"]
     assert "foobar2", file_2[:content]
     assert_equal :legacy, file_2[:type]
   end


### PR DESCRIPTION
We have not yet added support for readonly "editor" files. This PR does that. I need to add some tests to this but I think it'll work. I also renamed `solution_files` to `files_for_editor` as part of this.

Closes https://github.com/exercism/v3-beta/issues/275 (Take a read for an example exercise to test with)