### PR TITLE
Dispatch repo_update event when appends file or org-wide-files config changes

### DIFF
--- a/app/commands/github/dispatch_event_to_org_wide_files_repo.rb
+++ b/app/commands/github/dispatch_event_to_org_wide_files_repo.rb
@@ -21,7 +21,7 @@ module Github
       }.to_json
     end
 
-    EVENT_TYPES = %i[appends_update].freeze
+    EVENT_TYPES = %i[repo_update].freeze
     private_constant :EVENT_TYPES
   end
 end

--- a/test/commands/github/dispatch_event_to_org_wide_files_repo_test.rb
+++ b/test/commands/github/dispatch_event_to_org_wide_files_repo_test.rb
@@ -3,23 +3,23 @@ require "test_helper"
 class Github::DispatchEventToOrgWideFilesRepoTest < ActiveJob::TestCase
   test "dispatch repository event for single repo" do
     stub_request(:post, "https://api.github.com/repos/exercism/org-wide-files/dispatches").
-      with(body: '{"event_type":"appends_update","client_payload":{"repos":["exercism/ruby"],"pusher":"user17"}}')
+      with(body: '{"event_type":"repo_update","client_payload":{"repos":["exercism/ruby"],"pusher":"user17"}}')
 
-    Github::DispatchEventToOrgWideFilesRepo.(:appends_update, ["exercism/ruby"], 'user17')
+    Github::DispatchEventToOrgWideFilesRepo.(:repo_update, ["exercism/ruby"], 'user17')
 
     assert_requested(:post, "https://api.github.com/repos/exercism/org-wide-files/dispatches", times: 1) do |req|
-      req.body == '{"event_type":"appends_update","client_payload":{"repos":["exercism/ruby"],"pusher":"user17"}}'
+      req.body == '{"event_type":"repo_update","client_payload":{"repos":["exercism/ruby"],"pusher":"user17"}}'
     end
   end
 
   test "dispatch repository event for multiples repos" do
     stub_request(:post, "https://api.github.com/repos/exercism/org-wide-files/dispatches").
-      with(body: '{"event_type":"appends_update","client_payload":{"repos":["exercism/website","exercism/configlet"],"pusher":"user17"}}') # rubocop:disable Layout/LineLength
+      with(body: '{"event_type":"repo_update","client_payload":{"repos":["exercism/website","exercism/configlet"],"pusher":"user17"}}') # rubocop:disable Layout/LineLength
 
-    Github::DispatchEventToOrgWideFilesRepo.(:appends_update, ["exercism/website", "exercism/configlet"], 'user17')
+    Github::DispatchEventToOrgWideFilesRepo.(:repo_update, ["exercism/website", "exercism/configlet"], 'user17')
 
     assert_requested(:post, "https://api.github.com/repos/exercism/org-wide-files/dispatches", times: 1) do |req|
-      req.body == '{"event_type":"appends_update","client_payload":{"repos":["exercism/website","exercism/configlet"],"pusher":"user17"}}' # rubocop:disable Layout/LineLength
+      req.body == '{"event_type":"repo_update","client_payload":{"repos":["exercism/website","exercism/configlet"],"pusher":"user17"}}' # rubocop:disable Layout/LineLength
     end
   end
 

--- a/test/commands/webhooks/process_push_update_test.rb
+++ b/test/commands/webhooks/process_push_update_test.rb
@@ -44,7 +44,7 @@ class Webhooks::ProcessPushUpdateTest < ActiveSupport::TestCase
   end
 
   test "should dispatch org-wide-files event when commit contains added file in .appends directory" do
-    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:appends_update, ['exercism/ruby'], 'user17')
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/ruby'], 'user17')
 
     Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'ruby', 'user17', [
                                    { added: ['.appends/labels.yml'], removed: [], modified: [] }
@@ -52,7 +52,7 @@ class Webhooks::ProcessPushUpdateTest < ActiveSupport::TestCase
   end
 
   test "should dispatch org-wide-files event when commit contains removed file from .appends directory" do
-    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:appends_update, ['exercism/website'], 'user17')
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/website'], 'user17')
 
     Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'website', 'user17', [
                                    { added: [], removed: ['.appends/issues.json'], modified: [] }
@@ -60,7 +60,7 @@ class Webhooks::ProcessPushUpdateTest < ActiveSupport::TestCase
   end
 
   test "should dispatch org-wide-files event when commit contains modified file in .appends directory" do
-    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:appends_update, ['exercism/configlet'], 'user17')
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/configlet'], 'user17')
 
     Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'configlet', 'user17', [
                                    { added: [], removed: [], modified: ['.appends/LICENSE.md'] }
@@ -72,6 +72,30 @@ class Webhooks::ProcessPushUpdateTest < ActiveSupport::TestCase
 
     Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'ruby', 'user17', [
                                    { added: ['README.md'], removed: ['GENERATORS.md'], modified: ['CONTRIBUTING.md'] }
+                                 ])
+  end
+
+  test "should dispatch org-wide-files event when commit contains added org-wide-files-config file" do
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/ruby'], 'user17')
+
+    Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'ruby', 'user17', [
+                                   { added: ['.github/org-wide-files-config.toml'], removed: [], modified: [] }
+                                 ])
+  end
+
+  test "should dispatch org-wide-files event when commit contains removed org-wide-files-config file" do
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/website'], 'user17')
+
+    Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'website', 'user17', [
+                                   { added: [], removed: ['.github/org-wide-files-config.toml'], modified: [] }
+                                 ])
+  end
+
+  test "should dispatch org-wide-files event when commit contains modified org-wide-files-config file" do
+    Github::DispatchEventToOrgWideFilesRepo.expects(:call).with(:repo_update, ['exercism/configlet'], 'user17')
+
+    Webhooks::ProcessPushUpdate.('refs/heads/main', 'exercism', 'configlet', 'user17', [
+                                   { added: [], removed: [], modified: ['.github/org-wide-files-config.toml'] }
                                  ])
   end
 end


### PR DESCRIPTION
Recently, we added support for a `.github/org-wide-files-config.toml` file to specify some org-wide-files syncing options.
Currently, we only use this to allow tracks to enable running `configlet fmt` in their `configlet` workflow: https://github.com/exercism/csharp/blob/main/.github/org-wide-files-config.toml
This PR now also submits the (renamed) `repo_update` event (used to be `appends_update`, but we're renaming that) when the above-mentioned config file changes. 
This is needed as otherwise changing that config file would not do anything unless somehow a new org-wide-files run starts.

Once this is merged and deployed, https://github.com/exercism/org-wide-files/pull/186 should be merged.

CC @SaschaMann 