### PR TITLE
Return 404 for missing docs

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -14,7 +14,7 @@ class DocsController < ApplicationController
   end
 
   def show
-    @doc = Document.where(section: @section).find(params[:slug])
+    @doc = @nav_docs.find(params[:slug])
     render action: :show
   rescue ActiveRecord::RecordNotFound
     render_404
@@ -25,7 +25,7 @@ class DocsController < ApplicationController
   def track_index; end
 
   def track_show
-    @doc = Document.where(track: @track).find(params[:slug])
+    @doc = @nav_docs.find(params[:slug])
     @section = :tracks
     render action: :show
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -9,15 +9,11 @@ class DocsController < ApplicationController
   def section
     @doc = Document.find_by!(section: @section, slug: "APEX")
     render action: :show
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def show
     @doc = @nav_docs.find(params[:slug])
     render action: :show
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def tracks; end
@@ -28,8 +24,6 @@ class DocsController < ApplicationController
     @doc = @nav_docs.find(params[:slug])
     @section = :tracks
     render action: :show
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   private
@@ -43,7 +37,5 @@ class DocsController < ApplicationController
     @nav_docs = Document.where(track_id: @track.id)
 
     render_404 unless @track.accessible_by?(current_user)
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -7,13 +7,17 @@ class DocsController < ApplicationController
   def index; end
 
   def section
-    @doc = Document.find_by(section: @section, slug: "APEX")
+    @doc = Document.find_by!(section: @section, slug: "APEX")
     render action: :show
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def show
     @doc = Document.where(section: @section).find(params[:slug])
     render action: :show
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def tracks; end
@@ -24,6 +28,8 @@ class DocsController < ApplicationController
     @doc = Document.where(track: @track).find(params[:slug])
     @section = :tracks
     render action: :show
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   private
@@ -37,5 +43,7 @@ class DocsController < ApplicationController
     @nav_docs = Document.where(track_id: @track.id)
 
     render_404 unless @track.accessible_by?(current_user)
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
 
   # Enable server timing
   config.server_timing = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable server timing
   config.server_timing = true

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -40,6 +40,11 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     assert_response 200
   end
 
+  test "section shows 404s for missing document" do
+    get docs_section_path(:mentoring)
+    assert_rendered_404
+  end
+
   test "tracks shows when logged out" do
     get docs_tracks_path
     assert_response 200
@@ -79,6 +84,11 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     assert_response 200
   end
 
+  test "track index shows 404s for unknown track" do
+    get track_docs_path('unknown')
+    assert_rendered_404
+  end
+
   test "track shows when logged out" do
     doc = create :document, :track
     get track_doc_path(doc.track, doc)
@@ -98,5 +108,11 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     sign_in!(user)
     get track_doc_path(doc.track, doc)
     assert_response 200
+  end
+
+  test "track shows 404s for missing document" do
+    track = create :track
+    get track_doc_path(track, 'missing')
+    assert_rendered_404
   end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -57,4 +57,25 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     get docs_tracks_path
     assert_response 200
   end
+
+  test "track index shows when logged out" do
+    track = create :track
+    get track_docs_path(track)
+    assert_response 200
+  end
+
+  test "track index shows when logged in" do
+    track = create :track
+    sign_in!
+    get track_docs_path(track)
+    assert_response 200
+  end
+
+  test "track index shows when not onboarded" do
+    track = create :track
+    user = create :user, :not_onboarded
+    sign_in!(user)
+    get track_docs_path(track)
+    assert_response 200
+  end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -41,8 +41,9 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "section shows 404s for missing document" do
-    get docs_section_path(:mentoring)
-    assert_rendered_404
+    assert_raises ActiveRecord::RecordNotFound do
+      get docs_section_path(:mentoring)
+    end
   end
 
   test "tracks shows when logged out" do
@@ -85,8 +86,9 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "track index shows 404s for unknown track" do
-    get track_docs_path('unknown')
-    assert_rendered_404
+    assert_raises ActiveRecord::RecordNotFound do
+      get track_docs_path('unknown')
+    end
   end
 
   test "track shows when logged out" do
@@ -112,7 +114,8 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
 
   test "track shows 404s for missing document" do
     track = create :track
-    get track_doc_path(track, 'missing')
-    assert_rendered_404
+    assert_raises ActiveRecord::RecordNotFound do
+      get track_doc_path(track, 'missing')
+    end
   end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -39,4 +39,22 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     get docs_section_path(:mentoring)
     assert_response 200
   end
+
+  test "tracks shows when logged out" do
+    get docs_tracks_path
+    assert_response 200
+  end
+
+  test "tracks shows when logged in" do
+    sign_in!
+    get docs_tracks_path
+    assert_response 200
+  end
+
+  test "tracks shows when not onboarded" do
+    user = create :user, :not_onboarded
+    sign_in!(user)
+    get docs_tracks_path
+    assert_response 200
+  end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -78,4 +78,25 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     get track_docs_path(track)
     assert_response 200
   end
+
+  test "track shows when logged out" do
+    doc = create :document, :track
+    get track_doc_path(doc.track, doc)
+    assert_response 200
+  end
+
+  test "track shows when logged in" do
+    doc = create :document, :track
+    sign_in!
+    get track_doc_path(doc.track, doc)
+    assert_response 200
+  end
+
+  test "track shows when not onboarded" do
+    doc = create :document, :track
+    user = create :user, :not_onboarded
+    sign_in!(user)
+    get track_doc_path(doc.track, doc)
+    assert_response 200
+  end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -18,4 +18,25 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
     get docs_path
     assert_response 200
   end
+
+  test "section shows when logged out" do
+    create :document, section: :mentoring, slug: 'APEX'
+    get docs_section_path(:mentoring)
+    assert_response 200
+  end
+
+  test "section shows when logged in" do
+    create :document, section: :mentoring, slug: 'APEX'
+    sign_in!
+    get docs_section_path(:mentoring)
+    assert_response 200
+  end
+
+  test "section shows when not onboarded" do
+    create :document, section: :mentoring, slug: 'APEX'
+    user = create :user, :not_onboarded
+    sign_in!(user)
+    get docs_section_path(:mentoring)
+    assert_response 200
+  end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -1,21 +1,21 @@
 require "test_helper"
 
 class DocsControllerTest < ActionDispatch::IntegrationTest
-  test "works logged out" do
+  test "docs shows when logged out" do
     get docs_path
     assert_response 200
   end
 
-  test "works logged in" do
+  test "docs shows when logged in" do
     sign_in!
     get docs_path
     assert_response 200
   end
 
-  test "works not onboarded" do
+  test "docs shows when not onboarded" do
     user = create :user, :not_onboarded
     sign_in!(user)
-    get user_onboarding_path
+    get docs_path
     assert_response 200
   end
 end

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -7,4 +7,8 @@ FactoryBot.define do
     section { :contributing }
     title { "Running the Tests" }
   end
+
+  trait :track do
+    track { create :track }
+  end
 end

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :document do
     uuid { SecureRandom.uuid }
     slug { SecureRandom.uuid }
-    git_repo { TestHelpers.git_repo_url("docs") }
+    git_repo { TestHelpers.git_repo_url("track-with-exercises") }
     git_path { "docs/TESTS.md" }
     section { :contributing }
     title { "Running the Tests" }

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :document do
     uuid { SecureRandom.uuid }
     slug { SecureRandom.uuid }
-    git_repo { TestHelpers.git_repo_url("track-with-exercises") }
+    git_repo { TestHelpers.git_repo_url("docs") }
     git_path { "docs/TESTS.md" }
     section { :contributing }
     title { "Running the Tests" }


### PR DESCRIPTION
This PR ensures that a 404 is rendered when a document is not found, instead of a 500 (which would 
also result in a bugsnag entry I believe).
Whilst implementing this, I found that unit tests were a bit lacking, so I added some.

- Rename tests for docs controller
- Add tests for docs section
- Add tests for docs tracks section
- Add tests for docs track index section
- Add tests for docs track doc section
- Add 404 tests to docs controller tests
- Simplify code a bit

Closes https://github.com/exercism/exercism/issues/6341