### PR TITLE
Enable test-run jobs

### DIFF
--- a/app/assemblers/assemble_exercise_community_solutions_list.rb
+++ b/app/assemblers/assemble_exercise_community_solutions_list.rb
@@ -26,7 +26,7 @@ class AssembleExerciseCommunitySolutionsList
       criteria: params[:criteria],
       sync_status: params[:up_to_date].present? ? :up_to_date : nil,
       tests_status: params[:passed_tests].present? ? :passed : nil,
-      head_tests_status: params[:passed_head_tests].present? ? %i[queued passed] : nil
+      head_tests_status: params[:passed_head_tests].present? ? %i[not_queued queued passed] : nil
     )
   end
 end

--- a/app/jobs/queue_solution_head_test_run_job.rb
+++ b/app/jobs/queue_solution_head_test_run_job.rb
@@ -2,6 +2,6 @@ class QueueSolutionHeadTestRunJob < ApplicationJob
   queue_as :default
 
   def perform(solution)
-    # Solution::QueueHeadTestRun.(solution)
+    Solution::QueueHeadTestRun.(solution)
   end
 end

--- a/app/jobs/queue_solution_head_test_runs_job.rb
+++ b/app/jobs/queue_solution_head_test_runs_job.rb
@@ -2,6 +2,6 @@ class QueueSolutionHeadTestRunsJob < ApplicationJob
   queue_as :default
 
   def perform(exercise)
-    # Exercise::QueueSolutionHeadTestRuns.(exercise)
+    Exercise::QueueSolutionHeadTestRuns.(exercise)
   end
 end

--- a/test/commands/solution/search_community_solutions_test.rb
+++ b/test/commands/solution/search_community_solutions_test.rb
@@ -118,16 +118,19 @@ status: :published
   end
 
   test "filter: head_tests_status" do
+    # If we let this run it will override the solutions below
+    Solution::QueueHeadTestRun.stubs(:call)
+
     track = create :track
     exercise = create :concept_exercise, track: track
     solution_1 = create :concept_solution, exercise: exercise, num_stars: 11, published_at: Time.current, status: :published,
-published_iteration_head_tests_status: :passed
+                                           published_iteration_head_tests_status: :passed
     submission_1 = create :submission, solution: solution_1, tests_status: :passed
     solution_2 = create :concept_solution, exercise: exercise, num_stars: 22, published_at: Time.current, status: :published,
-published_iteration_head_tests_status: :passed
+                                          published_iteration_head_tests_status: :passed
     submission_2 = create :submission, solution: solution_2, tests_status: :passed
     solution_3 = create :concept_solution, exercise: exercise, num_stars: 33, published_at: Time.current, status: :published,
-published_iteration_head_tests_status: :errored
+                                          published_iteration_head_tests_status: :errored
     submission_3 = create :submission, solution: solution_3, tests_status: :failed
     solution_1.update!(published_iteration: create(:iteration, solution: solution_1, submission: submission_1))
     solution_2.update!(published_iteration: create(:iteration, solution: solution_2, submission: submission_2))

--- a/test/controllers/api/community_solutions_controller_test.rb
+++ b/test/controllers/api/community_solutions_controller_test.rb
@@ -16,7 +16,7 @@ module API
         criteria: "author",
         sync_status: :up_to_date,
         tests_status: nil,
-        head_tests_status: %i[queued passed]
+        head_tests_status: %i[not_queued queued passed]
       ).returns(Solution.page(1))
 
       get api_track_exercise_community_solutions_path(

--- a/test/system/flows/profile/user_views_published_solutions_test.rb
+++ b/test/system/flows/profile/user_views_published_solutions_test.rb
@@ -5,6 +5,14 @@ module Flows
   class UserViewsPublishedSolutionsTest < ApplicationSystemTestCase
     include CapybaraHelpers
 
+    def setup
+      super
+
+      # If we let this run then we need valid git filepaths
+      # for all of the stub exercises below, so we stub it
+      Solution::QueueHeadTestRun.stubs(:call)
+    end
+
     test "shows published solutions" do
       # TODO: Change this stub
       User::Profile.any_instance.expects(solutions_tab?: true).at_least_once

--- a/test/system/flows/user_views_community_solutions_test.rb
+++ b/test/system/flows/user_views_community_solutions_test.rb
@@ -54,6 +54,9 @@ module Flows
     end
 
     test "filter community solutions" do
+      # If we let this run it will override the solutions below
+      Solution::QueueHeadTestRun.stubs(:call)
+
       user = create :user
       author = create :user, handle: "author1"
       other_author = create :user, handle: "author2"


### PR DESCRIPTION
This enables the jobs that mean solutions should now jut continue to have head test runs created for them.