### PR TITLE
Only send welcome email when someone has confirmed or skipped confirmation

### DIFF
--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -7,7 +7,6 @@ class User
     def call
       user.auth_tokens.create!
       AwardBadgeJob.perform_later(user, :member)
-      User::Notification::CreateEmailOnly.(user, :joined_exercism, {})
     end
   end
 end

--- a/app/commands/user/notification/retrieve.rb
+++ b/app/commands/user/notification/retrieve.rb
@@ -33,7 +33,7 @@ class User::Notification
     end
 
     def setup!
-      @notifications = user.notifications.not_pending
+      @notifications = user.notifications.visible
     end
 
     def sort!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,15 @@ class User < ApplicationRecord
     create_communication_preferences
   end
 
+  def after_confirmation
+    User::Notification::CreateEmailOnly.(self, :joined_exercism, {})
+  end
+
+  def skip_confirmation!
+    super
+    after_confirmation
+  end
+
   def self.for!(param)
     return param if param.is_a?(User)
     return find_by!(id: param) if param.is_a?(Numeric)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,15 +91,12 @@ class User < ApplicationRecord
 
   after_create_commit do
     create_communication_preferences
+
+    after_confirmation if confirmed?
   end
 
   def after_confirmation
     User::Notification::CreateEmailOnly.(self, :joined_exercism, {})
-  end
-
-  def skip_confirmation!
-    super
-    after_confirmation
   end
 
   def self.for!(param)

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -17,6 +17,7 @@ class User::Notification < ApplicationRecord
   enum status: { pending: 0, unread: 1, read: 2, email_only: 3 }
 
   scope :pending_or_unread, -> { where(status: %i[pending unread]) }
+  scope :visible, -> { where(status: %i[unread read]) }
 
   before_validation on: :create do
     self.uuid = SecureRandom.compact_uuid

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -201,4 +201,20 @@ class UserTest < ActiveSupport::TestCase
     user.dismiss_introducer!('scratchpad')
     assert user.introducer_dismissed?('scratchpad')
   end
+
+  test "email is sent after confirmation" do
+    user = create :user
+
+    User::Notification::CreateEmailOnly.expects(:call).with(user, :joined_exercism, {})
+
+    user.confirm
+  end
+
+  test "email is sent if confirmation is skipped" do
+    user = create :user
+
+    User::Notification::CreateEmailOnly.expects(:call).with(user, :joined_exercism, {})
+
+    user.skip_confirmation!
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -202,7 +202,12 @@ class UserTest < ActiveSupport::TestCase
     assert user.introducer_dismissed?('scratchpad')
   end
 
-  test "email is sent after confirmation" do
+  test "welcome email is not sent for normal user creation" do
+    User::Notification::CreateEmailOnly.expects(:call).never
+    create :user
+  end
+
+  test "welcome email is sent after confirmation" do
     user = create :user
 
     User::Notification::CreateEmailOnly.expects(:call).with(user, :joined_exercism, {})
@@ -210,11 +215,12 @@ class UserTest < ActiveSupport::TestCase
     user.confirm
   end
 
-  test "email is sent if confirmation is skipped" do
-    user = create :user
+  test "welcome email is sent when a confirmed user is created" do
+    user = build :user
+    user.skip_confirmation!
 
     User::Notification::CreateEmailOnly.expects(:call).with(user, :joined_exercism, {})
 
-    user.skip_confirmation!
+    user.save!
   end
 end

--- a/test/system/flows/user_registration_test.rb
+++ b/test/system/flows/user_registration_test.rb
@@ -10,6 +10,8 @@ module Flows
     end
 
     test "user registers successfully" do
+      User::Notification::CreateEmailOnly.expects(:call).never
+
       allow_captcha_request do
         visit new_user_registration_path
         fill_in "Email", with: "user@exercism.org"
@@ -56,6 +58,8 @@ module Flows
     end
 
     test "user registers via Github" do
+      User::Notification::CreateEmailOnly.expects(:call)
+
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
         provider: "github",


### PR DESCRIPTION
It's **really** confusing some people that they get the confirmation email and the welcome email at the same time.

e.g.

<img width="826" alt="Screenshot 2021-09-24 at 14 33 35" src="https://user-images.githubusercontent.com/286476/134683041-8fbebe2a-bf33-4991-8a63-bc2da590574c.png">
<img width="883" alt="Screenshot 2021-09-24 at 14 33 55" src="https://user-images.githubusercontent.com/286476/134683086-c6ae2fd2-b6c6-4950-9249-c7c5a8574f69.png">

(Yes, this is the sort of email I get daily about all sorts of stuff)