### PR TITLE
Set page size to 24 for solutions

### DIFF
--- a/app/commands/solution/search_community_solutions.rb
+++ b/app/commands/solution/search_community_solutions.rb
@@ -3,7 +3,7 @@ class Solution
     include Mandate
 
     DEFAULT_PAGE = 1
-    DEFAULT_PER = 30
+    DEFAULT_PER = 24
     MAX_ROWS = 10_000
 
     def self.default_per

--- a/app/commands/solution/search_user_solutions.rb
+++ b/app/commands/solution/search_user_solutions.rb
@@ -3,7 +3,7 @@ class Solution
     include Mandate
 
     DEFAULT_PAGE = 1
-    DEFAULT_PER = 25
+    DEFAULT_PER = 24
 
     def self.default_per
       DEFAULT_PER


### PR DESCRIPTION
Setting the page size to 24 allows the displayed items to be aligned in a grid of size 1, 2, 3, 4, 6, 12 (or 24).

Closes https://github.com/exercism/exercism/issues/6339
