### PR TITLE
Add temporary hiring endpoint

### DIFF
--- a/app/controllers/api/profiles/testimonials_controller.rb
+++ b/app/controllers/api/profiles/testimonials_controller.rb
@@ -3,5 +3,44 @@ module API::Profiles
     def index
       render json: AssembleProfileTestimonialsList.(@user)
     end
+
+    def hiring
+      testimonials = @user.mentor_testimonials.published.joins(solution: { exercise: :track })
+      testimonials = testimonials.where('exercises.track_id': Track.find(params[:track])) if params[:track]
+      testimonials = testimonials.where('exercises.title LIKE ?': "%#{params[:track]}%") if params[:exercise]
+      testimonials = testimonials.order(id: params[:order] == "newest_first" ? :desc : :asc)
+      testimonials = testimonials.page(params[:page]).per(20)
+
+      serialized = {
+        results: testimonials.map do |t|
+                   {
+                     id: t.id,
+                     track: {
+                       slug: t.track.slug,
+                       title: t.track.title,
+                       icon_url: t.track.icon_url
+                     },
+                     exercise: {
+                       slug: t.exercise.slug,
+                       title: t.exercise.title,
+                       icon_url: t.exercise.icon_url
+                     },
+                     author: {
+                       handle: t.student.handle,
+                       avatar_url: t.student.avatar_url
+                     },
+                     content: t.content,
+                     created_at: t.created_at
+                   }
+                 end,
+        meta: {
+          current_page: testimonials.current_page,
+          total_count: testimonials.total_count,
+          total_pages: testimonials.total_pages
+        }
+      }
+
+      render json: { testimonials: serialized }
+    end
   end
 end

--- a/app/controllers/api/profiles/testimonials_controller.rb
+++ b/app/controllers/api/profiles/testimonials_controller.rb
@@ -7,7 +7,7 @@ module API::Profiles
     def hiring
       testimonials = @user.mentor_testimonials.published.joins(solution: { exercise: :track })
       testimonials = testimonials.where('exercises.track_id': Track.find(params[:track])) if params[:track]
-      testimonials = testimonials.where('exercises.title LIKE ?': "%#{params[:track]}%") if params[:exercise]
+      testimonials = testimonials.where('exercises.title LIKE ?', "%#{params[:exercise]}%") if params[:exercise]
       testimonials = testimonials.order(id: params[:order] == "newest_first" ? :desc : :asc)
       testimonials = testimonials.page(params[:page]).per(20)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,9 @@ Rails.application.routes.draw do
       resources :profiles, only: [], param: :handle do
         get :summary, on: :member
 
-        resources :testimonials, only: %i[index], controller: "profiles/testimonials", param: :uuid
+        resources :testimonials, only: %i[index], controller: "profiles/testimonials", param: :uuid do
+          get :hiring, on: :collection
+        end
         resources :solutions, only: [:index], controller: 'profiles/solutions'
         resources :contributions, only: [], controller: 'profiles/contributions' do
           collection do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,7 +174,7 @@ ruby.practice_exercises.limit(10).each do |exercise|
 
   Mentor::Testimonial.create!(
     mentor: iHiD, student: erik, discussion: discussion,
-    content: "For the first time in my life, someone got my name right the first time round. I’m not really sure what that means, but, I think I’m gonna go and celebrate. Man, I can’t believe this. I can’t believe SleeplessByte got my name right!"[0,(20+rand(210))]
+    content: "#{exercise.id} For the first time in my life, someone got my name right the first time round. I’m not really sure what that means, but, I think I’m gonna go and celebrate. Man, I can’t believe this. I can’t believe SleeplessByte got my name right!"[0,(20+rand(210))]
   )
 end
 


### PR DESCRIPTION
This adds a temporary endpoint at `api/v2/profiles/ihid/testimonials/hiring` which can be used for the front-end hiring role.

This is the JSON that is returned
```
{"testimonials":{"results":[{"id":1,"track":{"slug":"ruby","title":"Ruby","icon_url":"https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/tracks/ruby.svg"},"exercise":{"slug":"kindergarten-garden","title":"Kindergarten Garden","icon_url":"https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/exercises/kindergarten-garden.svg"},"author":{"handle":"erikSchierboom","avatar_url":"https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/placeholders/user-avatar.svg"},"content":"274 For the first time in my life, someone got my name right the first time round. I’m not really sure what that means, but, I think I’m gonna go and celebrate. Man, I can’t believe this. I can’t believe SleeplessByte got ","created_at":"2022-02-11T12:16:35.107Z"}],"meta":{"current_page":1,"total_count":1,"total_pages":1}}}
```

This is what candidates will be asked to make.

<img width="790" alt="Screenshot 2022-02-11 at 12 26 44" src="https://user-images.githubusercontent.com/286476/153591271-592d9b5d-8e9e-49f8-9bb2-cb09943de5d5.png">

