### PR TITLE
Restrict access to inactive tracks to maintainers

### DIFF
--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -23,7 +23,7 @@ module API
         return render_404(:track_not_found, fallback_url: tracks_url)
       end
 
-      return render_404(:track_not_found, fallback_url: tracks_url) unless track.active || current_user.maintainer?
+      return render_404(:track_not_found, fallback_url: tracks_url) unless track.accessible_by?(current_user)
 
       render json: {
         track: {

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -23,6 +23,8 @@ module API
         return render_404(:track_not_found, fallback_url: tracks_url)
       end
 
+      return render_404(:track_not_found, fallback_url: tracks_url) unless track.active || current_user.maintainer?
+
       render json: {
         track: {
           slug: track.slug,

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -36,6 +36,6 @@ class DocsController < ApplicationController
     @track = Track.find(params[:track_slug])
     @nav_docs = Document.where(track_id: @track.id)
 
-    render_404 unless @track.active || current_user&.maintainer?
+    render_404 unless @track.accessible_by?(current_user)
   end
 end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -35,5 +35,7 @@ class DocsController < ApplicationController
   def use_track
     @track = Track.find(params[:track_slug])
     @nav_docs = Document.where(track_id: @track.id)
+
+    render_404 unless @track.active || current_user&.maintainer?
   end
 end

--- a/app/controllers/temp/tracks/exercises_controller.rb
+++ b/app/controllers/temp/tracks/exercises_controller.rb
@@ -9,6 +9,8 @@ module Temp
     def use_track
       @track = Track.find(params[:track_id])
       @user_track = UserTrack.for(current_user, @track)
+
+      render_404 unless @track.active || current_user&.maintainer?
     end
 
     def use_exercise

--- a/app/controllers/temp/tracks/exercises_controller.rb
+++ b/app/controllers/temp/tracks/exercises_controller.rb
@@ -10,7 +10,7 @@ module Temp
       @track = Track.find(params[:track_id])
       @user_track = UserTrack.for(current_user, @track)
 
-      render_404 unless @track.active || current_user&.maintainer?
+      render_404 unless @track.accessible_by?(current_user)
     end
 
     def use_exercise

--- a/app/controllers/tracks/community_solutions_controller.rb
+++ b/app/controllers/tracks/community_solutions_controller.rb
@@ -35,6 +35,8 @@ class Tracks::CommunitySolutionsController < ApplicationController
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
+
+    render_404 unless @track.active || current_user&.maintainer?
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks/community_solutions_controller.rb
+++ b/app/controllers/tracks/community_solutions_controller.rb
@@ -36,7 +36,7 @@ class Tracks::CommunitySolutionsController < ApplicationController
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
 
-    render_404 unless @track.active || current_user&.maintainer?
+    render_404 unless @track.accessible_by?(current_user)
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -52,6 +52,8 @@ class Tracks::ConceptsController < ApplicationController
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
+
+    render_404 unless @track.active || current_user&.maintainer?
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -53,7 +53,7 @@ class Tracks::ConceptsController < ApplicationController
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
 
-    render_404 unless @track.active || current_user&.maintainer?
+    render_404 unless @track.accessible_by?(current_user)
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -43,6 +43,8 @@ class Tracks::ExercisesController < ApplicationController
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
+
+    render_404 unless @track.active || current_user&.maintainer?
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -44,7 +44,7 @@ class Tracks::ExercisesController < ApplicationController
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)
 
-    render_404 unless @track.active || current_user&.maintainer?
+    render_404 unless @track.accessible_by?(current_user)
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -29,8 +29,6 @@ class TracksController < ApplicationController
       return render "tracks/about"
     end
 
-    return render_404 unless @track.active || current_user.maintainer?
-
     # TODO: (Optional) Move this into a method somewhere else and add tests
     data = @user_track.solutions.
       where('completed_at > ?', Time.current.beginning_of_week - 8.weeks).
@@ -51,6 +49,8 @@ class TracksController < ApplicationController
   def use_track
     @track = Track.find(params[:id])
     @user_track = UserTrack.for(current_user, @track)
+
+    render_404 unless @track.active || current_user&.maintainer?
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -50,7 +50,7 @@ class TracksController < ApplicationController
     @track = Track.find(params[:id])
     @user_track = UserTrack.for(current_user, @track)
 
-    render_404 unless @track.active || current_user&.maintainer?
+    render_404 unless @track.accessible_by?(current_user)
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -29,6 +29,8 @@ class TracksController < ApplicationController
       return render "tracks/about"
     end
 
+    return render_404 unless @track.active || current_user.maintainer?
+
     # TODO: (Optional) Move this into a method somewhere else and add tests
     data = @user_track.solutions.
       where('completed_at > ?', Time.current.beginning_of_week - 8.weeks).

--- a/app/models/git/track.rb
+++ b/app/models/git/track.rb
@@ -146,7 +146,7 @@ module Git
 
     memoize
     def online_editor
-      config[:online_editor]
+      config[:online_editor] || {}
     end
 
     memoize

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -93,6 +93,10 @@ class Track < ApplicationRecord
     git.average_test_duration + INFRASTRUCTURE_DURATION_S
   end
 
+  def accessible_by?(user)
+    active || user&.maintainer? || user&.admin?
+  end
+
   CATGEORIES = {
     paradigm: "Paradigm",
     typing: "Typing",

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -92,6 +92,8 @@ class UserTrack < ApplicationRecord
   end
 
   def completed_percentage
+    return 100.0 if num_exercises.zero?
+
     c = (num_completed_exercises / num_exercises.to_f) * 100
     c.denominator == 1 ? c.round : c.round(1)
   end

--- a/app/views/tracks/about.html.haml
+++ b/app/views/tracks/about.html.haml
@@ -67,7 +67,8 @@
           %h2
             %em.c-underline #{@user_track.num_exercises} coding exercises
             for #{@track.title} on Exercism.
-            From #{@showcase_exercises.first.title} to #{@showcase_exercises.last.title}.
+            - unless @showcase_exercises.empty?
+              From #{@showcase_exercises.first.title} to #{@showcase_exercises.last.title}.
           %hr.c-divider
           %p Get better at programming through fun, rewarding coding exercises that test your understanding of concepts with Exercism.
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,7 +27,7 @@ iHiD = User.find_by(handle: 'iHiD') || User.create!(
   bio: "Co-founder of Exercism. I'm an entrepreneur and software developer, and have been running a variety of businesses and non-for-profits for the last decade in the fields of medicine, education and artificial intelligence",
   location: "Bree, Middle Earth",
   pronouns: "He/Him",
-  roles: [:admin]
+  roles: [:admin, :maintainer]
 )
 iHiD.confirm
 iHiD.update!(accepted_privacy_policy_at: Time.current, accepted_terms_at: Time.current)
@@ -50,7 +50,7 @@ erik = User.find_by(handle: 'erikSchierboom') || User.create!(
   github_username: 'ErikSchierboom',
   password: 'password',
   bio: "I am a developer with a passion for learning new languages. I love programming. I've done all the languages. I like the good languages the best.",
-  roles: [:admin]
+  roles: [:admin, :maintainer]
 )
 erik.confirm
 erik.update!(accepted_privacy_policy_at: Time.current, accepted_terms_at: Time.current)
@@ -64,7 +64,7 @@ karlo = User.find_by(handle: 'kntsoriano') || User.create!(
   password: 'password',
   github_username: 'kntsoriano',
   bio: "I am a developer with a passion for learning new languages. I love programming. I've done all the languages. I like the good languages the best.",
-  roles: [:admin]
+  roles: [:admin, :maintainer]
 )
 karlo.confirm
 karlo.update!(accepted_privacy_policy_at: Time.current, accepted_terms_at: Time.current)

--- a/test/controllers/api/iterations_controller_test.rb
+++ b/test/controllers/api/iterations_controller_test.rb
@@ -15,7 +15,7 @@ class API::IterationsControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "latest_status should 404 if the solution belongs to someone else" do
+  test "latest_status should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     get latest_status_api_solution_iterations_path(solution.uuid), headers: @headers, as: :json
@@ -81,13 +81,13 @@ class API::IterationsControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "create should 404 if the submission doesn't exist" do
+  test "create should 403 if the submission doesn't exist" do
     setup_user
     post api_solution_iterations_path(create(:concept_solution).uuid, submission_id: 999), headers: @headers, as: :json
     assert_response 403
   end
 
-  test "create should 404 if the solution belongs to someone else" do
+  test "create should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     submission = create :submission, solution: solution
@@ -172,7 +172,7 @@ class API::IterationsControllerTest < API::BaseTestCase
     assert_equal expected.to_json, response.body
   end
 
-  test "destroy should 404 if the solution belongs to someone else" do
+  test "destroy should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     iteration = create :iteration, solution: solution

--- a/test/controllers/api/solutions/mentor_requests_controller_test.rb
+++ b/test/controllers/api/solutions/mentor_requests_controller_test.rb
@@ -13,7 +13,7 @@ class API::Solutions::MentorRequestControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "create should 404 if the solution belongs to someone else" do
+  test "create should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     create :user_track, user: @current_user, track: solution.track

--- a/test/controllers/api/solutions/submission_files_controller_test.rb
+++ b/test/controllers/api/solutions/submission_files_controller_test.rb
@@ -21,7 +21,7 @@ class API::Solutions::SubmissionFilesControllerTest < API::BaseTestCase
     assert_equal expected, actual
   end
 
-  test "index should return 404 when submission is inaccessible" do
+  test "index should return 403 when submission is inaccessible" do
     setup_user
     submission = create :submission
 

--- a/test/controllers/api/solutions/submission_test_runs_controller.rb
+++ b/test/controllers/api/solutions/submission_test_runs_controller.rb
@@ -13,7 +13,7 @@ class API::Solutions::SubmissionsControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "cancel should 404 if the solution belongs to someone else" do
+  test "cancel should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     submission = create :submission, solution: solution

--- a/test/controllers/api/solutions/submissions_controller_test.rb
+++ b/test/controllers/api/solutions/submissions_controller_test.rb
@@ -12,7 +12,7 @@ class API::Solutions::SubmissionsControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "create should 404 if the solution belongs to someone else" do
+  test "create should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     post api_solution_submissions_path(solution.uuid), headers: @headers, as: :json

--- a/test/controllers/api/solutions_controller_test.rb
+++ b/test/controllers/api/solutions_controller_test.rb
@@ -98,7 +98,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "Show should 404 if the solution belongs to someone else" do
+  test "Show should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     get api_solution_path(solution.uuid), headers: @headers, as: :json
@@ -159,7 +159,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "Diff should 404 if the solution belongs to someone else" do
+  test "Diff should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     get diff_api_solution_path(solution.uuid), headers: @headers, as: :json
@@ -234,7 +234,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "complete should 404 if the solution belongs to someone else" do
+  test "complete should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     patch complete_api_solution_path(solution.uuid), headers: @headers, as: :json
@@ -418,7 +418,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "publish should 404 if the solution belongs to someone else" do
+  test "publish should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     patch publish_api_solution_path(solution.uuid), headers: @headers, as: :json
@@ -538,7 +538,7 @@ class API::SolutionsControllerTest < API::BaseTestCase
     )
   end
 
-  test "unpublish should 404 if the solution belongs to someone else" do
+  test "unpublish should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     patch unpublish_api_solution_path(solution.uuid), headers: @headers, as: :json

--- a/test/controllers/api/tracks_controller_test.rb
+++ b/test/controllers/api/tracks_controller_test.rb
@@ -21,4 +21,51 @@ class API::TracksControllerTest < API::BaseTestCase
     expected = { tracks: SerializeTracks.([track_1], user) }.to_json
     assert_equal expected, response.body
   end
+
+  test "show should return track if the track is active" do
+    setup_user
+    track = create :track, active: true
+    get api_track_path(track.slug), headers: @headers, as: :json
+
+    assert_response 200
+    expected = {
+      track: {
+        slug: track.slug,
+        language: track.title
+      }
+    }.to_json
+    assert_equal expected, response.body
+  end
+
+  test "show should return track if the track is inactive and the user is a maintainer" do
+    user = create :user, roles: [:maintainer]
+    setup_user(user)
+    track = create :track, active: false
+    get api_track_path(track.slug), headers: @headers, as: :json
+
+    assert_response 200
+    expected = {
+      track: {
+        slug: track.slug,
+        language: track.title
+      }
+    }.to_json
+    assert_equal expected, response.body
+  end
+
+  test "show should 404 if the track is inactive and the user is not a maintainer" do
+    user = create :user, roles: []
+    setup_user(user)
+    track = create :track, active: false
+    get api_track_path(track.slug), headers: @headers, as: :json
+
+    assert_response 404
+    expected = { error: {
+      type: "track_not_found",
+      message: I18n.t('api.errors.track_not_found'),
+      fallback_url: "http://test.exercism.org/tracks"
+    } }
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal expected, actual
+  end
 end

--- a/test/controllers/api/v1/solutions_controller_test.rb
+++ b/test/controllers/api/v1/solutions_controller_test.rb
@@ -249,7 +249,7 @@ class API::V1::SolutionsControllerTest < API::BaseTestCase
     assert_response 404
   end
 
-  test "update should 404 if the solution belongs to someone else" do
+  test "update should 403 if the solution belongs to someone else" do
     setup_user
     solution = create :concept_solution
     patch api_v1_solution_path(solution.uuid), headers: @headers, as: :json

--- a/test/controllers/tracks/community_solutions_controller_test.rb
+++ b/test/controllers/tracks/community_solutions_controller_test.rb
@@ -38,6 +38,31 @@ class Tracks::CommunitySolutionsControllerTest < ActionDispatch::IntegrationTest
     assert_rendered_404
   end
 
+  test "show: 404s silently for published solution on inactive track and user is not a maintainer" do
+    exercise = create :practice_exercise
+    exercise.track.update!(active: false)
+    solution = create :practice_solution, :published, exercise: exercise
+
+    sign_in!(solution.user)
+
+    get track_exercise_solution_url(exercise.track, exercise, solution.user)
+
+    assert_rendered_404
+  end
+
+  test "show: 200s for published solution on inactive track and user is a maintainer" do
+    exercise = create :practice_exercise
+    exercise.track.update!(active: false)
+    solution = create :practice_solution, :published, exercise: exercise
+    solution.user.update!(roles: [:maintainer])
+
+    sign_in!(solution.user)
+
+    get track_exercise_solution_url(exercise.track, exercise, solution.user.reload)
+
+    assert_response 200
+  end
+
   test "show: 200s for published solution" do
     exercise = create :practice_exercise
     solution = create :practice_solution, :published, exercise: exercise

--- a/test/controllers/tracks/concepts_controller_test.rb
+++ b/test/controllers/tracks/concepts_controller_test.rb
@@ -49,6 +49,27 @@ class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
     assert_template "tracks/concepts/index"
   end
 
+  test "index: renders correctly for inactive track and user is a maintainer" do
+    user = create :user, roles: [:maintainer]
+    track = create :track, active: false, course: true
+
+    sign_in!(user)
+
+    get track_concepts_url(track)
+    assert_template "tracks/concepts/index"
+  end
+
+  test "index: 404s silently for inactive track and user is not a maintainer" do
+    user = create :user
+    track = create :track, active: false, course: true
+
+    sign_in!(user)
+
+    get track_concepts_url(track)
+
+    assert_rendered_404
+  end
+
   test "show: 404s silently for missing track" do
     get track_concept_url('foobar', 'foobar')
 
@@ -57,6 +78,31 @@ class Tracks::ConceptsControllerTest < ActionDispatch::IntegrationTest
 
   test "show: 404s silently for missing concept" do
     get track_concept_url(create(:track), 'foobar')
+
+    assert_rendered_404
+  end
+
+  test "show: renders correctly for inactive track and user is a maintainer" do
+    concept = create :concept, :with_git_data
+    concept.track.update!(active: false)
+    user = create :user, roles: [:maintainer]
+    ut = create :user_track, track: concept.track, user: user
+
+    sign_in!(user)
+
+    get track_concept_url(ut.track, concept)
+    assert_template "tracks/concepts/show"
+  end
+
+  test "show: 404s silently for inactive track and user is not a maintainer" do
+    concept = create :concept, :with_git_data
+    concept.track.update!(active: false)
+    user = create :user
+    ut = create :user_track, track: concept.track, user: user
+
+    sign_in!(user)
+
+    get track_concept_url(ut.track, concept)
 
     assert_rendered_404
   end

--- a/test/controllers/tracks/exercises_controller_test.rb
+++ b/test/controllers/tracks/exercises_controller_test.rb
@@ -29,6 +29,28 @@ class Tracks::ExercisesControllerTest < ActionDispatch::IntegrationTest
     assert_template "tracks/exercises/index"
   end
 
+  test "index: renders correctly for inactive track and user is a maintainer" do
+    user = create :user, roles: [:maintainer]
+    track = create :track, active: false
+
+    sign_in!(user)
+
+    get track_exercises_url(track)
+
+    assert_template "tracks/exercises/index"
+  end
+
+  test "index: 404s silently for inactive track and user is not a maintainer" do
+    user = create :user
+    track = create :track, active: false
+
+    sign_in!(user)
+
+    get track_exercises_url(track)
+
+    assert_rendered_404
+  end
+
   test "show: 404s silently for missing track" do
     get track_exercise_url('foobar', 'foobar')
 
@@ -39,6 +61,29 @@ class Tracks::ExercisesControllerTest < ActionDispatch::IntegrationTest
     get track_exercise_url(create(:track), 'foobar')
 
     assert_rendered_404
+  end
+
+  test "show: 404s silently for inactive track and user is not a maintainer" do
+    user = create :user
+    track = create :track, active: false
+    exercise = create :practice_exercise, track: track
+
+    sign_in!(user)
+
+    get track_exercise_url(exercise.track, exercise)
+
+    assert_rendered_404
+  end
+
+  test "show: renders correctly for inactive track and user is a maintainer" do
+    user = create :user, roles: [:maintainer]
+    track = create :track, active: false
+    exercise = create :practice_exercise, track: track
+
+    sign_in!(user)
+
+    get track_exercise_url(exercise.track, exercise)
+    assert_template "tracks/exercises/show"
   end
 
   test "concept/show: renders correctly for external" do

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -17,6 +17,12 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     assert_template "tracks/index"
   end
 
+  test "show: 404s silently for missing track" do
+    get track_url('foobar')
+
+    assert_rendered_404
+  end
+
   test "show: renders correctly for active track" do
     track = create :track, active: true
 

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -17,8 +17,32 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     assert_template "tracks/index"
   end
 
-  test "show: 404s silently for missing track" do
-    get track_url('foobar')
+  test "show: renders correctly for active track" do
+    track = create :track, active: true
+
+    get track_url(track)
+
+    assert_response 200
+  end
+
+  test "show: renders correctly for inactive track but user is a maintainer" do
+    user = create :user, roles: [:maintainer]
+    sign_in!(user)
+    track = create :track, active: false
+    create :user_track, user: user, track: track
+
+    get track_url(track)
+
+    assert_response 200
+  end
+
+  test "show: 404s silently for inactive track and user is not a maintainer" do
+    user = create :user, roles: []
+    sign_in!(user)
+    track = create :track, active: false
+    create :user_track, user: user, track: track
+
+    get track_url(track)
 
     assert_rendered_404
   end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -112,4 +112,28 @@ class TrackTest < ActiveSupport::TestCase
 
     assert_equal 3, track_1.num_mentors
   end
+
+  test "accessible_by? on active track" do
+    track = create :track, active: true
+    user = create :user, roles: []
+    maintainer = create :user, roles: [:maintainer]
+    admin = create :user, roles: [:admin]
+
+    assert track.accessible_by?(nil)
+    assert track.accessible_by?(user)
+    assert track.accessible_by?(maintainer)
+    assert track.accessible_by?(admin)
+  end
+
+  test "accessible_by? on inactive track" do
+    track = create :track, active: false
+    user = create :user, roles: []
+    maintainer = create :user, roles: [:maintainer]
+    admin = create :user, roles: [:admin]
+
+    refute track.accessible_by?(nil)
+    refute track.accessible_by?(user)
+    assert track.accessible_by?(maintainer)
+    assert track.accessible_by?(admin)
+  end
 end


### PR DESCRIPTION
- Fix invalid 404 in unauthorized tests
- Gracefully handle track without online_editor
- Gracefully handle user_track without exercises
- Gracefully handle track without exercises
- Render 404 when viewing inactive track using non-maintainer user
- Seed users with maintainer role
- Restrict inactive track usage more
