### PR TITLE
Fix typo "experince" in docs

### DIFF
--- a/app/views/docs/track_index.html.haml
+++ b/app/views/docs/track_index.html.haml
@@ -10,4 +10,4 @@
       %hr.c-divider
 
       .c-textual-content.--large
-        %p Explore our #{@track.title} docs and discover everything you need to know to make the most of your #{@track.title} experince on Exercism, from installing #{@track.title} to running the tests, learning the language, and useful resources.
+        %p Explore our #{@track.title} docs and discover everything you need to know to make the most of your #{@track.title} experience on Exercism, from installing #{@track.title} to running the tests, learning the language, and useful resources.


### PR DESCRIPTION
Closes https://github.com/exercism/website-copy/issues/2076