### PR TITLE
Use POST when connecting to GitHub from settings

### DIFF
--- a/app/views/settings/show.html.haml
+++ b/app/views/settings/show.html.haml
@@ -41,8 +41,10 @@
               reputation
               = icon "external-link", "(opens in a new tab)"
             on Exercism when your submit pull requests on GitHub, please connect your accounts using the button below.
-          = link_to omniauth_authorize_path(:user, :github),
-            class: "btn-enhanced btn-m github-btn",
+          = button_to omniauth_authorize_path(:user, :github),
+            form_class: "github-btn",
+            class: "btn-enhanced btn-m",
+            method: :post,
             data: { turbo: false } do
             = graphical_icon 'external-site-github'
             Connect with GitHub


### PR DESCRIPTION
The GitHub authentication button on the settings page was still using a link, whereas on other pages a (POST) form with a button was used.

@iHiD Is there an easy to test if this fixes it? ﻿

Closes https://github.com/exercism/exercism/issues/6151