### PR TITLE
Add close button to publish solution modal

### DIFF
--- a/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
@@ -18,7 +18,13 @@ export const PublishSolutionModal = ({
   onSuccess: (data: ExerciseCompletion) => void
 }): JSX.Element => {
   return (
-    <Modal cover={true} open={open} className="m-publish-exercise" {...props}>
+    <Modal
+      cover={true}
+      open={open}
+      className="m-publish-exercise"
+      closeButton
+      {...props}
+    >
       <div className="content">
         <GraphicalIcon icon="publish" className="publish-icon" />
         <div className="title">Publish your code and share your knowledge</div>


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5637.

The modal can also be closed by clicking outside it.

![Screen Shot 2021-09-09 at 6 46 17 AM](https://user-images.githubusercontent.com/1901520/132596486-b0f908d2-05cc-472d-a611-d8a5806fd89e.png)

