### PR TITLE
Increment num_comments on solution when a new comment is added

### DIFF
--- a/app/models/solution/comment.rb
+++ b/app/models/solution/comment.rb
@@ -1,5 +1,5 @@
 class Solution::Comment < ApplicationRecord
-  belongs_to :solution
+  belongs_to :solution, counter_cache: :num_comments
   belongs_to :author, class_name: "User", foreign_key: :user_id, inverse_of: :solution_comments
 
   validates :content_markdown, presence: true

--- a/test/commands/solution/comment/create_test.rb
+++ b/test/commands/solution/comment/create_test.rb
@@ -13,4 +13,15 @@ class Solution::Comment::CreateTest < ActiveSupport::TestCase
     assert_equal markdown, comment.content_markdown
     assert_equal "<p>foo</p>\n<p>bar</p>\n", comment.content_html
   end
+
+  test "increments num_comments on solution" do
+    user = create :user
+    solution = create :practice_solution
+
+    Solution::Comment::Create.(user, solution, "first comment")
+    assert_equal 1, solution.num_comments
+
+    Solution::Comment::Create.(user, solution, "second comment")
+    assert_equal 2, solution.num_comments
+  end
 end


### PR DESCRIPTION
This PR fixes the `num_comments` field not having the correct count (it is always `0`).

We could update the existing solutions with the following query:

```ruby
ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
  Solution.update_all("num_comments = (SELECT COUNT(*) FROM solution_comments WHERE solution_comments.solution_id=solutions.id)")
end
```

Closes https://github.com/exercism/exercism/issues/6281