### PR TITLE
Exclude editor files from valid file paths

### DIFF
--- a/app/models/git/exercise.rb
+++ b/app/models/git/exercise.rb
@@ -46,6 +46,9 @@ module Git
       return false if filepath.starts_with?(".docs/")
       return false if filepath.starts_with?(".exercism/")
 
+      # We don't want to let students override the editor files
+      return false if editor_filepaths.include?(filepath)
+
       # We don't want to let students override the test files. However, some languages
       # have solutions and tests in the same file so we need the second guard for that.
       return false if test_filepaths.include?(filepath) && !solution_filepaths.include?(filepath)

--- a/test/models/git/exercise_test.rb
+++ b/test/models/git/exercise_test.rb
@@ -151,6 +151,31 @@ module Git
       assert_equal expected_filepaths, exercise.important_filepaths
     end
 
+    test "valid_filepaths" do
+      exercise = Git::Exercise.new(:bob, "practice", "HEAD",
+        repo_url: TestHelpers.git_repo_url("track-with-exercises"))
+
+      assert exercise.valid_submission_filepath?('bob.rb')
+      assert exercise.valid_submission_filepath?('subdir/more_bob.rb')
+      refute exercise.valid_submission_filepath?('bob_test.rb')
+      refute exercise.valid_submission_filepath?('.meta/config.json')
+      refute exercise.valid_submission_filepath?('.meta/example.rb')
+      refute exercise.valid_submission_filepath?('.docs/instructions.md')
+    end
+
+    test "valid_filepaths with editor files" do
+      exercise = Git::Exercise.new(:isogram, "practice", "HEAD",
+        repo_url: TestHelpers.git_repo_url("track-with-exercises"))
+
+      assert exercise.valid_submission_filepath?('isogram.rb')
+      assert exercise.valid_submission_filepath?('subdir/more_isogram.rb')
+      refute exercise.valid_submission_filepath?('helper.rb')
+      refute exercise.valid_submission_filepath?('isogram_test.rb')
+      refute exercise.valid_submission_filepath?('.meta/config.json')
+      refute exercise.valid_submission_filepath?('.meta/example.rb')
+      refute exercise.valid_submission_filepath?('.docs/instructions.md')
+    end
+
     test "retrieves instructions" do
       exercise = Git::Exercise.new(:isogram, "practice", "HEAD",
         repo_url: TestHelpers.git_repo_url("track-with-exercises"))


### PR DESCRIPTION
We didn't yet exclude `.editor` files﻿from valid submissions, which meant that:

- Students could override the editor files and submit them to pass tests that should not be passing
- The lines of code counts are off for exercises with editor files

See https://github.com/exercism/exercism/issues/6302