### PR TITLE
Update site updates when exercises change and add wip guard

### DIFF
--- a/app/commands/concept_exercise/create.rb
+++ b/app/commands/concept_exercise/create.rb
@@ -10,10 +10,7 @@ class ConceptExercise
         track: track,
         **attributes
       ).tap do |exercise|
-        SiteUpdates::NewExerciseUpdate.create!(
-          exercise: exercise,
-          track: track
-        )
+        SiteUpdates::ProcessNewExerciseUpdate.(exercise)
       end
     rescue ActiveRecord::RecordNotUnique
       ConceptExercise.find_by!(uuid: uuid, track: track)

--- a/app/commands/git/sync_concept_exercise.rb
+++ b/app/commands/git/sync_concept_exercise.rb
@@ -27,6 +27,7 @@ module Git
 
       SyncExerciseAuthors.(exercise)
       SyncExerciseContributors.(exercise)
+      SiteUpdates::ProcessNewExerciseUpdate.(exercise)
     end
 
     private

--- a/app/commands/git/sync_practice_exercise.rb
+++ b/app/commands/git/sync_practice_exercise.rb
@@ -28,6 +28,7 @@ module Git
 
       SyncExerciseAuthors.(exercise)
       SyncExerciseContributors.(exercise)
+      SiteUpdates::ProcessNewExerciseUpdate.(exercise)
     end
 
     private

--- a/app/commands/practice_exercise/create.rb
+++ b/app/commands/practice_exercise/create.rb
@@ -10,10 +10,7 @@ class PracticeExercise
         track: track,
         **attributes
       ).tap do |exercise|
-        SiteUpdates::NewExerciseUpdate.create!(
-          exercise: exercise,
-          track: track
-        )
+        SiteUpdates::ProcessNewExerciseUpdate.(exercise)
       end
     rescue ActiveRecord::RecordNotUnique
       PracticeExercise.find_by!(uuid: uuid, track: track)

--- a/app/commands/site_updates/process_new_exercise_update.rb
+++ b/app/commands/site_updates/process_new_exercise_update.rb
@@ -1,0 +1,40 @@
+module SiteUpdates
+  class ProcessNewExerciseUpdate
+    include Mandate
+
+    initialize_with :exercise
+
+    def call
+      if exercise.wip?
+        destroy!
+      else
+        begin
+          create!
+        rescue ActiveRecord::RecordNotUnique
+          update!
+        end
+      end
+    end
+
+    def destroy!
+      SiteUpdates::NewExerciseUpdate.where(
+        exercise: exercise,
+        track: exercise.track
+      ).destroy_all
+    end
+
+    def create!
+      SiteUpdates::NewExerciseUpdate.create!(
+        exercise: exercise,
+        track: exercise.track
+      )
+    end
+
+    def update!
+      SiteUpdates::NewExerciseUpdate.find_by!(
+        exercise: exercise,
+        track: exercise.track
+      ).regenerate_rendering_data!
+    end
+  end
+end

--- a/app/commands/site_updates/process_new_exercise_update.rb
+++ b/app/commands/site_updates/process_new_exercise_update.rb
@@ -5,7 +5,7 @@ module SiteUpdates
     initialize_with :exercise
 
     def call
-      if exercise.wip?
+      if exercise.wip? || exercise.deprecated?
         destroy!
       else
         begin

--- a/app/models/concerns/is_paramaterised_sti.rb
+++ b/app/models/concerns/is_paramaterised_sti.rb
@@ -108,6 +108,10 @@ module IsParamaterisedSTI
     end
   end
 
+  def regenerate_rendering_data!
+    update!(rendering_data_cache: {})
+  end
+
   def rendering_data
     data = rendering_data_cache
     if data.blank?

--- a/db/migrate/20211001151540_add_index_to_uniqueness_key_on_site_updates.rb
+++ b/db/migrate/20211001151540_add_index_to_uniqueness_key_on_site_updates.rb
@@ -1,0 +1,5 @@
+class AddIndexToUniquenessKeyOnSiteUpdates < ActiveRecord::Migration[6.1]
+  def change
+    add_index :site_updates, :uniqueness_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_25_111900) do
+ActiveRecord::Schema.define(version: 2021_10_01_151540) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -449,6 +449,7 @@ ActiveRecord::Schema.define(version: 2021_09_25_111900) do
     t.index ["exercise_id"], name: "index_site_updates_on_exercise_id"
     t.index ["pull_request_id"], name: "index_site_updates_on_pull_request_id"
     t.index ["track_id"], name: "index_site_updates_on_track_id"
+    t.index ["uniqueness_key"], name: "index_site_updates_on_uniqueness_key", unique: true
   end
 
   create_table "solution_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/test/commands/concept_exercise/create_test.rb
+++ b/test/commands/concept_exercise/create_test.rb
@@ -66,15 +66,12 @@ class ConceptExercise::CreateTest < ActiveSupport::TestCase
   end
 
   test "creates site_update" do
-    track = create :track
-    exercise = ConceptExercise::Create.(
+    SiteUpdates::ProcessNewExerciseUpdate.expects(:call)
+
+    ConceptExercise::Create.(
       SecureRandom.uuid,
-      track,
+      create(:track),
       build(:concept_exercise).attributes.symbolize_keys
     )
-
-    update = SiteUpdate.first
-    assert_equal exercise, update.exercise
-    assert_equal track, update.track
   end
 end

--- a/test/commands/git/sync_concept_exercise_test.rb
+++ b/test/commands/git/sync_concept_exercise_test.rb
@@ -352,4 +352,11 @@ class Git::SyncConceptExerciseTest < ActiveSupport::TestCase
 
     assert_equal 'log-levels', exercise.slug
   end
+
+  test "updates site_update" do
+    exercise = create :concept_exercise, uuid: 'f4f7de13-a9ee-4251-8796-006ed85b3f70', slug: 'logs', git_sha: "c75486b75db8012646b0e1c667cb1db47ff5a9d5", synced_to_git_sha: "c75486b75db8012646b0e1c667cb1db47ff5a9d5" # rubocop:disable Layout/LineLength
+    SiteUpdates::ProcessNewExerciseUpdate.expects(:call).with(exercise)
+
+    Git::SyncConceptExercise.(exercise, force_sync: true)
+  end
 end

--- a/test/commands/git/sync_practice_exercise_test.rb
+++ b/test/commands/git/sync_practice_exercise_test.rb
@@ -333,4 +333,11 @@ class Git::SyncPracticeExerciseTest < ActiveSupport::TestCase
 
     assert exercise.reload.has_test_runner?
   end
+
+  test "updates site_update" do
+    exercise = create :practice_exercise, uuid: '185b964c-1ec1-4d60-b9b9-fa20b9f57b4a'
+    SiteUpdates::ProcessNewExerciseUpdate.expects(:call).with(exercise)
+
+    Git::SyncPracticeExercise.(exercise, force_sync: true)
+  end
 end

--- a/test/commands/practice_exercise/create_test.rb
+++ b/test/commands/practice_exercise/create_test.rb
@@ -61,15 +61,12 @@ class PracticeExercise::CreateTest < ActiveSupport::TestCase
   end
 
   test "creates site_update" do
-    track = create :track
-    exercise = PracticeExercise::Create.(
+    SiteUpdates::ProcessNewExerciseUpdate.expects(:call)
+
+    PracticeExercise::Create.(
       SecureRandom.uuid,
-      track,
+      create(:track),
       build(:practice_exercise).attributes.symbolize_keys
     )
-
-    update = SiteUpdate.first
-    assert_equal exercise, update.exercise
-    assert_equal track, update.track
   end
 end

--- a/test/commands/site_updates/process_new_exercise_update_test.rb
+++ b/test/commands/site_updates/process_new_exercise_update_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ConceptExercise::CreateTest < ActiveSupport::TestCase
+class SiteUpdates::ProcessNewExerciseUpdateTest < ActiveSupport::TestCase
   %i[active beta].each do |status|
     test "creates if #{status}" do
       exercise = create :concept_exercise, status: status

--- a/test/commands/site_updates/process_new_exercise_update_test.rb
+++ b/test/commands/site_updates/process_new_exercise_update_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class ConceptExercise::CreateTest < ActiveSupport::TestCase
+  test "no-op if wip and not present" do
+    exercise = create :concept_exercise, status: :wip
+
+    SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    refute SiteUpdate.exists?
+  end
+
+  test "deletes if wip and was present" do
+    exercise = create :concept_exercise, status: :wip
+
+    create :new_exercise_site_update, exercise: exercise
+
+    SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    refute SiteUpdate.exists?
+  end
+
+  test "creates if not wip" do
+    exercise = create :concept_exercise
+
+    SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    assert SiteUpdate.where(exercise: exercise).exists?
+  end
+
+  test "updates if not wip and exists" do
+    exercise = create :concept_exercise
+    update = create :new_exercise_site_update, exercise: exercise
+    update.update_column(:rendering_data_cache, { "foo" => "bar" })
+    assert_equal({ "foo" => "bar" }, update.rendering_data_cache) # Sanity
+
+    SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    assert_equal JSON.parse(update.cacheable_rendering_data.to_json), update.reload.rendering_data_cache
+  end
+end


### PR DESCRIPTION
This moves the guarding and updating into one command.

We currently have a race condition where this happens:
- Exercise created
- Site updated created
- Authors added

This change means that every time the exercise syncs, the site update is refreshed, not just when it's created.

---

Closes https://github.com/exercism/website/pull/2009
