### PR TITLE
Improve eslint conformance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
       version: 'detect',
     },
   },
+  ignorePatterns: ['**/*.config.js', '**/config/webpack/*.js', '.eslintrc.js'],
   overrides: [
     {
       files: ['*.ts', '*.tsx'],

--- a/app/javascript/images/GlobalImageStub.js
+++ b/app/javascript/images/GlobalImageStub.js
@@ -1,1 +1,0 @@
-module.exports = {}

--- a/test/javascript/setupTests.js
+++ b/test/javascript/setupTests.js
@@ -14,6 +14,7 @@ afterEach(async () => {
   // waitFor is important here. If there are queries that are being fetched at
   // the end of the test and we continue on to the next test before waiting for
   // them to finalize, the tests can impact each other in strange ways.
+  // eslint-disable-next-line jest/no-standalone-expect
   await waitFor(() => expect(queryCache.isFetching).toBe(0))
 
   await flushPromises()


### PR DESCRIPTION
This takes a step towards #200 but does not finish the work. `app/javascript/hooks/use-list.js` needs boundary types, after an hour I decided to give this first part to PR while I try to understand the type structure over there.

- Exclude config files from eslint
- Change stub to ES6 module format
- Carve linting exception for test setup