### PR TITLE
Fix deprecated `--auto-correct` rubocop option

### DIFF
--- a/bin/rubocop-quick
+++ b/bin/rubocop-quick
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.rb$' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion Gemfile.lock && \
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.rb$' | xargs bundle exec rubocop --except Metrics --autocorrect --format quiet --force-exclusion Gemfile.lock && \
 git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*\.rb$' | xargs git add


### PR DESCRIPTION
If you run rubocop with `--auto-correct`, the following warning is
output:

```shell
--auto-correct is deprecated; use --autocorrect
```

This commit upgrades to rubocop command to use the newer `--autocorrect`
option.
