### PR TITLE
Fix task text being invalid when using newlines in text

### DIFF
--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -66,7 +66,7 @@ class SerializeExerciseAssignment
       chunk_while { |_, nxt| nxt.type != :header }.
       map do |nodes|
         task_title = parse_title(nodes.first)
-        task_text = Markdown::Parse.(nodes[1..].each.map(&:to_commonmark).join)
+        task_text = Markdown::Parse.(nodes[1..].each.map(&:to_commonmark).join("\n"))
         task_hints = hints[task_title.downcase].to_a
 
         { title: task_title, text: task_text, hints: task_hints }

--- a/test/serializers/serialize_exercise_assignment_test.rb
+++ b/test/serializers/serialize_exercise_assignment_test.rb
@@ -142,4 +142,33 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     refute_includes serialized[:overview], 'that keeps track of how'
     assert_includes serialized[:overview], 'that tracks how'
   end
+
+  test "serialize task with multiple lines of text" do
+    solution = create :concept_solution
+
+    instructions = <<~INSTRUCTIONS.strip
+      # Instructions
+
+      ## 1. Document filling out fields with blank values
+
+      Add documentation and a typespec to the `Form.blanks/1` function. The documentation should read:
+
+      ```
+      Generates a string of a given length.
+
+      This string can be used to fill out a form field that is supposed to have no value.
+      Such fields cannot be left empty because a malicious third party could fill them out with false data.
+      ```
+
+      The typespec should explain that the function accepts a single argument, a non-negative integer, and returns a string.
+    INSTRUCTIONS
+
+    solution.git_exercise.stubs(:instructions).returns(instructions)
+
+    serialized = SerializeExerciseAssignment.(solution)
+
+    task = serialized[:tasks].first
+    assert_equal "Document filling out fields with blank values", task[:title]
+    assert_equal "<p>Add documentation and a typespec to the <code>Form.blanks/1</code> function. The documentation should read:</p>\n<pre><code class=\"language-plain\">Generates a string of a given length.\n\nThis string can be used to fill out a form field that is supposed to have no value.\nSuch fields cannot be left empty because a malicious third party could fill them out with false data.\n</code></pre>\n<p>The typespec should explain that the function accepts a single argument, a non-negative integer, and returns a string.</p>\n", task[:text] # rubocop:disable Layout/LineLength
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5780
Closes https://github.com/exercism/v3-beta/issues/172

See:

![image](https://user-images.githubusercontent.com/135246/132314557-7bf3dab3-c9c0-4880-b7ae-e32e04bc2398.png)
