### PR TITLE
Add support for running the head-tests on non-published solutions

### DIFF
--- a/app/commands/solution/create_search_index_document.rb
+++ b/app/commands/solution/create_search_index_document.rb
@@ -36,6 +36,7 @@ class Solution::CreateSearchIndexDocument
       } : nil,
       latest_iteration: latest_iteration ? {
         tests_status: latest_iteration.tests_status,
+        head_tests_status: solution.latest_iteration_head_tests_status,
         code: latest_iteration.submission.files.map(&:content) || []
       } : nil
     }

--- a/app/commands/solution/sync_latest_iteration_head_tests_status.rb
+++ b/app/commands/solution/sync_latest_iteration_head_tests_status.rb
@@ -1,4 +1,4 @@
-class Solution::SyncPublishedIterationHeadTestsStatus
+class Solution::SyncLatestIterationHeadTestsStatus
   include Mandate
 
   initialize_with :solution
@@ -16,15 +16,15 @@ class Solution::SyncPublishedIterationHeadTestsStatus
       status = :errored
     end
 
-    return true if solution.published_iteration_head_tests_status == status
+    return true if solution.latest_iteration_head_tests_status == status
 
-    solution.update_published_iteration_head_tests_status!(status)
+    solution.update_latest_iteration_head_tests_status!(status)
 
     true
   end
 
   memoize
   def test_run
-    solution.latest_published_iteration_submission&.head_test_run
+    solution.latest_iteration&.submission&.head_test_run
   end
 end

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -18,14 +18,24 @@ class Submission
 
       private
       attr_reader :submission, :git_sha, :type, :run_in_background
+      delegate :solution, to: :submission
 
+      # rubocop:disable Style/IfUnlessModifier
+      # rubocop:disable Style/GuardClause
       def update_status!
-        if type == :solution
+        return submission.tests_queued! unless type == :solution
+
+        if submission == solution.latest_submission
+          submission.solution.update_latest_iteration_head_tests_status!(:queued)
+        end
+
+        if submission == solution.latest_published_iteration_submission
           submission.solution.update_published_iteration_head_tests_status!(:queued)
-        else
-          submission.tests_queued!
         end
       end
+      # rubocop:enable Style/GuardClause
+      # rubocop:enable Style/IfUnlessModifier
+
     end
   end
 end

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -18,6 +18,7 @@ class Submission
 
       private
       attr_reader :submission, :git_sha, :type, :run_in_background
+
       delegate :solution, to: :submission
 
       # rubocop:disable Style/IfUnlessModifier
@@ -35,7 +36,6 @@ class Submission
       end
       # rubocop:enable Style/GuardClause
       # rubocop:enable Style/IfUnlessModifier
-
     end
   end
 end

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -86,7 +86,11 @@ class Submission
         # it affects the published status too.
         return unless submission.exercise.git_important_files_hash == git_important_files_hash
 
+        # All the logic about whether we should do this etc is encapsulated
+        # into the two downstream commands, so we can just proxy to them and
+        # leave them to work it all out.
         Solution::SyncPublishedIterationHeadTestsStatus.(solution)
+        Solution::SyncLatestIterationHeadTestsStatus.(solution)
       end
 
       def broadcast!(test_run)

--- a/db/migrate/20211214145146_add_latest_iteration_head_tests_status_to_solutions.rb
+++ b/db/migrate/20211214145146_add_latest_iteration_head_tests_status_to_solutions.rb
@@ -1,0 +1,5 @@
+class AddLatestIterationHeadTestsStatusToSolutions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :solutions, :latest_iteration_head_tests_status, :tinyint, default: 0, null: false, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -528,6 +528,7 @@ ActiveRecord::Schema.define(version: 2021_12_18_160303) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "published_iteration_head_tests_status", default: 0, null: false
+    t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
     t.index ["num_stars", "id"], name: "solutions_popular_new", order: :desc
     t.index ["public_uuid"], name: "index_solutions_on_public_uuid", unique: true

--- a/test/commands/solution/sync_all_to_search_index_test.rb
+++ b/test/commands/solution/sync_all_to_search_index_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class Solution::SyncAllToSearchIndexTest < ActiveSupport::TestCase
   test "indexes all solutions" do
+    Solution::QueueHeadTestRun.stubs(:call)
+
     track = create :track
     users = build_list(:user, 10)
     exercises = build_list(:practice_exercise, 20, :random_slug, track: track)
@@ -74,7 +76,8 @@ class Solution::SyncAllToSearchIndexTest < ActiveSupport::TestCase
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "not_queued", "head_tests_status" => "not_queued",
                                    "code" => ["module LogLineParser"] },
-        "latest_iteration" => { "tests_status" => "not_queued", "code" => ["module LogLineParser"] }
+        "latest_iteration" => { "tests_status" => "not_queued", "head_tests_status" => "not_queued",
+                                "code" => ["module LogLineParser"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")

--- a/test/commands/solution/sync_latest_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/sync_latest_iteration_head_tests_status_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
+  test "returns status correctly" do
+    solution = create :practice_solution
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission
+
+    refute Solution::SyncLatestIterationHeadTestsStatus.(solution.reload)
+
+    create :submission_test_run, submission: submission, git_important_files_hash: 'foobar'
+    refute Solution::SyncLatestIterationHeadTestsStatus.(solution.reload)
+
+    create :submission_test_run, submission: submission
+    assert Solution::SyncLatestIterationHeadTestsStatus.(solution.reload)
+  end
+
+  test "updates and queues search index job but does not touch user_track solution run" do
+    time = Time.current - 4.months
+
+    solution = create :practice_solution
+    submission = create :submission, solution: solution
+    create :iteration, submission: submission
+    create :submission_test_run, submission: submission
+    user_track = create :user_track, user: submission.user, track: submission.track, last_touched_at: time
+
+    SyncSolutionToSearchIndexJob.expects(:perform_later).with(submission.solution)
+
+    assert Solution::SyncLatestIterationHeadTestsStatus.(solution)
+
+    assert_equal time.to_i, user_track.reload.last_touched_at.to_i
+    assert_equal :passed, solution.latest_iteration_head_tests_status
+  end
+end

--- a/test/commands/solution/sync_latest_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/sync_latest_iteration_head_tests_status_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
+class Solution::SyncLatestIterationHeadTestsStatusTest < ActiveSupport::TestCase
   test "returns status correctly" do
     solution = create :practice_solution
     submission = create :submission, solution: solution

--- a/test/commands/solution/sync_published_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/sync_published_iteration_head_tests_status_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
+class Solution::SyncPublishedIterationHeadTestsStatusTest < ActiveSupport::TestCase
   test "returns status correctly" do
     solution = create :practice_solution, :published
     submission = create :submission, solution: solution

--- a/test/commands/solution/sync_to_search_index_test.rb
+++ b/test/commands/solution/sync_to_search_index_test.rb
@@ -51,7 +51,7 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "track" => { "id" => 11, "slug" => "fsharp", "title" => "F#" },
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "passed", "head_tests_status" => "failed", "code" => ["module LogLineParser"] },
-        "latest_iteration" => { "tests_status" => "passed", "code" => ["module LogLineParser"] }
+        "latest_iteration" => { "tests_status" => "passed", "head_tests_status" => "not_queued", "code" => ["module LogLineParser"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")
@@ -107,7 +107,7 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "track" => { "id" => 11, "slug" => "fsharp", "title" => "F#" },
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "failed", "head_tests_status" => "failed", "code" => ["module LogLineParser"] },
-        "latest_iteration" => { "tests_status" => "failed", "code" => ["module LogLineParser"] }
+        "latest_iteration" => { "tests_status" => "failed", "head_tests_status" => "not_queued", "code" => ["module LogLineParser"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")
@@ -162,7 +162,7 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "track" => { "id" => 11, "slug" => "fsharp", "title" => "F#" },
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "passed", "head_tests_status" => "passed", "code" => ["module LogLineParser"] },
-        "latest_iteration" => { "tests_status" => "passed", "code" => ["module LogLineParser"] }
+        "latest_iteration" => { "tests_status" => "passed", "head_tests_status" => "not_queued", "code" => ["module LogLineParser"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")
@@ -223,7 +223,8 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "track" => { "id" => 11, "slug" => "fsharp", "title" => "F#" },
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "failed", "head_tests_status" => "passed", "code" => ["module LogLineParser"] },
-        "latest_iteration" => { "tests_status" => "passed", "code" => ["module LogLineParser\n\nlet parse str = 2"] }
+        "latest_iteration" => { "tests_status" => "passed", "head_tests_status" => "not_queued",
+                                "code" => ["module LogLineParser\n\nlet parse str = 2"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")
@@ -283,7 +284,8 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "track" => { "id" => 11, "slug" => "fsharp", "title" => "F#" },
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => nil,
-        "latest_iteration" => { "tests_status" => "passed", "code" => ["module LogLineParser\n\nlet parse str = 2"] }
+        "latest_iteration" => { "tests_status" => "passed", "head_tests_status" => "not_queued",
+                                "code" => ["module LogLineParser\n\nlet parse str = 2"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")
@@ -396,7 +398,8 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
         "user" => { "id" => 7, "handle" => "jane" },
         "published_iteration" => { "tests_status" => "not_queued", "head_tests_status" => "not_queued",
                                    "code" => ["module LogLineParser", "module Helper"] },
-        "latest_iteration" => { "tests_status" => "not_queued", "code" => ["module LogLineParser", "module Helper"] }
+        "latest_iteration" => { "tests_status" => "not_queued", "head_tests_status" => "not_queued",
+                                "code" => ["module LogLineParser", "module Helper"] }
       }
     }
     assert_equal expected, doc.except("_version", "_seq_no", "_primary_term")

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -163,6 +163,7 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
 
     assert submission.reload.tests_not_queued?
     assert submission.solution.reload.published_iteration_head_tests_status_passed?
+    assert submission.solution.reload.latest_iteration_head_tests_status_passed?
   end
 
   test "changes solution and submission if they're the same" do


### PR DESCRIPTION
Currently we only re-run the HEAD tests on published iterations. This adds support for adding on the latest iterations.

Following merging:
- [ ] Run all solutions through again (using `Solution::QueueHeadTestRun`)
- [ ] Work out how to store this in OpenSearch
- [ ] Reprocess everything in OpenSearch
- [ ] Update user solution searching