### PR TITLE
Fix reputation not being assigned to tracks correctly

### DIFF
--- a/app/models/user/reputation_tokens/mentored_token.rb
+++ b/app/models/user/reputation_tokens/mentored_token.rb
@@ -7,7 +7,9 @@ class User::ReputationTokens::MentoredToken < User::ReputationToken
   value 5
 
   before_validation on: :create do
-    self.earned_on = self.discussion.finished_at unless earned_on
+    self.track = discussion.track unless track
+    self.exercise = discussion.exercise unless exercise
+    self.earned_on = discussion.finished_at unless earned_on
   end
 
   def guard_params

--- a/app/models/user/reputation_tokens/published_solution_token.rb
+++ b/app/models/user/reputation_tokens/published_solution_token.rb
@@ -6,7 +6,9 @@ class User::ReputationTokens::PublishedSolutionToken < User::ReputationToken
   values({ concept: 1, easy: 1, medium: 2, hard: 3 })
 
   before_validation on: :create do
-    self.earned_on = self.solution.published_at unless earned_on
+    self.track = solution.track unless track
+    self.exercise = solution.exercise unless exercise
+    self.earned_on = solution.published_at unless earned_on
   end
 
   def guard_params

--- a/test/models/user/reputation_tokens/mentored_token_test.rb
+++ b/test/models/user/reputation_tokens/mentored_token_test.rb
@@ -24,5 +24,7 @@ class User::ReputationTokens::MentoredTokenTest < ActiveSupport::TestCase
     assert_equal 5, rt.value
     assert_equal discussion.finished_at.to_date, rt.earned_on
     assert_equal Exercism::Routes.mentoring_discussion_url(discussion), rt.rendering_data[:internal_url]
+    assert_equal discussion.track, rt.track
+    assert_equal discussion.exercise, rt.exercise
   end
 end

--- a/test/models/user/reputation_tokens/published_solution_token_test.rb
+++ b/test/models/user/reputation_tokens/published_solution_token_test.rb
@@ -24,6 +24,8 @@ class User::ReputationTokens::PublishedSolutionTokenTest < ActiveSupport::TestCa
     assert_equal 2, rt.value
     assert_equal solution.published_at.to_date, rt.earned_on
     assert_equal Exercism::Routes.published_solution_url(solution), rt.rendering_data[:internal_url]
+    assert_equal solution.track, rt.track
+    assert_equal solution.exercise, rt.exercise
   end
 
   test "correct levels" do


### PR DESCRIPTION
This fixes the bug. I then need to reprocess the data for all reputation without a track.

---

Fixes https://github.com/exercism/exercism/issues/6065
Fixes https://github.com/exercism/exercism/issues/5948
Fixes https://github.com/exercism/exercism/issues/5824

---

Currently running:
```ruby
def update_mentored_tokens(tokens)
  tokens.each do |token|
    token.update(track: token.discussion.track, exercise: token.discussion.exercise)

    User::ReputationPeriod::MarkForNewToken.(token)
  end
end

def update_published_tokens(tokens)
  tokens.each do |token|
    token.update(track: token.solution.track, exercise: token.solution.exercise)

    User::ReputationPeriod::MarkForNewToken.(token)
  end
end

def cycle_mentored
  while true
    tokens = User::ReputationTokens::MentoredToken.where(track_id: nil).limit(50)
    return if tokens.empty?

    update_mentored_tokens(tokens)
  end
end

def cycle_published
  while true
    tokens = User::ReputationTokens::PublishedSolutionToken.where(track_id: nil).limit(50)
    return if tokens.empty?

    update_published_tokens(tokens)
  end
end


cycle_mentored()
cycle_published()
```