### PR TITLE
Update MentoringRequestForm.tsx

### DIFF
--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
@@ -110,7 +110,7 @@ export const MentoringRequestForm = ({
           </label>
           <p id="request-mentoring-form-solution-description">
             Give your mentor a starting point for the conversation. This will be
-            your first comment during the session (markdown is permitted).
+            your first comment during the session. Markdown is permitted.
           </p>
           <textarea
             ref={solutionCommentRef}

--- a/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
+++ b/app/javascript/components/student/mentoring-session/mentoring-request/MentoringRequestForm.tsx
@@ -110,7 +110,7 @@ export const MentoringRequestForm = ({
           </label>
           <p id="request-mentoring-form-solution-description">
             Give your mentor a starting point for the conversation. This will be
-            your first comment on during the session.
+            your first comment during the session (markdown is permitted).
           </p>
           <textarea
             ref={solutionCommentRef}


### PR DESCRIPTION
May close [exercism/exercism/issues/6233](https://github.com/exercism/exercism/issues/6233).

Corrects typo and adds comment that markdown is supported in the opening comment.

@iHid This may be considered as a complete solution to the above issue. In the alternative, this could be extended with some kind of explanation of markdown (e.g., a tooltip or a link to some resource). I would be happy to add this if you prefer.