### PR TITLE
Enable esbuild splitting

### DIFF
--- a/app/javascript/esbuild.js
+++ b/app/javascript/esbuild.js
@@ -17,6 +17,8 @@ function build() {
       ],
       bundle: true,
       sourcemap: true,
+      format: 'esm',
+      splitting: true,
       minify: process.env.NODE_ENV === 'production',
       watch: process.argv.includes('--watch'),
       outdir: '.built-assets',

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,12 +10,12 @@
     = stylesheet_link_tag "internal", "data-turbo-track": "reload"
     = stylesheet_link_tag "website", "data-turbo-track": "reload"
 
-    = javascript_include_tag('core', 'data-turbo-track': 'reload', 'data-turbo-eval': false)
+    = javascript_include_tag('core', type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
     - js_packs.each do |pack|
-      = javascript_include_tag(pack, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
+      = javascript_include_tag(pack, type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
 
     - deferred_js_packs.each do |pack|
-      = javascript_include_tag(pack, 'data-turbo-track': 'reload', 'data-turbo-eval': false, defer: true)
+      = javascript_include_tag(pack, type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false, defer: true)
 
     // TODO - Remove any unused weights
     %link{ href: "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Source+Code+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,900&display=swap", rel: "stylesheet" }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,6 +4,8 @@ Rails.application.configure do
   config.assets.paths << '.built-assets'
 end
 
+# This code is taken from https://github.com/rails/propshaft/blob/main/lib/propshaft/server.rb#L8
+# and modified to ignore esbuild derrived chunks and related files
 require 'propshaft/server'
 module Propshaft
   class Server

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,3 +3,31 @@ Rails.application.configure do
   config.assets.paths << 'app/images'
   config.assets.paths << '.built-assets'
 end
+
+require 'propshaft/server'
+module Propshaft
+  class Server
+    def call(env)
+      path, digest = extract_path_and_digest(env)
+
+      esbuild_split_asset = (path.include?('-') && path.ends_with?('.js'))
+      if (asset = @assembly.load_path.find(path)) && (asset.fresh?(digest) || esbuild_split_asset)
+        compiled_content = @assembly.compilers.compile(asset)
+
+        [
+          200,
+          {
+            "Content-Length" => compiled_content.length.to_s,
+            "Content-Type" => asset.content_type.to_s,
+            "Accept-Encoding" => "Vary",
+            "ETag" => asset.digest,
+            "Cache-Control" => "public, max-age=31536000, immutable"
+          },
+          [compiled_content]
+        ]
+      else
+        [404, { "Content-Type" => "text/plain", "Content-Length" => "9" }, ["Not found"]]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This:
- Enables splitting in esbuild
- Adds `type: module` to allow Chrome to still read the files
- Overrides propshaft server to not try and server digested versions of esbuild-created files.

If it works:
- You should see chunk-xxx.js and FooterForm-xxx.js and such things in the network traffic.
- The donations footer is probably the best place to see if this is working properly or not