### PR TITLE
Fix creation issue with Exercises

### DIFF
--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -78,7 +78,7 @@ module Git
           blurb: git_concept.blurb,
           synced_to_git_sha: head_git_track.commit.oid
         ).tap do |concept|
-          Git::SyncConcept.(concept, force_sync: force_sync)
+          Git::SyncConcept.(concept, force_sync: force_sync || concept.id_previously_changed?)
         end
       end
     end
@@ -102,7 +102,7 @@ module Git
           prerequisites: exercise_concepts(exercise_config[:prerequisites]),
           has_test_runner: git_exercise.has_test_runner?
         )
-        Git::SyncConceptExercise.(exercise, force_sync: force_sync || exercise.id_changed?)
+        Git::SyncConceptExercise.(exercise, force_sync: force_sync || exercise.id_previously_changed?)
       end
     end
 
@@ -126,7 +126,7 @@ module Git
           practiced_concepts: exercise_concepts(exercise_config[:practices]),
           has_test_runner: git_exercise.has_test_runner?
         )
-        Git::SyncPracticeExercise.(exercise, force_sync: force_sync)
+        Git::SyncPracticeExercise.(exercise, force_sync: force_sync || exercise.id_previously_changed?)
       end
     end
 

--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -102,7 +102,7 @@ module Git
           prerequisites: exercise_concepts(exercise_config[:prerequisites]),
           has_test_runner: git_exercise.has_test_runner?
         )
-        Git::SyncConceptExercise.(exercise, force_sync: force_sync)
+        Git::SyncConceptExercise.(exercise, force_sync: force_sync || exercise.id_changed?)
       end
     end
 

--- a/test/commands/git/sync_track_test.rb
+++ b/test/commands/git/sync_track_test.rb
@@ -470,4 +470,58 @@ class Git::SyncTrackTest < ActiveSupport::TestCase
 
     assert track.course?
   end
+
+  test "new concept syncs with force_sync even when track is not force synced" do
+    track = create :track, synced_to_git_sha: "HEAD"
+
+    Git::SyncConcept.expects(:call).with(anything, force_sync: true).at_least_once
+
+    Git::SyncTrack.(track)
+  end
+
+  test "new concept exercise syncs with force_sync even when track is not force synced" do
+    track = create :track, synced_to_git_sha: "HEAD"
+
+    Git::SyncConceptExercise.expects(:call).with(anything, force_sync: true).at_least_once
+
+    Git::SyncTrack.(track)
+  end
+
+  test "new practice exercise syncs with force_sync even when track is not force synced" do
+    track = create :track, synced_to_git_sha: "HEAD"
+
+    Git::SyncPracticeExercise.expects(:call).with(anything, force_sync: true).at_least_once
+
+    Git::SyncTrack.(track)
+  end
+
+  test "existing concept does not sync with force_sync" do
+    track = create :track, synced_to_git_sha: "HEAD"
+    Git::SyncTrack.(track)
+
+    Git::SyncConcept.expects(:call).with(anything, force_sync: true).never
+    Git::SyncConcept.expects(:call).with(anything, force_sync: false).at_least_once
+
+    Git::SyncTrack.(track)
+  end
+
+  test "existing concept exercise does not sync with force_sync" do
+    track = create :track, synced_to_git_sha: "HEAD"
+    Git::SyncTrack.(track)
+
+    Git::SyncConceptExercise.expects(:call).with(anything, force_sync: true).never
+    Git::SyncConceptExercise.expects(:call).with(anything, force_sync: false).at_least_once
+
+    Git::SyncTrack.(track)
+  end
+
+  test "existing practice exercise does not sync with force_sync" do
+    track = create :track, synced_to_git_sha: "HEAD"
+    Git::SyncTrack.(track)
+
+    Git::SyncPracticeExercise.expects(:call).with(anything, force_sync: true).never
+    Git::SyncPracticeExercise.expects(:call).with(anything, force_sync: false).at_least_once
+
+    Git::SyncTrack.(track)
+  end
 end


### PR DESCRIPTION
@ErikSchierboom We need to force_sync for new exercises to get the authors/contributors to create. I think this needs copying for both types of exercises and concept, and tests adding.

This also guarantees we don't don't issues like the test_runner stauts one from before (in fact we could now actively leave that field out in this bit if we wanted, and set the exercise's status here to `wip` and let the force_sync set the right values)