### PR TITLE
Fix notification asset path duplicate slashes

### DIFF
--- a/app/controllers/api/mentoring/discussions_controller.rb
+++ b/app/controllers/api/mentoring/discussions_controller.rb
@@ -1,6 +1,6 @@
 module API
   class Mentoring::DiscussionsController < BaseController
-    include ActionView::Helpers::AssetUrlHelper
+    include Propshaft::Helper
 
     # TODO: (Optional) Add filters (the criteria aren't the filters?)
     def index

--- a/app/helpers/react_components/mentoring/testimonials_list.rb
+++ b/app/helpers/react_components/mentoring/testimonials_list.rb
@@ -1,7 +1,7 @@
 module ReactComponents
   module Mentoring
     class TestimonialsList < ReactComponent
-      include ActionView::Helpers::AssetUrlHelper
+      include Propshaft::Helper
 
       initialize_with :params
 

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -33,8 +33,8 @@ class BlogPost < ApplicationRecord
   def image_url
     attributes['image_url'].presence ||
       [
-        Rails.application.config.action_controller.asset_host,
-        compute_asset_path("graphics/blog-placeholder-article.svg")
+        Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
+        compute_asset_path("graphics/blog-placeholder-article.svg")&.delete_prefix('/')
       ].compact.join('/')
   end
 

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -1,5 +1,5 @@
 class BlogPost < ApplicationRecord
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   extend FriendlyId
   friendly_id :slug, use: [:history]

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -32,10 +32,7 @@ class BlogPost < ApplicationRecord
 
   def image_url
     attributes['image_url'].presence ||
-      [
-        Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
-        compute_asset_path("graphics/blog-placeholder-article.svg")&.delete_prefix('/')
-      ].compact.join('/')
+      "#{Rails.application.config.action_controller.asset_host}#{compute_asset_path('graphics/blog-placeholder-article.svg')}"
   end
 
   # TODO: Guarantee all posts have descriptions instead

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -67,10 +67,7 @@ class User::Notification < ApplicationRecord
   end
 
   def image_url
-    [
-      Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
-      compute_asset_path(image_path)&.delete_prefix('/')
-    ].compact.join('/')
+    "#{Rails.application.config.action_controller.asset_host}#{compute_asset_path(image_path)}"
   end
 
   private

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -68,8 +68,8 @@ class User::Notification < ApplicationRecord
 
   def image_url
     [
-      Rails.application.config.action_controller.asset_host,
-      compute_asset_path(image_path)
+      Rails.application.config.action_controller.asset_host.delete_suffix('/'),
+      compute_asset_path(image_path).delete_prefix('/')
     ].compact.join('/')
   end
 

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -68,8 +68,8 @@ class User::Notification < ApplicationRecord
 
   def image_url
     [
-      Rails.application.config.action_controller.asset_host.delete_suffix('/'),
-      compute_asset_path(image_path).delete_prefix('/')
+      Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
+      compute_asset_path(image_path)&.delete_prefix('/')
     ].compact.join('/')
   end
 

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -109,10 +109,7 @@ class User::ReputationToken < ApplicationRecord
   def icon_url
     return exercise.icon_url if exercise
 
-    [
-      Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
-      compute_asset_path("graphics/#{icon_name}.svg")&.delete_prefix('/')
-    ].compact.join('/')
+    "#{Rails.application.config.action_controller.asset_host}#{compute_asset_path("graphics/#{icon_name}.svg")}"
   end
 
   # To be overriden in children classes

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -110,8 +110,8 @@ class User::ReputationToken < ApplicationRecord
     return exercise.icon_url if exercise
 
     [
-      Rails.application.config.action_controller.asset_host,
-      compute_asset_path("graphics/#{icon_name}.svg")
+      Rails.application.config.action_controller.asset_host&.delete_suffix('/'),
+      compute_asset_path("graphics/#{icon_name}.svg")&.delete_prefix('/')
     ].compact.join('/')
   end
 

--- a/test/commands/solution/unpublish_test.rb
+++ b/test/commands/solution/unpublish_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Solution::UncompleteTest < ActiveSupport::TestCase
+class Solution::UnpublishTest < ActiveSupport::TestCase
   test "unpublishes solution" do
     solution = create :concept_solution
     iteration = create :iteration, solution: solution

--- a/test/controllers/api/mentoring/discussions_controller_test.rb
+++ b/test/controllers/api/mentoring/discussions_controller_test.rb
@@ -1,7 +1,7 @@
 require_relative '../base_test_case'
 
 class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   guard_incorrect_token! :api_mentoring_discussions_path
   guard_incorrect_token! :tracks_api_mentoring_discussions_path

--- a/test/models/blog_post_test.rb
+++ b/test/models/blog_post_test.rb
@@ -36,7 +36,7 @@ class BlogPostTest < ActiveSupport::TestCase
     Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org').at_least_once
     blog_post = create :blog_post, image_url: nil
 
-    assert_equal "http://test.exercism.org/graphics/blog-placeholder-article.svg",
+    assert_equal "http://test.exercism.org/assets/graphics/blog-placeholder-article-242f2203f76126e572ded5bd56d8d7942e0475cf.svg",
       blog_post.image_url
   end
 
@@ -44,7 +44,7 @@ class BlogPostTest < ActiveSupport::TestCase
     Rails.application.config.action_controller.expects(:asset_host).returns('/my-assets').at_least_once
     blog_post = create :blog_post, image_url: nil
 
-    assert_equal "/my-assets/graphics/blog-placeholder-article.svg",
+    assert_equal "/my-assets/assets/graphics/blog-placeholder-article-242f2203f76126e572ded5bd56d8d7942e0475cf.svg",
       blog_post.image_url
   end
 end

--- a/test/models/blog_post_test.rb
+++ b/test/models/blog_post_test.rb
@@ -31,4 +31,20 @@ class BlogPostTest < ActiveSupport::TestCase
     expected = "<p>This is some great blog content\nFTW!!</p>\n"
     assert_equal expected, create(:blog_post).content_html
   end
+
+  test "image_url for asset host that is domain" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org').at_least_once
+    blog_post = create :blog_post, image_url: nil
+
+    assert_equal "http://test.exercism.org/graphics/blog-placeholder-article.svg",
+      blog_post.image_url
+  end
+
+  test "image_url for asset host that is path" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('/my-assets').at_least_once
+    blog_post = create :blog_post, image_url: nil
+
+    assert_equal "/my-assets/graphics/blog-placeholder-article.svg",
+      blog_post.image_url
+  end
 end

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -67,13 +67,23 @@ class NotificationTest < ActiveSupport::TestCase
     assert_equal expected, notification.rendering_data
   end
 
-  test "image_url strips duplicate slashes" do
-    Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org/').at_least_once
+  test "image_url for asset host that is domain" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org').at_least_once
     user = create :user
 
     notification = User::Notifications::AddedToContributorsPageNotification.create!(user:)
 
     assert_equal "http://test.exercism.org/assets/icons/contributors-8873894d89a89d8a22512b9253d17a57b91df2d7.svg",
+      notification.image_url
+  end
+
+  test "image_url for asset host that is path" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('/my-assets').at_least_once
+    user = create :user
+
+    notification = User::Notifications::AddedToContributorsPageNotification.create!(user:)
+
+    assert_equal "/my-assets/assets/icons/contributors-8873894d89a89d8a22512b9253d17a57b91df2d7.svg",
       notification.image_url
   end
 end

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -66,4 +66,14 @@ class NotificationTest < ActiveSupport::TestCase
 
     assert_equal expected, notification.rendering_data
   end
+
+  test "image_url strips duplicate slashes" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org/').at_least_once
+    user = create :user
+
+    notification = User::Notifications::AddedToContributorsPageNotification.create!(user:)
+
+    assert_equal "http://test.exercism.org/assets/icons/contributors-8873894d89a89d8a22512b9253d17a57b91df2d7.svg",
+      notification.image_url
+  end
 end

--- a/test/models/user/notifications/acquired_badge_notification_test.rb
+++ b/test/models/user/notifications/acquired_badge_notification_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class User::Notifications::AcquiredBadgeNotificationTest < ActiveSupport::TestCase
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   test "keys are valid" do
     user = create :user

--- a/test/models/user/notifications/added_to_contributors_page_notification_test.rb
+++ b/test/models/user/notifications/added_to_contributors_page_notification_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class User::Notifications::AddedToContributorsPageNotificationTest < ActiveSupport::TestCase
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   test "keys are valid" do
     user = create :user

--- a/test/models/user/notifications/joined_exercism_notification_test.rb
+++ b/test/models/user/notifications/joined_exercism_notification_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class User::Notifications::JoinedExercismNotificationTest < ActiveSupport::TestCase
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   test "keys are valid" do
     user = create :user

--- a/test/models/user/notifications/nudge_to_request_mentoring_notification_test.rb
+++ b/test/models/user/notifications/nudge_to_request_mentoring_notification_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class User::Notifications::NudgeToRequestMentoringNotificationTest < ActiveSupport::TestCase
-  include ActionView::Helpers::AssetUrlHelper
+  include Propshaft::Helper
 
   test "keys are valid" do
     user = create :user

--- a/test/models/user/reputation_token_test.rb
+++ b/test/models/user/reputation_token_test.rb
@@ -78,4 +78,20 @@ class User::ReputationTokenTest < ActiveSupport::TestCase
 
     assert 10, user.reload.reputation
   end
+
+  test "image_url for asset host that is domain" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('http://test.exercism.org').at_least_once
+    reputation_token = create :user_reputation_token
+
+    assert_equal "http://test.exercism.org/assets/graphics/pull-request-open-8e7b2001eac43dd3a84577f0f5ccfca4c8cc9088.svg",
+      reputation_token.rendering_data[:icon_url]
+  end
+
+  test "image_url for asset host that is path" do
+    Rails.application.config.action_controller.expects(:asset_host).returns('/my-assets').at_least_once
+    reputation_token = create :user_reputation_token
+
+    assert_equal "/my-assets/assets/graphics/pull-request-open-8e7b2001eac43dd3a84577f0f5ccfca4c8cc9088.svg",
+      reputation_token.rendering_data[:icon_url]
+  end
 end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/135246/153610797-2ae80352-6b10-4be7-858a-a1365cdf0465.png)

Once this is merged, the cache needs to be cleared for the involved records