### PR TITLE
Show submissions that were submitted via online editor as such

### DIFF
--- a/app/javascript/components/track/IterationSummary.tsx
+++ b/app/javascript/components/track/IterationSummary.tsx
@@ -10,7 +10,7 @@ import { OutOfDateNotice } from './iteration-summary/OutOfDateNotice'
 
 const SUBMISSION_METHOD_LABELS = {
   cli: 'CLI',
-  api: 'API',
+  api: 'Editor',
 }
 
 type IterationSummaryProps = {


### PR DESCRIPTION
Currently, submissions that are submitted via the online editor show up in the iteration view as "Submitted via API".
While technically correct, this might be confusing to students, especially as the other value is "Submitted via CLI".
This PR changes "Submitted via API" to "Submitted via Editor".
If we ever do want to differentiate between solutions that are submitted via the API vs solutions submitted via the Editor, we can change this then.

p.s. we did use the "via Editor" text in the submission method icon's alt text: https://github.com/exercism/website/blob/main/app/javascript/components/track/iteration-summary/SubmissionMethodIcon.tsx#L11-L26
