### PR TITLE
Submission analysis status takes into account has_representer and has_analyzer

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -68,6 +68,10 @@ class Submission < ApplicationRecord
     return false if (representation_exceptioned? || representation_cancelled?) &&
                     (analysis_exceptioned? || analysis_cancelled?)
     return false if representation_not_queued? && analysis_not_queued?
+
+    # TODO: materialize the track's has_representer and has_analyzer status to the
+    # submission when it is created, and then use those here instead of the track's
+    # status fields
     return true if !representation_generated? && !analysis_completed? && track.has_representer? && track.has_analyzer?
     return false if has_automated_feedback?
     return true if (representation_queued? || representation_not_queued?) && track.has_representer?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -68,11 +68,10 @@ class Submission < ApplicationRecord
     return false if (representation_exceptioned? || representation_cancelled?) &&
                     (analysis_exceptioned? || analysis_cancelled?)
     return false if representation_not_queued? && analysis_not_queued?
-    return true if !representation_generated? && !analysis_completed?
-
+    return true if !representation_generated? && !analysis_completed? && track.has_representer? && track.has_analyzer?
     return false if has_automated_feedback?
-    return true if representation_queued? || representation_not_queued?
-    return true if analysis_queued? || analysis_not_queued?
+    return true if (representation_queued? || representation_not_queued?) && track.has_representer?
+    return true if (analysis_queued? || analysis_not_queued?) && track.has_analyzer?
 
     false
   end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -154,6 +154,116 @@ class SubmissionTest < ActiveSupport::TestCase
     refute submission.has_automated_feedback?
   end
 
+  test "automated_feedback_pending for track without analyzer" do
+    # Pending without queued
+    submission = create :submission, representation_status: :not_queued, analysis_status: :not_queued
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    refute submission.automated_feedback_pending?
+
+    # Pending with queued
+    submission = create :submission, representation_status: :not_queued, analysis_status: :queued
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    assert submission.automated_feedback_pending?
+
+    # Present only if there is actual feedback on analysis
+    submission = create :submission, representation_status: :not_queued, analysis_status: :completed
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    refute submission.automated_feedback_pending?
+
+    sa = create :submission_analysis, submission: submission
+    refute Submission.find(submission.id).automated_feedback_pending?
+
+    sa.update(data: { comments: ['asd'] })
+    submission = Submission.find(submission.id)
+    refute submission.automated_feedback_pending?
+    assert submission.has_automated_feedback?
+
+    # Check if completed but without have feedback
+    submission = create :submission, representation_status: :not_queued, analysis_status: :completed
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+
+    # Check exceptioned state
+    submission = create :submission, representation_status: :not_queued, analysis_status: :exceptioned
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+
+    # Check cancelled state
+    submission = create :submission, representation_status: :not_queued, analysis_status: :cancelled
+    submission.track.update!(has_representer: false, has_analyzer: true)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+  end
+
+  test "automated_feedback_pending for track without representer" do
+    # Pending without queued
+    submission = create :submission, representation_status: :not_queued, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+
+    # Pending with queued
+    submission = create :submission, representation_status: :queued, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    assert submission.automated_feedback_pending?
+
+    # Present only if there is actual feedback on representation
+    submission = create :submission, representation_status: :generated, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+
+    create :submission_representation, ast_digest: "foobar", submission: submission
+    er = create :exercise_representation, ast_digest: "foobar", exercise: submission.exercise
+    refute Submission.find(submission.id).automated_feedback_pending?
+
+    er.update!(feedback_markdown: "foobar", feedback_author: create(:user), feedback_type: :non_actionable)
+    submission = Submission.find(submission.id)
+    refute submission.automated_feedback_pending?
+    refute submission.has_essential_automated_feedback?
+    refute submission.has_actionable_automated_feedback?
+    assert submission.has_non_actionable_automated_feedback?
+
+    er.update!(feedback_type: :actionable)
+    submission = Submission.find(submission.id)
+    refute submission.automated_feedback_pending?
+    refute submission.has_essential_automated_feedback?
+    assert submission.has_actionable_automated_feedback?
+    refute submission.has_non_actionable_automated_feedback?
+
+    er.update!(feedback_type: :essential)
+    submission = Submission.find(submission.id)
+    refute submission.automated_feedback_pending?
+    assert submission.has_essential_automated_feedback?
+    refute submission.has_actionable_automated_feedback?
+    refute submission.has_non_actionable_automated_feedback?
+
+    # Check if completed but without feedback
+    submission = create :submission, representation_status: :generated, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+
+    # Check exceptioned state
+    submission = create :submission, representation_status: :exceptioned, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+
+    # Check cancelled state
+    submission = create :submission, representation_status: :cancelled, analysis_status: :not_queued
+    submission.track.update!(has_representer: true, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+  end
+
+  test "automated_feedback_pending for track without representer nor analyzer" do
+    submission = create :submission, representation_status: :not_queued, analysis_status: :not_queued
+    submission.track.update!(has_representer: false, has_analyzer: false)
+    refute submission.automated_feedback_pending?
+    refute submission.has_automated_feedback?
+  end
+
   test "representer_feedback is correctly nil" do
     submission = create :submission, representation_status: :generated
     assert_nil submission.representer_feedback


### PR DESCRIPTION
The pending analysis status did not account for the fact that a `not_queued` status for the representation or analysis could simply be a result of the track not having a representer and/or analyzer.

Closes https://github.com/exercism/exercism/issues/6325
