### PR TITLE
[WIP] Don't create site updates for wip exercises

### DIFF
--- a/app/commands/concept_exercise/create.rb
+++ b/app/commands/concept_exercise/create.rb
@@ -10,10 +10,12 @@ class ConceptExercise
         track: track,
         **attributes
       ).tap do |exercise|
-        SiteUpdates::NewExerciseUpdate.create!(
-          exercise: exercise,
-          track: track
-        )
+        unless exercise.wip?
+          SiteUpdates::NewExerciseUpdate.create!(
+            exercise: exercise,
+            track: track
+          )
+        end
       end
     rescue ActiveRecord::RecordNotUnique
       ConceptExercise.find_by!(uuid: uuid, track: track)

--- a/app/commands/practice_exercise/create.rb
+++ b/app/commands/practice_exercise/create.rb
@@ -10,10 +10,12 @@ class PracticeExercise
         track: track,
         **attributes
       ).tap do |exercise|
-        SiteUpdates::NewExerciseUpdate.create!(
-          exercise: exercise,
-          track: track
-        )
+        unless exercise.wip?
+          SiteUpdates::NewExerciseUpdate.create!(
+            exercise: exercise,
+            track: track
+          )
+        end
       end
     rescue ActiveRecord::RecordNotUnique
       PracticeExercise.find_by!(uuid: uuid, track: track)

--- a/test/commands/concept_exercise/create_test.rb
+++ b/test/commands/concept_exercise/create_test.rb
@@ -77,4 +77,14 @@ class ConceptExercise::CreateTest < ActiveSupport::TestCase
     assert_equal exercise, update.exercise
     assert_equal track, update.track
   end
+
+  test "does not create site_update for wip exercise" do
+    ConceptExercise::Create.(
+      SecureRandom.uuid,
+      create(:track),
+      build(:concept_exercise).attributes.symbolize_keys.merge(status: :wip)
+    )
+
+    assert_equal 0, SiteUpdate.count
+  end
 end

--- a/test/commands/practice_exercise/create_test.rb
+++ b/test/commands/practice_exercise/create_test.rb
@@ -72,4 +72,14 @@ class PracticeExercise::CreateTest < ActiveSupport::TestCase
     assert_equal exercise, update.exercise
     assert_equal track, update.track
   end
+
+  test "does not create site_update for wip exercise" do
+    PracticeExercise::Create.(
+      SecureRandom.uuid,
+      create(:track),
+      build(:practice_exercise).attributes.symbolize_keys.merge(status: :wip)
+    )
+
+    assert_equal 0, SiteUpdate.count
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/v3-beta/issues/365

Todo: we need to create a site update when a wip exercise become a beta or active exercise

Note: we don't have wip concepts (yet)