### PR TITLE
Specify IDs for system and ghost users in seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 # Create system user
-User.find_by_id(1) || User.create!(
+User.find_by_id(User::SYSTEM_USER_ID) || User.create!(
+  id: User::SYSTEM_USER_ID,
   handle: 'exercism-bot',
   email: "#{SecureRandom.uuid}@exercism.org",
   name: 'Exercism Bot',
@@ -7,7 +8,10 @@ User.find_by_id(1) || User.create!(
   password: SecureRandom.uuid,
   bio: "I am the Exercism Bot"
 )
-User.find_by_id(2) || User.create!(
+
+# Create ghost user
+User.find_by_id(User::GHOST_USER_ID) || User.create!(
+  id: User::GHOST_USER_ID,
   handle: 'exercism-ghost',
   email: "#{SecureRandom.uuid}@exercism.org",
   name: 'Exercism Ghost',
@@ -15,7 +19,6 @@ User.find_by_id(2) || User.create!(
   password: SecureRandom.uuid,
   bio: "I am the Ghost of old users who have left"
 )
-
 
 puts "Creating User iHiD"
 iHiD = User.find_by(handle: 'iHiD') || User.create!(


### PR DESCRIPTION
I tried to reset my track locally, but that failed due to the query setting the user ID to the ghost user ID, which was seeded with a 
different ID in the `seeds.db` script.
