### PR TITLE
Upgrade react query

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-image-crop": "^8.6.9",
     "react-modal": "^3.13.1",
     "react-popper": "^2.2.3",
-    "react-query": "2.23.1",
+    "react-query": "^2.26.4",
     "react-query-devtools": "^2.6.3",
     "react-simplemde-editor": "^5",
     "reconnecting-websocket": "3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8478,10 +8478,10 @@ react-query-devtools@^2.6.3:
   dependencies:
     match-sorter "^4.1.0"
 
-react-query@2.23.1:
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.23.1.tgz#7d676f56d3c6e96b4de4d0b178baf6bb6a0ec272"
-  integrity sha512-qIma0Kvr//LWgWFah7RcntvD4FurXXdQaQeIfqhCWKdhihhe3Xs5BHsljAP68jo719/+xhWxL3I96SvrU4gGHA==
+react-query@^2.26.4:
+  version "2.26.4"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.26.4.tgz#18239b4c0b61d0b744f0d4a91f566b294fa9f752"
+  integrity sha512-sXGG0gh1ah11AcfptYOCRpGDoYMnssq6riQUpQaLSM2EOodVkexp3zNLk1MFDgfRGuXQst40Tnu17oNwni66aA==
   dependencies:
     "@babel/runtime" "^7.5.5"
 


### PR DESCRIPTION
Upgrade the `react-query` library fixes an issue where the latest submitted iteration is not shown.
It appears to have been an invalidation bug.

Closes https://github.com/exercism/exercism/issues/6182﻿
