### PR TITLE
Search for docs and solutions using keyword terms.

### DIFF
--- a/app/commands/document/search_docs.rb
+++ b/app/commands/document/search_docs.rb
@@ -60,7 +60,7 @@ class Document
       {
         bool: {
           must: [
-            track_slug.blank? ? nil : { terms: { 'track.slug': [track_slug].flatten } },
+            track_slug.blank? ? nil : { terms: { 'track.slug.keyword': [track_slug].flatten } },
             criteria.blank? ? nil : {
               query_string: {
                 query: criteria.split(' ').map { |c| "*#{c}*" }.join(' AND '),

--- a/app/commands/solution/search_community_solutions.rb
+++ b/app/commands/solution/search_community_solutions.rb
@@ -78,10 +78,10 @@ class Solution
         bool: {
           must: [
             { term: { 'exercise.id': exercise.id } },
-            { term: { status: 'published' } },
+            { term: { 'status.keyword': 'published' } },
             @sync_status.nil? ? nil : { term: { 'out_of_date': @sync_status == :out_of_date } },
-            @tests_status.blank? ? nil : { terms: { 'published_iteration.tests_status': to_terms(@tests_status) } },
-            @head_tests_status.blank? ? nil : { terms: { 'published_iteration.head_tests_status': to_terms(@head_tests_status) } },
+            @tests_status.blank? ? nil : { terms: { 'published_iteration.tests_status.keyword': to_terms(@tests_status) } },
+            @head_tests_status.blank? ? nil : { terms: { 'published_iteration.head_tests_status.keyword': to_terms(@head_tests_status) } }, # rubocop:disable Layout/LineLength
             @criteria.blank? ? nil : {
               query_string: {
                 query: criteria.split(' ').map { |c| "*#{c}*" }.join(' AND '),

--- a/app/commands/solution/search_user_solutions.rb
+++ b/app/commands/solution/search_user_solutions.rb
@@ -73,12 +73,12 @@ class Solution
         bool: {
           must: [
             { term: { 'user.id': user.id } },
-            track_slug.blank? ? nil : { terms: { 'track.slug': [track_slug].flatten } },
-            status.blank? ? nil : { terms: { status: [status].flatten } },
-            mentoring_status.blank? ? nil : { terms: { mentoring_status: [mentoring_status].flatten } },
+            track_slug.blank? ? nil : { terms: { 'track.slug.keyword': [track_slug].flatten } },
+            status.blank? ? nil : { terms: { 'status.keyword': [status].flatten } },
+            mentoring_status.blank? ? nil : { terms: { 'mentoring_status.keyword': [mentoring_status].flatten } },
             sync_status.nil? ? nil : { term: { 'out_of_date': sync_status == :out_of_date } },
-            tests_status.blank? ? nil : { terms: { 'published_iteration.tests_status': to_terms(tests_status) } },
-            head_tests_status.blank? ? nil : { terms: { 'published_iteration.head_tests_status': to_terms(head_tests_status) } },
+            tests_status.blank? ? nil : { terms: { 'published_iteration.tests_status.keyword': to_terms(tests_status) } },
+            head_tests_status.blank? ? nil : { terms: { 'published_iteration.head_tests_status.keyword': to_terms(head_tests_status) } }, # rubocop:disable Layout/LineLength
             criteria.blank? ? nil : {
               query_string: {
                 query: criteria.split(' ').map { |c| "*#{c}*" }.join(' AND '),

--- a/test/commands/document/search_docs_test.rb
+++ b/test/commands/document/search_docs_test.rb
@@ -76,6 +76,7 @@ class Document::SearchDocsTest < ActiveSupport::TestCase
   test "track_slug" do
     ruby = create :track, title: "Ruby", slug: "ruby"
     elixir = create :track, title: "Elixir", slug: 'elixir'
+    common_lisp = create :track, title: "Common Lisp", slug: 'common-lisp'
 
     # Sanity check: non track doc should not be included
     non_track_doc = create :document, track: nil
@@ -83,15 +84,17 @@ class Document::SearchDocsTest < ActiveSupport::TestCase
     ruby_doc_1 = create :document, track: ruby
     ruby_doc_2 = create :document, track: ruby
     elixir_doc = create :document, track: elixir
+    common_lisp_doc = create :document, track: common_lisp
 
     # Sanity check: ensure that the results are not returned using the fallback
     Document::SearchDocs::Fallback.expects(:call).never
 
     wait_for_opensearch_to_be_synced
 
-    assert_equal [non_track_doc, ruby_doc_1, ruby_doc_2, elixir_doc], Document::SearchDocs.()
+    assert_equal [non_track_doc, ruby_doc_1, ruby_doc_2, elixir_doc, common_lisp_doc], Document::SearchDocs.()
     assert_equal [ruby_doc_1, ruby_doc_2, elixir_doc], Document::SearchDocs.(track_slug: %i[ruby elixir])
     assert_equal [ruby_doc_1, ruby_doc_2], Document::SearchDocs.(track_slug: "ruby")
+    assert_equal [common_lisp_doc], Document::SearchDocs.(track_slug: "common-lisp")
   end
 
   test "pagination" do

--- a/test/commands/solution/search_user_solutions_test.rb
+++ b/test/commands/solution/search_user_solutions_test.rb
@@ -47,22 +47,26 @@ class Solution::SearchUserSolutionsTest < ActiveSupport::TestCase
     javascript = create :track, title: "JavaScript", slug: "javascript"
     ruby = create :track, title: "Ruby", slug: "ruby"
     elixir = create :track, title: "Elixir", slug: 'elixir'
+    common_lisp = create :track, title: "Common Lisp", slug: 'common-lisp'
     ruby_exercise = create :practice_exercise, track: ruby
     js_exercise = create :practice_exercise, track: javascript
     elixir_exercise = create :practice_exercise, track: elixir
+    common_lisp_exercise = create :practice_exercise, track: common_lisp
 
     ruby_solution = create :practice_solution, user: user, exercise: ruby_exercise, published_at: 3.weeks.ago
     js_solution = create :practice_solution, user: user, exercise: js_exercise, num_stars: 1
     elixir_solution = create :practice_solution, user: user, exercise: elixir_exercise, num_stars: 2
+    common_lisp_solution = create :practice_solution, user: user, exercise: common_lisp_exercise, num_stars: 3
 
     # Sanity check: ensure that the results are not returned using the fallback
     Solution::SearchUserSolutions::Fallback.expects(:call).never
 
     wait_for_opensearch_to_be_synced
 
-    assert_equal [elixir_solution, js_solution, ruby_solution], Solution::SearchUserSolutions.(user)
+    assert_equal [common_lisp_solution, elixir_solution, js_solution, ruby_solution], Solution::SearchUserSolutions.(user)
     assert_equal [js_solution, ruby_solution], Solution::SearchUserSolutions.(user, track_slug: %i[ruby javascript])
     assert_equal [ruby_solution], Solution::SearchUserSolutions.(user, track_slug: "ruby")
+    assert_equal [common_lisp_solution], Solution::SearchUserSolutions.(user, track_slug: "common-lisp")
   end
 
   test "filter: status" do


### PR DESCRIPTION
Using the keyword terms helps speed up searches and fixes issues with
character like `-` appearing in queries.

Closes https://github.com/exercism/exercism/issues/6398
