### PR TITLE
Fix problem report

### DIFF
--- a/app/controllers/api/bug_reports_controller.rb
+++ b/app/controllers/api/bug_reports_controller.rb
@@ -1,10 +1,23 @@
+# TODO: This whole class needs tests
+# TODO: Rename to ProblemReports
 module API
   class BugReportsController < BaseController
     def create
+      begin
+        exercise_slug = params[:bug_report][:exercise_slug]
+        track_slug = params[:bug_report][:track_slug]
+        if track_slug.present? && exercise_slug.present?
+          exercise = Exercise.joins(:track).where('tracks.slug': track_slug).find(exercise_slug)
+        end
+      rescue StandardError
+        # Don't let this being wrong break the bug report
+      end
+
       @report = ProblemReport.create!(
         bug_report_params.merge(
           type: :bug,
-          user: current_user
+          user: current_user,
+          about: exercise
         )
       )
 

--- a/app/helpers/react_components/editor.rb
+++ b/app/helpers/react_components/editor.rb
@@ -35,7 +35,8 @@ module ReactComponents
             slug: track.slug
           },
           exercise: {
-            title: solution.exercise.title
+            title: solution.exercise.title,
+            slug: solution.exercise.slug
           },
           links: {
             run_tests: Exercism::Routes.api_solution_submissions_url(solution.uuid),

--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -311,6 +311,8 @@ export default ({
               <Header.ActionMore
                 onRevertToExerciseStart={handleRevertToExerciseStart}
                 onRevertToLastIteration={handleRevertToLastIteration}
+                trackSlug={track.slug}
+                exerciseSlug={exercise.slug}
               />
             </div>
           </div>

--- a/app/javascript/components/editor/Props.tsx
+++ b/app/javascript/components/editor/Props.tsx
@@ -18,6 +18,7 @@ type Track = {
 
 type Exercise = {
   title: string
+  slug: string
 }
 
 type AutosaveConfig = {

--- a/app/javascript/components/editor/header/ActionMore.tsx
+++ b/app/javascript/components/editor/header/ActionMore.tsx
@@ -6,9 +6,13 @@ import { useDropdown } from '../../dropdowns/useDropdown'
 export const ActionMore = ({
   onRevertToLastIteration,
   onRevertToExerciseStart,
+  trackSlug,
+  exerciseSlug,
 }: {
   onRevertToLastIteration: () => void
   onRevertToExerciseStart: () => void
+  trackSlug: string
+  exerciseSlug: string
 }): JSX.Element => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const {
@@ -52,6 +56,8 @@ export const ActionMore = ({
       <BugReportModal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+        trackSlug={trackSlug}
+        exerciseSlug={exerciseSlug}
       />
       <button {...buttonAttributes} className="more-btn">
         <Icon icon="more-horizontal" alt="Open more options" />

--- a/app/javascript/components/modals/BugReportModal.tsx
+++ b/app/javascript/components/modals/BugReportModal.tsx
@@ -12,10 +12,14 @@ enum BugReportModalStatus {
 export const BugReportModal = ({
   open,
   onClose,
+  trackSlug,
+  exerciseSlug,
   ...props
 }: {
   open: boolean
   onClose: () => void
+  trackSlug?: string
+  exerciseSlug?: string
 }): JSX.Element => {
   const handleClose = useCallback(() => {
     onClose()
@@ -38,6 +42,8 @@ export const BugReportModal = ({
         body: JSON.stringify({
           bug_report: {
             content_markdown: textareaRef.current?.value,
+            track_slug: trackSlug,
+            exercise_slug: exerciseSlug,
           },
         }),
       })

--- a/test/system/components/editor_test.rb
+++ b/test/system/components/editor_test.rb
@@ -467,6 +467,11 @@ module Components
 
         assert_text "Bug report submitted. Thank you!"
       end
+
+      report = ProblemReport.last
+      assert_equal exercise, report.about
+      assert_equal user, report.user
+      assert_equal "I found a bug", report.content_markdown
     end
 
     test "user views hints" do


### PR DESCRIPTION
@kntsoriano This is a good example of why I argue so hard that system tests should also test the actual flow works properly, not just what the user gets back. We didn't get the `about` field filled in for problem reports in the editor, so now we have 500 bug reports with no data as to what they're about 🙈 If we'd checked that in the system test, we'd probably have tracked down the bug before it bit us 🙂 

---

Closes https://github.com/exercism/exercism/issues/5969