### PR TITLE
Allow preloading JS from other domain

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,12 +10,12 @@
     = stylesheet_link_tag "internal", "data-turbo-track": "reload"
     = stylesheet_link_tag "website", "data-turbo-track": "reload"
 
-    = javascript_include_tag('core', type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
+    = javascript_include_tag('core', type: :module, crossorigin: :anonymous, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
     - js_packs.each do |pack|
-      = javascript_include_tag(pack, type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
+      = javascript_include_tag(pack, type: :module, crossorigin: :anonymous, 'data-turbo-track': 'reload', 'data-turbo-eval': false)
 
     - deferred_js_packs.each do |pack|
-      = javascript_include_tag(pack, type: :module, 'data-turbo-track': 'reload', 'data-turbo-eval': false, defer: true)
+      = javascript_include_tag(pack, type: :module, crossorigin: :anonymous, 'data-turbo-track': 'reload', 'data-turbo-eval': false, defer: true)
 
     // TODO - Remove any unused weights
     %link{ href: "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Source+Code+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,900&display=swap", rel: "stylesheet" }


### PR DESCRIPTION
Without this change, this appeared in the console log of the browser:

> A preload for 'https://d24y9kuxp2d7l2.cloudfront.net/assets/core-8e98e125fb7acfe200ab5d1acf16a3dd2216e4fe.js' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.

After this change, that message disappears.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin for more information