### PR TITLE
Show general hints if there are no task-based hints

### DIFF
--- a/app/javascript/components/modals/HintsModal.tsx
+++ b/app/javascript/components/modals/HintsModal.tsx
@@ -6,22 +6,29 @@ import { GraphicalIcon } from '../common'
 const Hints = ({
   heading,
   hints,
+  expanded,
+  collapsable,
 }: {
   heading: string
   hints: string[] | undefined
+  expanded: boolean
+  collapsable: boolean
 }) => {
   if (hints === undefined || hints.length === 0) {
     return null
   }
 
   return (
-    <details className="c-details">
+    <details className="c-details" open={expanded}>
       <summary className="--summary">
         <div className="--summary-inner">
           {heading}
-
-          <GraphicalIcon icon="plus-circle" className="--closed-icon" />
-          <GraphicalIcon icon="minus-circle" className="--open-icon" />
+          {collapsable ? (
+            <>
+              <GraphicalIcon icon="plus-circle" className="--closed-icon" />
+              <GraphicalIcon icon="minus-circle" className="--open-icon" />
+            </>
+          ) : null}
         </div>
       </summary>
       <ul>
@@ -53,12 +60,19 @@ export const HintsModal = ({
         <GraphicalIcon icon="hints" category="graphics" />
         <h2>Hints and Tips</h2>
       </header>
-      <Hints hints={assignment.generalHints} heading="General" />
+      <Hints
+        hints={assignment.generalHints}
+        heading="General"
+        expanded={assignment.tasks.length === 0}
+        collapsable={assignment.tasks.length > 0}
+      />
       {assignment.tasks.map((task, idx) => (
         <Hints
           key={idx}
           hints={task.hints}
           heading={`${idx + 1}. ${task.title}`}
+          expanded={false}
+          collapsable={true}
         />
       ))}
     </Modal>

--- a/test/javascript/components/modals/HintsModal.test.jsx
+++ b/test/javascript/components/modals/HintsModal.test.jsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { HintsModal } from '../../../../app/javascript/components/modals/HintsModal'
 
-test('general hints are shown when clicked on heading', async () => {
+test('general hints do not require clicking on heading where there are no task hints', async () => {
   const { getByText } = render(
     <div>
       <HintsModal
@@ -19,13 +19,38 @@ test('general hints are shown when clicked on heading', async () => {
 
   const generalHeading = getByText('General')
   expect(generalHeading).toBeVisible()
+  expect(getByText('Please use the docs')).toBeVisible()
+  expect(getByText('It is recommended')).toBeVisible()
+})
+
+test('general hints are shown when heading is clicked', async () => {
+  const { getByText } = render(
+    <div>
+      <HintsModal
+        assignment={{
+          generalHints: ['Please use the docs', 'It is recommended'],
+          tasks: [
+            {
+              title: 'Do complex task',
+              hints: ['Really you should!', 'I am sure'],
+            },
+          ],
+        }}
+        open={true}
+        ariaHideApp={false}
+      />
+    </div>
+  )
+
+  const generalHeading = getByText('General')
+  expect(generalHeading).toBeVisible()
 
   fireEvent.click(generalHeading)
   expect(getByText('Please use the docs')).toBeVisible()
   expect(getByText('It is recommended')).toBeVisible()
 })
 
-test('task hints are shown when clicked on heading', async () => {
+test('task hints are shown when heading is clicked', async () => {
   const { getByText } = render(
     <div>
       <HintsModal


### PR DESCRIPTION
If an exercise only has general hints, the hints modal (shown when clicking on the lightbulk icon) requires clicking on the "General" hints section to actually show the hints. In the case of an exercise not having any task-based hints (e.g. a Practice Exercise), this makes little sense. This PR expands the general hints if there are no task-based hints.

CC @bethanyg