### PR TITLE
Hide avg waiting time while it isn't computed yet

### DIFF
--- a/app/javascript/components/mentoring/TrackSelector.tsx
+++ b/app/javascript/components/mentoring/TrackSelector.tsx
@@ -15,7 +15,7 @@ export type Track = {
   slug: string
   title: string
   iconUrl: string
-  avgWaitTime: string
+  avgWaitTime: string | null
   numSolutionsQueued: number
 }
 

--- a/app/javascript/components/mentoring/track-selector/TrackCheckbox.tsx
+++ b/app/javascript/components/mentoring/track-selector/TrackCheckbox.tsx
@@ -33,7 +33,7 @@ export const TrackCheckbox = ({
         <TrackIcon iconUrl={iconUrl} title={title} />
         <div className="title">{title}</div>
         <div className="info">
-          Avg. wait time ~ {avgWaitTime}
+          {avgWaitTime ? `Avg. wait time ~ ${avgWaitTime}` : null}
           <br />
           {numSolutionsQueued} {pluralize('solution', numSolutionsQueued)}{' '}
           queued

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -97,6 +97,11 @@ class Track < ApplicationRecord
     "6 hrs"
   end
 
+  # TODO: Set this properly
+  def avg_wait_time
+    nil
+  end
+
   CATGEORIES = {
     paradigm: "Paradigm",
     typing: "Typing",

--- a/app/serializers/serialize_tracks_for_mentoring.rb
+++ b/app/serializers/serialize_tracks_for_mentoring.rb
@@ -18,7 +18,7 @@ class SerializeTracksForMentoring
       title: track.title,
       icon_url: track.icon_url,
       num_solutions_queued: request_counts[track.id].to_i,
-      avg_wait_time: "2 days", # TODO
+      avg_wait_time: track.avg_wait_time,
       links: {
         exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: track.slug)
       }

--- a/test/helpers/react_components/mentoring/queue_test.rb
+++ b/test/helpers/react_components/mentoring/queue_test.rb
@@ -61,7 +61,7 @@ class MentoringQueueTest < ReactComponentTestCase
                   title: "C#",
                   icon_url: csharp.icon_url,
                   num_solutions_queued: 6,
-                  avg_wait_time: "2 days",
+                  avg_wait_time: nil,
                   links: {
                     exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: csharp.slug)
                   }
@@ -71,7 +71,7 @@ class MentoringQueueTest < ReactComponentTestCase
                   title: "F#",
                   icon_url: fsharp.icon_url,
                   num_solutions_queued: 0,
-                  avg_wait_time: "2 days",
+                  avg_wait_time: nil,
                   links: {
                     exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: fsharp.slug)
                   }
@@ -81,7 +81,7 @@ class MentoringQueueTest < ReactComponentTestCase
                   title: "Ruby",
                   icon_url: ruby.icon_url,
                   num_solutions_queued: 3,
-                  avg_wait_time: "2 days",
+                  avg_wait_time: nil,
                   links: {
                     exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: ruby.slug)
                   }
@@ -96,7 +96,7 @@ class MentoringQueueTest < ReactComponentTestCase
           title: "C#",
           icon_url: csharp.icon_url,
           num_solutions_queued: 6,
-          avg_wait_time: "2 days",
+          avg_wait_time: nil,
           links: {
             exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: csharp.slug)
           },
@@ -192,7 +192,7 @@ class MentoringQueueTest < ReactComponentTestCase
                   title: "C#",
                   icon_url: csharp.icon_url,
                   num_solutions_queued: 6,
-                  avg_wait_time: "2 days",
+                  avg_wait_time: nil,
                   links: {
                     exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: csharp.slug)
                   }
@@ -202,7 +202,7 @@ class MentoringQueueTest < ReactComponentTestCase
                   title: "Ruby",
                   icon_url: ruby.icon_url,
                   num_solutions_queued: 3,
-                  avg_wait_time: "2 days",
+                  avg_wait_time: nil,
                   links: {
                     exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: ruby.slug)
                   }
@@ -217,7 +217,7 @@ class MentoringQueueTest < ReactComponentTestCase
           title: "C#",
           icon_url: csharp.icon_url,
           num_solutions_queued: 6,
-          avg_wait_time: "2 days",
+          avg_wait_time: nil,
           links: {
             exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: csharp.slug)
           },

--- a/test/serializers/serialize_tracks_for_mentoring_test.rb
+++ b/test/serializers/serialize_tracks_for_mentoring_test.rb
@@ -30,7 +30,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "C#",
         icon_url: csharp.icon_url,
         num_solutions_queued: 6,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'csharp')
         }
@@ -40,7 +40,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "F#",
         icon_url: fsharp.icon_url,
         num_solutions_queued: 0,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'fsharp')
         }
@@ -50,7 +50,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "Ruby",
         icon_url: ruby.icon_url,
         num_solutions_queued: 3,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'ruby')
         }
@@ -100,7 +100,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "C#",
         icon_url: csharp.icon_url,
         num_solutions_queued: 6,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'csharp')
         }
@@ -110,7 +110,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "Elixir",
         icon_url: elixir.icon_url,
         num_solutions_queued: 4,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'elixir')
         }
@@ -120,7 +120,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "F#",
         icon_url: fsharp.icon_url,
         num_solutions_queued: 0,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'fsharp')
         }
@@ -130,7 +130,7 @@ class Mentor::Request::RetrieveTracksTest < ActiveSupport::TestCase
         title: "Ruby",
         icon_url: ruby.icon_url,
         num_solutions_queued: 3,
-        avg_wait_time: "2 days",
+        avg_wait_time: nil,
         links: {
           exercises: Exercism::Routes.exercises_api_mentoring_requests_url(track_slug: 'ruby')
         }


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5685.

@iHiD I can't seem to find where the average waiting time for a track is computed. I've decided to hide it from the UI for now.

Screenshot:
![Screen Shot 2021-09-05 at 12 59 16 PM](https://user-images.githubusercontent.com/1901520/132115929-e409414e-1bfd-48b9-bb37-99e8ab46144c.png)
