### PR TITLE
Make timeouts explicit

### DIFF
--- a/app/javascript/components/editor/TestRunSummary.tsx
+++ b/app/javascript/components/editor/TestRunSummary.tsx
@@ -161,7 +161,7 @@ const TestRunSummaryContent = ({
           <p>
             Your tests timed out. This might mean that there was an issue in our
             infrastructure, but more likely it suggests that your code is
-            running slowly. Could you have an infinite loop or similar?
+            running slowly. Is there an infinite loop or something similar?
           </p>
           <p>
             Please check your code, and if nothing seems to be wrong, try

--- a/app/javascript/components/editor/TestRunSummary.tsx
+++ b/app/javascript/components/editor/TestRunSummary.tsx
@@ -160,8 +160,8 @@ const TestRunSummaryContent = ({
         <div className="ops-error">
           <p>
             Your tests timed out. This might mean that there was an issue in our
-            infrastructure, or it might mean that you have some infinite loop in
-            your code.
+            infrastructure, but more likely it suggests that your code is
+            running slowly. Could you have an infinite loop or similar?
           </p>
           <p>
             Please check your code, and if nothing seems to be wrong, try

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -28,6 +28,10 @@ class Submission::TestRun < ApplicationRecord
     ops_status == 200
   end
 
+  def timed_out?
+    ops_status == 408
+  end
+
   def ops_errored?
     !ops_success?
   end

--- a/app/serializers/serialize_submission_test_run.rb
+++ b/app/serializers/serialize_submission_test_run.rb
@@ -25,6 +25,7 @@ class SerializeSubmissionTestRun
 
   private
   def status
+    return TIMEOUT_STATUS if test_run.timed_out?
     return OPS_ERROR_STATUS unless test_run.ops_success?
     return :error unless VALID_STATUSES.include?(test_run.status)
 
@@ -39,7 +40,8 @@ class SerializeSubmissionTestRun
   end
 
   OPS_ERROR_STATUS = "ops_error".freeze
-  private_constant :OPS_ERROR_STATUS
+  TIMEOUT_STATUS = "timeout".freeze
+  private_constant :OPS_ERROR_STATUS, :TIMEOUT_STATUS
 
   VALID_STATUSES = %i[pass fail error].freeze
   private_constant :VALID_STATUSES

--- a/test/serializers/serialize_submission_test_run_test.rb
+++ b/test/serializers/serialize_submission_test_run_test.rb
@@ -63,6 +63,16 @@ class SerializeSubmissionTestRunTest < ActiveSupport::TestCase
     assert_equal :error, output[:status]
   end
 
+  test "status: returns timeout if timed out" do
+    test_run = create :submission_test_run,
+      ops_status: 408,
+      status: 'foobar'
+
+    output = SerializeSubmissionTestRun.(test_run)
+
+    assert_equal 'timeout', output[:status]
+  end
+
   test "status: returns error if unexpected" do
     test_run = create :submission_test_run,
       ops_status: 200,


### PR DESCRIPTION
Rather than showing a general error message, explicitely say if the tests timed out.

<img width="479" alt="Screenshot 2021-10-02 at 20 57 29" src="https://user-images.githubusercontent.com/286476/135730252-b25cb973-255c-454e-a319-433666b672bb.png">

---

Fixes https://github.com/exercism/exercism/issues/6006
