### PR TITLE
Hide learning mode and new tags for joined tracks

### DIFF
--- a/app/javascript/components/student/tracks-list/Track.tsx
+++ b/app/javascript/components/student/tracks-list/Track.tsx
@@ -22,16 +22,18 @@ export const Track = ({ track }: { track: StudentTrack }): JSX.Element => {
             className="block lg:hidden"
           />
           <h3 className="--title">{track.title}</h3>
-          <div className="items-center hidden md:flex">
-            {track.numConcepts > 5 ? (
-              <div className="--v3"> Learning Mode </div>
-            ) : track.isNew ? (
-              <div className="--new">
-                <Icon icon="stars" alt="This track is new" />
-                New
-              </div>
-            ) : null}
-          </div>
+          {!track.isJoined && (
+            <div className="items-center hidden md:flex">
+              {track.numConcepts > 5 ? (
+                <div className="--v3"> Learning Mode </div>
+              ) : track.isNew ? (
+                <div className="--new">
+                  <Icon icon="stars" alt="This track is new" />
+                  New
+                </div>
+              ) : null}
+            </div>
+          )}
           {track.hasNotifications && <div className="c-notification-dot" />}
           {track.isJoined && (
             <div className="--joined">

--- a/test/javascript/components/student/TracksList/Track.test.jsx
+++ b/test/javascript/components/student/TracksList/Track.test.jsx
@@ -111,7 +111,22 @@ test('hides new tag if track is not new', () => {
   expect(screen.queryByText('New')).not.toBeInTheDocument()
 })
 
-test('shows v3 tag if track has more than 5 concepts', () => {
+test('hides new tag if track is joined', () => {
+  render(
+    <Track
+      track={{
+        isJoined: true,
+        isNew: true,
+        tags: [],
+        numExercises: 5,
+      }}
+    />
+  )
+
+  expect(screen.queryByText('New')).not.toBeInTheDocument()
+})
+
+test('shows learning mode tag if track has more than 5 concepts', () => {
   render(
     <Track
       track={{
@@ -126,7 +141,7 @@ test('shows v3 tag if track has more than 5 concepts', () => {
   expect(screen.getByText('Learning Mode')).toBeInTheDocument()
 })
 
-test('hides v3 tag if track has less than 5 concepts', () => {
+test('hides learning mode tag if track has less than 5 concepts', () => {
   render(
     <Track
       track={{
@@ -134,6 +149,21 @@ test('hides v3 tag if track has less than 5 concepts', () => {
         isNew: true,
         tags: [],
         numConcepts: 5,
+      }}
+    />
+  )
+
+  expect(screen.queryByText('Learning Mode')).not.toBeInTheDocument()
+})
+
+test('hides learning mode tag if track is joined', () => {
+  render(
+    <Track
+      track={{
+        isJoined: true,
+        isNew: true,
+        tags: [],
+        numConcepts: 7,
       }}
     />
   )


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5807

![image](https://user-images.githubusercontent.com/135246/168073385-d58176e7-5aec-4ba5-bbaf-cf545a923ab2.png)

_Go would otherwise have had the Learning Mode tag_
