### PR TITLE
Clear iteration.published_at and solution.completed_at in Iteration::Destroy when needed

### DIFF
--- a/app/commands/iteration/destroy.rb
+++ b/app/commands/iteration/destroy.rb
@@ -6,7 +6,8 @@ class Iteration
 
     def call
       iteration.update!(deleted_at: Time.current)
-      solution.update!(published_iteration_id: nil) if solution.published_iteration_id == iteration.id
+      solution.update!(published_iteration_id: nil, published_at: nil) if solution.published_iteration_id == iteration.id
+      solution.update!(completed_at: nil) if solution.iterations.not_deleted.empty?
     end
 
     private

--- a/app/commands/iteration/destroy.rb
+++ b/app/commands/iteration/destroy.rb
@@ -7,7 +7,7 @@ class Iteration
     def call
       iteration.update!(deleted_at: Time.current)
       solution.update!(published_iteration_id: nil, published_at: nil) if solution.published_iteration_id == iteration.id
-      solution.update!(completed_at: nil) if solution.iterations.not_deleted.empty?
+      solution.update!(completed_at: nil) unless solution.iterations.not_deleted.exists?
     end
 
     private

--- a/app/commands/iteration/destroy.rb
+++ b/app/commands/iteration/destroy.rb
@@ -6,7 +6,11 @@ class Iteration
 
     def call
       iteration.update!(deleted_at: Time.current)
+
+      # Unpublish the solution if this was the published iteration
       solution.update!(published_iteration_id: nil, published_at: nil) if solution.published_iteration_id == iteration.id
+
+      # Uncomplete the solution if there are now no iterations
       solution.update!(completed_at: nil) unless solution.iterations.not_deleted.exists?
     end
 

--- a/test/commands/iteration/destroy_test.rb
+++ b/test/commands/iteration/destroy_test.rb
@@ -9,13 +9,61 @@ class Iteration::DestroyTest < ActiveSupport::TestCase
     assert iteration.deleted?
   end
 
-  test "updates published iteration on solution" do
+  test "unpublishes solution if iteration was published iteration" do
     iteration = create :iteration
-    iteration.solution.update!(published_iteration: iteration)
+    iteration.solution.update!(published_iteration: iteration, published_at: Time.current)
 
     Iteration::Destroy.(iteration)
 
     assert iteration.deleted?
     assert_nil iteration.solution.published_iteration
+    assert_nil iteration.solution.published_at
+  end
+
+  test "does not unpublish solution if iteration was not published iteration" do
+    freeze_time do
+      iteration = create :iteration
+      published_iteration = create :iteration, solution: iteration.solution
+      published_iteration.solution.update!(published_iteration: published_iteration, published_at: Time.current)
+
+      Iteration::Destroy.(iteration)
+
+      assert iteration.deleted?
+      assert_equal published_iteration, iteration.solution.published_iteration
+      assert_equal Time.current, iteration.solution.published_at
+    end
+  end
+
+  test "uncompletes solution if deleted iteration was only iteration" do
+    iteration = create :iteration
+    iteration.solution.update!(published_iteration: iteration, published_at: Time.current, completed_at: Time.current)
+
+    Iteration::Destroy.(iteration)
+
+    assert_nil iteration.solution.completed_at
+  end
+
+  test "uncompletes solution if only deleted iterations remain" do
+    iteration = create :iteration
+    create :iteration, solution: iteration.solution, deleted_at: Time.current
+    create :iteration, solution: iteration.solution, deleted_at: Time.current
+    iteration.solution.update!(published_iteration: iteration, published_at: Time.current, completed_at: Time.current)
+
+    Iteration::Destroy.(iteration)
+
+    assert_nil iteration.solution.completed_at
+  end
+
+  test "does not uncomplete solution if a non-deleted iteration remains" do
+    freeze_time do
+      iteration = create :iteration
+      create :iteration, solution: iteration.solution, deleted_at: Time.current
+      create :iteration, solution: iteration.solution # non-deleted iteration
+      iteration.solution.update!(published_iteration: iteration, published_at: Time.current, completed_at: Time.current)
+
+      Iteration::Destroy.(iteration)
+
+      assert_equal Time.current, iteration.solution.completed_at
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5909
