### PR TITLE
Two fixes for the mentor track selection page

### DIFF
--- a/app/helpers/react_components/mentoring/try_mentoring_button.rb
+++ b/app/helpers/react_components/mentoring/try_mentoring_button.rb
@@ -25,7 +25,7 @@ module ReactComponents
       def links
         {
           choose_track_step: {
-            tracks: Exercism::Routes.api_tracks_url
+            tracks: Exercism::Routes.api_mentoring_tracks_url
           },
           commit_step: {
             code_of_conduct: Exercism::Routes.code_of_conduct_path,

--- a/app/javascript/components/modals/mentor-registration-modal/ChooseTrackStep.tsx
+++ b/app/javascript/components/modals/mentor-registration-modal/ChooseTrackStep.tsx
@@ -20,7 +20,7 @@ export const ChooseTrackStep = ({
     <section className="tracks-section">
       <h2>Select the tracks you want to mentor</h2>
       <p>
-        This allows us to only show you the solutions you want to mentor.
+        This allows us to only show you the solutions you want to mentor.{' '}
         <strong>
           Don’t worry, you can change these selections at anytime.
         </strong>


### PR DESCRIPTION
I noticed two problems with the mentor track selection page:
 1. The number of solutions queued is missing.
 2. There should be a space between the two sentences when signing up to be a mentor.

![image](https://user-images.githubusercontent.com/6759716/135523236-4b5c5912-3402-4e82-85f8-26bf5f0f276e.png)
