### PR TITLE
Escape code

### DIFF
--- a/app/javascript/components/common/CommunitySolution.tsx
+++ b/app/javascript/components/common/CommunitySolution.tsx
@@ -100,10 +100,9 @@ export const CommunitySolution = ({
         <ProcessingStatusSummary iterationStatus={solution.iterationStatus} />
       </header>
       <pre ref={snippetRef}>
-        <code
-          className={solution.track.highlightjsLanguage}
-          dangerouslySetInnerHTML={{ __html: solution.snippet }}
-        />
+        <code className={solution.track.highlightjsLanguage}>
+          {solution.snippet}
+        </code>
       </pre>
       <footer className="--footer">
         {solution.publishedAt ? (

--- a/app/javascript/components/editor/TestsPanel.tsx
+++ b/app/javascript/components/editor/TestsPanel.tsx
@@ -19,8 +19,9 @@ export const TestsPanel = ({
           className={highlightjsLanguage}
           data-highlight-line-numbers={true}
           data-highlight-line-number-start={1}
-          dangerouslySetInnerHTML={{ __html: tests }}
-        />
+        >
+          {tests}
+        </code>
       </pre>
     </Tab.Panel>
   )


### PR DESCRIPTION
This is how the tests were rendered previously (no escaping loses the `<>` characters):

![image](https://user-images.githubusercontent.com/135246/131839966-a4c9da8b-8315-4c96-96c6-585d06dba225.png)

And this is how they're displayed with this change:

![image](https://user-images.githubusercontent.com/135246/131840038-e3cc7b45-8aa5-4481-a8e0-e85df4ae2753.png)

I don't know if there was any particular reason to use the `dangerouslySetInnerHTML` option here, but the new version still has syntax highlighting so 🤷 . @kntsoriano?

Closes https://github.com/exercism/fsharp/issues/970
Closes https://github.com/exercism/exercism/issues/5610