### PR TITLE
fixes typos like 'once its publish'

### DIFF
--- a/app/css/pages/editor.css
+++ b/app/css/pages/editor.css
@@ -166,7 +166,7 @@
                             }
 
                             /* It would be nice to DRY this up with application.css
-                             * but its tricky with the adjecent element. */
+                             * but it's tricky with the adjacent element. */
                             &:focus {
                                 & + .label {
                                     outline: 5px auto -webkit-focus-ring-color;

--- a/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
+++ b/app/javascript/components/misc/CodeMirror/a11yTabBinding.ts
@@ -135,7 +135,7 @@ export function a11yTabBindingPanel() {
     showPanel.of(createA11yTabBindingPanel),
     a11yTabBindingPanelTheme,
 
-    // We'll ideally add this here too, but currently its needed
+    // We'll ideally add this here too, but currently it's needed
     // for when the editor gets reconfigured downstream of this.
     // tabCaptureCompartment.of( keymap.of(isTabCaptured ? [a11yTabBinding] : [])),
   ]

--- a/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/PublishSolutionModal.tsx
@@ -30,8 +30,8 @@ export const PublishSolutionModal = ({
         <div className="title">Publish your code and share your knowledge</div>
         <p>
           By publishing your code, you'll help others learn from your work. You
-          can choose which iterations you publish, add more iterations once its
-          publish, and unpublish it at any time.
+          can choose which iterations you publish, add more iterations once it's
+          published, and unpublish it at any time.
         </p>
         <PublishSolutionForm
           endpoint={endpoint}

--- a/app/views/temp/modals/publish_exercise.html.haml
+++ b/app/views/temp/modals/publish_exercise.html.haml
@@ -6,7 +6,7 @@
         Publish your code and share your knowledge
       %p
         By publishing your code, you’ll help others learn from your work.
-        You can choose which iterations you publish, add more iterations once its published, and unpublish it at any time.
+        You can choose which iterations you publish, add more iterations once it's published, and unpublish it at any time.
 
       / TODO: There's probably a11y stuff to add to this tag
       / If there's not, it can be deleted

--- a/test/commands/track/search_test.rb
+++ b/test/commands/track/search_test.rb
@@ -42,7 +42,7 @@ class Track::SearchTest < ActiveSupport::TestCase
     end
   end
 
-  test "status: raises unless its valid" do
+  test "status: raises unless it's valid" do
     assert_raises TrackSearchInvalidStatusError do
       Track::Search.(status: :foobar, user: create(:user))
     end

--- a/test/flows/exercise_flows_test.rb
+++ b/test/flows/exercise_flows_test.rb
@@ -14,7 +14,7 @@ class ExerciseFlowsTest < ActiveSupport::TestCase
     create :hello_world_solution, :completed, track: track, user: user
 
     # User joins the track
-    # Check its retrieved correctly.
+    # Check it's retrieved correctly.
     ut = UserTrack::Create.(user, track)
     assert_equal ut, UserTrack.for!(user, track)
 


### PR DESCRIPTION
This fixes a few typos like `once its publish` -> `once it's published` as in this screenshot, and a few related bad uses of `its`.

![Captura de pantalla 2021-11-11 a las 13 13 42](https://user-images.githubusercontent.com/2629/141297726-069943d6-82d8-44cf-a121-9059eabd271c.png)
