### PR TITLE
Fix video previews when requesting mentorship

### DIFF
--- a/app/css/components/mentor/discussion.css
+++ b/app/css/components/mentor/discussion.css
@@ -740,7 +740,9 @@
                             width: 85px;
                             @apply rounded-8;
                             @apply mr-20;
-                            background: lightgray; /* TODO: REMOVE */
+                            background-color: lightgray;
+                            background-size: cover;
+                            background-position: center;
                         }
                         & .info {
                             @apply flex-grow overflow-hidden;

--- a/app/helpers/react_components/student/mentoring_session.rb
+++ b/app/helpers/react_components/student/mentoring_session.rb
@@ -71,9 +71,8 @@ module ReactComponents
         [
           {
             url: Exercism::Routes.doc_path(:using, "feedback/guide-to-being-mentored"),
-            # TODO: Change this
-            thumb: "https://i.vimeocdn.com/video/1230063662?mw=800&mh=450",
-            title: "Make the most of being mentored",
+            thumb: "https://exercism-static.s3.eu-west-1.amazonaws.com/blog/tutorial-making-the-most-of-being-mentored.png",
+            title: "Making the most of being mentored",
             date: Date.new(2021, 9, 1).iso8601
           }
         ]

--- a/app/helpers/react_components/student/mentoring_session.rb
+++ b/app/helpers/react_components/student/mentoring_session.rb
@@ -68,22 +68,13 @@ module ReactComponents
       def videos
         return [] if discussion
 
-        # TODO: (required)
         [
           {
-            url: "#",
-            title: "Start mentoring on Exercism..",
-            date: Date.new(2020, 1, 24).iso8601
-          },
-          {
-            url: "#",
-            title: "Best practices writing feedback trrrrrruuuuunnnncaaatteeee",
-            date: Date.new(2020, 1, 24).iso8601
-          },
-          {
-            url: "#",
-            title: "Beginners’ Guide to Mentoring",
-            date: Date.new(2020, 1, 24).iso8601
+            url: Exercism::Routes.doc_path(:using, "feedback/guide-to-being-mentored"),
+            # TODO: Change this
+            thumb: "https://i.vimeocdn.com/video/1230063662?mw=800&mh=450",
+            title: "Make the most of being mentored",
+            date: Date.new(2021, 9, 1).iso8601
           }
         ]
       end

--- a/app/javascript/components/student/MentoringSession.tsx
+++ b/app/javascript/components/student/MentoringSession.tsx
@@ -29,6 +29,7 @@ export type Links = {
 
 export type Video = {
   url: string
+  thumb: string
   title: string
   date: string
 }

--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
@@ -112,10 +112,17 @@ export const MentoringRequestInfo = ({
   )
 }
 
-const Video = ({ title, date, url }: VideoProps) => {
+const Video = ({ title, date, thumb, url }: VideoProps) => {
   return (
-    <a href={url} className="video">
-      <div className="img" />
+    <a href={url} target="_blank" rel="noreferrer" className="video">
+      <div
+        className="img"
+        style={{
+          backgroundImage: `url('${thumb}')`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center center',
+        }}
+      />
       <div className="info">
         <div className="title">{title}</div>
         <time dateTime={date} className="date">

--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestInfo.tsx
@@ -119,8 +119,6 @@ const Video = ({ title, date, thumb, url }: VideoProps) => {
         className="img"
         style={{
           backgroundImage: `url('${thumb}')`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center center',
         }}
       />
       <div className="info">

--- a/test/helpers/react_components/student/mentoring_session_test.rb
+++ b/test/helpers/react_components/student/mentoring_session_test.rb
@@ -89,21 +89,11 @@ module ReactComponents::Student
           out_of_date: false,
           videos: [
             {
-              url: "#",
-              title: "Start mentoring on Exercism..",
-              date: Date.new(2020, 1, 24).iso8601
-            },
-            {
-              url: "#",
-              title: "Best practices writing feedback trrrrrruuuuunnnncaaatteeee",
-              date: Date.new(2020, 1, 24).iso8601
-            },
-            {
-              url: "#",
-              title: "Beginners’ Guide to Mentoring",
-              date: Date.new(2020, 1, 24).iso8601
+              url: Exercism::Routes.doc_path(:using, "feedback/guide-to-being-mentored"),
+              thumb: "https://exercism-static.s3.eu-west-1.amazonaws.com/blog/tutorial-making-the-most-of-being-mentored.png",
+              title: "Making the most of being mentored",
+              date: Date.new(2021, 9, 1).iso8601
             }
-
           ],
           links: {
             exercise: Exercism::Routes.track_exercise_mentor_discussions_url(track, exercise),


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5794.
Closes https://github.com/exercism/exercism/issues/5799.

![Screen Shot 2021-09-06 at 8 55 06 AM](https://user-images.githubusercontent.com/1901520/132146854-1078449e-8558-4207-a4b6-150dd79b9b03.png)

Aside: I noticed that the link in the description and the link in the video point to the same thing. It doesn't really matter right now.