### PR TITLE
Fix date formatting issue when date is over 5 years ago

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -16,8 +16,11 @@ module TimeHelper
 
     # If the time is more than 5 years ago, the value is literally "over 5 years" as opposed
     # to "3 years" or "2 months"
-    is_over = parts[0] == "over"
-    parts.shift if is_over
+    if parts[0] == "over"
+      prefix = "over " unless short
+      suffix = "+" if short
+      parts.shift
+    end
 
     case parts[1]
     when "month", "months"
@@ -26,6 +29,6 @@ module TimeHelper
       unit = parts[1][0]
     end
 
-    "#{"over " if is_over}#{parts[0]}#{unit}"
+    "#{prefix}#{parts[0]}#{unit}#{suffix}"
   end
 end

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -13,6 +13,12 @@ module TimeHelper
     return "1s" if t == "less than a minute"
 
     parts = t.split(' ')
+
+    # If the time is more than 5 years ago, the value is literally "over 5 years" as opposed
+    # to "3 years" or "2 months"
+    is_over = parts[0] == "over"
+    parts.shift if is_over
+
     case parts[1]
     when "month", "months"
       unit = "mo"
@@ -20,6 +26,6 @@ module TimeHelper
       unit = parts[1][0]
     end
 
-    "#{parts[0]}#{unit}"
+    "#{"over " if is_over}#{parts[0]}#{unit}"
   end
 end

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -27,6 +27,6 @@ class TimeHelperTest < ActionView::TestCase
     assert_equal "3mo", time_ago_in_words(Time.current - 3.months, short: true)
     assert_equal "1y", time_ago_in_words(Time.current - 1.year, short: true)
     assert_equal "5y", time_ago_in_words(Time.current - 5.years, short: true)
-    assert_equal "over 5y", time_ago_in_words(Time.current - 5.years - 3.months, short: true)
+    assert_equal "5y+", time_ago_in_words(Time.current - 5.years - 3.months, short: true)
   end
 end

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -9,6 +9,8 @@ class TimeHelperTest < ActionView::TestCase
     assert_equal "1 minute", time_ago_in_words(Time.current - 50.seconds)
     assert_equal "1 minute", time_ago_in_words(Time.current - 1.minute)
     assert_equal "30 minutes", time_ago_in_words(Time.current - 30.minutes)
+    assert_equal "5 years", time_ago_in_words(Time.current - 5.years)
+    assert_equal "over 5 years", time_ago_in_words(Time.current - 5.years - 3.months)
   end
 
   test "time_ago_in_words short" do
@@ -24,5 +26,7 @@ class TimeHelperTest < ActionView::TestCase
     assert_equal "1mo", time_ago_in_words(Time.current - 1.month, short: true)
     assert_equal "3mo", time_ago_in_words(Time.current - 3.months, short: true)
     assert_equal "1y", time_ago_in_words(Time.current - 1.year, short: true)
+    assert_equal "5y", time_ago_in_words(Time.current - 5.years, short: true)
+    assert_equal "over 5y", time_ago_in_words(Time.current - 5.years - 3.months, short: true)
   end
 end


### PR DESCRIPTION
I noticed this while browsing my profile (with some old solutions!)

<img width="870" alt="Screen Shot 2021-09-02 at 5 39 07 pm" src="https://user-images.githubusercontent.com/543859/131821173-8ba5d320-7f6e-4276-b144-8fe832b0bf39.png">
