### PR TITLE
Award growth mindset badge

### DIFF
--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -24,6 +24,7 @@ class Iteration
         CalculateLinesOfCodeJob.perform_later(iteration)
         ProcessIterationForDiscussionsJob.perform_later(iteration)
         AwardBadgeJob.perform_later(user, :die_unendliche_geschichte)
+        AwardBadgeJob.perform_later(user, :growth_mindset)
         record_activity!(iteration)
       end
     rescue ActiveRecord::RecordNotUnique

--- a/test/commands/iteration/create_test.rb
+++ b/test/commands/iteration/create_test.rb
@@ -182,4 +182,31 @@ class Iteration::CreateTest < ActiveSupport::TestCase
       assert_equal Badges::DieUnendlicheGeschichteBadge, user.reload.badges.first.class
     end
   end
+
+  test "awards growth mindset badge when solution has mentor discussion" do
+    user = create :user
+    solution = create :concept_solution, user: user
+    submission_1 = create :submission, solution: solution
+    Iteration::Create.(solution, submission_1)
+    perform_enqueued_jobs
+
+    # Sanity check: no discussion present
+    refute user.badges.present?
+
+    create :mentor_discussion, solution: solution.reload
+    submission_2 = create :submission, solution: solution
+    Iteration::Create.(solution, submission_2)
+    perform_enqueued_jobs
+
+    # Sanity check: discussion present, but no iteration after creation of discussion
+    refute user.reload.badges.present?
+
+    travel 1.day do
+      submission_3 = create :submission, solution: solution
+      Iteration::Create.(solution.reload, submission_3)
+      perform_enqueued_jobs
+    end
+
+    assert_equal Badges::GrowthMindsetBadge, user.reload.badges.first.class
+  end
 end

--- a/test/integration/iteration_created_test.rb
+++ b/test/integration/iteration_created_test.rb
@@ -21,7 +21,7 @@ class IterationCreatedTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal :awaiting_mentor, discussion.reload.status
-    email = ActionMailer::Base.deliveries.last
+    email = ActionMailer::Base.deliveries.first
     assert_equal(
       "[Mentoring] student has submitted a new iteration on the solution you are mentoring for Ruby/Strings",
       email.subject


### PR DESCRIPTION
This is what the badge currently looks like:

![image](https://user-images.githubusercontent.com/135246/159941909-1835874a-0145-42ad-a868-89b8f644826a.png)

The following script can be used to award the badges:

```ruby
# 4503 users will get this badge
growth_mindset_user_ids = 
    Arel.sql(
        Mentor::Discussion.joins(:solution).
            where('solutions.last_iterated_at > mentor_discussions.created_at').
            select('solutions.user_id').
            distinct.
            to_sql)
            count = 0
User.where("id IN (#{growth_mindset_user_ids})").find_each do |user|
count = count + 1
    AwardBadgeJob.perform_later(user, :growth_mindset, send_email: false)
end
```