### PR TITLE
Update iterations-footer.css

### DIFF
--- a/app/css/components/iterations-footer.css
+++ b/app/css/components/iterations-footer.css
@@ -1,6 +1,7 @@
 .c-iterations-footer {
     @apply flex items-center px-24 py-16;
     z-index: 1;
+    overflow-x: auto;
 
     background: linear-gradient(
         180deg,


### PR DESCRIPTION
When there are many iterations that overflow, the footer is not responsive, so to make up for this error without a lot of work that the iterations/additional options in the footer are cut off, I added an option \`overflow-x: auto\` to allow the footer to scroll if there are many iterations.