### PR TITLE
Add missing space in ChooseTrackStep

### DIFF
--- a/app/javascript/components/modals/mentor-registration-modal/ChooseTrackStep.tsx
+++ b/app/javascript/components/modals/mentor-registration-modal/ChooseTrackStep.tsx
@@ -20,7 +20,7 @@ export const ChooseTrackStep = ({
     <section className="tracks-section">
       <h2>Select the tracks you want to mentor</h2>
       <p>
-        This allows us to only show you the solutions you want to mentor.
+        This allows us to only show you the solutions you want to mentor.{' '}
         <strong>
           Don’t worry, you can change these selections at anytime.
         </strong>


### PR DESCRIPTION
Add a space between sentences on the Mentoring track selection page. 

_Before_
<img width="1183" alt="Screen Shot 2021-09-18 at 5 27 32 PM" src="https://user-images.githubusercontent.com/15083303/133894076-408a8ec2-8ad3-4f23-859e-c63915ee8b51.png">
