### PR TITLE
This fixes rugged 1.3.1 not installing on macOS Catalina.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,7 +427,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.8.1)
       fugit (~> 1.1, >= 1.1.6)
-    rugged (1.3.1)
+    rugged (1.4.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)


### PR DESCRIPTION
See https://github.com/libgit2/rugged/pull/906/files
