### PR TITLE
Fix iteration publishing not showing all iterations

### DIFF
--- a/app/controllers/tracks/community_solutions_controller.rb
+++ b/app/controllers/tracks/community_solutions_controller.rb
@@ -22,6 +22,7 @@ class Tracks::CommunitySolutionsController < ApplicationController
 
     @author = @solution.user
     @comments = @solution.comments
+    @own_solution = @author == @current_user
 
     # TODO: (Required) Real algorithm here
     @other_solutions = @exercise.solutions.published.where.not(id: @solution.id).limit(3)

--- a/app/helpers/react_components/common/solution_view.rb
+++ b/app/helpers/react_components/common/solution_view.rb
@@ -5,16 +5,24 @@ module ReactComponents
 
       def to_s
         super("common-solution-view", {
-          iterations: solution.published_iterations.map { |iteration| SerializeIteration.(iteration) },
+          iterations: iterations.map { |iteration| SerializeIteration.(iteration) },
           language: solution.track.highlightjs_language,
           indent_size: solution.track.indent_size,
           out_of_date: solution.out_of_date?,
           published_iteration_idx: solution.published_iteration.try(:idx),
+          published_iteration_idxs: solution.published_iterations.pluck(:idx),
           links: {
             change_iteration: change_iteration_link,
             unpublish: unpublish_link
           }
         })
+      end
+
+      private
+      def iterations
+        return solution.iterations.not_deleted if solution.user == current_user
+
+        solution.published_iterations
       end
 
       def change_iteration_link

--- a/app/helpers/react_components/student/published_solution.rb
+++ b/app/helpers/react_components/student/published_solution.rb
@@ -9,7 +9,7 @@ module ReactComponents
           {
             solution: SerializeCommunitySolution.(solution),
             published_iteration_idx: solution.published_iteration.try(:idx),
-            iterations: solution.iterations.order(idx: :desc).map { |iteration| SerializeIteration.(iteration) },
+            iterations: solution.iterations.not_deleted.order(idx: :desc).map { |iteration| SerializeIteration.(iteration) },
             links: {
               change_iteration: Exercism::Routes.published_iteration_api_solution_url(solution.uuid),
               unpublish: Exercism::Routes.unpublish_api_solution_url(solution.uuid)

--- a/app/javascript/components/common/SolutionView.tsx
+++ b/app/javascript/components/common/SolutionView.tsx
@@ -19,6 +19,7 @@ export type Links = {
 export type Props = {
   iterations: readonly Iteration[]
   publishedIterationIdx: number | null
+  publishedIterationIdxs: readonly number[]
   language: string
   indentSize: number
   outOfDate: boolean
@@ -30,13 +31,17 @@ const DEFAULT_ERROR = new Error('Unable to load files')
 export const SolutionView = ({
   iterations,
   publishedIterationIdx,
+  publishedIterationIdxs,
   language,
   indentSize,
   outOfDate,
   links,
 }: Props): JSX.Element => {
+  const publishedIterations = iterations.filter((iteration) =>
+    publishedIterationIdxs.includes(iteration.idx)
+  )
   const [currentIteration, setCurrentIteration] = useState(
-    iterations[iterations.length - 1]
+    publishedIterations[publishedIterations.length - 1]
   )
   const { resolvedData, error, status, isFetching } = usePaginatedRequestQuery<{
     files: File[]
@@ -72,9 +77,9 @@ export const SolutionView = ({
         </FetchingBoundary>
       </ResultsZone>
       <footer className="c-iterations-footer">
-        {iterations.length > 1 ? (
+        {publishedIterations.length > 1 ? (
           <IterationsList
-            iterations={iterations}
+            iterations={publishedIterations}
             onClick={setCurrentIteration}
             current={currentIteration}
           />

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -132,6 +132,7 @@ initReact({
       language={data.language}
       indentSize={data.indent_size}
       publishedIterationIdx={data.published_iteration_idx}
+      publishedIterationIdxs={data.published_iteration_idxs}
       outOfDate={data.out_of_date}
       links={camelizeKeysAs<SolutionViewLinks>(data.links)}
     />

--- a/app/views/tracks/community_solutions/show.html.haml
+++ b/app/views/tracks/community_solutions/show.html.haml
@@ -19,7 +19,7 @@
         .seperator /
         = link_to "Community Solutions", track_exercise_solutions_path(@track, @exercise)
         .seperator /
-        .exercise-title #{@author.handle}'s solution
+        .exercise-title #{@own_solution ? 'Your' : "#{@author.handle}'s"} solution
 
     .content.lg-container.flex.flex-col.lg:flex-row.lg:items-center
       = track_icon @track
@@ -32,7 +32,9 @@
 
         %h1
           .name
-            - if @author.profile
+            - if @own_solution
+              Your
+            - elsif @author.profile
               = link_to "#{@author.handle}'s", profile_path(@author)
             - else
               #{@author.handle}'s

--- a/test/javascript/components/common/SolutionView.test.tsx
+++ b/test/javascript/components/common/SolutionView.test.tsx
@@ -12,6 +12,7 @@ const buildProps = build<Props>({
   fields: {
     iterations: [createIteration({})],
     publishedIterationIdx: 1,
+    publishedIterationIdxs: [1],
     language: 'ruby',
     indentSize: 2,
     outOfDate: perBuild(() => true),

--- a/test/system/flows/community_solutions/user_changes_published_iteration_test.rb
+++ b/test/system/flows/community_solutions/user_changes_published_iteration_test.rb
@@ -6,29 +6,132 @@ module Flows
     class PublishSolutionTest < ApplicationSystemTestCase
       include CapybaraHelpers
 
-      test "user changes a published iteration" do
+      test "views own community solution and changes published iteration" do
         track = create :track
         exercise = create :concept_exercise, track: track
         author = create :user, handle: "author"
         create :user_track, user: author, track: track
         solution = create :concept_solution, :completed, :published, user: author, exercise: exercise
-        submission = create :submission, solution: solution
-        create :iteration, idx: 1, submission: submission
-        submission = create :submission, solution: solution
-        iteration_2 = create :iteration, idx: 2, submission: submission
-        solution.update!(published_iteration: iteration_2)
+        submission_1 = create :submission, solution: solution
+        iteration_1 = create :iteration, idx: 1, submission: submission_1
+        create :submission_file, content: "module Bob\nend", filename: "bob.rb", submission: submission_1
+        submission_2 = create :submission, solution: solution
+        create :iteration, idx: 2, submission: submission_2
+        create :submission_file, content: "class Bob\nend", filename: "bob.rb", submission: submission_2
+        submission_3 = create :submission, solution: solution
+        create :iteration, :deleted, idx: 3, submission: submission_3
+        create :submission_file, content: "just Bob\nend", filename: "bob.rb", submission: submission_3
+
+        solution.update!(published_iteration: iteration_1)
 
         use_capybara_host do
           sign_in!(author)
           visit track_exercise_solution_url(track, exercise, "author")
 
+          # Change published iteration to all iterations
           click_on "Publish settings"
           click_on "Change published iterations…"
           find("label", text: "All iterations").click
           click_on "Update published solution"
 
-          assert_button "1"
-          assert_button "2", disabled: true
+          assert_text "Your solution"
+          assert_text "class Bob"
+          assert_button("1", class: "iteration")
+          assert_button("2", class: "iteration", disabled: true)
+          refute_button("3", class: "iteration")
+
+          visit track_exercise_solution_url(track, exercise, "author")
+
+          # Change published iteration to specific iteration
+          click_on "Publish settings"
+          click_on "Change published iteration"
+          find("label", text: "Single iteration").click
+          within(".c-single-select") do
+            find("button").click
+            assert_text "Iteration 1" # Show active iteration
+            assert_text "Iteration 2" # Show active iteration
+            refute_text "Iteration 3" # Don't show deleted iteration
+
+            find(".row", text: "Iteration 1").find(:xpath, '../input', visible: false).click
+            find("button").click
+          end
+
+          click_on "Update published solution"
+          assert_text "Your solution"
+          assert_text "module Bob"
+
+          # Single published iterations don't have iteration buttons
+          refute_button("1", class: "iteration")
+          refute_button("2", class: "iteration")
+          refute_button("3", class: "iteration")
+        end
+      end
+
+      test "views other community solution with single published iteration" do
+        user = create :user
+        track = create :track
+        exercise = create :concept_exercise, track: track
+        author = create :user, handle: "author"
+        create :user_track, user: author, track: track
+        solution = create :concept_solution, :completed, :published, user: author, exercise: exercise
+        submission_1 = create :submission, solution: solution
+        iteration_1 = create :iteration, idx: 1, submission: submission_1
+        create :submission_file, content: "module Bob\nend", filename: "bob.rb", submission: submission_1
+        submission_2 = create :submission, solution: solution
+        create :iteration, idx: 2, submission: submission_2
+        create :submission_file, content: "class Bob\nend", filename: "bob.rb", submission: submission_2
+        submission_3 = create :submission, solution: solution
+        create :iteration, :deleted, idx: 3, submission: submission_3
+        create :submission_file, content: "just Bob\nend", filename: "bob.rb", submission: submission_3
+
+        solution.update!(published_iteration: iteration_1)
+
+        use_capybara_host do
+          sign_in!(user)
+          visit track_exercise_solution_url(track, exercise, "author")
+
+          assert_text "author's solution"
+          assert_text "module Bob"
+
+          # Single published iterations don't have iteration buttons
+          refute_button("1", class: "iteration")
+          refute_button("2", class: "iteration")
+          refute_button("3", class: "iteration")
+        end
+      end
+
+      test "views other community solution with all iterations published" do
+        user = create :user
+        track = create :track
+        exercise = create :concept_exercise, track: track
+        author = create :user, handle: "author"
+        create :user_track, user: author, track: track
+        solution = create :concept_solution, :completed, :published, user: author, exercise: exercise
+        submission_1 = create :submission, solution: solution
+        create :iteration, idx: 1, submission: submission_1
+        create :submission_file, content: "module Bob\nend", filename: "bob.rb", submission: submission_1
+        submission_2 = create :submission, solution: solution
+        create :iteration, idx: 2, submission: submission_2
+        create :submission_file, content: "class Bob\nend", filename: "bob.rb", submission: submission_2
+        submission_3 = create :submission, solution: solution
+        create :iteration, :deleted, idx: 3, submission: submission_3
+        create :submission_file, content: "just Bob\nend", filename: "bob.rb", submission: submission_3
+
+        use_capybara_host do
+          sign_in!(user)
+          visit track_exercise_solution_url(track, exercise, "author")
+
+          assert_text "author's solution"
+          assert_text "class Bob"
+          assert_button("1", class: "iteration")
+          assert_button("2", class: "iteration", disabled: true)
+          refute_button("3", class: "iteration")
+
+          click_on("1", class: "iteration")
+          assert_text "module Bob"
+          assert_button("1", class: "iteration", disabled: true)
+          assert_button("2", class: "iteration")
+          refute_button("3", class: "iteration")
         end
       end
     end

--- a/test/system/flows/publish_solution_test.rb
+++ b/test/system/flows/publish_solution_test.rb
@@ -95,25 +95,49 @@ module Flows
       user = create :user
       create :user_track, user: user, track: track
       solution = create :concept_solution, :completed, :published, user: user, exercise: strings
-      submission = create :submission, solution: solution
-      iteration_2 = create :iteration, idx: 2, submission: submission
-      submission = create :submission, solution: solution
-      create :iteration, idx: 1, submission: submission
+      submission_1 = create :submission, solution: solution
+      create :iteration, idx: 1, submission: submission_1
+      create :submission_file, content: "module Bob\nend", filename: "bob.rb", submission: submission_1
+      submission_2 = create :submission, solution: solution
+      iteration_2 = create :iteration, idx: 2, submission: submission_2
+      create :submission_file, content: "class Bob\nend", filename: "bob.rb", submission: submission_2
+      submission_3 = create :submission, solution: solution
+      create :iteration, :deleted, idx: 3, submission: submission_3
+      create :submission_file, content: "just Bob\nend", filename: "bob.rb", submission: submission_3
+
       solution.update!(published_iteration: iteration_2)
 
       use_capybara_host do
         sign_in!(user)
         visit track_exercise_url(track, strings)
 
+        # Change published iteration to all iterations
         click_on "Publish settings"
         click_on "Change published iteration"
         find("label", text: "All iterations").click
         click_on "Update published solution"
-
         assert_text "Your published solution"
-        # There is no way to determine from the screen which iteration was published. We can only check the solution record.
-        solution.reload
-        assert_nil solution.published_iteration
+        click_on(class: "c-community-solution")
+        assert_text "class Bob"
+
+        visit track_exercise_url(track, strings)
+
+        # Change published iteration to specific iteration
+        click_on "Publish settings"
+        click_on "Change published iteration"
+        find("label", text: "Single iteration").click
+        within(".c-single-select") do
+          find("button").click
+          assert_text "Iteration 1" # Don't show deleted iteration
+          assert_text "Iteration 2" # Show active iteration
+          refute_text "Iteration 3" # Show active iteration
+
+          find(".row", text: "Iteration 1").find(:xpath, '../input', visible: false).click
+        end
+
+        click_on "Update published solution"
+        click_on(class: "c-community-solution")
+        assert_text "module Bob"
       end
     end
 

--- a/test/system/flows/publish_solution_test.rb
+++ b/test/system/flows/publish_solution_test.rb
@@ -128,9 +128,9 @@ module Flows
         find("label", text: "Single iteration").click
         within(".c-single-select") do
           find("button").click
-          assert_text "Iteration 1" # Don't show deleted iteration
+          assert_text "Iteration 1" # Show active iteration
           assert_text "Iteration 2" # Show active iteration
-          refute_text "Iteration 3" # Show active iteration
+          refute_text "Iteration 3" # Don't show deleted iteration
 
           find(".row", text: "Iteration 1").find(:xpath, '../input', visible: false).click
         end


### PR DESCRIPTION
This PR fixes two things:

1. There was a bug where the publishing on the community solutions page only showed a single iteration if the solution on published a single iteration
2. There was a bug the you could publish a deleted iteration

Closes https://github.com/exercism/exercism/issues/6303
Closes https://github.com/exercism/exercism/issues/6385