### PR TITLE
Don't link to concept pages if no concepts

### DIFF
--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -4,6 +4,7 @@ class Tracks::ConceptsController < ApplicationController
   before_action :use_concept, only: %i[show tooltip start complete]
 
   before_action :guard_practice_mode!, only: [:index]
+  before_action :guard_course!, only: [:index]
   skip_before_action :authenticate_user!, only: %i[index show tooltip]
 
   def index
@@ -67,6 +68,12 @@ class Tracks::ConceptsController < ApplicationController
 
   def guard_practice_mode!
     return unless @user_track.practice_mode?
+
+    redirect_to track_path(@track)
+  end
+
+  def guard_course!
+    return if @track.course?
 
     redirect_to track_path(@track)
   end

--- a/app/javascript/components/modals/complete-exercise-modal/TutorialCompletedModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/TutorialCompletedModal.tsx
@@ -26,7 +26,7 @@ export const TutorialCompletedModal = ({
       <p>
         You’re now ready to get stuck into some{' '}
         <a href={completion.track.links.exercises}>real exercises</a>.
-        {completion.track.course && completion.track.numConcepts > 0 ? (
+        {completion.track.course ? (
           <>
             <br />
             We’ve also revealed {completion.track.title}’s{' '}
@@ -41,7 +41,7 @@ export const TutorialCompletedModal = ({
         section on your track too.
       </div>
       <div className="btns">
-        {completion.track.course && completion.track.numConcepts > 0 ? (
+        {completion.track.course ? (
           <a
             href={completion.track.links.concepts}
             className="btn-primary btn-m"

--- a/app/javascript/components/modals/complete-exercise-modal/TutorialCompletedModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/TutorialCompletedModal.tsx
@@ -20,14 +20,13 @@ export const TutorialCompletedModal = ({
       <GraphicalIcon icon="hello-world" category="graphics" />
       <h2>You’ve completed “{completion.exercise.title}”</h2>
       <h3>
-        This is just the start of your journey on the {completion.track.title} track
-        🚀
+        This is just the start of your journey on the {completion.track.title}{' '}
+        track 🚀
       </h3>
       <p>
         You’re now ready to get stuck into some{' '}
         <a href={completion.track.links.exercises}>real exercises</a>.
-        {/* TODO: Change to track.course */}
-        {completion.track.numConcepts > 0 ? (
+        {completion.track.course && completion.track.numConcepts > 0 ? (
           <>
             <br />
             We’ve also revealed {completion.track.title}’s{' '}
@@ -42,8 +41,7 @@ export const TutorialCompletedModal = ({
         section on your track too.
       </div>
       <div className="btns">
-        {/* TODO: Change to track.course */}
-        {completion.track.numConcepts > 0 ? (
+        {completion.track.course && completion.track.numConcepts > 0 ? (
           <a
             href={completion.track.links.concepts}
             className="btn-primary btn-m"

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -260,6 +260,7 @@ export type Track = {
   slug: string
   title: string
   iconUrl: string
+  course: boolean
   numConcepts: number
   numExercises: number
   numSolutions: number

--- a/app/serializers/serialize_track.rb
+++ b/app/serializers/serialize_track.rb
@@ -11,6 +11,7 @@ class SerializeTrack
     {
       slug: track.slug,
       title: track.title,
+      course: track.course?,
       num_concepts: user_track.num_concepts,
       num_exercises: user_track.num_exercises,
       web_url: Exercism::Routes.track_url(track),

--- a/app/views/tracks/about.html.haml
+++ b/app/views/tracks/about.html.haml
@@ -13,7 +13,7 @@
             %em.c-underline
               %strong #{@user_track.num_exercises} exercises
 
-            - if @track.course? && @user_track.num_concepts.positive?
+            - if @track.course?
               grouped into #{@user_track.num_concepts} #{@track.title} Concepts,
             with automatic analysis
             of your code and

--- a/app/views/tracks/about.html.haml
+++ b/app/views/tracks/about.html.haml
@@ -13,8 +13,7 @@
             %em.c-underline
               %strong #{@user_track.num_exercises} exercises
 
-            / TODO: Check numbers are active
-            - if @user_track.num_concepts.positive?
+            - if @track.course? && @user_track.num_concepts.positive?
               grouped into #{@user_track.num_concepts} #{@track.title} Concepts,
             with automatic analysis
             of your code and

--- a/app/views/tracks/about/_upsell.html.haml
+++ b/app/views/tracks/about/_upsell.html.haml
@@ -21,7 +21,7 @@
         %h3 Community-sourced #{track.title} exercises
         %p
           The #{track.title} track on Exercism has
-          - if track.num_concepts.positive?
+          - if @track.course? && track.num_concepts.positive?
             #{track.num_concepts} concepts and
 
           #{track.num_exercises} exercises to help you write better code.

--- a/app/views/tracks/about/_upsell.html.haml
+++ b/app/views/tracks/about/_upsell.html.haml
@@ -21,7 +21,7 @@
         %h3 Community-sourced #{track.title} exercises
         %p
           The #{track.title} track on Exercism has
-          - if @track.course? && track.num_concepts.positive?
+          - if @track.course?
             #{track.num_concepts} concepts and
 
           #{track.num_exercises} exercises to help you write better code.

--- a/app/views/tracks/exercises/show/_action_box_join_exercism.html.haml
+++ b/app/views/tracks/exercises/show/_action_box_join_exercism.html.haml
@@ -10,7 +10,7 @@
     Sign up to Exercism to learn and master
     = link_to track.title, track_path(track)
     with
-    - if user_track.num_concepts.positive?
+    - if @track.course? && user_track.num_concepts.positive?
       #{link_to "#{user_track.num_concepts} #{'concept'.pluralize(user_track.num_concepts)}", track_concepts_path(track)},
     #{link_to "#{user_track.num_exercises} #{'exercise'.pluralize(user_track.num_exercises)}", track_exercises_path(track)},
     and real human mentoring,

--- a/app/views/tracks/exercises/show/_action_box_join_exercism.html.haml
+++ b/app/views/tracks/exercises/show/_action_box_join_exercism.html.haml
@@ -10,7 +10,7 @@
     Sign up to Exercism to learn and master
     = link_to track.title, track_path(track)
     with
-    - if @track.course? && user_track.num_concepts.positive?
+    - if @track.course?
       #{link_to "#{user_track.num_concepts} #{'concept'.pluralize(user_track.num_concepts)}", track_concepts_path(track)},
     #{link_to "#{user_track.num_exercises} #{'exercise'.pluralize(user_track.num_exercises)}", track_exercises_path(track)},
     and real human mentoring,

--- a/app/views/tracks/exercises/show/_action_box_join_track.html.haml
+++ b/app/views/tracks/exercises/show/_action_box_join_track.html.haml
@@ -5,7 +5,7 @@
     Ready to start #{exercise.title}?
   %p
     Join the #{track.title} track with
-    - if user_track.num_concepts.positive?
+    - if @track.course? && user_track.num_concepts.positive?
       = link_to "#{user_track.num_concepts} #{'concept'.pluralize(user_track.num_concepts)}", track_concepts_path(track)
       and
     = link_to "#{user_track.num_exercises} #{'exercise'.pluralize(user_track.num_exercises)}", track_exercises_path(track)

--- a/app/views/tracks/exercises/show/_action_box_join_track.html.haml
+++ b/app/views/tracks/exercises/show/_action_box_join_track.html.haml
@@ -5,7 +5,7 @@
     Ready to start #{exercise.title}?
   %p
     Join the #{track.title} track with
-    - if @track.course? && user_track.num_concepts.positive?
+    - if @track.course?
       = link_to "#{user_track.num_concepts} #{'concept'.pluralize(user_track.num_concepts)}", track_concepts_path(track)
       and
     = link_to "#{user_track.num_exercises} #{'exercise'.pluralize(user_track.num_exercises)}", track_exercises_path(track)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -528,7 +528,6 @@ ActiveRecord::Schema.define(version: 2021_12_15_182149) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "published_iteration_head_tests_status", default: 0, null: false
-    t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
     t.index ["num_stars", "id"], name: "solutions_popular_new", order: :desc
     t.index ["public_uuid"], name: "index_solutions_on_public_uuid", unique: true
@@ -583,7 +582,6 @@ ActiveRecord::Schema.define(version: 2021_12_15_182149) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "git_important_files_hash", limit: 50
     t.string "git_sha", limit: 50
-    t.index ["git_important_files_hash", "submission_id"], name: "submissions-git-optimiser-2"
     t.index ["submission_id"], name: "index_submission_test_runs_on_submission_id"
     t.index ["uuid"], name: "index_submission_test_runs_on_uuid", unique: true
   end
@@ -600,11 +598,6 @@ ActiveRecord::Schema.define(version: 2021_12_15_182149) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "git_important_files_hash", limit: 50
-    t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
-    t.index ["git_sha", "git_important_files_hash", "solution_id"], name: "ihid-3"
-    t.index ["git_sha", "solution_id", "git_important_files_hash"], name: "ihid-1"
-    t.index ["git_sha", "solution_id", "git_important_files_hash"], name: "submissions-git-optimiser-1"
-    t.index ["solution_id", "git_sha", "git_important_files_hash"], name: "ihid-2"
     t.index ["solution_id"], name: "index_submissions_on_solution_id"
     t.index ["uuid"], name: "index_submissions_on_uuid", unique: true
   end

--- a/test/controllers/tracks/concepts_controller_test.rb
+++ b/test/controllers/tracks/concepts_controller_test.rb
@@ -2,7 +2,17 @@ require "test_helper"
 
 class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
   test "index: redirects if in practice mode" do
-    track = create :track
+    track = create :track, course: true
+    user = create :user
+    create :user_track, track: track, user: user, practice_mode: true
+    sign_in!(user)
+
+    get track_concepts_url(track)
+    assert_redirected_to track_path(track)
+  end
+
+  test "index: redirects if track does not have course" do
+    track = create :track, course: false
     user = create :user
     create :user_track, track: track, user: user, practice_mode: true
     sign_in!(user)
@@ -12,7 +22,7 @@ class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index: renders correctly for external" do
-    track = create :track
+    track = create :track, course: true
 
     get track_concepts_url(track)
     assert_template "tracks/concepts/index"
@@ -20,7 +30,7 @@ class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
 
   test "index: renders correctly for joined" do
     user = create :user
-    track = create :track
+    track = create :track, course: true
     create :user_track, user: user, track: track
 
     sign_in!(user)
@@ -31,7 +41,7 @@ class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
 
   test "index: renders correctly for unjoined" do
     user = create :user
-    track = create :track
+    track = create :track, course: true
 
     sign_in!(user)
 

--- a/test/helpers/react_components/dropdowns/track_menu_test.rb
+++ b/test/helpers/react_components/dropdowns/track_menu_test.rb
@@ -3,8 +3,7 @@ require_relative "../react_component_test_case"
 module ReactComponents::Dropdowns
   class TrackMenuTest < ReactComponentTestCase
     test "external course" do
-      track = create :track
-      track.expects(:course?).never
+      track = create :track, course: false
 
       component = render(ReactComponents::Dropdowns::TrackMenu.new(track))
       assert_component component,
@@ -19,8 +18,7 @@ module ReactComponents::Dropdowns
     end
 
     test "joined course in learning mode" do
-      track = create :track
-      track.expects(course?: true)
+      track = create :track, course: true
       user = create :user
       user_track = create :user_track, track: track, user: user
 
@@ -44,8 +42,7 @@ module ReactComponents::Dropdowns
     end
 
     test "joined course in practice mode" do
-      track = create :track
-      track.expects(course?: true)
+      track = create :track, course: true
       user = create :user
       user_track = create :user_track, track: track, user: user, practice_mode: true
 
@@ -69,8 +66,7 @@ module ReactComponents::Dropdowns
     end
 
     test "joined non-course track" do
-      track = create :track
-      track.expects(course?: false)
+      track = create :track, course: false
       user = create :user
       user_track = create :user_track, track: track, user: user, practice_mode: true
 

--- a/test/models/exercise/taught_concept_test.rb
+++ b/test/models/exercise/taught_concept_test.rb
@@ -17,26 +17,37 @@ class Exercise::TaughtConceptTest < ActiveSupport::TestCase
     c_1 = create :concept
     c_2 = create :concept
     c_3 = create :concept
+    c_4 = create :concept
 
     # Sanity check
     assert_equal 0, track.num_concepts
 
-    ce_1 = create :concept_exercise, track: track
+    ce_1 = create :concept_exercise, track: track, status: :active
     create :exercise_taught_concept, exercise: ce_1, concept: c_1
     assert_equal 1, track.reload.num_concepts
 
-    ce_2 = create :concept_exercise, track: track
+    ce_2 = create :concept_exercise, track: track, status: :beta
     create :exercise_taught_concept, exercise: ce_2, concept: c_2
     assert_equal 2, track.reload.num_concepts
 
     # Sanity check: duplicate taught concept should not count
-    ce_3 = create :concept_exercise, track: track
+    ce_3 = create :concept_exercise, track: track, status: :active
     create :exercise_taught_concept, exercise: ce_3, concept: c_2
     assert_equal 2, track.reload.num_concepts
 
     # Sanity check: taught concepts in other track should not count
-    ce_4 = create :concept_exercise, track: (create :track, :random_slug)
+    ce_4 = create :concept_exercise, track: (create :track, :random_slug), status: :active
     create :exercise_taught_concept, exercise: ce_4, concept: c_3
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: taught concept of wip exercise should not count
+    ce_5 = create :concept_exercise, track: track, status: :wip
+    create :exercise_taught_concept, exercise: ce_5, concept: c_4
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: taught concept of deprecated exercise should not count
+    ce_5 = create :concept_exercise, track: track, status: :deprecated
+    create :exercise_taught_concept, exercise: ce_5, concept: c_4
     assert_equal 2, track.reload.num_concepts
   end
 end

--- a/test/serializers/serialize_track_test.rb
+++ b/test/serializers/serialize_track_test.rb
@@ -25,6 +25,7 @@ class SerializeTrackTest < ActiveSupport::TestCase
     expected = {
       slug: track.slug,
       title: track.title,
+      course: track.course?,
       num_concepts: num_concepts,
       num_exercises: num_concept_exercises + num_practice_exercises,
       web_url: "https://test.exercism.org/tracks/#{track.slug}",


### PR DESCRIPTION
Closes https://github.com/exercism/julia/issues/478

@iHiD Do we want to redirect from the concept page for tracks without a course? As in: if someone just goes to that page directly.