### PR TITLE
Speed things up

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Tests](https://github.com/exercism/website/workflows/Tests/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/b47ec4d5081d8abb59fa/maintainability)](https://codeclimate.com/github/exercism/website/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/b47ec4d5081d8abb59fa/test_coverage)](https://codeclimate.com/github/exercism/website/test_coverage)
+[![View performance data on Skylight](https://badges.skylight.io/typical/VNpB7GqXZDpQ.svg)](https://oss.skylight.io/app/applications/VNpB7GqXZDpQ)
 
 This is the website component of Exercism. It is Ruby on Rails app, backed by MySQL. It also relies on Redis and AnyCable.
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,10 +257,7 @@ class User < ApplicationRecord
     dismissed_introducers.where(slug: slug).exists?
   end
 
-  # TODO: Remove if not used by launch
-  # def favorited_by?(mentor)
-  #   relationship = Mentor::StudentRelationship.find_by(student: self, mentor: mentor)
-
-  #   relationship ? relationship.favorited? : false
-  # end
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end

--- a/db/migrate/20211028110123_change_solutions_num_loc_to_null.rb
+++ b/db/migrate/20211028110123_change_solutions_num_loc_to_null.rb
@@ -1,5 +1,6 @@
 class ChangeSolutionsNumLocToNull < ActiveRecord::Migration[6.1]
   def change
     change_column_null :solutions, :num_loc, true
+    change_column_default :solutions, :num_loc, nil
   end
 end

--- a/db/migrate/20211101120614_add_extra_indexes.rb
+++ b/db/migrate/20211101120614_add_extra_indexes.rb
@@ -1,0 +1,14 @@
+class AddExtraIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :unconfirmed_email, if_not_exists: true
+
+    add_index :user_reputation_tokens, [:user_id, :type], name: 'index_user_reputation_tokens_query_1', if_not_exists: true
+    add_index :user_reputation_tokens, [:user_id, :track_id, :type], name: 'index_user_reputation_tokens_query_2', if_not_exists: true
+    add_index :user_reputation_tokens, [:user_id, :earned_on, :type], name: 'index_user_reputation_tokens_query_3', if_not_exists: true
+    add_index :user_reputation_tokens, [:user_id, :track_id, :earned_on, :type], name: 'index_user_reputation_tokens_query_4', if_not_exists: true
+
+    add_index :mentor_requests, :uuid, name: 'index_mentor_requests_on_uuid', unique: true, if_not_exists: true
+
+    add_foreign_key :solution_comments, :solutions
+  end
+end

--- a/db/migrate/20211101120614_add_extra_indexes.rb
+++ b/db/migrate/20211101120614_add_extra_indexes.rb
@@ -9,6 +9,6 @@ class AddExtraIndexes < ActiveRecord::Migration[6.1]
 
     add_index :mentor_requests, :uuid, name: 'index_mentor_requests_on_uuid', unique: true, if_not_exists: true
 
-    add_foreign_key :solution_comments, :solutions
+    add_foreign_key :solution_comments, :solutions unless foreign_key_exists?(:solution_comments, :solutions)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_110123) do
+ActiveRecord::Schema.define(version: 2021_11_01_120614) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -391,6 +391,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_110123) do
     t.index ["student_id"], name: "index_mentor_requests_on_student_id"
     t.index ["track_id", "status"], name: "index_mentor_requests_on_track_id_and_status"
     t.index ["track_id"], name: "index_mentor_requests_on_track_id"
+    t.index ["uuid"], name: "index_mentor_requests_on_uuid", unique: true
   end
 
   create_table "mentor_student_relationships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -523,7 +524,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_110123) do
     t.integer "num_views", limit: 3, default: 0, null: false
     t.integer "num_stars", limit: 3, default: 0, null: false
     t.integer "num_comments", limit: 3, default: 0, null: false
-    t.integer "num_loc"
+    t.integer "num_loc", limit: 3, default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
@@ -807,6 +808,10 @@ ActiveRecord::Schema.define(version: 2021_10_28_110123) do
     t.index ["exercise_id"], name: "index_user_reputation_tokens_on_exercise_id"
     t.index ["track_id"], name: "index_user_reputation_tokens_on_track_id"
     t.index ["uniqueness_key", "user_id"], name: "index_user_reputation_tokens_on_uniqueness_key_and_user_id", unique: true
+    t.index ["user_id", "earned_on", "type"], name: "index_user_reputation_tokens_query_3"
+    t.index ["user_id", "track_id", "earned_on", "type"], name: "index_user_reputation_tokens_query_4"
+    t.index ["user_id", "track_id", "type"], name: "index_user_reputation_tokens_query_2"
+    t.index ["user_id", "type"], name: "index_user_reputation_tokens_query_1"
     t.index ["user_id"], name: "index_user_reputation_tokens_on_user_id"
     t.index ["uuid"], name: "index_user_reputation_tokens_on_uuid", unique: true
   end
@@ -878,6 +883,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_110123) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
+    t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -524,7 +524,7 @@ ActiveRecord::Schema.define(version: 2021_11_01_120614) do
     t.integer "num_views", limit: 3, default: 0, null: false
     t.integer "num_stars", limit: 3, default: 0, null: false
     t.integer "num_comments", limit: 3, default: 0, null: false
-    t.integer "num_loc", limit: 3, default: 0
+    t.integer "num_loc", limit: 3
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"

--- a/test/system/flows/settings/user_resends_confirmation_email_test.rb
+++ b/test/system/flows/settings/user_resends_confirmation_email_test.rb
@@ -12,12 +12,17 @@ module Flows
         create :user_profile, user: user
 
         use_capybara_host do
-          sign_in!(user)
+          perform_enqueued_jobs do
+            sign_in!(user)
 
-          visit settings_path
-          change_email
-          visit settings_path
-          click_on "Resend email"
+            visit settings_path
+            change_email
+            visit settings_path
+
+            click_on "Resend email"
+
+            sleep(0.1)
+          end
 
           assert_text "We've sent a confirmation email to newemail@exercism.org"
           assert_equal 3, ActionMailer::Base.deliveries.count


### PR DESCRIPTION
This PR speeds up the slowest requests by about 2s, the average 95th percentile request by 50ms. I also added another missing index in production on the auth-tokens, which has sped up all API requests by about 200ms.

I've already run the migrations in production FYI.