### PR TITLE
Support passing parameters to badges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem 'rest-client' # http
 gem 'octokit' # GitHub
 
 # General-purpose gems
-# gem 'mandate', '1.0.0.beta1'
-gem 'mandate', path: '../../mandate'
+gem 'mandate', '2.0.0'
 gem 'kaminari'
 gem 'oj'
 
@@ -55,7 +54,7 @@ gem 'devise', '~> 4.7'
 
 # Omniauth
 gem 'omniauth-github'
-gem "omniauth-rails_csrf_protection"
+gem 'omniauth-rails_csrf_protection'
 
 # Payments
 gem 'stripe'

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem 'kaminari'
 gem 'oj'
 
 # Setup dependencies
-gem 'exercism-config', '>= 0.83.0' # gem 'exercism-config', path: '../exercism_config'
+gem 'exercism-config', '>= 0.83.0'
+# gem 'exercism-config', path: '../exercism_config'
 
 # Model-level dependencies
 gem 'image_processing', '~> 1.2'
@@ -54,7 +55,7 @@ gem 'devise', '~> 4.7'
 
 # Omniauth
 gem 'omniauth-github'
-gem 'omniauth-rails_csrf_protection'
+gem "omniauth-rails_csrf_protection"
 
 # Payments
 gem 'stripe'

--- a/Gemfile
+++ b/Gemfile
@@ -29,13 +29,13 @@ gem 'rest-client' # http
 gem 'octokit' # GitHub
 
 # General-purpose gems
-gem 'mandate', '1.0.0.beta1'
+# gem 'mandate', '1.0.0.beta1'
+gem 'mandate', path: '../../mandate'
 gem 'kaminari'
 gem 'oj'
 
 # Setup dependencies
-gem 'exercism-config', '>= 0.83.0'
-# gem 'exercism-config', path: '../exercism_config'
+gem 'exercism-config', '>= 0.83.0' # gem 'exercism-config', path: '../exercism_config'
 
 # Model-level dependencies
 gem 'image_processing', '~> 1.2'
@@ -54,7 +54,7 @@ gem 'devise', '~> 4.7'
 
 # Omniauth
 gem 'omniauth-github'
-gem "omniauth-rails_csrf_protection"
+gem 'omniauth-rails_csrf_protection'
 
 # Payments
 gem 'stripe'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,6 @@ GIT
   specs:
     mysql2 (0.5.3)
 
-PATH
-  remote: ../../mandate
-  specs:
-    mandate (1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -269,6 +264,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mandate (2.0.0)
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -541,7 +537,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
-  mandate!
+  mandate (= 2.0.0)
   mini_magick
   minitest
   minitest-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,11 @@ GIT
   specs:
     mysql2 (0.5.3)
 
+PATH
+  remote: ../../mandate
+  specs:
+    mandate (1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -264,7 +269,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mandate (1.0.0.beta1)
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -537,7 +541,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
-  mandate (= 1.0.0.beta1)
+  mandate!
   mini_magick
   minitest
   minitest-retry

--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -23,7 +23,7 @@ class Iteration
         GenerateIterationSnippetJob.perform_later(iteration)
         CalculateLinesOfCodeJob.perform_later(iteration)
         ProcessIterationForDiscussionsJob.perform_later(iteration)
-        AwardBadgeJob.perform_later(user, :die_unendliche_geschichte, iteration_idx: iteration.idx)
+        AwardBadgeJob.perform_later(user, :die_unendliche_geschichte, context: iteration)
         AwardBadgeJob.perform_later(user, :growth_mindset)
         record_activity!(iteration)
       end

--- a/app/commands/iteration/create.rb
+++ b/app/commands/iteration/create.rb
@@ -23,7 +23,7 @@ class Iteration
         GenerateIterationSnippetJob.perform_later(iteration)
         CalculateLinesOfCodeJob.perform_later(iteration)
         ProcessIterationForDiscussionsJob.perform_later(iteration)
-        AwardBadgeJob.perform_later(user, :die_unendliche_geschichte)
+        AwardBadgeJob.perform_later(user, :die_unendliche_geschichte, iteration_idx: iteration.idx)
         AwardBadgeJob.perform_later(user, :growth_mindset)
         record_activity!(iteration)
       end

--- a/app/commands/solution/complete.rb
+++ b/app/commands/solution/complete.rb
@@ -14,10 +14,10 @@ class Solution
       end
 
       %i[anybody_there all_your_base whatever lackadaisical].each do |badge|
-        AwardBadgeJob.perform_later(user, badge, exercise_slug: exercise.slug)
+        AwardBadgeJob.perform_later(user, badge, context: exercise)
       end
 
-      AwardBadgeJob.perform_later(user, :conceptual, exercise_type: exercise.type)
+      AwardBadgeJob.perform_later(user, :conceptual, context: exercise)
       AwardBadgeJob.perform_later(user, :completer)
 
       record_activity!

--- a/app/commands/solution/complete.rb
+++ b/app/commands/solution/complete.rb
@@ -14,12 +14,11 @@ class Solution
       end
 
       %i[anybody_there all_your_base whatever lackadaisical].each do |badge|
-        AwardBadgeJob.perform_later(user, badge, exercise: exercise.slug)
+        AwardBadgeJob.perform_later(user, badge, exercise_slug: exercise.slug)
       end
 
-      %i[completer conceptual].each do |badge|
-        AwardBadgeJob.perform_later(user, badge)
-      end
+      AwardBadgeJob.perform_later(user, :conceptual, exercise_type: exercise.type)
+      AwardBadgeJob.perform_later(user, :completer)
 
       record_activity!
     end

--- a/app/commands/solution/complete.rb
+++ b/app/commands/solution/complete.rb
@@ -13,12 +13,14 @@ class Solution
         solution.update!(completed_at: Time.current)
       end
 
-      # TODO: Think about how we can add a guard here for hello-world so
-      # we only go through the checks in the job if the exercise is hello-world.
-      # But at the job level, not at this level. So passing some args etc?
-      %i[anybody_there all_your_base whatever lackadaisical completer conceptual].each do |badge|
+      %i[anybody_there all_your_base whatever lackadaisical].each do |badge|
+        AwardBadgeJob.perform_later(user, badge, exercise: exercise.slug)
+      end
+
+      %i[completer conceptual].each do |badge|
         AwardBadgeJob.perform_later(user, badge)
       end
+
       record_activity!
     end
 

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution)
+          AwardBadgeJob.perform_later(user, :new_years_resolution, context: solution)
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution, day_of_year: Time.now.utc.yday)
+          AwardBadgeJob.perform_later(user, :new_years_resolution)
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution)
+          AwardBadgeJob.perform_later(user, :new_years_resolution, day_of_year: Time.now.utc.yday)
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution, context: { day_of_year: Time.current.yday })
+          AwardBadgeJob.perform_later(user, :new_years_resolution, day_of_year: Time.current.yday)
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution)
+          AwardBadgeJob.perform_later(user, :new_years_resolution, context: { day_of_year: Time.current.yday })
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/solution/create.rb
+++ b/app/commands/solution/create.rb
@@ -9,7 +9,7 @@ class Solution
       begin
         solution_class.create!(user: user, exercise: exercise).tap do |solution|
           record_activity!(solution)
-          AwardBadgeJob.perform_later(user, :new_years_resolution, day_of_year: Time.current.yday)
+          AwardBadgeJob.perform_later(user, :new_years_resolution)
         end
       rescue ActiveRecord::RecordNotUnique
         solution_class.find_by!(

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,11 +3,10 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, send_email:, **context)
+      def initialize(user, slug, send_email:)
         @user = user
         @slug = slug
         @send_email = send_email
-        @context = context
       end
 
       def call
@@ -18,7 +17,7 @@ class User
 
         # Check if the badge should be awarded.
         # Raise an exception if not
-        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user, **context)
+        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user)
 
         # Build the badge
         begin
@@ -46,7 +45,7 @@ class User
       end
 
       private
-      attr_reader :user, :slug, :send_email, :context
+      attr_reader :user, :slug, :send_email
 
       memoize
       def badge

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,10 +3,11 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, send_email: true)
+      def initialize(user, slug, send_email: true, context: {})
         @user = user
         @slug = slug
         @send_email = send_email
+        @context = context
       end
 
       def call
@@ -17,7 +18,7 @@ class User
 
         # Check if the badge should be awarded.
         # Raise an exception if not
-        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user)
+        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user, *context)
 
         # Build the badge
         begin
@@ -45,7 +46,7 @@ class User
       end
 
       private
-      attr_reader :user, :slug, :send_email
+      attr_reader :user, :slug, :send_email, :context
 
       memoize
       def badge

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,11 +3,11 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, send_email:, **kwargs)
+      def initialize(user, slug, send_email:, **context)
         @user = user
         @slug = slug
         @send_email = send_email
-        @context = kwargs
+        @context = context
       end
 
       def call

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,11 +3,11 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, send_email: true, context: {})
+      def initialize(user, slug, send_email:, **kwargs)
         @user = user
         @slug = slug
         @send_email = send_email
-        @context = context
+        @context = kwargs
       end
 
       def call
@@ -18,7 +18,7 @@ class User
 
         # Check if the badge should be awarded.
         # Raise an exception if not
-        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user, *context)
+        raise BadgeCriteriaNotFulfilledError unless badge.award_to?(user, **context)
 
         # Build the badge
         begin

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -3,7 +3,7 @@ class User
     class Create
       include Mandate
 
-      def initialize(user, slug, send_email:)
+      def initialize(user, slug, send_email: true)
         @user = user
         @slug = slug
         @send_email = send_email

--- a/app/commands/user/reputation_token/create.rb
+++ b/app/commands/user/reputation_token/create.rb
@@ -16,7 +16,7 @@ class User
         ).tap do |token|
           token.save!
 
-          AwardBadgeJob.perform_later(user, :contributor)
+          AwardBadgeJob.perform_later(user, :contributor, category: token.category)
           User::ReputationPeriod::MarkForToken.(token)
         rescue ActiveRecord::RecordNotUnique
           return klass.find_by!(user: user, uniqueness_key: token.uniqueness_key)

--- a/app/commands/user/reputation_token/create.rb
+++ b/app/commands/user/reputation_token/create.rb
@@ -16,7 +16,7 @@ class User
         ).tap do |token|
           token.save!
 
-          AwardBadgeJob.perform_later(user, :contributor, category: token.category)
+          AwardBadgeJob.perform_later(user, :contributor, context: token)
           User::ReputationPeriod::MarkForToken.(token)
         rescue ActiveRecord::RecordNotUnique
           return klass.find_by!(user: user, uniqueness_key: token.uniqueness_key)

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -4,7 +4,7 @@ class AwardBadgeJob < ApplicationJob
   discard_on BadgeCriteriaNotFulfilledError
 
   def self.perform_later(user, badge_slug, send_email: true, context: nil)
-    return unless badge(badge_slug).worth_queuing?(**worth_queuing_context(context))
+    return unless self.worth_queuing?(badge_slug, context:)
 
     super(user, badge_slug, send_email:)
   end
@@ -13,13 +13,11 @@ class AwardBadgeJob < ApplicationJob
     User::AcquiredBadge::Create.(user, badge_slug, send_email:)
   end
 
-  def self.badge(badge_slug)
-    "Badges::#{badge_slug.to_s.camelize}Badge".constantize
-  end
+  def self.worth_queuing?(badge_slug, context:)
+    return true if context.nil?
 
-  def self.worth_queuing_context(context)
-    return {} if context.nil?
-
-    { context.class.base_class.name.demodulize.underscore => context }.symbolize_keys
+    context_key = context.class.base_class.name.demodulize.underscore
+    badge = "Badges::#{badge_slug.to_s.camelize}Badge".constantize
+    badge.worth_queuing?(**{ context_key => context }.symbolize_keys)
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,7 +3,17 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def perform(user, badge_slug, send_email: true, **context)
-    User::AcquiredBadge::Create.(user, badge_slug, send_email:, **context)
+  def self.perform_later(user, badge_slug, send_email: true, **context)
+    return unless badge(badge_slug).worth_queuing?(**context)
+
+    super(user, badge_slug, send_email:)
+  end
+
+  def perform(user, badge_slug, send_email: true)
+    User::AcquiredBadge::Create.(user, badge_slug, send_email:)
+  end
+
+  def self.badge(badge_slug)
+    "Badges::#{badge_slug.to_s.camelize}Badge".constantize
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,7 +3,7 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def perform(user, badge_slug, send_email: true)
-    User::AcquiredBadge::Create.(user, badge_slug, send_email:)
+  def perform(user, badge_slug, send_email: true, **kwargs)
+    User::AcquiredBadge::Create.(user, badge_slug, send_email:, context: kwargs)
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -4,6 +4,6 @@ class AwardBadgeJob < ApplicationJob
   discard_on BadgeCriteriaNotFulfilledError
 
   def perform(user, badge_slug, send_email: true, **kwargs)
-    User::AcquiredBadge::Create.(user, badge_slug, send_email:, context: kwargs)
+    User::AcquiredBadge::Create.(user, badge_slug, send_email:, **kwargs)
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,8 +3,8 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def self.perform_later(user, badge_slug, send_email: true, **context)
-    return unless badge(badge_slug).worth_queuing?(**context)
+  def self.perform_later(user, badge_slug, send_email: true, context: nil)
+    return unless badge(badge_slug).worth_queuing?(**worth_queuing_context(context))
 
     super(user, badge_slug, send_email:)
   end
@@ -15,5 +15,11 @@ class AwardBadgeJob < ApplicationJob
 
   def self.badge(badge_slug)
     "Badges::#{badge_slug.to_s.camelize}Badge".constantize
+  end
+
+  def self.worth_queuing_context(context)
+    return {} if context.nil?
+
+    { context.class.base_class.name.demodulize.underscore => context }.symbolize_keys
   end
 end

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -14,7 +14,7 @@ class AwardBadgeJob < ApplicationJob
   end
 
   def self.worth_queuing?(badge_slug, context:)
-    return true if context.nil?
+    return true if context.blank?
 
     context_key = context.class.base_class.name.demodulize.underscore
     badge = "Badges::#{badge_slug.to_s.camelize}Badge".constantize

--- a/app/jobs/award_badge_job.rb
+++ b/app/jobs/award_badge_job.rb
@@ -3,7 +3,7 @@ class AwardBadgeJob < ApplicationJob
 
   discard_on BadgeCriteriaNotFulfilledError
 
-  def perform(user, badge_slug, send_email: true, **kwargs)
-    User::AcquiredBadge::Create.(user, badge_slug, send_email:, **kwargs)
+  def perform(user, badge_slug, send_email: true, **context)
+    User::AcquiredBadge::Create.(user, badge_slug, send_email:, **context)
   end
 end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -48,7 +48,7 @@ class Badge < ApplicationRecord
   # notifications when they are created
   def notification_key; end
 
-  def award_to?(_user)
+  def award_to?(_user, **_kwargs)
     raise "Implement this method in the child class"
   end
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -48,7 +48,7 @@ class Badge < ApplicationRecord
   # notifications when they are created
   def notification_key; end
 
-  def award_to?(_user, **_kwargs)
+  def award_to?(_user, **_context)
     raise "Implement this method in the child class"
   end
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -48,7 +48,12 @@ class Badge < ApplicationRecord
   # notifications when they are created
   def notification_key; end
 
-  def award_to?(_user, **_context)
+  # Stub to allow badges to short-circuit queueing
+  def self.worth_queuing?(**_context)
+    true
+  end
+
+  def award_to?(_user)
     raise "Implement this method in the child class"
   end
 

--- a/app/models/badges/all_your_base_badge.rb
+++ b/app/models/badges/all_your_base_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'all-your-base',
       'Completed the "All Your Base" exercise'
 
-    def self.worth_queuing?(exercise_slug:)
-      exercise_slug == 'all-your-base'
+    def self.worth_queuing?(exercise:)
+      exercise.slug == 'all-your-base'
     end
 
     def award_to?(user)

--- a/app/models/badges/all_your_base_badge.rb
+++ b/app/models/badges/all_your_base_badge.rb
@@ -5,7 +5,9 @@ module Badges
       'all-your-base',
       'Completed the "All Your Base" exercise'
 
-    def award_to?(user)
+    def award_to?(user, exercise:)
+      return false unless exercise == 'all-your-base'
+
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'all-your-base').
         any?

--- a/app/models/badges/all_your_base_badge.rb
+++ b/app/models/badges/all_your_base_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'all-your-base',
       'Completed the "All Your Base" exercise'
 
-    def self.worth_queuing?(exercise:)
-      exercise == 'all-your-base'
+    def self.worth_queuing?(exercise_slug:)
+      exercise_slug == 'all-your-base'
     end
 
     def award_to?(user)

--- a/app/models/badges/all_your_base_badge.rb
+++ b/app/models/badges/all_your_base_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'all-your-base',
       'Completed the "All Your Base" exercise'
 
-    def self.worth_queuing?(context)
-      context[:exercise] == 'all-your-base'
+    def self.worth_queuing?(exercise:)
+      exercise == 'all-your-base'
     end
 
     def award_to?(user)

--- a/app/models/badges/all_your_base_badge.rb
+++ b/app/models/badges/all_your_base_badge.rb
@@ -5,9 +5,11 @@ module Badges
       'all-your-base',
       'Completed the "All Your Base" exercise'
 
-    def award_to?(user, exercise:)
-      return false unless exercise == 'all-your-base'
+    def self.worth_queuing?(context)
+      context[:exercise] == 'all-your-base'
+    end
 
+    def award_to?(user)
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'all-your-base').
         any?

--- a/app/models/badges/anybody_there_badge.rb
+++ b/app/models/badges/anybody_there_badge.rb
@@ -5,7 +5,9 @@ module Badges
       'hello-world',
       'Completed "Hello, World!" in five languages'
 
-    def award_to?(user)
+    def award_to?(user, exercise:)
+      return false unless exercise == 'hello-world'
+
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': "hello-world").
         count >= 5

--- a/app/models/badges/anybody_there_badge.rb
+++ b/app/models/badges/anybody_there_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'hello-world',
       'Completed "Hello, World!" in five languages'
 
-    def self.worth_queuing?(exercise:)
-      exercise == 'hello-world'
+    def self.worth_queuing?(exercise_slug:)
+      exercise_slug == 'hello-world'
     end
 
     def award_to?(user)

--- a/app/models/badges/anybody_there_badge.rb
+++ b/app/models/badges/anybody_there_badge.rb
@@ -5,9 +5,11 @@ module Badges
       'hello-world',
       'Completed "Hello, World!" in five languages'
 
-    def award_to?(user, exercise:)
-      return false unless exercise == 'hello-world'
+    def self.worth_queuing?(context)
+      context[:exercise] == 'hello-world'
+    end
 
+    def award_to?(user)
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': "hello-world").
         count >= 5

--- a/app/models/badges/anybody_there_badge.rb
+++ b/app/models/badges/anybody_there_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'hello-world',
       'Completed "Hello, World!" in five languages'
 
-    def self.worth_queuing?(context)
-      context[:exercise] == 'hello-world'
+    def self.worth_queuing?(exercise:)
+      exercise == 'hello-world'
     end
 
     def award_to?(user)

--- a/app/models/badges/anybody_there_badge.rb
+++ b/app/models/badges/anybody_there_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'hello-world',
       'Completed "Hello, World!" in five languages'
 
-    def self.worth_queuing?(exercise_slug:)
-      exercise_slug == 'hello-world'
+    def self.worth_queuing?(exercise:)
+      exercise.slug == 'hello-world'
     end
 
     def award_to?(user)

--- a/app/models/badges/conceptual_badge.rb
+++ b/app/models/badges/conceptual_badge.rb
@@ -5,8 +5,8 @@ module Badges
       :conceptual,
       "Completed all learning exercises in a track"
 
-    def self.worth_queuing?(exercise_type:)
-      exercise_type == 'ConceptExercise'
+    def self.worth_queuing?(exercise:)
+      exercise.type == 'ConceptExercise'
     end
 
     def award_to?(user)

--- a/app/models/badges/conceptual_badge.rb
+++ b/app/models/badges/conceptual_badge.rb
@@ -5,6 +5,10 @@ module Badges
       :conceptual,
       "Completed all learning exercises in a track"
 
+    def self.worth_queuing?(exercise_type:)
+      exercise_type == 'ConceptExercise'
+    end
+
     def award_to?(user)
       user.user_tracks.joins(:track).
         where('tracks.active && tracks.course').

--- a/app/models/badges/contributor_badge.rb
+++ b/app/models/badges/contributor_badge.rb
@@ -5,11 +5,12 @@ module Badges
       :contributors,
       'Contributed to Exercism'
 
+    def self.worth_queuing?(category:)
+      CATEGORIES.include?(category)
+    end
+
     def award_to?(user)
-      User::ReputationToken.where(
-        category: %i[building maintaining mentoring authoring],
-        user_id: user.id
-      ).exists?
+      User::ReputationToken.where(category: CATEGORIES, user_id: user.id).exists?
     end
 
     def send_email_on_acquisition?
@@ -19,5 +20,8 @@ module Badges
     def notification_key
       :added_to_contributors_page
     end
+
+    CATEGORIES = %i[building maintaining mentoring authoring].freeze
+    private_constant :CATEGORIES
   end
 end

--- a/app/models/badges/contributor_badge.rb
+++ b/app/models/badges/contributor_badge.rb
@@ -5,8 +5,8 @@ module Badges
       :contributors,
       'Contributed to Exercism'
 
-    def self.worth_queuing?(category:)
-      CATEGORIES.include?(category)
+    def self.worth_queuing?(reputation_token:)
+      CATEGORIES.include?(reputation_token.category)
     end
 
     def award_to?(user)

--- a/app/models/badges/die_unendliche_geschichte_badge.rb
+++ b/app/models/badges/die_unendliche_geschichte_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'die-unendliche-geschichte',
       'Submitted 10 iterations to the same exercise'
 
-    def self.worth_queuing?(iteration_idx:)
-      iteration_idx >= 10
+    def self.worth_queuing?(iteration:)
+      iteration.idx >= 10
     end
 
     def award_to?(user)

--- a/app/models/badges/die_unendliche_geschichte_badge.rb
+++ b/app/models/badges/die_unendliche_geschichte_badge.rb
@@ -5,6 +5,10 @@ module Badges
       'die-unendliche-geschichte',
       'Submitted 10 iterations to the same exercise'
 
+    def self.worth_queuing?(iteration_idx:)
+      iteration_idx >= 10
+    end
+
     def award_to?(user)
       user.iterations.
         group(:solution_id).

--- a/app/models/badges/lackadaisical_badge.rb
+++ b/app/models/badges/lackadaisical_badge.rb
@@ -5,7 +5,9 @@ module Badges
       'lackadaisical',
       'Completed the "Bob" exercise in five languages'
 
-    def award_to?(user)
+    def award_to?(user, exercise:)
+      return false unless exercise == 'bob'
+
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'bob').
         count >= 5

--- a/app/models/badges/lackadaisical_badge.rb
+++ b/app/models/badges/lackadaisical_badge.rb
@@ -5,9 +5,11 @@ module Badges
       'lackadaisical',
       'Completed the "Bob" exercise in five languages'
 
-    def award_to?(user, exercise:)
-      return false unless exercise == 'bob'
+    def self.worth_queuing?(context)
+      context[:exercise] == 'bob'
+    end
 
+    def award_to?(user)
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'bob').
         count >= 5

--- a/app/models/badges/lackadaisical_badge.rb
+++ b/app/models/badges/lackadaisical_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'lackadaisical',
       'Completed the "Bob" exercise in five languages'
 
-    def self.worth_queuing?(exercise_slug:)
-      exercise_slug == 'bob'
+    def self.worth_queuing?(exercise:)
+      exercise.slug == 'bob'
     end
 
     def award_to?(user)

--- a/app/models/badges/lackadaisical_badge.rb
+++ b/app/models/badges/lackadaisical_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'lackadaisical',
       'Completed the "Bob" exercise in five languages'
 
-    def self.worth_queuing?(exercise:)
-      exercise == 'bob'
+    def self.worth_queuing?(exercise_slug:)
+      exercise_slug == 'bob'
     end
 
     def award_to?(user)

--- a/app/models/badges/lackadaisical_badge.rb
+++ b/app/models/badges/lackadaisical_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'lackadaisical',
       'Completed the "Bob" exercise in five languages'
 
-    def self.worth_queuing?(context)
-      context[:exercise] == 'bob'
+    def self.worth_queuing?(exercise:)
+      exercise == 'bob'
     end
 
     def award_to?(user)

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,7 +5,7 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def award_to?(user, **_context)
+    def award_to?(user, _context)
       user.solutions.
         where('DAYOFYEAR(solutions.created_at) = 1').
         exists?

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,7 +5,7 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def award_to?(user)
+    def award_to?(user, **_context)
       user.solutions.
         where('DAYOFYEAR(solutions.created_at) = 1').
         exists?

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,7 +5,7 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def award_to?(user, _context)
+    def award_to?(user, _day_of_year:)
       user.solutions.
         where('DAYOFYEAR(solutions.created_at) = 1').
         exists?

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,8 +5,10 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def award_to?(_user, day_of_year:)
-      day_of_year == 1
+    def award_to?(user)
+      user.solutions.
+        where('DAYOFYEAR(solutions.created_at) = 1').
+        exists?
     end
 
     def send_email_on_acquisition?

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,6 +5,10 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
+    def self.worth_queuing?(day_of_year:)
+      day_of_year == 1
+    end
+
     def award_to?(user)
       user.solutions.
         where('DAYOFYEAR(solutions.created_at) = 1').

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def self.worth_queuing?(day_of_year:)
-      day_of_year == 1
+    def self.worth_queuing?
+      Time.now.utc.yday == 1
     end
 
     def award_to?(user)

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,10 +5,8 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def award_to?(user, _day_of_year:)
-      user.solutions.
-        where('DAYOFYEAR(solutions.created_at) = 1').
-        exists?
+    def award_to?(_user, day_of_year:)
+      day_of_year == 1
     end
 
     def send_email_on_acquisition?

--- a/app/models/badges/new_years_resolution_badge.rb
+++ b/app/models/badges/new_years_resolution_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'new-years-resolution',
       'Submitted a solution on January 1st'
 
-    def self.worth_queuing?
-      Time.now.utc.yday == 1
+    def self.worth_queuing?(solution:)
+      solution.created_at.yday == 1
     end
 
     def award_to?(user)

--- a/app/models/badges/whatever_badge.rb
+++ b/app/models/badges/whatever_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'whatever',
       'Completed the "Bob" exercise'
 
-    def self.worth_queuing?(exercise:)
-      exercise == 'bob'
+    def self.worth_queuing?(exercise_slug:)
+      exercise_slug == 'bob'
     end
 
     def award_to?(user)

--- a/app/models/badges/whatever_badge.rb
+++ b/app/models/badges/whatever_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'whatever',
       'Completed the "Bob" exercise'
 
-    def self.worth_queuing?(context)
-      context[:exercise] == 'bob'
+    def self.worth_queuing?(exercise:)
+      exercise == 'bob'
     end
 
     def award_to?(user)

--- a/app/models/badges/whatever_badge.rb
+++ b/app/models/badges/whatever_badge.rb
@@ -5,7 +5,9 @@ module Badges
       'whatever',
       'Completed the "Bob" exercise'
 
-    def award_to?(user)
+    def award_to?(user, exercise:)
+      return false unless exercise == 'bob'
+
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'bob').
         any?

--- a/app/models/badges/whatever_badge.rb
+++ b/app/models/badges/whatever_badge.rb
@@ -5,9 +5,11 @@ module Badges
       'whatever',
       'Completed the "Bob" exercise'
 
-    def award_to?(user, exercise:)
-      return false unless exercise == 'bob'
+    def self.worth_queuing?(context)
+      context[:exercise] == 'bob'
+    end
 
+    def award_to?(user)
       user.solutions.completed.joins(:exercise).
         where('exercises.slug': 'bob').
         any?

--- a/app/models/badges/whatever_badge.rb
+++ b/app/models/badges/whatever_badge.rb
@@ -5,8 +5,8 @@ module Badges
       'whatever',
       'Completed the "Bob" exercise'
 
-    def self.worth_queuing?(exercise_slug:)
-      exercise_slug == 'bob'
+    def self.worth_queuing?(exercise:)
+      exercise.slug == 'bob'
     end
 
     def award_to?(user)

--- a/test/commands/donations/payment/create_test.rb
+++ b/test/commands/donations/payment/create_test.rb
@@ -21,12 +21,14 @@ class Donations::Payment::CreateTest < Donations::TestBase
     assert_equal amount, user.total_donated_in_cents
   end
 
-  test "enqueues badge job" do
+  test "awards supporter badge" do
     user = create :user
+    refute user.reload.badges.present?
 
-    assert_enqueued_with(job: AwardBadgeJob, args: [user, :supporter]) do
-      Donations::Payment::Create.(user, mock_stripe_payment(1, 1, ""))
-    end
+    Donations::Payment::Create.(user, mock_stripe_payment(1, 1, ""))
+
+    perform_enqueued_jobs
+    assert_includes user.reload.badges.map(&:class), Badges::SupporterBadge
   end
 
   test "enqueues email job" do

--- a/test/commands/donations/payment/create_test.rb
+++ b/test/commands/donations/payment/create_test.rb
@@ -25,7 +25,9 @@ class Donations::Payment::CreateTest < Donations::TestBase
     user = create :user
     refute user.reload.badges.present?
 
-    Donations::Payment::Create.(user, mock_stripe_payment(1, 1, ""))
+    assert_enqueued_with(job: AwardBadgeJob) do
+      Donations::Payment::Create.(user, mock_stripe_payment(1, 1, ""))
+    end
 
     perform_enqueued_jobs
     assert_includes user.reload.badges.map(&:class), Badges::SupporterBadge

--- a/test/commands/solution/complete_test.rb
+++ b/test/commands/solution/complete_test.rb
@@ -196,10 +196,10 @@ class Solution::CompleteTest < ActiveSupport::TestCase
     refute user.badges.present?
 
     create :hello_world_solution, :completed, user: user, track: track
-    create :concept_solution, :completed, user: user, track: track, exercise: concept_exercise
+    create :practice_solution, :completed, user: user, track: track, exercise: practice_exercise
     refute user.reload.badges.present?
 
-    solution = create :concept_solution, user: user, track: track, exercise: practice_exercise
+    solution = create :concept_solution, user: user, track: track, exercise: concept_exercise
     create :iteration, solution: solution
 
     Solution::Complete.(solution, user_track)

--- a/test/commands/user/acquired_badge/create_test.rb
+++ b/test/commands/user/acquired_badge/create_test.rb
@@ -26,7 +26,7 @@ class User::AcquiredBadge::CreateTest < ActiveSupport::TestCase
     Badges::ContributorBadge.any_instance.expects(:award_to?).with(user).returns(false)
 
     assert_raises BadgeCriteriaNotFulfilledError do
-      User::AcquiredBadge::Create.(user, :contributor)
+      User::AcquiredBadge::Create.(user, :contributor, send_email: false)
     end
   end
 

--- a/test/commands/user/reputation_token/create_test.rb
+++ b/test/commands/user/reputation_token/create_test.rb
@@ -6,7 +6,6 @@ class User::ReputationToken::CreateTest < ActiveSupport::TestCase
     contributorship = create :exercise_contributorship, contributor: user
 
     User::ReputationPeriod::MarkForToken.expects(:call)
-    AwardBadgeJob.expects(:perform_later).with(user, :contributor)
 
     2.times do
       User::ReputationToken::Create.(
@@ -58,5 +57,102 @@ class User::ReputationToken::CreateTest < ActiveSupport::TestCase
         }
       )
     end
+  end
+
+  test "awards contributor token if category is authoring" do
+    user = create :user, handle: "User22", github_username: "user22"
+    contributorship = create :exercise_contributorship, contributor: user
+
+    # The exercise contribution reputation token's category is authoring
+    User::ReputationToken::Create.(user, :exercise_contribution, { contributorship: contributorship })
+
+    perform_enqueued_jobs
+    assert_includes user.reload.badges.map(&:class), Badges::ContributorBadge
+  end
+
+  test "awards contributor token if category is building" do
+    user = create :user, handle: "User22", github_username: "user22"
+
+    # The code contribution reputation token's category is building
+    User::ReputationToken::Create.(
+      user,
+      :code_contribution,
+      repo: 'exercism/ruby',
+      level: :large,
+      pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+      pr_number: 1347,
+      pr_title: 'The cat sat on the mat',
+      merged_at: Time.parse('2020-04-03T14:54:57Z').utc,
+      external_url: 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    )
+
+    perform_enqueued_jobs
+    assert_includes user.reload.badges.map(&:class), Badges::ContributorBadge
+  end
+
+  test "awards contributor token if category is maintaining" do
+    user = create :user, handle: "User22", github_username: "user22"
+
+    # The code merge reputation token's category is maintaining
+    User::ReputationToken::Create.(
+      user,
+      :code_merge,
+      repo: 'exercism/ruby',
+      level: :janitorial,
+      pr_node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+      pr_number: 1347,
+      pr_title: 'The cat sat on the mat',
+      merged_at: Time.parse('2020-04-03T14:54:57Z').utc,
+      external_url: 'https://api.github.com/repos/exercism/v3/pulls/1347'
+    )
+
+    perform_enqueued_jobs
+    assert_includes user.reload.badges.map(&:class), Badges::ContributorBadge
+  end
+
+  test "awards contributor token if category is mentoring" do
+    user = create :user
+    discussion = create :mentor_discussion, :mentor_finished, mentor: user
+
+    # The mentor reputation token's category is building
+    User::ReputationToken::Create.(
+      user,
+      :mentored,
+      discussion: discussion
+    )
+
+    perform_enqueued_jobs
+    assert_includes user.reload.badges.map(&:class), Badges::ContributorBadge
+  end
+
+  test "does not award contributor token if category is publishing" do
+    user = create :user
+    solution = create :practice_solution, :published, user: user
+
+    # The published reputation token's category is publishing
+    User::ReputationToken::Create.(
+      user,
+      :published_solution,
+      solution: solution,
+      level: :medium
+    )
+
+    perform_enqueued_jobs
+    refute_includes user.reload.badges.map(&:class), Badges::ContributorBadge
+  end
+
+  test "does not award contributor token if category is misc" do
+    user = create :user
+
+    # The arbitrary reputation token's category is misc
+    User::ReputationToken::Create.(
+      user,
+      :arbitrary,
+      arbitrary_value: 23,
+      arbitrary_reason: 'For helping troubleshoot'
+    )
+
+    perform_enqueued_jobs
+    refute_includes user.reload.badges.map(&:class), Badges::ContributorBadge
   end
 end

--- a/test/jobs/award_badge_job_test.rb
+++ b/test/jobs/award_badge_job_test.rb
@@ -51,8 +51,7 @@ class AwardBadgeJobTest < ActiveJob::TestCase
     User::AcquiredBadge::Create.expects(:call).never
 
     # The new_years_resolution badge is only queued on the first day of the year
-    travel_to(Date.ordinal(2021, 13)) do
-      AwardBadgeJob.perform_later(user, :new_years_resolution)
-    end
+    solution = create :concept_solution, created_at: Date.ordinal(2021, 13)
+    AwardBadgeJob.perform_later(user, :new_years_resolution, context: solution)
   end
 end

--- a/test/jobs/award_badge_job_test.rb
+++ b/test/jobs/award_badge_job_test.rb
@@ -50,7 +50,9 @@ class AwardBadgeJobTest < ActiveJob::TestCase
 
     User::AcquiredBadge::Create.expects(:call).never
 
-    # The whatever badge is only queued when the exercise is bob
-    AwardBadgeJob.perform_later(user, 'whatever', exercise_slug: 'leap')
+    # The new_years_resolution badge is only queued on the first day of the year
+    travel_to(Date.ordinal(2021, 13)) do
+      AwardBadgeJob.perform_later(user, :new_years_resolution)
+    end
   end
 end

--- a/test/jobs/award_badge_job_test.rb
+++ b/test/jobs/award_badge_job_test.rb
@@ -51,6 +51,6 @@ class AwardBadgeJobTest < ActiveJob::TestCase
     User::AcquiredBadge::Create.expects(:call).never
 
     # The whatever badge is only queued when the exercise is bob
-    AwardBadgeJob.perform_later(user, 'whatever', exercise: 'leap')
+    AwardBadgeJob.perform_later(user, 'whatever', exercise_slug: 'leap')
   end
 end

--- a/test/jobs/award_badge_job_test.rb
+++ b/test/jobs/award_badge_job_test.rb
@@ -44,4 +44,13 @@ class AwardBadgeJobTest < ActiveJob::TestCase
       AwardBadgeJob.perform_now(user.reload, :growth_mindset, send_email: false)
     end
   end
+
+  test "badge create is not called when badge is not worth queueing" do
+    user = mock
+
+    User::AcquiredBadge::Create.expects(:call).never
+
+    # The whatever badge is only queued when the exercise is bob
+    AwardBadgeJob.perform_later(user, 'whatever', exercise: 'leap')
+  end
 end

--- a/test/models/badges/all_your_base_badge_test.rb
+++ b/test/models/badges/all_your_base_badge_test.rb
@@ -39,8 +39,8 @@ class Badge::AllYourBaseBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'hello-world')
-    refute Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'bob')
-    assert Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'all-your-base')
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'hello-world'))
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'bob'))
+    assert Badges::AllYourBaseBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'all-your-base'))
   end
 end

--- a/test/models/badges/all_your_base_badge_test.rb
+++ b/test/models/badges/all_your_base_badge_test.rb
@@ -39,9 +39,8 @@ class Badge::AllYourBaseBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: nil)
-    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: 'hello-world')
-    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: 'bob')
-    assert Badges::AllYourBaseBadge.worth_queuing?(exercise: 'all-your-base')
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'hello-world')
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'bob')
+    assert Badges::AllYourBaseBadge.worth_queuing?(exercise_slug: 'all-your-base')
   end
 end

--- a/test/models/badges/all_your_base_badge_test.rb
+++ b/test/models/badges/all_your_base_badge_test.rb
@@ -37,4 +37,11 @@ class Badge::AllYourBaseBadgeTest < ActiveSupport::TestCase
     solution.update(completed_at: Time.current)
     assert badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: nil)
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: 'hello-world')
+    refute Badges::AllYourBaseBadge.worth_queuing?(exercise: 'bob')
+    assert Badges::AllYourBaseBadge.worth_queuing?(exercise: 'all-your-base')
+  end
 end

--- a/test/models/badges/anybody_there_badge_test.rb
+++ b/test/models/badges/anybody_there_badge_test.rb
@@ -39,4 +39,11 @@ class Badge::AnybodyThereBadgeTest < ActiveSupport::TestCase
     solution.update(completed_at: Time.current)
     assert badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: nil)
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: 'leap')
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: 'bob')
+    assert Badges::AnybodyThereBadge.worth_queuing?(exercise: 'hello-world')
+  end
 end

--- a/test/models/badges/anybody_there_badge_test.rb
+++ b/test/models/badges/anybody_there_badge_test.rb
@@ -41,8 +41,8 @@ class Badge::AnybodyThereBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'leap')
-    refute Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'bob')
-    assert Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'hello-world')
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'leap'))
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'bob'))
+    assert Badges::AnybodyThereBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'hello-world'))
   end
 end

--- a/test/models/badges/anybody_there_badge_test.rb
+++ b/test/models/badges/anybody_there_badge_test.rb
@@ -41,9 +41,8 @@ class Badge::AnybodyThereBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: nil)
-    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: 'leap')
-    refute Badges::AnybodyThereBadge.worth_queuing?(exercise: 'bob')
-    assert Badges::AnybodyThereBadge.worth_queuing?(exercise: 'hello-world')
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'leap')
+    refute Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'bob')
+    assert Badges::AnybodyThereBadge.worth_queuing?(exercise_slug: 'hello-world')
   end
 end

--- a/test/models/badges/conceptual_badge_test.rb
+++ b/test/models/badges/conceptual_badge_test.rb
@@ -78,7 +78,7 @@ class Badge::ConceptualBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::ConceptualBadge.worth_queuing?(exercise_type: 'PracticeExercise')
-    assert Badges::ConceptualBadge.worth_queuing?(exercise_type: 'ConceptExercise')
+    refute Badges::ConceptualBadge.worth_queuing?(exercise: create(:practice_exercise))
+    assert Badges::ConceptualBadge.worth_queuing?(exercise: create(:concept_exercise))
   end
 end

--- a/test/models/badges/conceptual_badge_test.rb
+++ b/test/models/badges/conceptual_badge_test.rb
@@ -76,4 +76,9 @@ class Badge::ConceptualBadgeTest < ActiveSupport::TestCase
     create :concept_solution, :completed, user: user, track: track, exercise: concept_exercise
     refute badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::ConceptualBadge.worth_queuing?(exercise_type: 'PracticeExercise')
+    assert Badges::ConceptualBadge.worth_queuing?(exercise_type: 'ConceptExercise')
+  end
 end

--- a/test/models/badges/contributor_badge_test.rb
+++ b/test/models/badges/contributor_badge_test.rb
@@ -50,4 +50,14 @@ class Badge::ContributorBadgeTest < ActiveSupport::TestCase
 
     assert badge.award_to?(user)
   end
+
+  test "worth_queuing?" do
+    %i[misc publishing].each do |category|
+      refute Badges::ContributorBadge.worth_queuing?(category:)
+    end
+
+    %i[building maintaining mentoring authoring].each do |category|
+      assert Badges::ContributorBadge.worth_queuing?(category:)
+    end
+  end
 end

--- a/test/models/badges/contributor_badge_test.rb
+++ b/test/models/badges/contributor_badge_test.rb
@@ -52,12 +52,22 @@ class Badge::ContributorBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    %i[misc publishing].each do |category|
-      refute Badges::ContributorBadge.worth_queuing?(category:)
-    end
+    # category: misc
+    refute Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_arbitrary_reputation_token))
 
-    %i[building maintaining mentoring authoring].each do |category|
-      assert Badges::ContributorBadge.worth_queuing?(category:)
-    end
+    # category: publishing
+    refute Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_published_solution_reputation_token))
+
+    # category: building
+    assert Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_code_contribution_reputation_token))
+
+    # category: maintaining
+    assert Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_code_merge_reputation_token))
+
+    # category: mentoring
+    assert Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_mentored_reputation_token))
+
+    # category: authoring
+    assert Badges::ContributorBadge.worth_queuing?(reputation_token: create(:user_exercise_author_reputation_token))
   end
 end

--- a/test/models/badges/die_unendliche_geschichte_badge_test.rb
+++ b/test/models/badges/die_unendliche_geschichte_badge_test.rb
@@ -44,4 +44,11 @@ class Badge::DieUnendlicheGeschichteBadgeTest < ActiveSupport::TestCase
     create :iteration, solution: solution
     assert badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 1)
+    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 9)
+    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 10)
+    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 11)
+  end
 end

--- a/test/models/badges/die_unendliche_geschichte_badge_test.rb
+++ b/test/models/badges/die_unendliche_geschichte_badge_test.rb
@@ -46,9 +46,9 @@ class Badge::DieUnendlicheGeschichteBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 1)
-    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 9)
-    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 10)
-    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration_idx: 11)
+    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration: create(:iteration, idx: 1))
+    refute Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration: create(:iteration, idx: 9))
+    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration: create(:iteration, idx: 10))
+    assert Badges::DieUnendlicheGeschichteBadge.worth_queuing?(iteration: create(:iteration, idx: 11))
   end
 end

--- a/test/models/badges/lackadaisical_badge_test.rb
+++ b/test/models/badges/lackadaisical_badge_test.rb
@@ -44,8 +44,8 @@ class Badge::LackadaisicalBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'leap')
-    refute Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'hello-world')
-    assert Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'bob')
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'leap'))
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'hello-world'))
+    assert Badges::LackadaisicalBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'bob'))
   end
 end

--- a/test/models/badges/lackadaisical_badge_test.rb
+++ b/test/models/badges/lackadaisical_badge_test.rb
@@ -42,4 +42,11 @@ class Badge::LackadaisicalBadgeTest < ActiveSupport::TestCase
     solution.update(completed_at: Time.current)
     assert badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: nil)
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: 'leap')
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: 'hello-world')
+    assert Badges::LackadaisicalBadge.worth_queuing?(exercise: 'bob')
+  end
 end

--- a/test/models/badges/lackadaisical_badge_test.rb
+++ b/test/models/badges/lackadaisical_badge_test.rb
@@ -44,9 +44,8 @@ class Badge::LackadaisicalBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: nil)
-    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: 'leap')
-    refute Badges::LackadaisicalBadge.worth_queuing?(exercise: 'hello-world')
-    assert Badges::LackadaisicalBadge.worth_queuing?(exercise: 'bob')
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'leap')
+    refute Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'hello-world')
+    assert Badges::LackadaisicalBadge.worth_queuing?(exercise_slug: 'bob')
   end
 end

--- a/test/models/badges/new_years_resolution_badge_test.rb
+++ b/test/models/badges/new_years_resolution_badge_test.rb
@@ -35,4 +35,12 @@ class Badge::NewYearsResolutionBadgeTest < ActiveSupport::TestCase
     solution.update(created_at: Time.utc(2019, 1, 2, 0, 0, 0))
     refute badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 2)
+    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 196)
+    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 365)
+    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 366)
+    assert Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 1)
+  end
 end

--- a/test/models/badges/new_years_resolution_badge_test.rb
+++ b/test/models/badges/new_years_resolution_badge_test.rb
@@ -38,13 +38,11 @@ class Badge::NewYearsResolutionBadgeTest < ActiveSupport::TestCase
 
   test "worth_queuing?" do
     (2..366).each do |day|
-      travel_to(Date.ordinal(2020, day)) do
-        refute Badges::NewYearsResolutionBadge.worth_queuing?
-      end
+      solution = create :concept_solution, created_at: Date.ordinal(2020, day)
+      refute Badges::NewYearsResolutionBadge.worth_queuing?(solution:)
     end
 
-    travel_to(Date.ordinal(2020, 1)) do
-      assert Badges::NewYearsResolutionBadge.worth_queuing?
-    end
+    solution = create :concept_solution, created_at: Date.ordinal(2020, 1)
+    assert Badges::NewYearsResolutionBadge.worth_queuing?(solution:)
   end
 end

--- a/test/models/badges/new_years_resolution_badge_test.rb
+++ b/test/models/badges/new_years_resolution_badge_test.rb
@@ -37,10 +37,14 @@ class Badge::NewYearsResolutionBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 2)
-    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 196)
-    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 365)
-    refute Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 366)
-    assert Badges::NewYearsResolutionBadge.worth_queuing?(day_of_year: 1)
+    (2..366).each do |day|
+      travel_to(Date.ordinal(2020, day)) do
+        refute Badges::NewYearsResolutionBadge.worth_queuing?
+      end
+    end
+
+    travel_to(Date.ordinal(2020, 1)) do
+      assert Badges::NewYearsResolutionBadge.worth_queuing?
+    end
   end
 end

--- a/test/models/badges/whatever_badge_test.rb
+++ b/test/models/badges/whatever_badge_test.rb
@@ -37,4 +37,11 @@ class Badge::WhateverBadgeTest < ActiveSupport::TestCase
     solution.update(completed_at: Time.current)
     assert badge.award_to?(user.reload)
   end
+
+  test "worth_queuing?" do
+    refute Badges::WhateverBadge.worth_queuing?(exercise: nil)
+    refute Badges::WhateverBadge.worth_queuing?(exercise: 'leap')
+    refute Badges::WhateverBadge.worth_queuing?(exercise: 'hello-world')
+    assert Badges::WhateverBadge.worth_queuing?(exercise: 'bob')
+  end
 end

--- a/test/models/badges/whatever_badge_test.rb
+++ b/test/models/badges/whatever_badge_test.rb
@@ -39,9 +39,8 @@ class Badge::WhateverBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::WhateverBadge.worth_queuing?(exercise: nil)
-    refute Badges::WhateverBadge.worth_queuing?(exercise: 'leap')
-    refute Badges::WhateverBadge.worth_queuing?(exercise: 'hello-world')
-    assert Badges::WhateverBadge.worth_queuing?(exercise: 'bob')
+    refute Badges::WhateverBadge.worth_queuing?(exercise_slug: 'leap')
+    refute Badges::WhateverBadge.worth_queuing?(exercise_slug: 'hello-world')
+    assert Badges::WhateverBadge.worth_queuing?(exercise_slug: 'bob')
   end
 end

--- a/test/models/badges/whatever_badge_test.rb
+++ b/test/models/badges/whatever_badge_test.rb
@@ -39,8 +39,8 @@ class Badge::WhateverBadgeTest < ActiveSupport::TestCase
   end
 
   test "worth_queuing?" do
-    refute Badges::WhateverBadge.worth_queuing?(exercise_slug: 'leap')
-    refute Badges::WhateverBadge.worth_queuing?(exercise_slug: 'hello-world')
-    assert Badges::WhateverBadge.worth_queuing?(exercise_slug: 'bob')
+    refute Badges::WhateverBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'leap'))
+    refute Badges::WhateverBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'hello-world'))
+    assert Badges::WhateverBadge.worth_queuing?(exercise: create(:practice_exercise, slug: 'bob'))
   end
 end


### PR DESCRIPTION
This PR takes a stab at implementing the TODO described at https://github.com/exercism/website/blob/main/app/commands/solution/complete.rb#L16-L18

At its core, the TODO is about optimizing the badge awarding, where we don't do (expensive) queries if we don't need to.
One example being that we only need to check whether the `whatever` should be awarded if the completed exercise is `bob`.
When completing any other exercise, this check should just be skipped.

Implementation-wise, we still want the `AwardBadgeJob` call to not contain any logic.
My proposed solution is to have a "context" that can be passed to the awarding of badges.
This context that the form of keywords, which are passed onto the badge's `award_to?` method.

I'll leave some comments on the source code to help clarify things.