### PR TITLE
Prevent race conditions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,7 +10,7 @@ class Document < ApplicationRecord
 
   belongs_to :track, optional: true
 
-  after_save do
+  after_save_commit do
     SyncDocToSearchIndexJob.perform_later(self)
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -62,7 +62,7 @@ class Exercise < ApplicationRecord
     self.git_important_files_hash = Git::GenerateHashForImportantExerciseFiles.(self) if git_sha_changed?
   end
 
-  after_update do
+  after_update_commit do
     if saved_changes.include?(:git_important_files_hash)
       MarkSolutionsAsOutOfDateInIndexJob.perform_later(self)
       QueueSolutionHeadTestRunsJob.perform_later(self)

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -66,11 +66,11 @@ class Solution < ApplicationRecord
     self.status = determine_status
   end
 
-  after_save do
+  after_save_commit do
     SyncSolutionToSearchIndexJob.perform_later(self)
   end
 
-  after_update do
+  after_update_commit do
     # It's basically never bad to run this.
     # There should always be a head test run and if there's
     # not we should make one. 99% of the time this will result

--- a/app/models/submission/file.rb
+++ b/app/models/submission/file.rb
@@ -13,7 +13,12 @@ class Submission::File < ApplicationRecord
   # any content that has been passed in via the
   # attr_writer. We only want to do this on create
   # and never want to update or change this content.
-  after_create_commit do
+  #
+  # Note that we don't use after_create_commit as
+  # we want this to be done as quickly as possible
+  # and all data that is used is present (no risk of
+  # a race condition).
+  after_create do
     if @content
       Exercism.s3_client.put_object(
         bucket: s3_bucket,

--- a/app/models/submission/file.rb
+++ b/app/models/submission/file.rb
@@ -13,7 +13,7 @@ class Submission::File < ApplicationRecord
   # any content that has been passed in via the
   # attr_writer. We only want to do this on create
   # and never want to update or change this content.
-  after_create do
+  after_create_commit do
     if @content
       Exercism.s3_client.put_object(
         bucket: s3_bucket,


### PR DESCRIPTION
Some models used the `after_save` and `after_update` callbacks, but these could lead to race conditions as the code called
within those methods could read an outdated version of the model as there was no guarantee the changes would have been committed.

This was e.g. problematic when dealing with a solution's published head tests status, which would not be updated due to the published
solution's published_iteration_id not having yet been updated.

See https://github.com/exercism/exercism/issues/5810
