### PR TITLE
Delete reputation gained for publishing solutions in a track when resetting that track

### DIFF
--- a/app/commands/user_track/reset.rb
+++ b/app/commands/user_track/reset.rb
@@ -3,6 +3,7 @@ class UserTrack
     include Mandate
 
     initialize_with :user_track
+    delegate :user, :track, to: :user_track
 
     def call
       user_track.solutions.update_all("user_id = #{User::GHOST_USER_ID}, unique_key = UUID()")
@@ -12,6 +13,7 @@ class UserTrack
         objectives: nil
       )
       user_track.reset_summary!
+      User::ReputationTokens::PublishedSolutionToken.where(user:, track:).destroy_all
     end
   end
 end

--- a/test/commands/user_track/reset_test.rb
+++ b/test/commands/user_track/reset_test.rb
@@ -39,4 +39,41 @@ class UserTrack::ResetTest < ActiveSupport::TestCase
       assert_equal Time.current, user_track.last_touched_at
     end
   end
+
+  test "removes track-specification reputation" do
+    freeze_time do
+      create :user, :ghost
+
+      user = create :user
+      track = create :track
+      concept_exercise = create :concept_exercise, track: track
+      practice_exercise = create :practice_exercise, track: track
+      user_track = create :user_track, user: user, track: track
+      solution_1 = create :concept_solution, exercise: concept_exercise, user: user
+      solution_2 = create :practice_solution, exercise: practice_exercise, user: user
+      create :iteration, solution: solution_1
+      create :iteration, solution: solution_2
+
+      # Sanity check: the user also has reputation in a different track,
+      # which should not be lost
+      other_track = create :track, :random_slug
+      other_exercise = create :practice_exercise, track: other_track
+      other_user_track = create :user_track, user: user, track: other_track
+      other_solution = create :concept_solution, exercise: other_exercise, user: user
+      create :iteration, solution: other_solution
+
+      perform_enqueued_jobs do
+        Solution::Publish.(solution_1, user_track, nil)
+        Solution::Publish.(solution_2, user_track, nil)
+        Solution::Publish.(other_solution, other_user_track, nil)
+      end
+
+      # Sanity check
+      assert_equal 3, user.reload.reputation
+
+      UserTrack::Reset.(user_track)
+
+      assert_equal 1, user.reload.reputation
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/5664

Note: we don't need to update everybody's reputation, as reputation is constantly being recalculatedy
