### PR TITLE
Fix badge email notification string

### DIFF
--- a/config/locales/communication_preferences/en.yml
+++ b/config/locales/communication_preferences/en.yml
@@ -19,4 +19,4 @@ en:
     email_on_nudge_notification: "Email me prompts about how to get the most out of Exercism"
 
     email_on_general_update_notification: "Email me about other non-essential updates to my account"
-    email_on_acquired_badge_notification: "Email me when I receive a unlock a new badge"
+    email_on_acquired_badge_notification: "Email me when I receive a new badge"

--- a/config/locales/communication_preferences/en.yml
+++ b/config/locales/communication_preferences/en.yml
@@ -19,4 +19,4 @@ en:
     email_on_nudge_notification: "Email me prompts about how to get the most out of Exercism"
 
     email_on_general_update_notification: "Email me about other non-essential updates to my account"
-    email_on_acquired_badge_notification: "Email me when I receive a new badge"
+    email_on_acquired_badge_notification: "Email me when I unlock a new badge"


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/6223

As far as I can tell, we don't need two verbs ("receive or unlock") because there aren't two different actions happening there, so they're synonyms. 