### PR TITLE
Fix assets deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload assets to s3
         run: |
-          aws s3 sync assets s3://${{ env.s3_bucket }}/assets --acl public-read --no-progress --cache-control max-age=31536000
+          aws s3 sync assets s3://${{ env.s3_bucket }} --acl public-read --no-progress --cache-control max-age=31536000
 
       #########################
       #########################


### PR DESCRIPTION
The assets deploy uses a `/assets` subdirectory, but the assets should be synced to the root.

Closes https://github.com/exercism/exercism/issues/6255