### PR TITLE
Allow reputation from issue creation

### DIFF
--- a/app/commands/user/reputation_period/mark_for_token.rb
+++ b/app/commands/user/reputation_period/mark_for_token.rb
@@ -1,5 +1,5 @@
 class User::ReputationPeriod
-  class MarkForNewToken
+  class MarkForToken
     include Mandate
 
     initialize_with :token

--- a/app/commands/user/reputation_token/award_for_issue.rb
+++ b/app/commands/user/reputation_token/award_for_issue.rb
@@ -7,22 +7,14 @@ class User
 
       def call
         return unless label_change?
-        return unless reputation_level
         return unless author
         return unless author.maintainer? || author.admin?
 
-        token = User::ReputationToken::Create.(
-          author,
-          :issue_author,
-          level: reputation_level,
-          repo: params[:repo],
-          issue_node_id: params[:node_id],
-          issue_number: params[:number],
-          issue_title: params[:title],
-          external_url: params[:html_url],
-          opened_at: params[:opened_at]
-        )
-        token&.update!(level: reputation_level)
+        if reputation_level
+          create_token!
+        else
+          delete_token!
+        end
       end
 
       private
@@ -41,6 +33,29 @@ class User
       memoize
       def author
         User.find_by(github_username: params[:opened_by_username])
+      end
+
+      def create_token!
+        User::ReputationToken::Create.(
+          author,
+          :issue_author,
+          level: reputation_level,
+          repo: params[:repo],
+          issue_node_id: params[:node_id],
+          issue_number: params[:number],
+          issue_title: params[:title],
+          external_url: params[:html_url],
+          opened_at: params[:opened_at]
+        )&.tap do |token|
+          token.update!(level: reputation_level)
+        end
+      end
+
+      def delete_token!
+        User::ReputationTokens::IssueAuthorToken.where(user: author, external_url: params[:html_url]).first&.tap do |token|
+          token.destroy!
+          User::ReputationPeriod::MarkForToken.(token)
+        end
       end
     end
   end

--- a/app/commands/user/reputation_token/award_for_issue.rb
+++ b/app/commands/user/reputation_token/award_for_issue.rb
@@ -1,0 +1,47 @@
+class User
+  class ReputationToken
+    class AwardForIssue
+      include Mandate
+
+      initialize_with :params
+
+      def call
+        return unless label_change?
+        return unless reputation_level
+        return unless author
+        return unless author.maintainer? || author.admin?
+
+        token = User::ReputationToken::Create.(
+          author,
+          :issue_author,
+          level: reputation_level,
+          repo: params[:repo],
+          issue_node_id: params[:node_id],
+          issue_number: params[:number],
+          issue_title: params[:title],
+          external_url: params[:html_url],
+          opened_at: params[:opened_at]
+        )
+        token&.update!(level: reputation_level)
+      end
+
+      private
+      def label_change?
+        %w[labeled unlabeled].include?(params[:action])
+      end
+
+      memoize
+      def reputation_level
+        # Sort descendingly to award greatest possible reputation
+        %i[massive large].find do |type|
+          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+        end
+      end
+
+      memoize
+      def author
+        User.find_by(github_username: params[:opened_by_username])
+      end
+    end
+  end
+end

--- a/app/commands/user/reputation_token/award_for_issue.rb
+++ b/app/commands/user/reputation_token/award_for_issue.rb
@@ -52,9 +52,8 @@ class User
       end
 
       def delete_token!
-        User::ReputationTokens::IssueAuthorToken.where(user: author, external_url: params[:html_url]).first&.tap do |token|
-          token.destroy!
-          User::ReputationPeriod::MarkForToken.(token)
+        User::ReputationTokens::IssueAuthorToken.find_by(user: author, external_url: params[:html_url])&.tap do |token|
+          User::ReputationToken::Destroy.(token)
         end
       end
     end

--- a/app/commands/user/reputation_token/create.rb
+++ b/app/commands/user/reputation_token/create.rb
@@ -17,7 +17,7 @@ class User
           token.save!
 
           AwardBadgeJob.perform_later(user, :contributor)
-          User::ReputationPeriod::MarkForNewToken.(token)
+          User::ReputationPeriod::MarkForToken.(token)
         rescue ActiveRecord::RecordNotUnique
           return klass.find_by!(user: user, uniqueness_key: token.uniqueness_key)
         end

--- a/app/commands/user/reputation_token/destroy.rb
+++ b/app/commands/user/reputation_token/destroy.rb
@@ -1,0 +1,14 @@
+class User
+  class ReputationToken
+    class Destroy
+      include Mandate
+
+      initialize_with :token
+
+      def call
+        token.destroy!
+        User::ReputationPeriod::MarkForToken.(token)
+      end
+    end
+  end
+end

--- a/app/jobs/process_issue_update_job.rb
+++ b/app/jobs/process_issue_update_job.rb
@@ -5,18 +5,20 @@ class ProcessIssueUpdateJob < ApplicationJob
     if issue[:action] == 'deleted'
       Github::Issue::Destroy.(issue[:node_id])
       Github::Task::Destroy.(issue[:html_url])
-    else
-      issue = Github::Issue::CreateOrUpdate.(
-        issue[:node_id],
-        number: issue[:number],
-        title: issue[:title],
-        state: issue[:state],
-        repo: issue[:repo],
-        labels: issue[:labels],
-        opened_at: issue[:opened_at],
-        opened_by_username: issue[:opened_by_username]
-      )
-      Github::Task::SyncTask.(issue)
+      return
     end
+
+    issue = Github::Issue::CreateOrUpdate.(
+      issue[:node_id],
+      number: issue[:number],
+      title: issue[:title],
+      state: issue[:state],
+      repo: issue[:repo],
+      labels: issue[:labels],
+      opened_at: issue[:opened_at],
+      opened_by_username: issue[:opened_by_username]
+    )
+    Github::Task::SyncTask.(issue)
+    User::ReputationToken::AwardForIssue.(issue)
   end
 end

--- a/app/jobs/process_issue_update_job.rb
+++ b/app/jobs/process_issue_update_job.rb
@@ -1,24 +1,24 @@
 class ProcessIssueUpdateJob < ApplicationJob
   queue_as :default
 
-  def perform(issue)
-    if issue[:action] == 'deleted'
-      Github::Issue::Destroy.(issue[:node_id])
-      Github::Task::Destroy.(issue[:html_url])
+  def perform(issue_data)
+    if issue_data[:action] == 'deleted'
+      Github::Issue::Destroy.(issue_data[:node_id])
+      Github::Task::Destroy.(issue_data[:html_url])
       return
     end
 
     issue = Github::Issue::CreateOrUpdate.(
-      issue[:node_id],
-      number: issue[:number],
-      title: issue[:title],
-      state: issue[:state],
-      repo: issue[:repo],
-      labels: issue[:labels],
-      opened_at: issue[:opened_at],
-      opened_by_username: issue[:opened_by_username]
+      issue_data[:node_id],
+      number: issue_data[:number],
+      title: issue_data[:title],
+      state: issue_data[:state],
+      repo: issue_data[:repo],
+      labels: issue_data[:labels],
+      opened_at: issue_data[:opened_at],
+      opened_by_username: issue_data[:opened_by_username]
     )
     Github::Task::SyncTask.(issue)
-    User::ReputationToken::AwardForIssue.(issue)
+    User::ReputationToken::AwardForIssue.(issue_data)
   end
 end

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -32,8 +32,9 @@ class User::ReputationToken < ApplicationRecord
     self.value = self.determine_value
   end
 
-  after_save_commit do
-    summing_sql = Arel.sql("(#{user.reputation_tokens.select('SUM(value)').to_sql})")
+  after_commit do
+    # The COALESCE is needed for the rare case where a user's single reputation token is deleted
+    summing_sql = Arel.sql("(#{user.reputation_tokens.select('COALESCE(SUM(value), 0)').to_sql})")
 
     # We're updating in a single query instead of two queries to avoid race-conditions
     # and using read_committed to avoid deadlocks

--- a/app/models/user/reputation_tokens/issue_author_token.rb
+++ b/app/models/user/reputation_tokens/issue_author_token.rb
@@ -1,0 +1,28 @@
+class User::ReputationTokens::IssueAuthorToken < User::ReputationToken
+  params :repo, :issue_node_id, :issue_number, :issue_title, :opened_at
+  category :maintaining
+  reason :opened_issue
+  levels %i[large massive]
+  values({ large: 30, massive: 100 })
+
+  before_validation on: :create do
+    self.earned_on = self.opened_at || Time.current unless earned_on
+
+    unless track
+      normalized_repo = repo.gsub(/-(test-runner|analyzer|representer)$/, '')
+      self.track_id = Track.where(repo_url: "https://github.com/#{normalized_repo}").pick(:id)
+    end
+  end
+
+  def guard_params
+    "issue##{issue_node_id}"
+  end
+
+  def i18n_params
+    {
+      repo: repo.split("/").last,
+      issue_number: issue_number,
+      issue_title: issue_title
+    }
+  end
+end

--- a/config/locales/user_reputation_tokens/en.yml
+++ b/config/locales/user_reputation_tokens/en.yml
@@ -27,3 +27,6 @@ en:
     published_solution:
       1: >
         You published your solution to <strong>%{exercise_title}</strong> in <strong>%{track_title}</strong>
+    issue_author:
+      1: >
+        You opened <strong>issue#%{issue_number}</strong> on <strong>%{repo}</strong>: %{issue_title}

--- a/test/commands/user/reputation_period/mark_for_new_token_test.rb
+++ b/test/commands/user/reputation_period/mark_for_new_token_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
-class User::ReputationPeriod::MarkForNewTokenTest < ActiveSupport::TestCase
+class User::ReputationPeriod::MarkForTokenTest < ActiveSupport::TestCase
   test "adds relevant rows with track for normal tokens" do
     handle = 'ihid'
     user = create :user, handle: handle
     track = create :track
     token = create :user_code_contribution_reputation_token, user: user, track: track
 
-    User::ReputationPeriod::MarkForNewToken.(token)
+    User::ReputationPeriod::MarkForToken.(token)
 
     args = { user_handle: handle, user_id: user.id, dirty: true }
 
@@ -44,7 +44,7 @@ class User::ReputationPeriod::MarkForNewTokenTest < ActiveSupport::TestCase
     token = create :user_code_contribution_reputation_token, user: user
     refute token.track # Sanity
 
-    User::ReputationPeriod::MarkForNewToken.(token)
+    User::ReputationPeriod::MarkForToken.(token)
 
     args = { user_handle: handle, user_id: user.id, dirty: true }
 
@@ -67,7 +67,7 @@ class User::ReputationPeriod::MarkForNewTokenTest < ActiveSupport::TestCase
     track = create :track
     token = create :user_published_solution_reputation_token, user: user, track: track
 
-    User::ReputationPeriod::MarkForNewToken.(token)
+    User::ReputationPeriod::MarkForToken.(token)
 
     refute User::ReputationPeriod.where.not(category: :any).exists?
     assert_equal 8, User::ReputationPeriod.where(category: :any).count

--- a/test/commands/user/reputation_period/mark_for_old_tokens_test.rb
+++ b/test/commands/user/reputation_period/mark_for_old_tokens_test.rb
@@ -12,9 +12,9 @@ class User::ReputationPeriod::MarkOutdatedTest < ActiveSupport::TestCase
     token_3 = create :user_code_contribution_reputation_token, user: user, track: track, earned_on: Date.new(2021, 1, 3)
 
     # Create all the relevant records
-    User::ReputationPeriod::MarkForNewToken.(token_1)
-    User::ReputationPeriod::MarkForNewToken.(token_2)
-    User::ReputationPeriod::MarkForNewToken.(token_3)
+    User::ReputationPeriod::MarkForToken.(token_1)
+    User::ReputationPeriod::MarkForToken.(token_2)
+    User::ReputationPeriod::MarkForToken.(token_3)
     User::ReputationPeriod::Sweep.()
 
     assert_equal 16, User::ReputationPeriod.count # Sanity
@@ -36,9 +36,9 @@ class User::ReputationPeriod::MarkOutdatedTest < ActiveSupport::TestCase
     token_3 = create :user_code_contribution_reputation_token, user: user, earned_on: Date.new(2021, 1, 3)
 
     # Create all the relevant records
-    User::ReputationPeriod::MarkForNewToken.(token_1)
-    User::ReputationPeriod::MarkForNewToken.(token_2)
-    User::ReputationPeriod::MarkForNewToken.(token_3)
+    User::ReputationPeriod::MarkForToken.(token_1)
+    User::ReputationPeriod::MarkForToken.(token_2)
+    User::ReputationPeriod::MarkForToken.(token_3)
     User::ReputationPeriod::Sweep.()
 
     assert_equal 8, User::ReputationPeriod.count # Sanity
@@ -58,8 +58,8 @@ class User::ReputationPeriod::MarkOutdatedTest < ActiveSupport::TestCase
     token_2 = create :user_reputation_token, user: user, earned_on: Date.new(2021, 1, 1)
 
     # Create all the relevant records
-    User::ReputationPeriod::MarkForNewToken.(token_1)
-    User::ReputationPeriod::MarkForNewToken.(token_2)
+    User::ReputationPeriod::MarkForToken.(token_1)
+    User::ReputationPeriod::MarkForToken.(token_2)
     User::ReputationPeriod::Sweep.()
 
     assert_equal 2, User::ReputationToken.count # Sanity

--- a/test/commands/user/reputation_token/award_for_issue_test.rb
+++ b/test/commands/user/reputation_token/award_for_issue_test.rb
@@ -1,0 +1,247 @@
+require "test_helper"
+
+class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
+  %w[labeled unlabeled].each do |action|
+    %i[admin maintainer].each do |role|
+      test "adds reputation token to issue author when action is #{action} and user is #{role}" do
+        opened_by_username = 'user22'
+        repo = 'exercism/v3'
+        node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+        number = 1347
+        title = "The cat sat on the mat"
+        opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+        url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+        html_url = 'https://github.com/exercism/v3/issue/1347'
+        labels = ['x:size/large']
+        user = create :user, handle: "User-22", github_username: "user22", roles: [role]
+
+        User::ReputationToken::AwardForIssue.(
+          action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+        )
+
+        assert_equal 1, User::ReputationTokens::IssueAuthorToken.where(user: user).count
+        token = User::ReputationTokens::IssueAuthorToken.where(user: user).first
+        assert opened_at.to_date, token.earned_on
+      end
+    end
+  end
+
+  %w[opened edited deleted closed reopened transferred].each do |action|
+    test "no reputation is awarded when action is #{action}" do
+      opened_by_username = 'user22'
+      repo = 'exercism/v3'
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      number = 1347
+      title = "The cat sat on the mat"
+      opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+      url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+      html_url = 'https://github.com/exercism/v3/issue/1347'
+      labels = ['x:size/large']
+      user = create :user, handle: "User-22", github_username: "user22", roles: [:admin]
+
+      User::ReputationToken::AwardForIssue.(
+        action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+      )
+
+      refute User::ReputationTokens::IssueAuthorToken.where(user: user).exists?
+    end
+  end
+
+  ['x:size/tiny', 'x:size/small', 'x:size/medium'].each do |label|
+    test "no reputation is awarded when size label is #{label}" do
+      action = 'labeled'
+      opened_by_username = 'user22'
+      repo = 'exercism/v3'
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      number = 1347
+      title = "The cat sat on the mat"
+      opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+      url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+      html_url = 'https://github.com/exercism/v3/issue/1347'
+      labels = [label]
+      user = create :user, handle: "User-22", github_username: "user22", roles: [:admin]
+
+      User::ReputationToken::AwardForIssue.(
+        action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+      )
+
+      refute User::ReputationTokens::IssueAuthorToken.where(user: user).exists?
+    end
+  end
+
+  test "no reputation is awarded when author is no admin or maintainer" do
+    action = 'labeled'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = ['x:size/large']
+    user = create :user, handle: "User-22", github_username: "user22", roles: []
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    refute User::ReputationTokens::IssueAuthorToken.where(user: user).exists?
+  end
+
+  test "no reputation is awarded when there is no size label" do
+    action = 'labeled'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = ['bug']
+    user = create :user, handle: "User-22", github_username: "user22", roles: [:admin]
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    refute User::ReputationTokens::IssueAuthorToken.where(user: user).exists?
+  end
+
+  test "reputation is awarded once per author per issue" do
+    action = 'closed'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = []
+    user = create :user, handle: "User-22", github_username: "user22"
+    create :user_issue_author_reputation_token, user: user, level: :large,
+      params: {
+        repo: repo,
+        pr_node_id: node_id,
+        opened_at: opened_at
+      }
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    assert_equal 1, User::ReputationTokens::IssueAuthorToken.where(user: user).size
+  end
+
+  %w[ruby ruby-test-runner ruby-analyzer ruby-representer].each do |repo_name|
+    test "reputation token with repo is #{repo_name} is linked to correct track" do
+      action = 'labeled'
+      opened_by_username = 'user22'
+      repo = "exercism/#{repo_name}"
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      number = 1347
+      title = "The cat sat on the mat"
+      opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+      url = "https://api.github.com/repos/exercism/#{repo_name}/issues/1347"
+      html_url = "https://github.com/exercism/#{repo_name}/issue/1347"
+      labels = ['x:size/massive']
+      user = create :user, handle: "User-22", github_username: "user22", roles: [:maintainer]
+      track = create :track, repo_url: 'https://github.com/exercism/ruby'
+
+      User::ReputationToken::AwardForIssue.(
+        action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+      )
+
+      token = User::ReputationTokens::IssueAuthorToken.where(user: user).first
+      assert_equal track, token.track
+    end
+  end
+
+  test "reputation not awarded to issue author if author is not known" do
+    action = 'closed'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = []
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    refute User::ReputationTokens::IssueAuthorToken.exists?
+  end
+
+  test "issue with large and massive sizes adds reputation token for greatest size" do
+    action = 'labeled'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = ['x:size/large', 'x:size/massive']
+    user = create :user, handle: "User-22", github_username: "user22", roles: [:admin]
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    assert_equal 100, user.reputation_tokens.last.value
+  end
+
+  test "issue ignores irrelevant labels" do
+    action = 'labeled'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = ['duplicate', 'x:size/large', 'bug']
+    user = create :user, handle: "User-22", github_username: "user22", roles: [:maintainer]
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    assert_equal 30, user.reputation_tokens.last.value
+  end
+
+  test "reputation value changed if size label changes" do
+    action = 'labeled'
+    opened_by_username = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    html_url = 'https://github.com/exercism/v3/issue/1347'
+    labels = ['x:size/large']
+    user = create :user, handle: "User-22", github_username: "user22", roles: [:maintainer]
+    reputation_token = create :user_issue_author_reputation_token, user: user, level: :massive,
+      params: {
+        repo: repo,
+        issue_node_id: node_id,
+        opened_at: opened_at
+      }
+
+    User::ReputationToken::AwardForIssue.(
+      action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+    )
+
+    assert_equal 1, user.reputation_tokens.size
+    assert_equal 30, reputation_token.reload.value
+  end
+end

--- a/test/commands/user/reputation_token/create_test.rb
+++ b/test/commands/user/reputation_token/create_test.rb
@@ -5,7 +5,7 @@ class User::ReputationToken::CreateTest < ActiveSupport::TestCase
     user = create :user, handle: "User22", github_username: "user22"
     contributorship = create :exercise_contributorship, contributor: user
 
-    User::ReputationPeriod::MarkForNewToken.expects(:call)
+    User::ReputationPeriod::MarkForToken.expects(:call)
     AwardBadgeJob.expects(:perform_later).with(user, :contributor)
 
     2.times do

--- a/test/commands/user/reputation_token/destroy_test.rb
+++ b/test/commands/user/reputation_token/destroy_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class User::ReputationToken::DestroyTest < ActiveSupport::TestCase
+  test "destroys token" do
+    token = create :user_issue_author_reputation_token
+
+    User::ReputationToken::Destroy.(token)
+
+    refute User::ReputationToken.where(id: token.id).exists?
+  end
+
+  test "triggers reputation period updating" do
+    token = create :user_issue_author_reputation_token
+
+    User::ReputationPeriod::MarkForToken.expects(:call).with(token)
+
+    User::ReputationToken::Destroy.(token)
+  end
+end

--- a/test/factories/user/reputation_tokens.rb
+++ b/test/factories/user/reputation_tokens.rb
@@ -119,4 +119,19 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :user_issue_author_reputation_token, class: 'User::ReputationTokens::IssueAuthorToken' do
+    user
+    level { :large }
+
+    params do
+      {
+        repo: "exercism/ruby",
+        issue_node_id: SecureRandom.uuid,
+        issue_number: SecureRandom.random_number(100_000),
+        issue_title: "The cat sat on the mat",
+        earned_on: Time.current - SecureRandom.random_number(100_000).seconds
+      }
+    end
+  end
 end

--- a/test/models/user/reputation_tokens/issue_author_token_test.rb
+++ b/test/models/user/reputation_tokens/issue_author_token_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+class User::ReputationTokens::IssueAuthorTokenTest < ActiveSupport::TestCase
+  test "creates issue author reputation token for large level" do
+    external_url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    repo = 'exercism/ruby'
+    issue_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    issue_number = 1347
+    issue_title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    level = :large
+    user = create :user, handle: "User22", github_username: "user22"
+
+    User::ReputationToken::Create.(
+      user,
+      :issue_author,
+      repo: repo,
+      level: level,
+      issue_node_id: issue_node_id,
+      issue_number: issue_number,
+      issue_title: issue_title,
+      opened_at: opened_at,
+      external_url: external_url
+    )
+
+    assert_equal 1, user.reputation_tokens.size
+    rt = user.reputation_tokens.first
+
+    assert_equal User::ReputationTokens::IssueAuthorToken, rt.class
+    assert_equal "You opened <strong>issue##{issue_number}</strong> on <strong>ruby</strong>: The cat sat on the mat", rt.text
+    assert_equal 'https://api.github.com/repos/exercism/v3/issues/1347', rt.external_url
+    assert_equal "#{user.id}|issue_author|issue#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
+    assert_equal :maintaining, rt.category
+    assert_equal :opened_issue, rt.reason
+    assert_equal level, rt.level
+    assert_equal 30, rt.value
+    assert_equal opened_at.to_date, rt.earned_on
+  end
+
+  test "creates issue author reputation token for massive level" do
+    external_url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+    repo = 'exercism/ruby'
+    issue_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    issue_number = 1347
+    issue_title = "The cat sat on the mat"
+    opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+    level = :massive
+    user = create :user, handle: "User22", github_username: "user22"
+
+    User::ReputationToken::Create.(
+      user,
+      :issue_author,
+      repo: repo,
+      level: level,
+      issue_node_id: issue_node_id,
+      issue_number: issue_number,
+      issue_title: issue_title,
+      opened_at: opened_at,
+      external_url: external_url
+    )
+
+    assert_equal 1, user.reputation_tokens.size
+    rt = user.reputation_tokens.first
+
+    assert_equal User::ReputationTokens::IssueAuthorToken, rt.class
+    assert_equal "You opened <strong>issue##{issue_number}</strong> on <strong>ruby</strong>: The cat sat on the mat", rt.text
+    assert_equal 'https://api.github.com/repos/exercism/v3/issues/1347', rt.external_url
+    assert_equal "#{user.id}|issue_author|issue#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
+    assert_equal :maintaining, rt.category
+    assert_equal :opened_issue, rt.reason
+    assert_equal level, rt.level
+    assert_equal 100, rt.value
+    assert_equal opened_at.to_date, rt.earned_on
+  end
+
+  test "uses current time for earned date when opened_at is nil" do
+    freeze_time do
+      external_url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+      repo = 'exercism/ruby'
+      issue_node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      issue_number = 1347
+      issue_title = "The cat sat on the mat"
+      level = :large
+      user = create :user, handle: "User22", github_username: "user22"
+
+      User::ReputationToken::Create.(
+        user,
+        :issue_author,
+        repo: repo,
+        level: level,
+        issue_node_id: issue_node_id,
+        issue_number: issue_number,
+        issue_title: issue_title,
+        opened_at: nil,
+        external_url: external_url
+      )
+
+      assert_equal 1, user.reputation_tokens.size
+      rt = user.reputation_tokens.first
+
+      assert_equal User::ReputationTokens::IssueAuthorToken, rt.class
+      assert_equal "You opened <strong>issue##{issue_number}</strong> on <strong>ruby</strong>: The cat sat on the mat", rt.text
+      assert_equal 'https://api.github.com/repos/exercism/v3/issues/1347', rt.external_url
+      assert_equal "#{user.id}|issue_author|issue#MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ", rt.uniqueness_key
+      assert_equal :maintaining, rt.category
+      assert_equal :opened_issue, rt.reason
+      assert_equal level, rt.level
+      assert_equal 30, rt.value
+      assert_equal Time.current.to_date, rt.earned_on
+    end
+  end
+
+  repos = [
+    ['exercism/ruby', 'track'],
+    ['exercism/ruby-test-runner', 'test runner'],
+    ['exercism/ruby-analyzer', 'analyzer'],
+    ['exercism/ruby-representer', 'representer']
+  ]
+  repos.each do |repo, description|
+    test "linked to track if repo is a #{description} repo" do
+      user = create :user, handle: "User22", github_username: "user22"
+      track = create :track, repo_url: 'https://github.com/exercism/ruby'
+
+      token = User::ReputationToken::Create.(
+        user,
+        :issue_author,
+        level: :large,
+        repo: repo,
+        issue_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+        issue_number: 1347,
+        issue_title: "The cat sat on the mat",
+        opened_at: Time.parse('2020-04-03T14:54:57Z').utc,
+        external_url: 'https://api.github.com/repos/exercism/ruby/issues/1347'
+      )
+
+      assert_equal track, token.track
+    end
+  end
+
+  test "not linked to track if repo is not a track repo" do
+    user = create :user, handle: "User22", github_username: "user22"
+
+    token = User::ReputationToken::Create.(
+      user,
+      :issue_author,
+      level: :large,
+      repo: 'exercism/v3',
+      issue_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+      issue_number: 1347,
+      issue_title: "The cat sat on the mat",
+      opened_at: Time.parse('2020-04-03T14:54:57Z').utc,
+      external_url: 'https://api.github.com/repos/exercism/v3/issues/1347'
+    )
+
+    assert_nil token.track
+  end
+end

--- a/test/system/flows/contributing/user_views_contributors_list_test.rb
+++ b/test/system/flows/contributing/user_views_contributors_list_test.rb
@@ -10,7 +10,7 @@ module Flows
         create :user
         contributor = create :user, handle: "contributor"
         token = create :user_reputation_token, user: contributor, value: 10
-        User::ReputationPeriod::MarkForNewToken.(token)
+        User::ReputationPeriod::MarkForToken.(token)
         User::ReputationPeriod::Sweep.()
 
         use_capybara_host do
@@ -26,9 +26,9 @@ module Flows
         create :user
         contributor = create :user, handle: "contributor"
         week_token = create :user_reputation_token, user: contributor, value: 10, earned_on: Time.zone.today
-        User::ReputationPeriod::MarkForNewToken.(week_token)
+        User::ReputationPeriod::MarkForToken.(week_token)
         month_token = create :user_reputation_token, user: contributor, value: 10, earned_on: 2.months.ago
-        User::ReputationPeriod::MarkForNewToken.(month_token)
+        User::ReputationPeriod::MarkForToken.(month_token)
         User::ReputationPeriod::Sweep.()
 
         use_capybara_host do
@@ -43,9 +43,9 @@ module Flows
         create :user
         contributor = create :user, handle: "contributor"
         building_token = create :user_reputation_token, user: contributor, value: 10
-        User::ReputationPeriod::MarkForNewToken.(building_token)
+        User::ReputationPeriod::MarkForToken.(building_token)
         maintaining_token = create :user_code_merge_reputation_token, user: contributor, value: 10
-        User::ReputationPeriod::MarkForNewToken.(maintaining_token)
+        User::ReputationPeriod::MarkForToken.(maintaining_token)
         User::ReputationPeriod::Sweep.()
 
         use_capybara_host do
@@ -63,10 +63,10 @@ module Flows
         contributor = create :user, handle: "contributor"
         ruby = create :track, title: "Ruby", slug: "ruby"
         ruby_token = create :user_reputation_token, user: contributor, value: 10, track: ruby
-        User::ReputationPeriod::MarkForNewToken.(ruby_token)
+        User::ReputationPeriod::MarkForToken.(ruby_token)
         go = create :track, title: "Go", slug: "go"
         go_token = create :user_reputation_token, user: contributor, value: 10, track: go
-        User::ReputationPeriod::MarkForNewToken.(go_token)
+        User::ReputationPeriod::MarkForToken.(go_token)
         User::ReputationPeriod::Sweep.()
 
         use_capybara_host do
@@ -84,10 +84,10 @@ module Flows
         contributor = create :user, handle: "contributor"
         ruby = create :track, title: "Ruby", slug: "ruby"
         ruby_token = create :user_reputation_token, user: contributor, value: 10, track: ruby
-        User::ReputationPeriod::MarkForNewToken.(ruby_token)
+        User::ReputationPeriod::MarkForToken.(ruby_token)
         go = create :track, title: "Go", slug: "go"
         go_token = create :user_reputation_token, user: contributor, value: 10, track: go
-        User::ReputationPeriod::MarkForNewToken.(go_token)
+        User::ReputationPeriod::MarkForToken.(go_token)
         User::ReputationPeriod::Sweep.()
 
         use_capybara_host do


### PR DESCRIPTION
One open issue is what do to with deleting a reputation token. So far, reputation tokens are never deleted AFAICT, but here it could be the case that a label is applied and then removed. This was not an issue for PRs, as they had a base reputation awarded. I think there are two solutions:

1. Removing the reputation token
2. Setting the reputation token's value to 0
