### PR TITLE
Add link for track documentation to exercise page

### DIFF
--- a/app/views/tracks/exercises/show.html.haml
+++ b/app/views/tracks/exercises/show.html.haml
@@ -78,4 +78,5 @@
       - else
         = render "tracks/exercises/show/action_box_join_exercism", exercise: @exercise, user_track: @user_track
 
-      = render ViewComponents::ProminentLink.new("View track documentation", Exercism::Routes.track_docs_path(@track))
+      .mt-28.ml-8
+        = render ViewComponents::ProminentLink.new("View track documentation", Exercism::Routes.track_docs_path(@track))

--- a/app/views/tracks/exercises/show.html.haml
+++ b/app/views/tracks/exercises/show.html.haml
@@ -78,3 +78,4 @@
       - else
         = render "tracks/exercises/show/action_box_join_exercism", exercise: @exercise, user_track: @user_track
 
+      = render ViewComponents::ProminentLink.new("View track documentation", Exercism::Routes.track_docs_path(@track))


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5765#event-6583943063

@ihid I don't have a good grasp of the CSS. Is there an existing link that I can copy this from?
