### PR TITLE
Use correct exercise/concept count for Track upsell

### DIFF
--- a/app/views/tracks/about/_upsell.html.haml
+++ b/app/views/tracks/about/_upsell.html.haml
@@ -2,7 +2,6 @@
 
 %section.upsell-section
   .md-container
-
     .feature.flex-col.md:flex-row
       .info
         = graphical_icon :logo, css_class: "small-icon"
@@ -20,7 +19,14 @@
       .info
         = graphical_icon :mentoring, css_class: "small-icon"
         %h3 Community-sourced #{track.title} exercises
-        %p The #{track.title} track on Exercism has #{"#{track.num_concepts} concepts and " if track.num_concepts > 0}#{track.num_exercises} exercises to help you write better code. Discover new exercises as you progress and get engrossed in learning new concepts and improving the way you currently write.
+        %p
+          The #{track.title} track on Exercism has
+          - if track.num_concepts.positive?
+            #{track.num_concepts} concepts and
+
+          #{track.num_exercises} exercises to help you write better code.
+          Discover new exercises as you progress and get engrossed in learning new concepts and improving the way you currently write.
+
         = render ViewComponents::ProminentLink.new("See all #{track.title} exercises", track_exercises_path(track))
       .flex-shrink-0.flex-grow.grid.place-items-center.mt-32.md:mt-0.md:mr-64
         = graphical_icon 'community-solutions', category: :graphics, css_class: 'graphic'

--- a/app/views/tracks/about/_upsell.html.haml
+++ b/app/views/tracks/about/_upsell.html.haml
@@ -7,7 +7,6 @@
       .info
         = graphical_icon :logo, css_class: "small-icon"
         %h3 Get mentored the #{track.title} way
-        / TODO: Use correct counts
         %p
           Every language has its own way of doing things.
           #{track.title} is no different.
@@ -21,8 +20,7 @@
       .info
         = graphical_icon :mentoring, css_class: "small-icon"
         %h3 Community-sourced #{track.title} exercises
-        / TODO: Use correct counts
-        %p The #{track.title} track on Exercism has 120 concepts and 100 exercises to help you write better code. Discover new exercises as you progress and get engrossed in learning new concepts and improving the way you currently write.
+        %p The #{track.title} track on Exercism has #{"#{track.num_concepts} concepts and " if track.num_concepts > 0}#{track.num_exercises} exercises to help you write better code. Discover new exercises as you progress and get engrossed in learning new concepts and improving the way you currently write.
         = render ViewComponents::ProminentLink.new("See all #{track.title} exercises", track_exercises_path(track))
       .flex-shrink-0.flex-grow.grid.place-items-center.mt-32.md:mt-0.md:mr-64
         = graphical_icon 'community-solutions', category: :graphics, css_class: 'graphic'


### PR DESCRIPTION
Currently the main Track page hardcodes 120 concepts/100 exercises - this uses the real values for a track instead.

<img width="692" alt="Screen Shot 2021-09-03 at 10 47 39 pm" src="https://user-images.githubusercontent.com/543859/132024728-80af1aa5-d23f-4a0e-bf32-4bef8fa1993f.png">

<img width="668" alt="Screen Shot 2021-09-03 at 10 47 48 pm" src="https://user-images.githubusercontent.com/543859/132024736-a6ba9f54-a527-4663-b43a-47f16dea5097.png">
