### PR TITLE
Update to use latest tooling jobs logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'kaminari'
 gem 'oj'
 
 # Setup dependencies
-gem 'exercism-config', '>= 0.75.0'
+gem 'exercism-config', '>= 0.76.0'
 # gem 'exercism-config', path: '../exercism_config'
 
 # Model-level dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
-    exercism-config (0.75.0)
+    exercism-config (0.76.0)
       aws-sdk-dynamodb (~> 1.0)
       aws-sdk-secretsmanager (~> 1.0)
       mandate
@@ -484,7 +484,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   commonmarker
   devise (~> 4.7.1)
-  exercism-config (>= 0.75.0)
+  exercism-config (>= 0.76.0)
   factory_bot_rails
   friendly_id (~> 5.4.0)
   haml_lint

--- a/app/models/concerns/has_tooling_job.rb
+++ b/app/models/concerns/has_tooling_job.rb
@@ -1,0 +1,14 @@
+module HasToolingJob
+  extend ActiveSupport::Concern
+  extend Mandate::Memoize
+
+  private
+  memoize
+  def tooling_job
+    Exercism::ToolingJob.new(tooling_job_id, {})
+  end
+
+  included do
+    delegate :stdout, :stderr, :metadata, to: :tooling_job
+  end
+end

--- a/app/models/submission/analysis.rb
+++ b/app/models/submission/analysis.rb
@@ -1,5 +1,6 @@
 class Submission::Analysis < ApplicationRecord
   extend Mandate::Memoize
+  include HasToolingJob
 
   serialize :data, JSON
 

--- a/app/models/submission/representation.rb
+++ b/app/models/submission/representation.rb
@@ -1,5 +1,6 @@
 class Submission::Representation < ApplicationRecord
   extend Mandate::Memoize
+  include HasToolingJob
 
   def self.digest_ast(ast)
     return nil if ast.blank?

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -1,5 +1,6 @@
 class Submission::TestRun < ApplicationRecord
   extend Mandate::Memoize
+  include HasToolingJob
 
   serialize :raw_results, JSON
 

--- a/test/commands/tooling_job/process_test.rb
+++ b/test/commands/tooling_job/process_test.rb
@@ -58,6 +58,5 @@ class ToolingJob::ProcessTest < ActiveSupport::TestCase
 
     redis = Exercism.redis_tooling_client
     assert_nil redis.lindex(Exercism::ToolingJob.key_for_executed, 0)
-    assert_equal job.id, redis.lindex(Exercism::ToolingJob.key_for_processed, 0)
   end
 end

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -101,5 +101,20 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal test_as_hash, result.as_json(1, 2, 3) # Test with arbitary args
   end
 
+  test "tooling_job" do
+    submission = create :submission
+    job = create_test_runner_job!(submission)
+    Submission::TestRun::Process.(job)
+    test_run = submission.test_run
+
+    Exercism::ToolingJob.expects(:new).with(test_run.tooling_job_id, {}).returns(job)
+    job.expects(:stdout)
+    job.expects(:stderr)
+    job.expects(:metadata)
+    test_run.stdout
+    test_run.stderr
+    test_run.metadata
+  end
+
   # TODO: - Add a test for if the raw_results is empty
 end


### PR DESCRIPTION
This is basically updating the gem, and adding a helper file.

There's one hole in this atm, which is that doing `find` after a job has been processed won't work any more, so we have to use `new, {}` but I'll refactor this later when we're under less time pressures.