### PR TITLE
Allow skip sending email when awarding badges

### DIFF
--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,10 +3,10 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, skip_email: false)
+      def initialize(user, slug, send_email: true)
         @user = user
         @slug = slug
-        @skip_email = skip_email
+        @send_email = send_email
       end
 
       def call
@@ -25,7 +25,7 @@ class User
             user: user,
             badge: badge
           ).tap do |uab|
-            if badge.send_email_on_acquisition? && !skip_email
+            if badge.send_email_on_acquisition? && send_email
               User::Notification::CreateEmailOnly.(user, :acquired_badge,
                 user_acquired_badge: uab)
             end
@@ -45,7 +45,7 @@ class User
       end
 
       private
-      attr_reader :user, :slug, :skip_email
+      attr_reader :user, :slug, :send_email
 
       memoize
       def badge

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,7 +3,7 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def perform(user, badge_slug, skip_email: false)
-    User::AcquiredBadge::Create.(user, badge_slug, skip_email:)
+  def perform(user, badge_slug, send_email: true)
+    User::AcquiredBadge::Create.(user, badge_slug, send_email:)
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,7 +3,7 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def perform(user, badge_slug)
-    User::AcquiredBadge::Create.(user, badge_slug)
+  def perform(user, badge_slug, skip_email: false)
+    User::AcquiredBadge::Create.(user, badge_slug, skip_email:)
   end
 end

--- a/test/commands/user/acquired_badge/create_test.rb
+++ b/test/commands/user/acquired_badge/create_test.rb
@@ -81,7 +81,7 @@ class User::AcquiredBadge::CreateTest < ActiveSupport::TestCase
     User::AcquiredBadge::Create.(user, :contributor)
   end
 
-  test "Does not send email if send_email_on_acquisition is true and skip_email is true" do
+  test "Does not send email if send_email_on_acquisition is true and send_email is false" do
     user = create :user
     force_award!(user)
 
@@ -89,7 +89,7 @@ class User::AcquiredBadge::CreateTest < ActiveSupport::TestCase
     Badges::ContributorBadge.any_instance.expects(:send_email_on_acquisition?).returns(true)
     User::Notification::CreateEmailOnly.expects(:call).never
 
-    User::AcquiredBadge::Create.(user, :contributor, skip_email: true)
+    User::AcquiredBadge::Create.(user, :contributor, send_email: false)
   end
 
   def force_award!(user)

--- a/test/commands/user/acquired_badge/create_test.rb
+++ b/test/commands/user/acquired_badge/create_test.rb
@@ -81,6 +81,17 @@ class User::AcquiredBadge::CreateTest < ActiveSupport::TestCase
     User::AcquiredBadge::Create.(user, :contributor)
   end
 
+  test "Does not send email if send_email_on_acquisition is true and skip_email is true" do
+    user = create :user
+    force_award!(user)
+
+    create :contributor_badge
+    Badges::ContributorBadge.any_instance.expects(:send_email_on_acquisition?).returns(true)
+    User::Notification::CreateEmailOnly.expects(:call).never
+
+    User::AcquiredBadge::Create.(user, :contributor, skip_email: true)
+  end
+
   def force_award!(user)
     Badges::ContributorBadge.any_instance.expects(:award_to?).with(user).returns(true)
   end

--- a/test/jobs/award_badge_job_test.rb
+++ b/test/jobs/award_badge_job_test.rb
@@ -5,7 +5,7 @@ class AwardBadgeJobTest < ActiveJob::TestCase
     user = mock
     slug = mock
 
-    User::AcquiredBadge::Create.expects(:call).with(user, slug, skip_email: false)
+    User::AcquiredBadge::Create.expects(:call).with(user, slug, send_email: true)
     AwardBadgeJob.perform_now(user, slug)
   end
 
@@ -13,7 +13,7 @@ class AwardBadgeJobTest < ActiveJob::TestCase
     user = mock
     slug = mock
 
-    User::AcquiredBadge::Create.expects(:call).with(user, slug, skip_email: false).raises(BadgeCriteriaNotFulfilledError)
+    User::AcquiredBadge::Create.expects(:call).with(user, slug, send_email: true).raises(BadgeCriteriaNotFulfilledError)
     AwardBadgeJob.perform_now(user, slug)
   end
 
@@ -41,7 +41,7 @@ class AwardBadgeJobTest < ActiveJob::TestCase
     perform_enqueued_jobs do
       # The default for the growth_mindset badge is to send an email, but we override that
       User::Notification::CreateEmailOnly.expects(:call).never
-      AwardBadgeJob.perform_now(user.reload, :growth_mindset, skip_email: true)
+      AwardBadgeJob.perform_now(user.reload, :growth_mindset, send_email: false)
     end
   end
 end


### PR DESCRIPTION
What is the best way to test whether or not an email actually gets sent? I think Rails will not send emails by default in development.