### PR TITLE
Add timeouts to CI builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -225,6 +226,7 @@ jobs:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.test-files.outputs.matrix }}
 
@@ -248,6 +250,7 @@ jobs:
       matrix: ${{ fromJson(needs.system-test-files.outputs.matrix) }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       ###
       # Checkout using GitHub's checkout action
@@ -85,6 +86,7 @@ jobs:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.test-files.outputs.matrix }}
 
@@ -108,6 +110,7 @@ jobs:
       matrix: ${{ fromJson(needs.ruby-test-files.outputs.matrix) }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       mysql:
         image: mysql:5.7
@@ -358,6 +361,7 @@ jobs:
     if: github.repository == 'exercism/website'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       ###
       # Checkout using GitHub's checkout action


### PR DESCRIPTION
Right now the builds are all stuck for some reason, clogging up the queues. They normal appear to be taking ~2-3 minutes, so a timeout of 30 minutes should be more than enough to prevent this issue in the future.