### PR TITLE
Check tooling status before initializing job

### DIFF
--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -32,8 +32,8 @@ class Iteration
 
     def init_services
       Submission::TestRun::Init.(submission) if submission.tests_not_queued? && solution.exercise.has_test_runner?
-      Submission::Representation::Init.(submission)
-      Submission::Analysis::Init.(submission)
+      Submission::Representation::Init.(submission) if solution.track.has_representer?
+      Submission::Analysis::Init.(submission) if solution.track.has_analyzer?
     end
 
     def record_activity!(iteration)

--- a/app/commands/solution/update_to_latest_exercise_version.rb
+++ b/app/commands/solution/update_to_latest_exercise_version.rb
@@ -21,7 +21,7 @@ class Solution
 
       # We run this in submission mode (the default) so as to set the last
       # iteration to look like it's reprocessing in the UI.
-      Submission::TestRun::Init.(submission, run_in_background: true)
+      Submission::TestRun::Init.(submission, run_in_background: true) if solution.exercise.has_test_runner?
     end
   end
 end

--- a/app/models/git/track.rb
+++ b/app/models/git/track.rb
@@ -51,22 +51,22 @@ module Git
 
     memoize
     def has_concept_exercises?
-      !!config[:status][:concept_exercises]
+      !!status[:concept_exercises]
     end
 
     memoize
     def has_test_runner?
-      !!config[:status][:test_runner]
+      !!status[:test_runner]
     end
 
     memoize
     def has_representer?
-      config[:status][:representer]
+      !!status[:representer]
     end
 
     memoize
     def has_analyzer?
-      config[:status][:analyzer]
+      !!status[:analyzer]
     end
 
     memoize
@@ -152,6 +152,11 @@ module Git
     memoize
     def test_runner
       config[:test_runner] || {}
+    end
+
+    memoize
+    def status
+      config[:status] || {}
     end
   end
 end

--- a/db/migrate/20220324090941_add_tooling_status_columns_to_tracks.rb
+++ b/db/migrate/20220324090941_add_tooling_status_columns_to_tracks.rb
@@ -1,0 +1,13 @@
+class AddToolingStatusColumnsToTracks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tracks, :has_representer, :boolean, null: false, default: false
+    add_column :tracks, :has_analyzer, :boolean, null: false, default: false
+
+    Track.find_each do |track|
+      track.update(
+         has_representer: track.git.has_representer?,
+         has_analyzer: track.git.has_analyzer?,
+      )
+    end
+  end
+end

--- a/db/migrate/20220324090941_add_tooling_status_columns_to_tracks.rb
+++ b/db/migrate/20220324090941_add_tooling_status_columns_to_tracks.rb
@@ -2,12 +2,5 @@ class AddToolingStatusColumnsToTracks < ActiveRecord::Migration[7.0]
   def change
     add_column :tracks, :has_representer, :boolean, null: false, default: false
     add_column :tracks, :has_analyzer, :boolean, null: false, default: false
-
-    Track.find_each do |track|
-      track.update(
-         has_representer: track.git.has_representer?,
-         has_analyzer: track.git.has_analyzer?,
-      )
-    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_18_160303) do
+ActiveRecord::Schema.define(version: 2022_03_24_090941) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -652,6 +652,8 @@ ActiveRecord::Schema.define(version: 2021_12_18_160303) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "course", default: false, null: false
     t.boolean "has_test_runner", default: false, null: false
+    t.boolean "has_representer", default: false, null: false
+    t.boolean "has_analyzer", default: false, null: false
     t.index ["slug"], name: "index_tracks_on_slug", unique: true
   end
 

--- a/test/commands/iteration/create_test.rb
+++ b/test/commands/iteration/create_test.rb
@@ -94,6 +94,26 @@ class Iteration::CreateTest < ActiveSupport::TestCase
     Iteration::Create.(solution, submission)
   end
 
+  test "do not create representation if there's no representer" do
+    track = create :track, has_representer: false
+    exercise = create :concept_exercise, track: track
+    solution = create :concept_solution, exercise: exercise
+    submission = create :submission, solution: solution
+
+    Submission::Representation::Init.expects(:call).never
+    Iteration::Create.(solution, submission)
+  end
+
+  test "do not analyze if there's no analyzer" do
+    track = create :track, has_analyzer: false
+    exercise = create :concept_exercise, track: track
+    solution = create :concept_solution, exercise: exercise
+    submission = create :submission, solution: solution
+
+    Submission::Analysis::Init.expects(:call).never
+    Iteration::Create.(solution, submission)
+  end
+
   test "starts analysis and representation" do
     filename_1 = "subdir/foobar.rb"
     content_1 = "'I think' = 'I am'"

--- a/test/commands/solution/update_to_latest_exercise_version_test.rb
+++ b/test/commands/solution/update_to_latest_exercise_version_test.rb
@@ -50,4 +50,16 @@ class Solution::UpdateToLatestExerciseVersionTest < ActiveSupport::TestCase
 
     Solution::UpdateToLatestExerciseVersion.(solution)
   end
+
+  test "don't rerun test if test runner is disabled" do
+    solution = create :concept_solution
+    solution.exercise.update(has_test_runner: false)
+    create(:iteration, solution: solution).submission
+    create(:iteration, solution: solution).submission
+    create(:iteration, solution: solution, deleted_at: Time.current).submission
+
+    Submission::TestRun::Init.expects(:call).never
+
+    Solution::UpdateToLatestExerciseVersion.(solution)
+  end
 end

--- a/test/controllers/api/profiles/solutions_controller_test.rb
+++ b/test/controllers/api/profiles/solutions_controller_test.rb
@@ -63,7 +63,7 @@ class API::Profiles::SolutionsControllerTest < API::BaseTestCase
     setup_user
 
     profile_user = create(:user_profile).user
-    5.times { create :practice_solution, :published, user: profile_user }
+    5.times { |i| create :practice_solution, :published, user: profile_user, num_stars: i }
 
     Solution.find_each { |solution| create :iteration, submission: create(:submission, solution: solution) }
 

--- a/test/factories/tracks.rb
+++ b/test/factories/tracks.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     synced_to_git_sha { "HEAD" }
     course { true }
     has_test_runner { true }
+    has_representer { true }
+    has_analyzer { true }
 
     trait :random_slug do
       slug { SecureRandom.hex }


### PR DESCRIPTION
We recently noticed that the Elm analyzer has run and added comments to a solution, even though the `status.analyzer` field was still disabled.
This is both wrong (an analyzer that is being built would already be running) and wasteful.
I've also done the same for the representer and for the one case where the test runner check was not applied.