### PR TITLE
Skip creating github issue in development

### DIFF
--- a/app/commands/github/issue/open.rb
+++ b/app/commands/github/issue/open.rb
@@ -6,6 +6,8 @@ module Github
       initialize_with :repo, :title, :body
 
       def call
+        return if Rails.env.development?
+
         if missing?
           create_issue
         elsif closed?


### PR DESCRIPTION
While testing the Rails 7 branch, any failures created issues on GH. This PR aims to prevent that from happening.