### PR TITLE
Fix issues with rerunning tests after a sync

### DIFF
--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -1,3 +1,6 @@
+# This queues a test-run for the latest published
+# iteration. By default it does not queue it if
+# the previous version passed, error or failed the tests.
 class Solution::QueueHeadTestRun
   include Mandate
 

--- a/app/commands/solution/update_to_latest_exercise_version.rb
+++ b/app/commands/solution/update_to_latest_exercise_version.rb
@@ -18,7 +18,10 @@ class Solution
       return unless submission
 
       submission.update!(git_sha: solution.git_sha, git_slug: solution.git_slug)
-      Submission::TestRun::Init.(submission, type: :solution)
+
+      # We run this in submission mode (the default) so as to set the last
+      # iteration to look like it's reprocessing in the UI.
+      Submission::TestRun::Init.(submission, run_in_background: true)
     end
   end
 end

--- a/app/commands/solution/update_to_latest_exercise_version.rb
+++ b/app/commands/solution/update_to_latest_exercise_version.rb
@@ -1,0 +1,24 @@
+class Solution
+  class UpdateToLatestExerciseVersion
+    include Mandate
+
+    initialize_with :solution
+
+    def call
+      solution.sync_git!
+      update_latest_iteration!
+    end
+
+    # This updates the submission of the latest iteration
+    # by setting its git_sha and then rerunning the tests
+    # in solution mode, which leads the status of the solution
+    # being set to the result of this latest run.
+    def update_latest_iteration!
+      submission = solution.latest_iteration&.submission
+      return unless submission
+
+      submission.update!(git_sha: solution.git_sha, git_slug: solution.git_slug)
+      Submission::TestRun::Init.(submission, type: :solution)
+    end
+  end
+end

--- a/app/commands/solution/update_to_latest_exercise_version.rb
+++ b/app/commands/solution/update_to_latest_exercise_version.rb
@@ -10,9 +10,9 @@ class Solution
     end
 
     # This updates the submission of the latest iteration
-    # by setting its git_sha and then rerunning the tests
-    # in solution mode, which leads the status of the solution
-    # being set to the result of this latest run.
+    # by setting its git_sha and then rerunning the tests.
+    # This then updates the status of both the solution and
+    # the submission to the result of this latest run.
     def update_latest_iteration!
       submission = solution.latest_iteration&.submission
       return unless submission

--- a/app/commands/tooling_job/create.rb
+++ b/app/commands/tooling_job/create.rb
@@ -22,7 +22,7 @@ module ToolingJob
           submission_efs_root: submission.uuid,
           submission_filepaths: submission.valid_filepaths,
           exercise_git_repo: solution.track.slug,
-          exercise_git_sha: solution.git_sha,
+          exercise_git_sha: git_sha,
           exercise_git_dir: exercise_repo.dir,
           exercise_filepaths: exercise_filepaths
         }

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -177,9 +177,7 @@ module API
       end
       return render_solution_not_accessible unless solution.user_id == current_user.id
 
-      solution.sync_git!
-      submission = solution.iterations.last&.submission
-      Submission::TestRun::Init.(submission) if submission
+      Solution::UpdateToLatestExerciseVersion.(solution)
 
       render json: { solution: SerializeSolution.(solution) }
     end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -247,7 +247,7 @@ class Solution < ApplicationRecord
     "anonymous-#{Digest::SHA1.hexdigest("#{id}-#{uuid}")}"
   end
 
-  # TODO: Move this into a command with tests
+  # TODO: Check this has tests
   def sync_git!
     update!(
       git_slug: exercise.slug,

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -247,7 +247,6 @@ class Solution < ApplicationRecord
     "anonymous-#{Digest::SHA1.hexdigest("#{id}-#{uuid}")}"
   end
 
-  # TODO: Check this has tests
   def sync_git!
     update!(
       git_slug: exercise.slug,

--- a/test/commands/solution/update_to_latest_exercise_version_test.rb
+++ b/test/commands/solution/update_to_latest_exercise_version_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Solution::UpdateToLatestExerciseVersionTest < ActiveSupport::TestCase
+  test "updates git data" do
+    solution = create :concept_solution
+    solution.update!(git_sha: "foo", git_slug: "bar")
+
+    # Sanity
+    assert_equal "foo", solution.git_sha
+    assert_equal "bar", solution.git_slug
+
+    Solution::UpdateToLatestExerciseVersion.(solution)
+    assert_equal solution.exercise.git_sha, solution.git_sha
+    assert_equal solution.exercise.slug, solution.git_slug
+    assert_equal solution.exercise.git_important_files_hash, solution.git_important_files_hash
+  end
+
+  test "updates last iteration submission's git data" do
+    solution = create :concept_solution
+    old_submission = create(:iteration, solution: solution).submission
+    new_submission = create(:iteration, solution: solution).submission
+    deleted_submission = create(:iteration, solution: solution, deleted_at: Time.current).submission
+
+    [old_submission, new_submission, deleted_submission].each do |submission|
+      submission.update!(git_sha: "foo", git_slug: "bar")
+
+      # Sanity
+      assert_equal "foo", submission.git_sha
+      assert_equal "bar", submission.git_slug
+    end
+
+    Solution::UpdateToLatestExerciseVersion.(solution)
+    [old_submission, new_submission, deleted_submission].each(&:reload)
+
+    assert_equal "foo", old_submission.git_sha
+    assert_equal "bar", old_submission.git_slug
+    assert_equal solution.exercise.git_sha, new_submission.git_sha
+    assert_equal solution.exercise.slug, new_submission.git_slug
+    assert_equal "foo", deleted_submission.git_sha
+    assert_equal "bar", deleted_submission.git_slug
+  end
+end

--- a/test/commands/solution/update_to_latest_exercise_version_test.rb
+++ b/test/commands/solution/update_to_latest_exercise_version_test.rb
@@ -39,4 +39,15 @@ class Solution::UpdateToLatestExerciseVersionTest < ActiveSupport::TestCase
     assert_equal "foo", deleted_submission.git_sha
     assert_equal "bar", deleted_submission.git_slug
   end
+
+  test "reruns test on latest iteration's submission" do
+    solution = create :concept_solution
+    create(:iteration, solution: solution).submission
+    new_submission = create(:iteration, solution: solution).submission
+    create(:iteration, solution: solution, deleted_at: Time.current).submission
+
+    Submission::TestRun::Init.expects(:call).with(new_submission, run_in_background: true)
+
+    Solution::UpdateToLatestExerciseVersion.(solution)
+  end
 end

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -164,4 +164,18 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     assert submission.reload.tests_not_queued?
     assert submission.solution.reload.published_iteration_head_tests_status_passed?
   end
+
+  test "changes solution and submission if they're the same" do
+    exercise = create :practice_exercise
+    solution = create :practice_solution, :published, exercise: exercise, git_sha: exercise.git_sha
+    submission = create :submission, solution: solution, git_sha: exercise.git_sha
+    create :iteration, solution: solution, submission: submission
+    results = { 'status' => 'pass', 'message' => "", 'tests' => [] }
+    job = create_test_runner_job!(submission, execution_status: 200, results: results, git_sha: exercise.git_sha)
+
+    Submission::TestRun::Process.(job)
+
+    assert submission.reload.tests_passed?
+    assert submission.solution.reload.published_iteration_head_tests_status_passed?
+  end
 end

--- a/test/commands/tooling_job/create_test.rb
+++ b/test/commands/tooling_job/create_test.rb
@@ -1,29 +1,73 @@
 require 'test_helper'
 
 class ToolingJob::CreateTest < ActiveSupport::TestCase
-  test "stores correctly in redis" do
+  test "stores correctly in redis with custom paths" do
     freeze_time do
+      exercise = create :practice_exercise
+      solution = create :practice_solution, exercise: exercise
+      submission = create :submission, solution: solution
+      git_sha = "ae1a56deb0941ac53da22084af8eb6107d4b5c3a"
       type = "foobars"
-      submission_uuid = SecureRandom.uuid
-      language = "ruby"
-      exercise = "two-fer"
-      attributes = { foo: :bar }
 
-      job = Exercism::ToolingJob.create!(type, submission_uuid, language, exercise, **attributes)
+      refute_equal submission.git_sha, git_sha # Sanity
+
+      job = ToolingJob::Create.(submission, type, git_sha: git_sha, run_in_background: false)
 
       redis = Exercism.redis_tooling_client
       expected = {
-        foo: :bar,
+        source: {
+          submission_efs_root: submission.uuid,
+          submission_filepaths: [],
+          exercise_git_repo: "ruby",
+          exercise_git_sha: git_sha,
+          exercise_git_dir: "exercises/practice/bob",
+          exercise_filepaths: [
+            ".meta/config.json",
+            "README.md",
+            "bob.rb",
+            "bob_test.rb",
+            "ignore.rb",
+            "subdir/more_bob.rb"
+          ]
+        },
         id: job.id,
-        submission_uuid: submission_uuid,
+        submission_uuid: submission.uuid,
         type: type,
-        language: language,
-        exercise: exercise,
+        language: submission.track.slug,
+        exercise: submission.exercise.slug,
         created_at: Time.current.utc.to_i
       }.to_json
+
       assert_equal expected, redis.get("job:#{job.id}")
       assert_equal job.id, redis.lindex(Exercism::ToolingJob.key_for_queued, 0)
-      assert_equal job.id, redis.get("submission:#{submission_uuid}:#{type}")
+      assert_equal job.id, redis.get("submission:#{submission.uuid}:#{type}")
     end
+  end
+
+  test "defaults to submission data" do
+    git_sha = "ae1a56deb0941ac53da22084af8eb6107d4b5c3a"
+
+    exercise = create :practice_exercise
+    solution = create :practice_solution, exercise: exercise, git_sha: "something-wrong"
+    submission = create :submission, solution: solution, git_sha: git_sha
+
+    assert_equal git_sha, submission.git_sha # Sanity
+
+    job = ToolingJob::Create.(submission, :test_runner)
+
+    redis = Exercism.redis_tooling_client
+    assert_equal git_sha, JSON.parse(redis.get("job:#{job.id}"))['source']['exercise_git_sha']
+  end
+
+  # We're in testing internals territory here, but I think it's best
+  # just to check the param is being passed through correctly anyway.
+  test "honours run in background" do
+    submission = create :submission
+
+    job = ToolingJob::Create.(submission, :test_runner, run_in_background: true)
+
+    redis = Exercism.redis_tooling_client
+    refute_equal job.id, redis.lindex(Exercism::ToolingJob.key_for_queued, 0)
+    assert_equal job.id, redis.lindex(Exercism::ToolingJob.key_for_queued_for_background_processing, 0)
   end
 end

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -203,18 +203,14 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "Sync should 404 if the solution belongs to someone else" do
+  test "Sync should work correctly" do
     setup_user
-    solution = create :concept_solution
+    solution = create :concept_solution, user: @current_user
+    Solution::UpdateToLatestExerciseVersion.expects(:call).with(solution)
+
     patch sync_api_solution_path(solution.uuid), headers: @headers, as: :json
 
-    assert_response 403
-    expected = { error: {
-      type: "solution_not_accessible",
-      message: I18n.t('api.errors.solution_not_accessible')
-    } }
-    actual = JSON.parse(response.body, symbolize_names: true)
-    assert_equal expected, actual
+    assert_response 200
   end
 
   ############


### PR DESCRIPTION
Fixes https://github.com/exercism/exercism/issues/6236
Fixes https://github.com/exercism/exercism/issues/6229

This does two things:
1. It fixes a bug where the wrong git_sha was being passed into the test runner.
2. This hardens the logic around updating an exercise. We now also update the most recent iteration's submission (ie the last meaningful submission the person did) to reflect the new git_sha, and we rerun the tests on that code. We **don't** as of yet rerun the analyzer/representer. Currently we (mentally) expect submission.git_sha to be immutable and so this breaks the (mental) model of how representers reference submissions, which will take some deeper thinking.