### PR TITLE
Use x:rep label instead of x:size for reputation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'jsbundling-rails'
 gem 'turbo-rails'
 gem 'propshaft', '0.4.0' # Changing this will break stuff. Work needed.
 
-gem 'mysql2', github: 'brianmario/mysql2', ref: '25c42c7'
+gem 'mysql2', github: 'brianmario/mysql2', ref: '56c0ced2afe2cabe0b3f1a05e8e5e86713ebbc87'
 gem 'redis', '~> 4.0'
 gem 'aws-sdk-s3', '~> 1'
 gem 'aws-sdk-ecr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/brianmario/mysql2.git
-  revision: 25c42c712118b046eb9df7a0f50ffde1a04ee6d1
-  ref: 25c42c7
+  revision: 56c0ced2afe2cabe0b3f1a05e8e5e86713ebbc87
+  ref: 56c0ced2afe2cabe0b3f1a05e8e5e86713ebbc87
   specs:
     mysql2 (0.5.3)
 
@@ -578,4 +578,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.3.4
+   2.3.7

--- a/app/commands/user/reputation_token/award_for_issue.rb
+++ b/app/commands/user/reputation_token/award_for_issue.rb
@@ -25,7 +25,7 @@ class User
       def reputation_level
         # Sort descendingly to award greatest possible reputation
         %i[massive large].find do |type|
-          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+          params[:labels].include?(Github::IssueLabel.for_type(:rep, type))
         end
       end
 

--- a/app/commands/user/reputation_token/award_for_pull_request_author.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_author.rb
@@ -43,7 +43,8 @@ class User
       def reputation_level
         # Sort descendingly to award greatest possible reputation
         %i[massive large medium small tiny].find do |type|
-          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+          params[:labels].include?(Github::IssueLabel.for_type(:size, type)) ||
+            params[:labels].include?(Github::IssueLabel.for_type(:rep, type))
         end || :medium
       end
     end

--- a/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
+++ b/app/commands/user/reputation_token/award_for_pull_request_reviewers.rb
@@ -55,7 +55,8 @@ class User
       def reputation_level
         # Sort descendingly to award greatest possible reputation
         %i[massive large medium small tiny].find do |type|
-          params[:labels].include?(Github::IssueLabel.for_type(:size, type))
+          params[:labels].include?(Github::IssueLabel.for_type(:size, type)) ||
+            params[:labels].include?(Github::IssueLabel.for_type(:rep, type))
         end || :medium
       end
     end

--- a/app/models/github/issue_label.rb
+++ b/app/models/github/issue_label.rb
@@ -57,6 +57,7 @@ class Github::IssueLabel < ApplicationRecord
     action: %i[create fix improve proofread sync],
     knowledge: %i[none elementary intermediate advanced],
     module: %i[analyzer concept-exercise concept generator practice-exercise representer test-runner],
+    rep: %i[tiny small medium large massive],
     size: %i[tiny small medium large massive],
     status: %i[claimed],
     type: %i[ci coding content docker docs]

--- a/test/commands/user/reputation_token/award_for_issue_test.rb
+++ b/test/commands/user/reputation_token/award_for_issue_test.rb
@@ -11,7 +11,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
       opened_at = Time.parse('2020-04-03T14:54:57Z').utc
       url = 'https://api.github.com/repos/exercism/v3/issues/1347'
       html_url = 'https://github.com/exercism/v3/issue/1347'
-      labels = ['x:size/large']
+      labels = ['x:rep/large']
       user = create :user, handle: "User-22", github_username: "user22"
 
       User::ReputationToken::AwardForIssue.(
@@ -34,7 +34,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
       opened_at = Time.parse('2020-04-03T14:54:57Z').utc
       url = 'https://api.github.com/repos/exercism/v3/issues/1347'
       html_url = 'https://github.com/exercism/v3/issue/1347'
-      labels = ['x:size/large']
+      labels = ['x:rep/large']
       user = create :user, handle: "User-22", github_username: "user22"
 
       User::ReputationToken::AwardForIssue.(
@@ -45,7 +45,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     end
   end
 
-  ['x:size/tiny', 'x:size/small', 'x:size/medium'].each do |label|
+  ['x:size/tiny', 'x:size/small', 'x:size/medium', 'x:size/large', 'x:size/massive'].each do |label|
     test "no reputation is awarded when size label is #{label}" do
       action = 'labeled'
       opened_by_username = 'user22'
@@ -67,6 +67,28 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     end
   end
 
+  ['x:rep/tiny', 'x:rep/small', 'x:rep/medium'].each do |label|
+    test "no reputation is awarded when rep label is #{label}" do
+      action = 'labeled'
+      opened_by_username = 'user22'
+      repo = 'exercism/v3'
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      number = 1347
+      title = "The cat sat on the mat"
+      opened_at = Time.parse('2020-04-03T14:54:57Z').utc
+      url = 'https://api.github.com/repos/exercism/v3/issues/1347'
+      html_url = 'https://github.com/exercism/v3/issue/1347'
+      labels = [label]
+      user = create :user, handle: "User-22", github_username: "user22", roles: [:admin]
+
+      User::ReputationToken::AwardForIssue.(
+        action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
+      )
+
+      refute User::ReputationTokens::IssueAuthorToken.where(user: user).exists?
+    end
+  end
+
   test "no reputation is awarded when author could not be found" do
     action = 'labeled'
     opened_by_username = 'user22'
@@ -77,7 +99,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     opened_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/issues/1347'
     html_url = 'https://github.com/exercism/v3/issue/1347'
-    labels = ['x:size/large']
+    labels = ['x:rep/large']
 
     User::ReputationToken::AwardForIssue.(
       action:, opened_by_username:, url:, html_url:, labels:, repo:, node_id:, number:, title:, opened_at:
@@ -86,7 +108,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     refute User::ReputationTokens::IssueAuthorToken.exists?
   end
 
-  test "no reputation is awarded when there is no size label" do
+  test "no reputation is awarded when there is no rep label" do
     action = 'labeled'
     opened_by_username = 'user22'
     repo = 'exercism/v3'
@@ -143,7 +165,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
       opened_at = Time.parse('2020-04-03T14:54:57Z').utc
       url = "https://api.github.com/repos/exercism/#{repo_name}/issues/1347"
       html_url = "https://github.com/exercism/#{repo_name}/issue/1347"
-      labels = ['x:size/massive']
+      labels = ['x:rep/massive']
       user = create :user, handle: "User-22", github_username: "user22"
       track = create :track, repo_url: 'https://github.com/exercism/ruby'
 
@@ -175,7 +197,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     refute User::ReputationTokens::IssueAuthorToken.exists?
   end
 
-  test "issue with large and massive sizes adds reputation token for greatest size" do
+  test "issue with large and massive rep adds reputation token for greatest rep" do
     action = 'labeled'
     opened_by_username = 'user22'
     repo = 'exercism/v3'
@@ -185,7 +207,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     opened_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/issues/1347'
     html_url = 'https://github.com/exercism/v3/issue/1347'
-    labels = ['x:size/large', 'x:size/massive']
+    labels = ['x:rep/large', 'x:rep/massive']
     user = create :user, handle: "User-22", github_username: "user22"
 
     User::ReputationToken::AwardForIssue.(
@@ -205,7 +227,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     opened_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/issues/1347'
     html_url = 'https://github.com/exercism/v3/issue/1347'
-    labels = ['duplicate', 'x:size/large', 'bug']
+    labels = ['duplicate', 'x:rep/large', 'bug']
     user = create :user, handle: "User-22", github_username: "user22"
 
     User::ReputationToken::AwardForIssue.(
@@ -225,7 +247,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     opened_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/issues/1347'
     html_url = 'https://github.com/exercism/v3/issue/1347'
-    labels = ['x:size/large']
+    labels = ['x:rep/large']
     user = create :user, handle: "User-22", github_username: "user22"
     reputation_token = create :user_issue_author_reputation_token, user: user, level: :massive,
       external_url: html_url,
@@ -245,8 +267,8 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     assert_equal 30, user.reputation
   end
 
-  ['x:size/tiny', 'x:size/small', 'x:size/medium'].each do |label|
-    test "reputation token removed if size label changes to #{label}" do
+  ['x:rep/tiny', 'x:rep/small', 'x:rep/medium'].each do |label|
+    test "reputation token removed if rep label changes to #{label}" do
       action = 'labeled'
       opened_by_username = 'user22'
       repo = 'exercism/v3'
@@ -278,7 +300,7 @@ class User::ReputationToken::AwardForIssueTest < ActiveSupport::TestCase
     end
   end
 
-  test "reputation token removed if size label is removed" do
+  test "reputation token removed if rep label is removed" do
     action = 'unlabeled'
     opened_by_username = 'user22'
     repo = 'exercism/v3'

--- a/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
@@ -168,7 +168,12 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     ['x:size/small', 5],
     ['x:size/medium', 12],
     ['x:size/large', 30],
-    ['x:size/massive', 100]
+    ['x:size/massive', 100],
+    ['x:rep/tiny', 3],
+    ['x:rep/small', 5],
+    ['x:rep/medium', 12],
+    ['x:rep/large', 30],
+    ['x:rep/massive', 100]
   ].each do |label, reputation|
     test "pull request with #{label} label adds reputation token with correct value" do
       action = 'closed'

--- a/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_request_author_test.rb
@@ -220,6 +220,28 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     assert_equal 30, user.reputation_tokens.last.value
   end
 
+  test "pull request with small and large rep adds reputation token for greatest rep" do
+    action = 'closed'
+    author = 'user22'
+    repo = 'exercism/v3'
+    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+    number = 1347
+    title = "The cat sat on the mat"
+    merged = true
+    merged_at = Time.parse('2020-04-03T14:54:57Z').utc
+    url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    html_url = 'https://github.com/exercism/v3/pull/1347'
+    labels = ['x:rep/small', 'x:rep/large']
+    user = create :user, handle: "User-22", github_username: "user22"
+
+    User::ReputationToken::AwardForPullRequestAuthor.(
+      action: action, author_username: author, url: url, html_url: html_url, labels: labels,
+      repo: repo, node_id: node_id, number: number, title: title, merged: merged, merged_at: merged_at
+    )
+
+    assert_equal 30, user.reputation_tokens.last.value
+  end
+
   test "pull request ignores irrelevant labels" do
     action = 'closed'
     author = 'user22'
@@ -253,7 +275,7 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     merged_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
     html_url = 'https://github.com/exercism/v3/pull/1347'
-    labels = ['x:size/small']
+    labels = ['x:rep/small']
     user = create :user, handle: "User-22", github_username: "user22"
     reputation_token = create :user_code_contribution_reputation_token,
       user: user,
@@ -288,7 +310,7 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     merged_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
     html_url = 'https://github.com/exercism/v3/pull/1347'
-    labels = ['x:size/large']
+    labels = ['x:rep/large']
     user = create :user, handle: "User-22", github_username: "user22"
     reputation_token = create :user_code_contribution_reputation_token,
       user: user, level: :small, params: { repo: repo, pr_node_id: node_id, merged_at: merged_at }
@@ -337,7 +359,7 @@ class User::ReputationToken::AwardForPullRequestAuthorTest < ActiveSupport::Test
     merged = false
     url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
     html_url = 'https://github.com/exercism/v3/pull/1347'
-    labels = ['x:size/large']
+    labels = ['x:rep/large']
     user = create :user, handle: "User-22", github_username: "user22"
 
     User::ReputationToken::AwardForPullRequestAuthor.(

--- a/test/commands/user/reputation_token/award_for_pull_request_reviewers_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_request_reviewers_test.rb
@@ -294,7 +294,12 @@ class User::ReputationToken::AwardForPullRequestReviewersTest < ActiveSupport::T
     ['x:size/small', 2],
     ['x:size/medium', 5],
     ['x:size/large', 10],
-    ['x:size/massive', 20]
+    ['x:size/massive', 20],
+    ['x:rep/tiny', 1],
+    ['x:rep/small', 2],
+    ['x:rep/medium', 5],
+    ['x:rep/large', 10],
+    ['x:rep/massive', 20]
   ].each do |label, reputation|
     test "pull request with #{label} label adds reputation token with correct value" do
       action = 'closed'
@@ -332,7 +337,7 @@ class User::ReputationToken::AwardForPullRequestReviewersTest < ActiveSupport::T
     merged_at = Time.parse('2020-04-03T14:54:57Z').utc
     url = 'https://api.github.com/repos/exercism/v3/pulls/1347'
     html_url = 'https://github.com/exercism/v3/pull/1347'
-    labels = ['x:size/small', 'x:size/large']
+    labels = ['x:size/small', 'x:rep/large']
     reviewer = create :user, handle: "Reviewer-71", github_username: "reviewer71"
     create :github_organization_member, username: "reviewer71"
     reviews = [{ reviewer_username: "reviewer71" }]

--- a/test/models/github/issue_label_test.rb
+++ b/test/models/github/issue_label_test.rb
@@ -42,8 +42,18 @@ class Github::IssueLabelTest < ActiveSupport::TestCase
     end
   end
 
-  test "for_typr with module is unknown" do
+  test "for_type with module is unknown" do
     assert_nil Github::IssueLabel.for_type(:module, :unknown)
+  end
+
+  %i[tiny small medium large massive].each do |rep|
+    test "for_type with rep is #{rep}" do
+      assert_equal "x:rep/#{rep}", Github::IssueLabel.for_type(:rep, rep)
+    end
+  end
+
+  test "for_type with rep is unknown" do
+    assert_nil Github::IssueLabel.for_type(:rep, :unknown)
   end
 
   %i[tiny small medium large massive].each do |size|


### PR DESCRIPTION
Use `x:rep` label to determine reputation for issues and pull requests.
For backwards compatibility, we'll still support the `x:size` label for pull requests.
