### PR TITLE
Use common serialization pattern

### DIFF
--- a/app/helpers/react_components/mentoring/session.rb
+++ b/app/helpers/react_components/mentoring/session.rb
@@ -31,7 +31,7 @@ module ReactComponents
               anonymous_mode: discussion&.anonymous_mode?
             ),
             mentor_solution: mentor_solution,
-            exemplar_files: ExemplarFileList.new(exercise.exemplar_files),
+            exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
             notes: exercise.mentoring_notes_content,
             out_of_date: solution.out_of_date?,
             download_command: solution.mentor_download_cmd,
@@ -97,12 +97,12 @@ module ReactComponents
         ScratchpadPage.new(about: exercise)
       end
 
-      class ExemplarFileList
-        extend Mandate::InitializerInjector
+      class SerializeExemplarFiles
+        include Mandate
 
         initialize_with :files
 
-        def as_json
+        def call
           files.map do |filename, content|
             {
               filename: filename.gsub(%r{^\.meta/}, ''),

--- a/test/helpers/react_components/mentoring/session_test.rb
+++ b/test/helpers/react_components/mentoring/session_test.rb
@@ -1,6 +1,6 @@
 require_relative "../react_component_test_case"
 
-module Mentoring
+module ReactComponents::Mentoring
   class SessionTest < ReactComponentTestCase
     test "mentoring request renders correctly" do
       TestHelpers.use_website_copy_test_repo!
@@ -42,12 +42,7 @@ module Mentoring
           tests: solution.tests,
           student: SerializeStudent.(student, mentor, relationship: nil, anonymous_mode: false, user_track: user_track),
           mentor_solution: nil,
-          exemplar_files: [
-            {
-              filename: "exemplar.rb",
-              content: exercise.exemplar_files.values.first
-            }
-          ],
+          exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
           notes: "<p>These are notes for lasagna.</p>\n",
           out_of_date: false,
           download_command: solution.mentor_download_cmd,
@@ -183,12 +178,7 @@ module Mentoring
           tests: solution.tests,
           student: SerializeStudent.(student, mentor, relationship: nil, anonymous_mode: false, user_track: user_track),
           mentor_solution: nil,
-          exemplar_files: [
-            {
-              filename: "exemplar.rb",
-              content: exercise.exemplar_files.values.first
-            }
-          ],
+          exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
           notes: "<p>These are notes for lasagna.</p>\n",
           out_of_date: false,
           download_command: solution.mentor_download_cmd,
@@ -210,7 +200,7 @@ module Mentoring
       )
     end
 
-    test "#as_json serializes files" do
+    test "exemplar files are serialized correctly" do
       files = {
         ".meta/exemplar1.rb" => "class Ruby\nend"
       }
@@ -222,7 +212,7 @@ module Mentoring
             content: "class Ruby\nend"
           }
         ],
-        ReactComponents::Mentoring::Session::ExemplarFileList.new(files).as_json
+        Session::SerializeExemplarFiles.(files)
       )
     end
   end


### PR DESCRIPTION
This addresses https://github.com/exercism/website/pull/1908#discussion_r716276505

We should only be checking for the functionality of the serializer in the class once as you say. The other checks should just reuse the serializer. This is how I've written it in all(?) the other places where serailizers are used. So the real change here is adding local serializers into the components, when those aren't shared with the API.