### PR TITLE
Refactor everything to be less racey

### DIFF
--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -7,15 +7,14 @@ class Solution::QueueHeadTestRun
   end
 
   def call
-    return unless submission
-
     # Get out of here if:
     # - we don't want to force run things
-    # - and we've got a head test run that succeeded
-    # - and the published iteration status makes sense
+    # - and the current head sync works fine
+    # - and the previous version didn't exception
     return if !force &&
-              submission.head_test_run&.ops_success? &&
-              %i[passed failed errored].include?(solution.published_iteration_head_tests_status)
+              Solution::SyncPublishedIterationHeadTestsStatus.(solution) &&
+              !solution.published_iteration_head_tests_status_exceptioned?
+    return unless submission
 
     unless solution.exercise.has_test_runner?
       solution.update_published_iteration_head_tests_status!(:not_queued)

--- a/app/commands/solution/sync_published_iteration_head_tests_status.rb
+++ b/app/commands/solution/sync_published_iteration_head_tests_status.rb
@@ -1,0 +1,30 @@
+class Solution::SyncPublishedIterationHeadTestsStatus
+  include Mandate
+
+  initialize_with :solution
+
+  def call
+    return false unless test_run
+
+    if test_run.ops_errored?
+      status = :exceptioned
+    elsif test_run.passed?
+      status = :passed
+    elsif test_run.failed?
+      status = :failed
+    else
+      status = :errored
+    end
+
+    return true if solution.published_iteration_head_tests_status == status
+
+    solution.update_published_iteration_head_tests_status!(status)
+
+    true
+  end
+
+  memoize
+  def test_run
+    solution.published_iterations.last&.submission&.head_test_run
+  end
+end

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -3,9 +3,8 @@ class Submission
     class Init
       include Mandate
 
-      def initialize(submission, type: :submission, git_sha: nil, run_in_background: false)
+      def initialize(submission, git_sha: nil, run_in_background: false)
         @submission = submission
-        @type = type.to_sym
         @git_sha = git_sha || solution.git_sha
         @run_in_background = !!run_in_background
       end
@@ -24,8 +23,7 @@ class Submission
             exercise_git_sha: git_sha,
             exercise_git_dir: exercise_repo.dir,
             exercise_filepaths: exercise_filepaths
-          },
-          test_run_type: type
+          }
         ).tap do
           case type
           when :solution

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -3,8 +3,9 @@ class Submission
     class Init
       include Mandate
 
-      def initialize(submission, git_sha: nil, run_in_background: false)
+      def initialize(submission, type: :submission, git_sha: nil, run_in_background: false)
         @submission = submission
+        @type = type.to_sym
         @git_sha = git_sha || solution.git_sha
         @run_in_background = !!run_in_background
       end

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -67,7 +67,7 @@ class Submission
 
       def update_status!(status)
         update_submission_status!(status)
-        update_solution_status!(status)
+        update_solution_status!
       end
 
       def update_submission_status!(status)
@@ -81,7 +81,7 @@ class Submission
         end
       end
 
-      def update_solution_status!(_status)
+      def update_solution_status!
         # If this is the latest head version then let's check whether
         # it affects the published status too.
         return unless submission.exercise.git_important_files_hash == git_important_files_hash

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -126,13 +126,6 @@ class Submission
       end
 
       memoize
-      def test_run_type
-        tooling_job.test_run_type.to_sym
-      rescue NoMethodError
-        :submission
-      end
-
-      memoize
       def git_important_files_hash
         Git::GenerateHashForImportantExerciseFiles.(exercise, git_sha: git_sha)
       end

--- a/test/commands/solution/queue_head_test_run_test.rb
+++ b/test/commands/solution/queue_head_test_run_test.rb
@@ -14,15 +14,17 @@ class Solution::QueueHeadTestRunTest < ActiveSupport::TestCase
   end
 
   %i[not_queued exceptioned].each do |status|
-    test "inits if there's a head run and but #{status}" do
+    test "updates status and exits if there's a good head run and but old #{status} status" do
       solution = create :practice_solution, :published, published_iteration_head_tests_status: status
       submission = create :submission, solution: solution
       create :iteration, submission: submission, solution: solution
       create :submission_test_run, submission: submission
 
-      Submission::TestRun::Init.expects(:call)
+      Submission::TestRun::Init.expects(:call).never
 
       Solution::QueueHeadTestRun.(solution)
+
+      assert_equal :passed, solution.reload.published_iteration_head_tests_status
     end
   end
 
@@ -36,6 +38,8 @@ class Solution::QueueHeadTestRunTest < ActiveSupport::TestCase
       Submission::TestRun::Init.expects(:call).never
 
       Solution::QueueHeadTestRun.(solution)
+
+      assert_equal :passed, solution.reload.published_iteration_head_tests_status
     end
   end
 
@@ -56,7 +60,6 @@ class Solution::QueueHeadTestRunTest < ActiveSupport::TestCase
     solution = create :practice_solution, :published
     submission = create :submission, solution: solution
     create :iteration, submission: submission, solution: solution
-    create :submission_test_run, submission: submission
     solution.exercise.expects(:has_test_runner?).returns(false)
 
     Submission::TestRun::Init.expects(:call).never

--- a/test/commands/solution/sync_published_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/sync_published_iteration_head_tests_status_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
+  test "returns status correctly" do
+    solution = create :practice_solution, :published
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission
+
+    refute Solution::SyncPublishedIterationHeadTestsStatus.(solution.reload)
+
+    create :submission_test_run, submission: submission, git_important_files_hash: 'foobar'
+    refute Solution::SyncPublishedIterationHeadTestsStatus.(solution.reload)
+
+    create :submission_test_run, submission: submission
+    assert Solution::SyncPublishedIterationHeadTestsStatus.(solution.reload)
+  end
+
+  test "updates and queues search index job but does not touch user_track solution run" do
+    time = Time.current - 4.months
+
+    solution = create :practice_solution, :published
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission
+    create :submission_test_run, submission: submission
+    user_track = create :user_track, user: submission.user, track: submission.track, last_touched_at: time
+
+    SyncSolutionToSearchIndexJob.expects(:perform_later).with(submission.solution)
+
+    assert Solution::SyncPublishedIterationHeadTestsStatus.(solution)
+
+    assert_equal time.to_i, user_track.reload.last_touched_at.to_i
+    assert_equal :passed, solution.published_iteration_head_tests_status
+  end
+end

--- a/test/commands/submission/test_run/init_test.rb
+++ b/test/commands/submission/test_run/init_test.rb
@@ -24,8 +24,7 @@ class Submission::TestRun::InitTest < ActiveSupport::TestCase
         exercise_git_dir: "exercises/concept/strings",
         # Check we exclude .docs, README and the overriden source file
         exercise_filepaths: [".meta/config.json", ".meta/design.md", ".meta/exemplar.rb", "log_line_parser_test.rb"]
-      },
-      test_run_type: :submission
+      }
     )
 
     Submission::TestRun::Init.(submission)

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+equire 'test_helper'
 
 class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "should not do anything if the test run is not pending" do
@@ -131,7 +131,7 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   end
 
   test "does not broadcast for solution run" do
-    # see changes solution not submission for solution run for explaination of this setup
+    # see changes solution not submission for solution run for explanation of this setup
     exercise = create :practice_exercise, git_important_files_hash: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
     solution = create :practice_solution, :published, exercise: exercise
     submission = create :submission, solution: solution, git_sha: "b72b0958a135cddd775bf116c128e6e859bf11e4"

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -131,8 +131,15 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   end
 
   test "does not broadcast for solution run" do
+    # see changes solution not submission for solution run for explaination of this setup
+    exercise = create :practice_exercise, git_important_files_hash: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    solution = create :practice_solution, :published, exercise: exercise
+    submission = create :submission, solution: solution, git_sha: "b72b0958a135cddd775bf116c128e6e859bf11e4"
+    create :iteration, solution: solution, submission: submission
+
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
-    job = create_test_runner_job!(create(:submission), execution_status: 200, results: results, type: :solution)
+    job = create_test_runner_job!(create(:submission), execution_status: 200, results: results,
+                                  git_sha: "ae1a56deb0941ac53da22084af8eb6107d4b5c3a")
 
     IterationChannel.expects(:broadcast!).never
     SubmissionChannel.expects(:broadcast!).never
@@ -149,7 +156,7 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     submission = create :submission, solution: solution, git_sha: "b72b0958a135cddd775bf116c128e6e859bf11e4"
     create :iteration, solution: solution, submission: submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
-    job = create_test_runner_job!(submission, execution_status: 200, results: results, type: :solution,
+    job = create_test_runner_job!(submission, execution_status: 200, results: results,
                                   git_sha: "ae1a56deb0941ac53da22084af8eb6107d4b5c3a")
 
     Submission::TestRun::Process.(job)

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -1,4 +1,4 @@
-equire 'test_helper'
+require 'test_helper'
 
 class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
   test "should not do anything if the test run is not pending" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,7 +166,7 @@ class ActiveSupport::TestCase
   ###################
   # Tooling Helpers #
   ###################
-  def create_test_runner_job!(submission, execution_status: nil, results: nil, type: nil, git_sha: nil)
+  def create_test_runner_job!(submission, execution_status: nil, results: nil, git_sha: nil)
     results ? execution_output = { "results.json" => results.to_json } : execution_output = nil
     create_tooling_job!(
       submission,
@@ -175,8 +175,7 @@ class ActiveSupport::TestCase
       execution_output: execution_output,
       source: {
         'exercise_git_sha' => git_sha || submission.git_sha
-      },
-      test_run_type: type
+      }
     )
   end
 


### PR DESCRIPTION
The TL;DR: on this is that we should now be able to run `Solution::QueueHeadTestRun` for every solution and it will do one of:
- Update the status if there's a head test run.
- Do nothing if the solution isn't published or there's no test runner.
- Queue a new head test run.

This is called whenever a solution is updated (in the after_save) so whenever a new iteration is published etc, this will be called. 99% of the time it will be a no-op but sometimes it'll do stuff.