### PR TITLE
Use Haskell for Unison editor syntax highlighting

### DIFF
--- a/app/javascript/components/misc/CodeMirror/languageCompartment.ts
+++ b/app/javascript/components/misc/CodeMirror/languageCompartment.ts
@@ -134,7 +134,8 @@ export const loadLanguageCompartment = async (
       return compartment.of(StreamLanguage.define(groovy))
     }
     case 'haskell':
-    case 'purescript': {
+    case 'purescript':
+    case 'unison': {
       const { haskell } = await import('@codemirror/legacy-modes/mode/haskell')
       return compartment.of(StreamLanguage.define(haskell))
     }


### PR DESCRIPTION
The Unison language doesn't yet have a codemirror grammar, but Haskell is close enough to be helpful to the student.

CC @rlmark
