### PR TITLE
Fix typos in `publish-exercise` modal

### DIFF
--- a/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
@@ -30,8 +30,8 @@ export const PublishSolutionModal = ({
         <div className="title">Publish your code and share your knowledge</div>
         <p>
           By publishing your code, you'll help others learn from your work. You
-          can choose which iterations you publish, add more iterations once its
-          publish, and unpublish it at any time.
+          can choose which iterations you publish, add more iterations once it's
+          published, and unpublish it at any time.
         </p>
         <PublishSolutionForm
           endpoint={endpoint}

--- a/app/views/temp/modals/publish_exercise.html.haml
+++ b/app/views/temp/modals/publish_exercise.html.haml
@@ -6,7 +6,7 @@
         Publish your code and share your knowledge
       %p
         By publishing your code, you’ll help others learn from your work.
-        You can choose which iterations you publish, add more iterations once its published, and unpublish it at any time.
+        You can choose which iterations you publish, add more iterations once it's published, and unpublish it at any time.
 
       / TODO: There's probably a11y stuff to add to this tag
       / If there's not, it can be deleted


### PR DESCRIPTION
`its publish` -> `it's published`

Also fixes inconsistency between `.haml` and `.tsx` files for this modal.