### PR TITLE
Support any markdown within hints

### DIFF
--- a/app/commands/solution/generate_hints_file.rb
+++ b/app/commands/solution/generate_hints_file.rb
@@ -5,7 +5,7 @@ class Solution
     initialize_with :solution
 
     def call
-      hints_text = Markdown::Render.(solution.git_exercise.hints, :text).strip
+      hints_text = Markdown::Render.(solution.hints, :text).strip
 
       <<~TEXT.strip
         # Hints

--- a/app/commands/solution/generate_readme_file.rb
+++ b/app/commands/solution/generate_readme_file.rb
@@ -15,7 +15,7 @@ class Solution
 
     private
     def preamble
-      hints_text = I18n.t("exercises.documents.hints_reference").strip if solution.git_exercise.hints.present?
+      hints_text = I18n.t("exercises.documents.hints_reference").strip if solution.hints.present?
 
       welcome_text = I18n.t("exercises.documents.welcome", exercise_title: solution.exercise.title,
         track_title: solution.track.title).strip

--- a/app/css/modals/editor-hints.css
+++ b/app/css/modals/editor-hints.css
@@ -39,6 +39,7 @@
 
         & .--summary-inner {
             @apply px-32 pt-16;
+
             @apply text-h5;
             @apply flex items-center;
             & .c-icon {
@@ -48,21 +49,20 @@
             }
         }
     }
-    & .single-task-hints {
-        @apply px-32 py-16;
-        & h3 {
-            @apply text-h5 mb-4;
-        }
+    & .c-textual-content {
+        @apply px-32 pb-16;
         & ul {
-            @apply pl-0;
+            @apply ml-0;
+            & li {
+                @apply text-18 leading-170;
+                list-style: disc;
+                @apply ml-20;
+            }
         }
     }
-    & ul {
-        @apply px-32;
-        & li {
-            @apply text-18 leading-170;
-            list-style: disc;
-            @apply ml-20;
+    & .single-task-hints {
+        & h3 {
+            @apply text-h5 px-32 py-16;
         }
     }
 }

--- a/app/javascript/components/modals/HintsModal.tsx
+++ b/app/javascript/components/modals/HintsModal.tsx
@@ -31,15 +31,13 @@ const Hints = ({
           ) : null}
         </div>
       </summary>
-      <ul>
-        {hints.map((hint, idx) => (
-          <li
-            className="c-textual-content --large"
-            key={idx}
-            dangerouslySetInnerHTML={{ __html: hint }}
-          ></li>
-        ))}
-      </ul>
+      {hints.map((hint, idx) => (
+        <div
+          className="c-textual-content --large"
+          key={idx}
+          dangerouslySetInnerHTML={{ __html: hint }}
+        ></div>
+      ))}
     </details>
   )
 }

--- a/app/javascript/components/modals/TaskHintsModal.tsx
+++ b/app/javascript/components/modals/TaskHintsModal.tsx
@@ -21,15 +21,13 @@ export const TaskHintsModal = ({
       </header>
       <div className="single-task-hints">
         <h3>{task.title}</h3>
-        <ul>
-          {task.hints.map((hint, idx) => (
-            <li
-              className="c-textual-content --large"
-              key={idx}
-              dangerouslySetInnerHTML={{ __html: hint }}
-            ></li>
-          ))}
-        </ul>
+        {task.hints.map((hint, idx) => (
+          <div
+            className="c-textual-content --large"
+            key={idx}
+            dangerouslySetInnerHTML={{ __html: hint }}
+          ></div>
+        ))}
       </div>
     </Modal>
   )

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -97,7 +97,7 @@ class Solution < ApplicationRecord
     end
   end
 
-  delegate :instructions, :introduction, :tests, :source, :source_url, to: :git_exercise
+  delegate :instructions, :introduction, :hints, :tests, :source, :source_url, to: :git_exercise
 
   def update_published_iteration_head_tests_status!(status)
     return if published_iteration_head_tests_status == status.to_sym

--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -83,6 +83,7 @@ class SerializeExerciseAssignment
 
   memoize
   def hints_doc
+    # TODO: remove
     hints = <<~HINTS.strip
       # Hints
 

--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -83,36 +83,6 @@ class SerializeExerciseAssignment
 
   memoize
   def hints_doc
-    # TODO: remove
-    # hints = <<~HINTS.strip
-    #   # Hints
-
-    #   ## General
-
-    #   - Hint one
-    #     - Sub hint one
-    #     - Sub hint two
-    #   - Hint two
-    #   - Hint three
-    #     - Sub hint three
-
-    #   These are more hints
-
-    #   ~~~exercism/note
-    #   This is a note
-    #   ~~~
-
-    #   ## 1. Task one
-
-    #   - Task hint one
-    #     - Task sub hint one
-
-    #   ## 2. Task two
-
-    #   - Task hint two
-    # HINTS
-
-    # return Markdown::Render.(hints, :doc)
     Markdown::Render.(solution.hints, :doc)
   end
 

--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -84,35 +84,36 @@ class SerializeExerciseAssignment
   memoize
   def hints_doc
     # TODO: remove
-    hints = <<~HINTS.strip
-      # Hints
+    # hints = <<~HINTS.strip
+    #   # Hints
 
-      ## General
+    #   ## General
 
-      - Hint one
-        - Sub hint one
-        - Sub hint two
-      - Hint two
-      - Hint three
-        - Sub hint three
+    #   - Hint one
+    #     - Sub hint one
+    #     - Sub hint two
+    #   - Hint two
+    #   - Hint three
+    #     - Sub hint three
 
-      These are more hints
+    #   These are more hints
 
-      ~~~exercism/note
-      This is a note
-      ~~~
+    #   ~~~exercism/note
+    #   This is a note
+    #   ~~~
 
-      ## 1. Task one
+    #   ## 1. Task one
 
-      - Task hint one
-        - Task sub hint one
+    #   - Task hint one
+    #     - Task sub hint one
 
-      ## 2. Task two
+    #   ## 2. Task two
 
-      - Task hint two
-    HINTS
+    #   - Task hint two
+    # HINTS
 
-    Markdown::Render.(hints, :doc)
+    # return Markdown::Render.(hints, :doc)
+    Markdown::Render.(solution.hints, :doc)
   end
 
   def parse_task_title(header)

--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -45,6 +45,18 @@ class SerializeExerciseAssignment
 
     hints_doc.
       each.
+      # Create chunks of nodes whenever the node types is a level 2 heading
+      # It will skip over any nodes before the first level 2 heading
+      # The level 2 heading node itself will be the first element of the chunk,
+      # and any nodes up until the next level 2 heading (or the end of the file)
+      # will be the other elements in the array
+      #
+      # Example: [h1, h2_a, p1, h2_b, p2, c1, h2_c, l1] is chunked as:
+      # [
+      #   [h2_a, p1],
+      #   [h2_b, p2, c1],
+      #   [h2_c, l1]
+      # ]
       slice_before { |x| x.type == :header && x.header_level == 2 }.
       each_with_object({}) do |chunk, hints|
         task_id = parse_task_id(chunk.each.first)

--- a/app/serializers/serialize_exercise_assignment.rb
+++ b/app/serializers/serialize_exercise_assignment.rb
@@ -85,7 +85,7 @@ class SerializeExerciseAssignment
 
   memoize
   def hints_doc
-    Markdown::Render.(solution.git_exercise.hints, :doc)
+    Markdown::Render.(solution.hints, :doc)
   end
 
   def parse_task_title(header)

--- a/test/serializers/serialize_exercise_assignment_test.rb
+++ b/test/serializers/serialize_exercise_assignment_test.rb
@@ -7,7 +7,11 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      "<ul>\n<li>The <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">rubymostas strings guide</a> has a nice\nintroduction to Ruby strings.</li>\n<li>The <code>String</code> object has many useful <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">built-in methods</a>.</li>\n</ul>\n" # rubocop:disable Layout/LineLength
+      <<~HINT
+        <ul>
+        <li>The <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">rubymostas strings guide</a> has a nice\nintroduction to Ruby strings.</li>\n<li>The <code>String</code> object has many useful <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">built-in methods</a>.</li>
+        </ul>
+      HINT
     ]
     assert_equal expected, serialized[:general_hints]
   end
@@ -18,7 +22,11 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      "<ul>\n<li>There are many useful string methods built-in</li>\n</ul>\n"
+      <<~HINT
+        <ul>
+        <li>There are many useful string methods built-in</li>
+        </ul>
+      HINT
     ]
     assert_equal expected, serialized[:general_hints]
   end
@@ -37,16 +45,18 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = "<p>In this exercise you'll be processing log-lines.</p>
-<p>Each log line is a string formatted as follows: <code>\"[&lt;LEVEL&gt;]: &lt;MESSAGE&gt;\"</code>.</p>
-<p>There are three different log levels:</p>
-<ul>
-<li><code>INFO</code></li>
-<li><code>WARNING</code></li>
-<li><code>ERROR</code></li>
-</ul>
-<p>You have three tasks, each of which will take a log line and ask you to do something with it.</p>
-"
+    expected = <<~OVERVIEW
+      <p>In this exercise you'll be processing log-lines.</p>
+      <p>Each log line is a string formatted as follows: <code>\"[&lt;LEVEL&gt;]: &lt;MESSAGE&gt;\"</code>.</p>
+      <p>There are three different log levels:</p>
+      <ul>
+      <li><code>INFO</code></li>
+      <li><code>WARNING</code></li>
+      <li><code>ERROR</code></li>
+      </ul>
+      <p>You have three tasks, each of which will take a log line and ask you to do something with it.</p>
+    OVERVIEW
+
     assert_equal expected, serialized[:overview]
   end
 
@@ -65,7 +75,10 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = "<p>Instructions for bob</p>\n<p>Extra instructions for bob</p>\n"
+    expected = <<~OVERVIEW
+      <p>Instructions for bob</p>
+      <p>Extra instructions for bob</p>
+    OVERVIEW
     assert_equal expected, serialized[:overview]
   end
 
@@ -92,11 +105,25 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = [
-      "<p>Implement the <code>LogLineParser.message</code> method to return a log line's message:</p>\n<pre><code class=\"language-ruby\">LogLineParser.message('[ERROR]: Invalid operation')\n// Returns: \"Invalid operation\"\n</code></pre>\n<p>Any leading or trailing white space should be removed:</p>\n<pre><code class=\"language-ruby\">LogLineParser.message('[WARNING]:  Disk almost full\\r\\n')\n// Returns: \"Disk almost full\"\n</code></pre>\n", # rubocop:disable Layout/LineLength
-      "<p>Implement the <code>LogLineParser.log_level</code> method to return a log line's log level, which should be returned in lowercase:</p>\n<pre><code class=\"language-ruby\">LogLineParser.log_level('[ERROR]: Invalid operation')\n// Returns: \"error\"\n</code></pre>\n", # rubocop:disable Layout/LineLength
-      "<p>Implement the <code>LogLineParser.reformat</code> method that reformats the log line, putting the message first and the log level\nafter it in parentheses:</p>\n<pre><code class=\"language-ruby\">LogLineParser.reformat('[INFO]: Operation completed')\n// Returns: \"Operation completed (info)\"\n</code></pre>\n" # rubocop:disable Layout/LineLength
-    ]
+    expected = [<<~HINT_1, <<~HINT_2, <<~HINT_3]
+      <p>Implement the <code>LogLineParser.message</code> method to return a log line's message:</p>
+      <pre><code class=\"language-ruby\">LogLineParser.message('[ERROR]: Invalid operation')
+      // Returns: \"Invalid operation\"\n</code></pre>
+      <p>Any leading or trailing white space should be removed:</p>
+      <pre><code class=\"language-ruby\">LogLineParser.message('[WARNING]:  Disk almost full\\r\\n')
+      // Returns: \"Disk almost full\"\n</code></pre>
+    HINT_1
+      <p>Implement the <code>LogLineParser.log_level</code> method to return a log line's log level, which should be returned in lowercase:</p>
+      <pre><code class=\"language-ruby\">LogLineParser.log_level('[ERROR]: Invalid operation')
+      // Returns: \"error\"\n</code></pre>
+    HINT_2
+      <p>Implement the <code>LogLineParser.reformat</code> method that reformats the log line, putting the message first and the log level
+      after it in parentheses:</p>
+      <pre><code class=\"language-ruby\">LogLineParser.reformat('[INFO]: Operation completed')
+      // Returns: \"Operation completed (info)\"
+      </code></pre>
+    HINT_3
+
     assert_equal expected, (serialized[:tasks].map { |task| task[:text] })
   end
 
@@ -105,11 +132,25 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = [
-      ["<ul>\n<li>There are different ways to search for text in a string, which can be found on the <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">Ruby language official\ndocumentation</a>.</li>\n<li>There are <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-strip\" target=\"_blank\" rel=\"noopener\">built in methods</a> to strip white space.</li>\n</ul>\n"], # rubocop:disable Layout/LineLength
-      ["<ul>\n<li>Ruby <code>String</code> objects have a <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-downcase\" target=\"_blank\" rel=\"noopener\">method</a> to perform this\noperation.</li>\n</ul>\n"], # rubocop:disable Layout/LineLength
-      ["<ul>\n<li>There are several ways to <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">concatenate\nstrings</a>, but the preferred one is usually\n<a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">string interpolation</a>\n</li>\n</ul>\n"] # rubocop:disable Layout/LineLength
-    ]
+    expected = [[<<~HINT_1], [<<~HINT_2], [<<~HINT_3]]
+      <ul>
+      <li>There are different ways to search for text in a string, which can be found on the <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">Ruby language official
+      documentation</a>.</li>
+      <li>There are <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-strip\" target=\"_blank\" rel=\"noopener\">built in methods</a> to strip white space.</li>
+      </ul>
+    HINT_1
+      <ul>
+      <li>Ruby <code>String</code> objects have a <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-downcase\" target=\"_blank\" rel=\"noopener\">method</a> to perform this
+      operation.</li>
+      </ul>
+    HINT_2
+      <ul>
+      <li>There are several ways to <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">concatenate
+      strings</a>, but the preferred one is usually
+      <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">string interpolation</a>
+      </li>
+      </ul>
+    HINT_3
     assert_equal expected, (serialized[:tasks].map { |task| task[:hints] })
   end
 
@@ -136,7 +177,14 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      "<ul>\n<li>Hint <a href=\"http://exercism.org/about\">number one</a>\n</li>\n<li>Hint <a href=\"http://exercism.org/tracks\">number two</a>\n</li>\n</ul>\n" # rubocop:disable Layout/LineLength
+      <<~HINT
+        <ul>
+        <li>Hint <a href=\"http://exercism.org/about\">number one</a>
+        </li>
+        <li>Hint <a href=\"http://exercism.org/tracks\">number two</a>
+        </li>
+        </ul>
+      HINT
     ]
     assert_equal expected, serialized[:general_hints]
   end
@@ -175,11 +223,31 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = [
-      "<ul>\n<li>Hint one\n<ul>\n<li>Sub hint one</li>\n<li>Sub hint two</li>\n</ul>\n</li>\n<li>Hint two</li>\n<li>Hint three\n<ul>\n<li>Sub hint three</li>\n</ul>\n</li>\n</ul>\n", # rubocop:disable Layout/LineLength
-      "<p>These are more hints</p>\n",
-      "<div class=\"c-textblock-note\">\n<div class=\"c-textblock-header\">Note</div>\n<div class=\"c-textblock-content\">\n<p>This is a note</p>\n</div>\n</div>\n" # rubocop:disable Layout/LineLength
-    ]
+    expected = [<<~HINT_1, <<~HINT_2, <<~HINT_3]
+      <ul>
+      <li>Hint one
+      <ul>
+      <li>Sub hint one</li>
+      <li>Sub hint two</li>
+      </ul>
+      </li>
+      <li>Hint two</li>
+      <li>Hint three
+      <ul>
+      <li>Sub hint three</li>
+      </ul>
+      </li>
+      </ul>
+    HINT_1
+      <p>These are more hints</p>
+    HINT_2
+      <div class=\"c-textblock-note\">
+      <div class=\"c-textblock-header\">Note</div>
+      <div class=\"c-textblock-content\">
+      <p>This is a note</p>
+      </div>
+      </div>
+    HINT_3
     assert_equal expected, serialized[:general_hints]
   end
 
@@ -247,7 +315,17 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     task = serialized[:tasks].first
+
     assert_equal "Document filling out fields with blank values", task[:title]
-    assert_equal "<p>Add documentation and a typespec to the <code>Form.blanks/1</code> function. The documentation should read:</p>\n<pre><code class=\"language-plain\">Generates a string of a given length.\n\nThis string can be used to fill out a form field that is supposed to have no value.\nSuch fields cannot be left empty because a malicious third party could fill them out with false data.\n</code></pre>\n<p>The typespec should explain that the function accepts a single argument, a non-negative integer, and returns a string.</p>\n", task[:text] # rubocop:disable Layout/LineLength
+    expected_text = <<~TEXT
+      <p>Add documentation and a typespec to the <code>Form.blanks/1</code> function. The documentation should read:</p>
+      <pre><code class=\"language-plain\">Generates a string of a given length.
+
+      This string can be used to fill out a form field that is supposed to have no value.
+      Such fields cannot be left empty because a malicious third party could fill them out with false data.
+      </code></pre>
+      <p>The typespec should explain that the function accepts a single argument, a non-negative integer, and returns a string.</p>
+    TEXT
+    assert_equal expected_text, task[:text]
   end
 end

--- a/test/serializers/serialize_exercise_assignment_test.rb
+++ b/test/serializers/serialize_exercise_assignment_test.rb
@@ -142,6 +142,48 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     assert_equal expected, serialized[:general_hints]
   end
 
+  test "serialize hints with complex content" do
+    hints = <<~HINTS.strip
+      # Hints
+
+      ## General
+
+      - Hint one
+        - Sub hint one
+        - Sub hint two
+      - Hint two
+      - Hint three
+        - Sub hint three
+
+      These are more hints
+
+      ~~~exercism/note
+      This is a note
+      ~~~
+
+      ## 1. Task one
+
+      - Task hint one
+        - Task sub hint one
+
+      ## 2. Task two
+
+      - Task hint two
+    HINTS
+
+    solution = create :concept_solution
+    solution.stubs(:hints).returns(hints)
+
+    serialized = SerializeExerciseAssignment.(solution)
+
+    expected = [
+      "<ul>\n<li>Hint one\n<ul>\n<li>Sub hint one</li>\n<li>Sub hint two</li>\n</ul>\n</li>\n<li>Hint two</li>\n<li>Hint three\n<ul>\n<li>Sub hint three</li>\n</ul>\n</li>\n</ul>\n", # rubocop:disable Layout/LineLength
+      "<p>These are more hints</p>\n",
+      "<div class=\"c-textblock-note\">\n<div class=\"c-textblock-header\">Note</div>\n<div class=\"c-textblock-content\">\n<p>This is a note</p>\n</div>\n</div>\n" # rubocop:disable Layout/LineLength
+    ]
+    assert_equal expected, serialized[:general_hints]
+  end
+
   test "serialize concept exercise without general hints" do
     exercise = create :concept_exercise, slug: 'numbers'
     solution = create :concept_solution, exercise: exercise

--- a/test/serializers/serialize_exercise_assignment_test.rb
+++ b/test/serializers/serialize_exercise_assignment_test.rb
@@ -7,8 +7,7 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      "<p>The <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">rubymostas strings guide</a> has a nice\nintroduction to Ruby strings.</p>\n", # rubocop:disable Layout/LineLength
-      "<p>The <code>String</code> object has many useful <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">built-in methods</a>.</p>\n" # rubocop:disable Layout/LineLength
+      "<ul>\n<li>The <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">rubymostas strings guide</a> has a nice\nintroduction to Ruby strings.</li>\n<li>The <code>String</code> object has many useful <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">built-in methods</a>.</li>\n</ul>\n" # rubocop:disable Layout/LineLength
     ]
     assert_equal expected, serialized[:general_hints]
   end
@@ -18,7 +17,9 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
 
     serialized = SerializeExerciseAssignment.(solution)
 
-    expected = ["<p>There are many useful string methods built-in</p>\n"]
+    expected = [
+      "<ul>\n<li>There are many useful string methods built-in</li>\n</ul>\n"
+    ]
     assert_equal expected, serialized[:general_hints]
   end
 
@@ -105,10 +106,9 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      ["<p>There are different ways to search for text in a string, which can be found on the <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">Ruby language official\ndocumentation</a>.</p>\n", # rubocop:disable Layout/LineLength
-       "<p>There are <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-strip\" target=\"_blank\" rel=\"noopener\">built in methods</a> to strip white space.</p>\n"], # rubocop:disable Layout/LineLength
-      ["<p>Ruby <code>String</code> objects have a <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-downcase\" target=\"_blank\" rel=\"noopener\">method</a> to perform this\noperation.</p>\n"], # rubocop:disable Layout/LineLength
-      ["<p>There are several ways to <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">concatenate\nstrings</a>, but the preferred one is usually\n<a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">string interpolation</a></p>\n"] # rubocop:disable Layout/LineLength
+      ["<ul>\n<li>There are different ways to search for text in a string, which can be found on the <a href=\"https://ruby-doc.org/core-2.7.0/String.html\" target=\"_blank\" rel=\"noopener\">Ruby language official\ndocumentation</a>.</li>\n<li>There are <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-strip\" target=\"_blank\" rel=\"noopener\">built in methods</a> to strip white space.</li>\n</ul>\n"], # rubocop:disable Layout/LineLength
+      ["<ul>\n<li>Ruby <code>String</code> objects have a <a href=\"https://ruby-doc.org/core-2.7.0/String.html#method-i-downcase\" target=\"_blank\" rel=\"noopener\">method</a> to perform this\noperation.</li>\n</ul>\n"], # rubocop:disable Layout/LineLength
+      ["<ul>\n<li>There are several ways to <a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">concatenate\nstrings</a>, but the preferred one is usually\n<a href=\"http://ruby-for-beginners.rubymonstas.org/built_in_classes/strings.html\" target=\"_blank\" rel=\"noopener\">string interpolation</a>\n</li>\n</ul>\n"] # rubocop:disable Layout/LineLength
     ]
     assert_equal expected, (serialized[:tasks].map { |task| task[:hints] })
   end
@@ -136,8 +136,7 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     serialized = SerializeExerciseAssignment.(solution)
 
     expected = [
-      "<p>Hint <a href=\"http://exercism.org/about\">number one</a></p>\n",
-      "<p>Hint <a href=\"http://exercism.org/tracks\">number two</a></p>\n"
+      "<ul>\n<li>Hint <a href=\"http://exercism.org/about\">number one</a>\n</li>\n<li>Hint <a href=\"http://exercism.org/tracks\">number two</a>\n</li>\n</ul>\n" # rubocop:disable Layout/LineLength
     ]
     assert_equal expected, serialized[:general_hints]
   end

--- a/test/serializers/serialize_exercise_assignment_test.rb
+++ b/test/serializers/serialize_exercise_assignment_test.rb
@@ -113,6 +113,35 @@ class SerializeExerciseAssignmentTest < ActiveSupport::TestCase
     assert_equal expected, (serialized[:tasks].map { |task| task[:hints] })
   end
 
+  test "serialize hints with reference links" do
+    hints = <<~HINTS.strip
+      # Hints
+
+      ## General
+
+      - Hint [number one][hint-one]
+      - Hint [number two][hint-two]
+
+      ## 1. Task
+
+      - Some task hints
+
+      [hint-one]: http://exercism.org/about
+      [hint-two]: http://exercism.org/tracks
+    HINTS
+
+    solution = create :concept_solution
+    solution.stubs(:hints).returns(hints)
+
+    serialized = SerializeExerciseAssignment.(solution)
+
+    expected = [
+      "<p>Hint <a href=\"http://exercism.org/about\">number one</a></p>\n",
+      "<p>Hint <a href=\"http://exercism.org/tracks\">number two</a></p>\n"
+    ]
+    assert_equal expected, serialized[:general_hints]
+  end
+
   test "serialize concept exercise without general hints" do
     exercise = create :concept_exercise, slug: 'numbers'
     solution = create :concept_solution, exercise: exercise


### PR DESCRIPTION
This PR adds support for any Markdown content to be used within hints.
As such, it also fixes the issue that nested list items would not be rendered.

Currently, we require the hints to all be list items, which is a bit limiting in terms of how the hints can be displayed visually.
For example, the admonitions that we support via `~~~exercism/note` and its siblings can't be used, but that could be really useful.
In some cases, people have also expressed a desire to work with paragraph in the notes, as that might provide for a better reading experience.

This PR aims to fix this by supporting _any_ Markdown content within the hints.
The main thing that needs to be done is to update the styling to work well with the different types of Markdown.
There is a bit commented code in app/serializers/serialize_exercise_assignment.rb:86 that can be used to force the hints contents to be what is specified there, which is really helpful when testing.
