### PR TITLE
Further tweaks

### DIFF
--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -15,6 +15,7 @@ class Solution::QueueHeadTestRun
     Submission::TestRun::Init.(submission, type: :solution, git_sha: exercise.git_sha, run_in_background: true)
   end
 
+  private
   memoize
   def submission
     solution.published_iterations.last&.submission

--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -8,8 +8,7 @@ class Solution::QueueHeadTestRun
 
   def call
     return unless submission
-
-    return if !force && submission.head_test_run
+    return if submission.head_test_run && !force
 
     submission.files.each(&:write_to_efs!) unless Dir.exist?(Exercism.config.efs_submissions_mount_point, submission.uuid)
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -13,13 +13,23 @@ class Submission < ApplicationRecord
   has_many :test_runs, class_name: "Submission::TestRun", dependent: :destroy
 
   # A head test run is one that's up to date with the head exercise's important files hash
+  # We use order id desc to get the latest
   has_one :head_test_run, # rubocop:disable Rails/InverseOf
-    -> { joins(submission: :exercise).where('submission_test_runs.git_important_files_hash = exercises.git_important_files_hash') },
+    lambda {
+      order(id: :desc).
+        joins(submission: :exercise).
+        where('submission_test_runs.git_important_files_hash = exercises.git_important_files_hash')
+    },
     class_name: "Submission::TestRun", dependent: :destroy
 
   # The "normal" one is the one run against the same git_sha as the submission
+  # We again use order id desc to get the latest
   has_one :test_run, # rubocop:disable Rails/InverseOf
-    -> { joins(:submission).where('submission_test_runs.git_sha = submissions.git_sha') },
+    lambda {
+      order(id: :desc).
+        joins(:submission).
+        where('submission_test_runs.git_sha = submissions.git_sha')
+    },
     class_name: "Submission::TestRun", dependent: :destroy
   has_one :analysis, class_name: "Submission::Analysis", dependent: :destroy
   has_one :submission_representation, class_name: "Submission::Representation", dependent: :destroy

--- a/test/commands/solution/queue_head_test_run_test.rb
+++ b/test/commands/solution/queue_head_test_run_test.rb
@@ -24,6 +24,19 @@ class Solution::QueueHeadTestRunTest < ActiveSupport::TestCase
     Solution::QueueHeadTestRun.(solution)
   end
 
+  test "inits if there's an exceptioned head run" do
+    solution = create :practice_solution, :published
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission, solution: solution
+    create :submission_test_run, submission: submission, ops_status: 405
+
+    Submission::TestRun::Init.expects(:call).with(
+      submission, type: :solution, git_sha: submission.exercise.git_sha, run_in_background: true
+    )
+
+    Solution::QueueHeadTestRun.(solution)
+  end
+
   test "inits if there's not a head run" do
     solution = create :practice_solution, :published
     submission = create :submission, solution: solution
@@ -33,6 +46,34 @@ class Solution::QueueHeadTestRunTest < ActiveSupport::TestCase
     Submission::TestRun::Init.expects(:call).with(
       submission, type: :solution, git_sha: submission.exercise.git_sha, run_in_background: true
     )
+
+    Solution::QueueHeadTestRun.(solution)
+  end
+
+  test "writes to efs if not already written" do
+    solution = create :practice_solution, :published
+    submission = create :submission, solution: solution
+    create :submission_file, submission: submission
+    create :iteration, submission: submission, solution: solution
+
+    dir = [Exercism.config.efs_submissions_mount_point, submission.uuid].join('/')
+    FileUtils.rm_rf(dir) if Dir.exist?(dir)
+
+    Submission::File.any_instance.expects(:write_to_efs!)
+
+    Solution::QueueHeadTestRun.(solution)
+  end
+
+  test "does not write to efs if dir exists" do
+    solution = create :practice_solution, :published
+    submission = create :submission, solution: solution
+    create :submission_file, submission: submission
+    create :iteration, submission: submission, solution: solution
+
+    dir = [Exercism.config.efs_submissions_mount_point, submission.uuid].join('/')
+    FileUtils.mkdir(dir) unless Dir.exist?(dir)
+
+    Submission::File.any_instance.expects(:write_to_efs!).never
 
     Solution::QueueHeadTestRun.(solution)
   end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -43,20 +43,26 @@ class SubmissionTest < ActiveSupport::TestCase
     exercise = create :practice_exercise, git_important_files_hash: exercise_hash
     submission = create :submission, git_sha: submission_sha, solution: create(:practice_solution, exercise: exercise)
     create :submission_test_run, submission: submission, git_sha: SecureRandom.uuid, git_important_files_hash: SecureRandom.uuid
-    head_run = create :submission_test_run, submission: submission, git_sha: SecureRandom.uuid, git_important_files_hash: exercise_hash
-    submission_run = create :submission_test_run, submission: submission, git_sha: submission_sha,
-                                                  git_important_files_hash: SecureRandom.uuid
+
+    # Create two head runs to check we get the latest
+    create :submission_test_run, submission: submission, git_sha: SecureRandom.uuid, git_important_files_hash: exercise_hash
+    head_run_2 = create :submission_test_run, submission: submission, git_sha: SecureRandom.uuid,
+                                              git_important_files_hash: exercise_hash
+    # Create two submission runs to check we get the latest
+    create :submission_test_run, submission: submission, git_sha: submission_sha, git_important_files_hash: SecureRandom.uuid
+    submission_run_2 = create :submission_test_run, submission: submission, git_sha: submission_sha,
+                                                    git_important_files_hash: SecureRandom.uuid
     create :submission_test_run, submission: submission, git_sha: SecureRandom.uuid, git_important_files_hash: SecureRandom.uuid
 
     # Sanity
     assert_equal exercise_hash, exercise.git_important_files_hash
-    assert_equal exercise_hash, head_run.git_important_files_hash
+    assert_equal exercise_hash, head_run_2.git_important_files_hash
     assert_equal submission_sha, submission.git_sha
-    assert_equal submission_sha, submission_run.git_sha
+    assert_equal submission_sha, submission_run_2.git_sha
 
-    assert_equal 4, submission.test_runs.size
-    assert_equal head_run, submission.head_test_run
-    assert_equal submission_run, submission.test_run
+    assert_equal 6, submission.test_runs.size
+    assert_equal head_run_2, submission.head_test_run
+    assert_equal submission_run_2, submission.test_run
   end
 
   test "exercise_representation" do


### PR DESCRIPTION
This allows the writing of EFS files if they're currently missing. Need to add:
- [x] Delete old head_test_run when writing a new one (or change the relationship maybe to allow multiple but always get last)