### PR TITLE
Fix order of they/them pronouns

### DIFF
--- a/app/javascript/components/settings/PronounsForm.tsx
+++ b/app/javascript/components/settings/PronounsForm.tsx
@@ -117,7 +117,7 @@ export const PronounsForm = ({
             type="button"
             onClick={() => setPronounParts(['They', 'them', 'their'])}
           >
-            they / their / them
+            they / them / their
           </button>
           <button
             type="button"


### PR DESCRIPTION
Fixes the order of `they/them/their` pronouns to be equivalent to `he/him/his` and `she/her/her`.