### PR TITLE
Allow for not-null solutions.num_loc

### DIFF
--- a/app/serializers/serialize_community_solution.rb
+++ b/app/serializers/serialize_community_solution.rb
@@ -11,7 +11,7 @@ class SerializeCommunitySolution
       num_stars: solution.num_stars,
       num_comments: solution.num_comments,
       num_iterations: solution.num_iterations,
-      num_loc: solution.num_loc,
+      num_loc: solution.num_loc.presence, # Currently this column is not-null in production
       iteration_status: solution.iteration_status,
       published_at: solution.published_at,
       is_out_of_date: solution.out_of_date?,

--- a/app/serializers/serialize_solution.rb
+++ b/app/serializers/serialize_solution.rb
@@ -19,7 +19,7 @@ class SerializeSolution
       num_stars: solution.num_stars,
       num_comments: solution.num_comments,
       num_iterations: solution.num_iterations,
-      num_loc: solution.num_loc,
+      num_loc: solution.num_loc.presence, # Currently this column is not-null in production
       is_out_of_date: solution.out_of_date?,
 
       published_at: solution.published_at&.iso8601,

--- a/test/serializers/serialize_community_solution_test.rb
+++ b/test/serializers/serialize_community_solution_test.rb
@@ -38,4 +38,10 @@ class SerializeCommunitySolutionTest < ActiveSupport::TestCase
 
     assert_equal expected, SerializeCommunitySolution.(solution)
   end
+
+  test "num_loc works" do
+    solution = create :practice_solution, num_loc: 10
+    output = SerializeCommunitySolution.(solution)
+    assert_equal 10, output[:num_loc]
+  end
 end

--- a/test/serializers/serialize_community_solution_test.rb
+++ b/test/serializers/serialize_community_solution_test.rb
@@ -12,7 +12,7 @@ class SerializeCommunitySolutionTest < ActiveSupport::TestCase
       num_stars: solution.num_stars,
       num_comments: solution.num_comments,
       num_iterations: solution.num_iterations,
-      num_loc: solution.num_loc,
+      num_loc: nil,
       iteration_status: iteration.status.to_s.to_sym,
       published_at: solution.published_at,
       is_out_of_date: solution.out_of_date?,

--- a/test/serializers/serialize_solution_test.rb
+++ b/test/serializers/serialize_solution_test.rb
@@ -18,7 +18,7 @@ class SerializeSolutionTest < ActiveSupport::TestCase
       num_stars: solution.num_stars,
       num_comments: solution.num_comments,
       num_iterations: solution.num_iterations,
-      num_loc: solution.num_loc,
+      num_loc: nil,
       published_at: solution.published_at.iso8601,
       completed_at: solution.completed_at.iso8601,
       updated_at: solution.updated_at.iso8601,

--- a/test/serializers/serialize_solution_test.rb
+++ b/test/serializers/serialize_solution_test.rb
@@ -39,6 +39,12 @@ class SerializeSolutionTest < ActiveSupport::TestCase
     assert_equal expected, SerializeSolution.(solution, user_track: user_track)
   end
 
+  test "num_loc works" do
+    solution = create :practice_solution, num_loc: 10
+    output = SerializeSolution.(solution)
+    assert_equal 10, output[:num_loc]
+  end
+
   test "with no submissions" do
     solution = create :practice_solution, status: :published, published_at: Time.current - 1.week, completed_at: Time.current
     user_track = create :user_track, user: solution.user, track: solution.track


### PR DESCRIPTION
Since in production, `solutions.num_loc` is not null, and instead 0 by default, we need to guard this in the website.