### PR TITLE
Store pull requests that have not been closed

### DIFF
--- a/app/commands/github/pull_request/create_or_update.rb
+++ b/app/commands/github/pull_request/create_or_update.rb
@@ -7,12 +7,12 @@ module Github
 
       def call
         pull_request = ::Github::PullRequest.create_or_find_by!(node_id:) do |pr|
-          pr.attributes = attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :data)
+          pr.attributes = attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :state, :data)
         end
 
         pull_request.tap do |pr|
           pr.update!(
-            attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :data).merge(reviews: reviews(pr))
+            attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :state, :data).merge(reviews: reviews(pr))
           )
         end
       end

--- a/app/commands/github/pull_request/create_or_update.rb
+++ b/app/commands/github/pull_request/create_or_update.rb
@@ -7,12 +7,12 @@ module Github
 
       def call
         pull_request = ::Github::PullRequest.create_or_find_by!(node_id:) do |pr|
-          pr.attributes = attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :state, :data)
+          pr.attributes = attributes.slice(:number, :title, :repo, :state, :author_username, :merged_by_username, :data)
         end
 
         pull_request.tap do |pr|
           pr.update!(
-            attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :state, :data).merge(reviews: reviews(pr))
+            attributes.slice(:number, :title, :repo, :state, :author_username, :merged_by_username, :data).merge(reviews: reviews(pr))
           )
         end
       end

--- a/app/commands/github/pull_request/create_or_update.rb
+++ b/app/commands/github/pull_request/create_or_update.rb
@@ -7,25 +7,14 @@ module Github
 
       def call
         pull_request = ::Github::PullRequest.create_or_find_by!(node_id:) do |pr|
-          pr.number = attributes[:number]
-          pr.title = attributes[:title]
-          pr.repo = attributes[:repo]
-          pr.author_username = attributes[:author_username]
-          pr.merged_by_username = attributes[:merged_by_username]
-          pr.data = attributes[:data]
+          pr.attributes = attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :data)
         end
 
-        pull_request.update!(
-          number: attributes[:number],
-          title: attributes[:title],
-          repo: attributes[:repo],
-          author_username: attributes[:author_username],
-          merged_by_username: attributes[:merged_by_username],
-          data: attributes[:data],
-          reviews: reviews(pull_request)
-        )
-
-        pull_request
+        pull_request.tap do |pr|
+          pr.update!(
+            attributes.slice(:number, :title, :repo, :author_username, :merged_by_username, :data).merge(reviews: reviews(pr))
+          )
+        end
       end
 
       private

--- a/app/commands/github/pull_request/create_or_update.rb
+++ b/app/commands/github/pull_request/create_or_update.rb
@@ -7,13 +7,11 @@ module Github
 
       def call
         pull_request = ::Github::PullRequest.create_or_find_by!(node_id:) do |pr|
-          pr.attributes = attributes.slice(:number, :title, :repo, :state, :author_username, :merged_by_username, :data)
+          pr.attributes = attributes.except(:reviews)
         end
 
         pull_request.tap do |pr|
-          pr.update!(
-            attributes.slice(:number, :title, :repo, :state, :author_username, :merged_by_username, :data).merge(reviews: reviews(pr))
-          )
+          pr.update!(attributes.merge(reviews: reviews(pr)))
         end
       end
 

--- a/app/commands/github/pull_request/sync_repo.rb
+++ b/app/commands/github/pull_request/sync_repo.rb
@@ -99,7 +99,7 @@ module Github
         # This allows us to work with pull requests using a single code path.
         response[:data][:repository][:pullRequests][:nodes].map do |pr|
           {
-            action: pr[:state].casecmp('open').zero? ? 'opened' : 'closed',
+            action: pr[:state].casecmp?('open') ? 'opened' : 'closed',
             author_username: pr[:author].present? ? pr[:author][:login] : nil,
             url: "https://api.github.com/repos/#{response[:data][:repository][:nameWithOwner]}/pulls/#{pr[:number]}",
             html_url: pr[:url],

--- a/app/commands/github/pull_request/sync_repo.rb
+++ b/app/commands/github/pull_request/sync_repo.rb
@@ -15,6 +15,7 @@ module Github
             merged_by_username: pr[:merged_by_username],
             repo: pr[:repo],
             reviews: pr[:reviews],
+            state: pr[:state].downcase.to_sym,
             data: pr
           )
         end
@@ -43,9 +44,7 @@ module Github
           query {
             repository(owner: "#{repo_owner}", name: "#{repo_name}") {
               nameWithOwner
-              pullRequests(first: 100,
-                          states:[CLOSED, MERGED]
-                          #{%(, after: "#{cursor}") if cursor}) {
+              pullRequests(first: 100, #{%(, after: "#{cursor}") if cursor}) {
                 nodes {
                   id
                   url
@@ -53,6 +52,7 @@ module Github
                   number
                   createdAt
                   closedAt
+                  state
                   merged
                   mergedAt
                   mergedBy {
@@ -99,12 +99,12 @@ module Github
         # This allows us to work with pull requests using a single code path.
         response[:data][:repository][:pullRequests][:nodes].map do |pr|
           {
-            action: 'closed',
+            action: pr[:state].casecmp('open').zero? ? 'opened' : 'closed',
             author_username: pr[:author].present? ? pr[:author][:login] : nil,
             url: "https://api.github.com/repos/#{response[:data][:repository][:nameWithOwner]}/pulls/#{pr[:number]}",
             html_url: pr[:url],
             labels: pr[:labels][:nodes].map { |node| node[:name] },
-            state: 'closed',
+            state: pr[:state].downcase,
             node_id: pr[:id],
             number: pr[:number],
             title: pr[:title],

--- a/app/commands/user/reputation_token/award_for_pull_requests.rb
+++ b/app/commands/user/reputation_token/award_for_pull_requests.rb
@@ -13,7 +13,7 @@ class User
 
       private
       def pull_requests
-        ::Github::PullRequest.left_joins(:reviews)
+        ::Github::PullRequest.not_open.left_joins(:reviews)
       end
     end
   end

--- a/app/commands/user/reputation_token/award_for_pull_requests_for_user.rb
+++ b/app/commands/user/reputation_token/award_for_pull_requests_for_user.rb
@@ -21,15 +21,15 @@ class User
       end
 
       def authored_pull_requests
-        ::Github::PullRequest.left_joins(:reviews).where(author_username: user.github_username)
+        ::Github::PullRequest.not_open.left_joins(:reviews).where(author_username: user.github_username)
       end
 
       def merged_pull_requests
-        ::Github::PullRequest.left_joins(:reviews).where(merged_by_username: user.github_username)
+        ::Github::PullRequest.not_open.left_joins(:reviews).where(merged_by_username: user.github_username)
       end
 
       def reviewed_pull_requests
-        ::Github::PullRequest.left_joins(:reviews).where(reviews: { reviewer_username: user.github_username })
+        ::Github::PullRequest.not_open.left_joins(:reviews).where(reviews: { reviewer_username: user.github_username })
       end
     end
   end

--- a/app/commands/webhooks/process_pull_request_update.rb
+++ b/app/commands/webhooks/process_pull_request_update.rb
@@ -2,22 +2,8 @@ module Webhooks
   class ProcessPullRequestUpdate
     include Mandate
 
-    initialize_with :params
+    initialize_with :pull_request_update
 
-    def call
-      return unless closed?
-      return unless valid_action?
-
-      ProcessPullRequestUpdateJob.perform_later(params)
-    end
-
-    private
-    def closed?
-      params[:state] == 'closed'
-    end
-
-    def valid_action?
-      %w[closed labeled unlabeled].include?(params[:action])
-    end
+    def call = ProcessPullRequestUpdateJob.perform_later(pull_request_update)
   end
 end

--- a/app/jobs/process_pull_request_update_job.rb
+++ b/app/jobs/process_pull_request_update_job.rb
@@ -24,6 +24,7 @@ class ProcessPullRequestUpdateJob < ApplicationJob
       merged_by_username: pull_request_update[:merged_by_username],
       repo: pull_request_update[:repo],
       reviews: pull_request_update[:reviews],
+      state: state(pull_request_update),
       data: pull_request_update
     )
 
@@ -37,6 +38,12 @@ class ProcessPullRequestUpdateJob < ApplicationJob
 
   def award_reputation_tokens?(pull_request_update)
     %w[closed labeled unlabeled].include?(pull_request_update[:action])
+  end
+
+  def state(pull_request_update)
+    return :merged if !!pull_request_update[:merged]
+
+    pull_request_update[:state].downcase.to_sym
   end
 
   def reviews(repo, number)

--- a/app/jobs/process_pull_request_update_job.rb
+++ b/app/jobs/process_pull_request_update_job.rb
@@ -27,12 +27,16 @@ class ProcessPullRequestUpdateJob < ApplicationJob
       data: pull_request_update
     )
 
-    User::ReputationToken::AwardForPullRequest.(pull_request_update)
+    User::ReputationToken::AwardForPullRequest.(pull_request_update) if award_reputation_tokens?(pull_request_update)
   end
 
   private
   def add_reviews!(pull_request_update)
     pull_request_update[:reviews] = reviews(pull_request_update[:repo], pull_request_update[:number])
+  end
+
+  def award_reputation_tokens?(pull_request_update)
+    %w[closed labeled unlabeled].include?(pull_request_update[:action])
   end
 
   def reviews(repo, number)

--- a/app/jobs/process_pull_request_update_job.rb
+++ b/app/jobs/process_pull_request_update_job.rb
@@ -1,6 +1,16 @@
 class ProcessPullRequestUpdateJob < ApplicationJob
   queue_as :default
 
+  def self.perform_later(pr_data)
+    return unless self.worth_queuing?(pr_data)
+
+    super(pr_data)
+  end
+
+  def self.worth_queuing?(pr_data) = self.closed?(pr_data) && self.valid_action?(pr_data)
+  def self.closed?(pr_data) = pr_data[:state] == 'closed'
+  def self.valid_action?(pr_data) = %w[closed labeled unlabeled].include?(pr_data[:action])
+
   def perform(pr_data)
     # Fetch and append the reviews which the pull request data does not contain
     pr_data[:reviews] = reviews(pr_data[:repo], pr_data[:number])

--- a/app/models/github/pull_request.rb
+++ b/app/models/github/pull_request.rb
@@ -3,6 +3,12 @@ class Github::PullRequest < ApplicationRecord
 
   serialize :data, JSON
 
+  enum state: {
+    open: 0,
+    closed: 1,
+    merged: 2
+  }
+
   has_many :reviews,
     dependent: :destroy,
     inverse_of: :pull_request,
@@ -10,7 +16,7 @@ class Github::PullRequest < ApplicationRecord
     foreign_key: "github_pull_request_id"
 
   memoize
-  def data
-    super.deep_symbolize_keys
-  end
+  def data =super.deep_symbolize_keys
+
+  def state = super.to_sym
 end

--- a/db/migrate/20220624090353_add_state_to_pull_requests.rb
+++ b/db/migrate/20220624090353_add_state_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddStateToPullRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :github_pull_requests, :state, :tinyint, default: 0, null: false, if_not_exists: true
+  end
+end

--- a/db/migrate/20220624090353_add_state_to_pull_requests.rb
+++ b/db/migrate/20220624090353_add_state_to_pull_requests.rb
@@ -1,5 +1,5 @@
 class AddStateToPullRequests < ActiveRecord::Migration[7.0]
   def change
-    add_column :github_pull_requests, :state, :tinyint, default: 0, null: false, if_not_exists: true
+    add_column :github_pull_requests, :state, :tinyint, default: 1, null: false, if_not_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_24_062903) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_24_090353) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -297,6 +297,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_24_062903) do
     t.text "data", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "state", limit: 1, default: 0, null: false
     t.index ["node_id"], name: "index_github_pull_requests_on_node_id", unique: true
   end
 

--- a/test/commands/github/pull_request/create_or_update_test.rb
+++ b/test/commands/github/pull_request/create_or_update_test.rb
@@ -5,6 +5,7 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     data = {
       url: "https://api.github.com/repos/exercism/ruby/pulls/2",
       repo: "exercism/ruby",
+      title: "A fine PR",
       node_id: "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz",
       number: 2,
       state: "closed",
@@ -18,11 +19,12 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      data[:node_id], **data.slice(:number, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
+      data[:node_id], **data.slice(:number, :title, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
     assert_equal 2, pr.number
+    assert_equal "A fine PR", pr.title
     assert_equal "exercism/ruby", pr.repo
     assert_equal "iHiD", pr.author_username
     assert_equal "ErikSchierboom", pr.merged_by_username
@@ -36,6 +38,7 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     data = {
       url: "https://api.github.com/repos/exercism/ruby/pulls/2",
       repo: "exercism/ruby",
+      title: "A fine PR",
       node_id: "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz",
       number: 2,
       state: "closed",
@@ -49,7 +52,7 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      data[:node_id], **data.slice(:number, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
+      data[:node_id], **data.slice(:number, :title, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
@@ -67,7 +70,9 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
 
     Github::PullRequest::CreateOrUpdate.(
       pr.node_id,
+      title: pr.title,
       number: pr.number,
+      state: pr.state,
       author_username: pr.author_username,
       merged_by_username: pr.merged_by_username,
       repo: pr.repo,
@@ -85,7 +90,9 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
 
       Github::PullRequest::CreateOrUpdate.(
         pr.node_id,
+        title: pr.title,
         number: pr.number,
+        state: pr.state,
         author_username: pr.author_username,
         merged_by_username: pr.merged_by_username,
         repo: pr.repo,
@@ -103,7 +110,9 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
 
     Github::PullRequest::CreateOrUpdate.(
       pr.node_id,
+      title: pr.title,
       number: pr.number,
+      state: pr.state,
       author_username: pr.author_username,
       merged_by_username: pr.merged_by_username,
       repo: pr.repo,

--- a/test/commands/github/pull_request/create_or_update_test.rb
+++ b/test/commands/github/pull_request/create_or_update_test.rb
@@ -2,35 +2,23 @@ require "test_helper"
 
 class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
   test "create pull request with reviewers" do
-    node_id = "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz"
-    number = 2
-    repo = "exercism/ruby"
-    author = "iHiD"
-    merged_by = "ErikSchierboom"
-    reviews = [{ node_id: "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4", reviewer_username: "ErikSchierboom" }]
     data = {
       url: "https://api.github.com/repos/exercism/ruby/pulls/2",
-      repo:,
-      node_id:,
-      number:,
+      repo: "exercism/ruby",
+      node_id: "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz",
+      number: 2,
       state: "closed",
       action: "closed",
-      author_username: author,
+      author_username: "iHiD",
       labels: [],
       merged: true,
-      merged_by_username: merged_by,
-      reviews:,
+      merged_by_username: "ErikSchierboom",
+      reviews: [{ node_id: "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4", reviewer_username: "ErikSchierboom" }],
       html_url: "https://github.com/exercism/ruby/pull/2"
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      node_id,
-      number:,
-      author_username: author,
-      merged_by_username: merged_by,
-      repo:,
-      reviews:,
-      data:
+      data[:node_id], **data.slice(:number, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
@@ -45,35 +33,23 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
   end
 
   test "create pull request without reviewers" do
-    node_id = "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz"
-    number = 2
-    repo = "exercism/ruby"
-    author = "iHiD"
-    merged_by = "ErikSchierboom"
-    reviews = []
     data = {
       url: "https://api.github.com/repos/exercism/ruby/pulls/2",
-      repo:,
-      node_id:,
-      number:,
+      repo: "exercism/ruby",
+      node_id: "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz",
+      number: 2,
       state: "closed",
       action: "closed",
-      author_username: author,
+      author_username: "iHiD",
       labels: [],
       merged: true,
-      merged_by_username: merged_by,
-      reviews:,
+      merged_by_username: "ErikSchierboom",
+      reviews: [],
       html_url: "https://github.com/exercism/ruby/pull/2"
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      node_id,
-      number:,
-      author_username: author,
-      merged_by_username: merged_by,
-      repo:,
-      reviews:,
-      data:
+      data[:node_id], **data.slice(:number, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
@@ -87,8 +63,7 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
 
   test "update pull request if data has changed" do
     pr = create :github_pull_request
-    changed_data = pr.data
-    changed_data[:labels] = ["new-label"]
+    changed_data = pr.data.merge(labels: ["new-label"])
 
     Github::PullRequest::CreateOrUpdate.(
       pr.node_id,

--- a/test/commands/github/pull_request/create_or_update_test.rb
+++ b/test/commands/github/pull_request/create_or_update_test.rb
@@ -19,13 +19,14 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      data[:node_id], **data.slice(:number, :title, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
+      data[:node_id], **data.slice(:number, :title, :state, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
     assert_equal 2, pr.number
     assert_equal "A fine PR", pr.title
     assert_equal "exercism/ruby", pr.repo
+    assert_equal :closed, pr.state
     assert_equal "iHiD", pr.author_username
     assert_equal "ErikSchierboom", pr.merged_by_username
     assert_equal data, pr.data
@@ -52,12 +53,13 @@ class Github::PullRequest::CreateOrUpdateTest < ActiveSupport::TestCase
     }
 
     pr = Github::PullRequest::CreateOrUpdate.(
-      data[:node_id], **data.slice(:number, :title, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
+      data[:node_id], **data.slice(:number, :title, :state, :author_username, :merged_by_username, :repo, :reviews).merge(data:)
     )
 
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.node_id
     assert_equal 2, pr.number
     assert_equal "exercism/ruby", pr.repo
+    assert_equal :closed, pr.state
     assert_equal "iHiD", pr.author_username
     assert_equal "ErikSchierboom", pr.merged_by_username
     assert_equal data, pr.data

--- a/test/commands/github/pull_request/sync_repo_test.rb
+++ b/test/commands/github/pull_request/sync_repo_test.rb
@@ -18,15 +18,13 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
                 },
                 number: 19,
                 title: "The cat sat on the mat",
-                state: 'MERGED',
+                state: 'OPEN',
                 author: {
                   login: 'ErikSchierboom'
                 },
-                merged: true,
-                mergedAt: '2020-04-03T14:54:57Z',
-                mergedBy: {
-                  login: 'iHiD'
-                },
+                merged: false,
+                mergedAt: nil,
+                mergedBy: nil,
                 reviews: {
                   nodes: [
                     {
@@ -49,11 +47,11 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
                 },
                 number: 8,
                 title: "The cat sat on the mat",
-                state: 'MERGED',
+                state: 'CLOSED',
                 author: {
                   login: 'ErikSchierboom'
                 },
-                merged: true,
+                merged: false,
                 mergedAt: nil,
                 mergedBy: nil,
                 reviews: {
@@ -92,7 +90,7 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
                 url: 'https://github.com/exercism/ruby/pull/2',
                 id: 'MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz',
                 createdAt: '2020-03-27T06:39:20Z',
-                closedAt: nil,
+                closedAt: '2020-03-29T18:24:47Z',
                 labels: {
                   nodes: []
                 },
@@ -142,10 +140,11 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
     assert_equal 'exercism/ruby', prs.first.repo
     assert_equal "MDExOlB1bGxSZXF1ZXN0NTY4NDMxMTE4", prs.first.node_id
     assert_equal 19, prs.first.number
+    assert_equal :open, prs.first.state
     assert_equal "The cat sat on the mat", prs.first.title
     assert_equal "exercism/ruby", prs.first.repo
     assert_equal "ErikSchierboom", prs.first.author_username
-    assert_equal "iHiD", prs.first.merged_by_username
+    assert_nil prs.first.merged_by_username
     expected_first_data = {
       url: "https://api.github.com/repos/exercism/ruby/pulls/19",
       html_url: "https://github.com/exercism/ruby/pull/19",
@@ -155,13 +154,13 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
       title: "The cat sat on the mat",
       created_at: Time.parse('2021-02-05T15:29:25Z').utc,
       closed_at: nil,
-      state: "closed",
-      action: "closed",
+      state: "open",
+      action: "opened",
       author_username: "ErikSchierboom",
       labels: [],
-      merged: true,
-      merged_at: Time.parse('2020-04-03T14:54:57Z').utc,
-      merged_by_username: "iHiD",
+      merged: false,
+      merged_at: nil,
+      merged_by_username: nil,
       reviews: [
         {
           node_id: "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTg5NDY1MzEx",
@@ -178,6 +177,7 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
     assert_equal 'exercism/ruby', prs.second.repo
     assert_equal "MDExOlB1bGxSZXF1ZXN0NTYzOTgwNTkw", prs.second.node_id
     assert_equal 8, prs.second.number
+    assert_equal :closed, prs.second.state
     assert_equal "The cat sat on the mat", prs.second.title
     assert_equal "exercism/ruby", prs.second.repo
     assert_equal "ErikSchierboom", prs.second.author_username
@@ -195,7 +195,7 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
       action: "closed",
       author_username: "ErikSchierboom",
       labels: [],
-      merged: true,
+      merged: false,
       merged_at: nil,
       merged_by_username: nil,
       reviews: [
@@ -215,6 +215,7 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
     assert_equal 'exercism/ruby', prs.third.repo
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", prs.third.node_id
     assert_equal 2, prs.third.number
+    assert_equal :merged, prs.third.state
     assert_equal "The cat sat on the mat", prs.third.title
     assert_equal "exercism/ruby", prs.third.repo
     assert_equal "porkostomus", prs.third.author_username
@@ -227,8 +228,8 @@ class Github::PullRequest::SyncRepoTest < ActiveSupport::TestCase
       number: 2,
       title: "The cat sat on the mat",
       created_at: Time.parse('2020-03-27T06:39:20Z').utc,
-      closed_at: nil,
-      state: "closed",
+      closed_at: Time.parse('2020-03-29T18:24:47Z').utc,
+      state: "merged",
       action: "closed",
       author_username: "porkostomus",
       labels: [],

--- a/test/commands/user/reputation_token/award_for_pull_requests_for_user_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_requests_for_user_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::TestCase
   test "awards reputation for authored pull requests" do
     user = create :user, handle: "User1", github_username: "iHiD"
-    create :github_pull_request, :random, author_username: "iHiD"
-    create :github_pull_request, :random, author_username: "ErikSchierboom"
-    create :github_pull_request, :random, author_username: "iHiD"
+    create :github_pull_request, :random, state: :closed, author_username: "iHiD"
+    create :github_pull_request, :random, state: :closed, author_username: "ErikSchierboom"
+    create :github_pull_request, :random, state: :merged, author_username: "iHiD"
 
     User::ReputationToken::AwardForPullRequestsForUser.(user)
 
@@ -14,10 +14,14 @@ class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::Te
 
   test "award reputation for reviewed pull requests" do
     user = create :user, handle: "User1", github_username: "ErikSchierboom"
-    create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
-    create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
-    create :github_pull_request_review, :random, reviewer_username: "iHiD"
-    create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
+    review_1 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
+    review_1.pull_request.update(state: :closed)
+    review_2 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
+    review_2.pull_request.update(state: :closed)
+    review_3 = create :github_pull_request_review, :random, reviewer_username: "iHiD"
+    review_3.pull_request.update(state: :closed)
+    review_4 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
+    review_4.pull_request.update(state: :closed)
     create :github_organization_member, username: "ErikSchierboom"
     create :github_organization_member, username: "iHiD"
 
@@ -28,8 +32,8 @@ class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::Te
 
   test "award reputation for merged pull requests" do
     user = create :user, handle: "User1", github_username: "ErikSchierboom"
-    create :github_pull_request, :random, merged_by_username: "ErikSchierboom"
-    create :github_pull_request, :random, merged_by_username: "iHiD"
+    create :github_pull_request, :random, state: :merged, merged_by_username: "ErikSchierboom"
+    create :github_pull_request, :random, state: :merged, merged_by_username: "iHiD"
 
     User::ReputationToken::AwardForPullRequestsForUser.(user)
 
@@ -43,6 +47,20 @@ class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::Te
 
     User::ReputationToken::AwardForPullRequestsForUser.(user)
 
-    assert_equal 0, User::ReputationTokens::CodeMergeToken.where(user:).size
+    assert_empty User::ReputationTokens::CodeMergeToken.where(user:)
+  end
+
+  test "don't award reputation for open pull requests" do
+    user = create :user, github_username: "user-1"
+    create :github_pull_request, :random, state: :open, author_username: user.github_username
+    create :github_pull_request, :random, state: :open, merged_by_username: user.github_username
+    review_pr = create :github_pull_request, :random, state: :open
+    create :github_pull_request_review, :random, reviewer_username: user.github_username, pull_request: review_pr
+
+    User::ReputationToken::AwardForPullRequestsForUser.(user)
+
+    refute User::ReputationTokens::CodeContributionToken.where(user:).exists?
+    refute User::ReputationTokens::CodeReviewToken.where(user:).exists?
+    refute User::ReputationTokens::CodeMergeToken.where(user:).exists?
   end
 end

--- a/test/commands/user/reputation_token/award_for_pull_requests_for_user_test.rb
+++ b/test/commands/user/reputation_token/award_for_pull_requests_for_user_test.rb
@@ -14,14 +14,10 @@ class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::Te
 
   test "award reputation for reviewed pull requests" do
     user = create :user, handle: "User1", github_username: "ErikSchierboom"
-    review_1 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
-    review_1.pull_request.update(state: :closed)
-    review_2 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
-    review_2.pull_request.update(state: :closed)
-    review_3 = create :github_pull_request_review, :random, reviewer_username: "iHiD"
-    review_3.pull_request.update(state: :closed)
-    review_4 = create :github_pull_request_review, :random, reviewer_username: "ErikSchierboom"
-    review_4.pull_request.update(state: :closed)
+    create :github_pull_request_review, :random, state: :closed, reviewer_username: "ErikSchierboom"
+    create :github_pull_request_review, :random, state: :closed, reviewer_username: "ErikSchierboom"
+    create :github_pull_request_review, :random, state: :closed, reviewer_username: "iHiD"
+    create :github_pull_request_review, :random, state: :closed, reviewer_username: "ErikSchierboom"
     create :github_organization_member, username: "ErikSchierboom"
     create :github_organization_member, username: "iHiD"
 
@@ -54,8 +50,7 @@ class User::ReputationToken::AwardForPullRequestsForUserTest < ActiveSupport::Te
     user = create :user, github_username: "user-1"
     create :github_pull_request, :random, state: :open, author_username: user.github_username
     create :github_pull_request, :random, state: :open, merged_by_username: user.github_username
-    review_pr = create :github_pull_request, :random, state: :open
-    create :github_pull_request_review, :random, reviewer_username: user.github_username, pull_request: review_pr
+    create :github_pull_request_review, :random, state: :open, reviewer_username: user.github_username
 
     User::ReputationToken::AwardForPullRequestsForUser.(user)
 

--- a/test/commands/webhooks/process_pull_request_update_test.rb
+++ b/test/commands/webhooks/process_pull_request_update_test.rb
@@ -1,93 +1,43 @@
 require "test_helper"
 
 class Webhooks::ProcessPullRequestUpdateTest < ActiveSupport::TestCase
-  test "should enqueue process pull request update when pr was closed" do
-    action = 'closed'
-    login = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    state = 'closed'
-    repo = 'exercism/fsharp'
-    number = 4
+  %w[closed edited opened reopened labeled unlabeled].each do |action|
+    test "should not process pull request when action is #{action}" do
+      pull_request_update = {
+        action:,
+        login: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        state: 'open',
+        repo: 'exercism/fsharp',
+        number: 4
+      }
 
-    assert_enqueued_jobs 1, only: ProcessPullRequestUpdateJob do
-      Webhooks::ProcessPullRequestUpdate.(
-        action:, login:, url:, html_url:,
-        labels:, state:, repo:, number:
-      )
+      assert_enqueued_jobs 1, only: ProcessPullRequestUpdateJob do
+        Webhooks::ProcessPullRequestUpdate.(**pull_request_update)
+      end
     end
   end
 
-  test "should enqueue process pull request update when pr was labeled" do
-    action = 'labeled'
-    login = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    state = 'closed'
-    repo = 'exercism/fsharp'
-    number = 4
+  %w[assigned auto_merge_disabled auto_merge_enabled converted_to_draft
+     locked ready_for_review review_request_removed review_requested
+     synchronize unassigned unlocked].each do |action|
+    test "should not process pull request when action is #{action}" do
+      pull_request_update = {
+        action:,
+        login: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        state: 'open',
+        repo: 'exercism/fsharp',
+        number: 4
+      }
 
-    assert_enqueued_jobs 1, only: ProcessPullRequestUpdateJob do
-      Webhooks::ProcessPullRequestUpdate.(
-        action:, login:, url:, html_url:,
-        labels:, state:, repo:, number:
-      )
-    end
-  end
-
-  test "should enqueue process pull request update when pr was unlabeled" do
-    action = 'unlabeled'
-    login = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    state = 'closed'
-    repo = 'exercism/fsharp'
-    number = 4
-
-    assert_enqueued_jobs 1, only: ProcessPullRequestUpdateJob do
-      Webhooks::ProcessPullRequestUpdate.(
-        action:, login:, url:, html_url:,
-        labels:, state:, repo:, number:
-      )
-    end
-  end
-
-  test "should not enqueue process pull request update when pr was opened" do
-    action = 'opened'
-    login = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    state = 'closed'
-    repo = 'exercism/fsharp'
-    number = 4
-
-    assert_enqueued_jobs 0, only: ProcessPullRequestUpdateJob do
-      Webhooks::ProcessPullRequestUpdate.(
-        action:, login:, url:, html_url:,
-        labels:, state:, repo:, number:
-      )
-    end
-  end
-
-  test "should not enqueue process pull request update when pr is open" do
-    action = 'labeled'
-    login = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    state = 'open'
-    repo = 'exercism/fsharp'
-    number = 4
-
-    assert_enqueued_jobs 0, only: ProcessPullRequestUpdateJob do
-      Webhooks::ProcessPullRequestUpdate.(
-        action:, login:, url:, html_url:,
-        labels:, state:, repo:, number:
-      )
+      assert_enqueued_jobs 0, only: ProcessPullRequestUpdateJob do
+        Webhooks::ProcessPullRequestUpdate.(**pull_request_update)
+      end
     end
   end
 end

--- a/test/factories/github/pull_request_reviews.rb
+++ b/test/factories/github/pull_request_reviews.rb
@@ -9,8 +9,13 @@ FactoryBot.define do
       node_id { SecureRandom.hex }
     end
 
-    before(:create) do |r|
+    transient do
+      state { :closed }
+    end
+
+    before(:create) do |r, e|
       r.pull_request.update!(
+        state: e.state,
         data: r.pull_request.data.tap do |d|
           d[:reviews] = [{ node_id: r.node_id, reviewer_username: r.reviewer_username }]
         end

--- a/test/factories/github/pull_requests.rb
+++ b/test/factories/github/pull_requests.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     repo { "exercism/ruby" }
     author_username { "iHiD" }
     merged_by_username { "ErikSchierboom" }
+    state { :open }
     data do
       {
         node_id:,

--- a/test/factories/github/pull_requests.rb
+++ b/test/factories/github/pull_requests.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     repo { "exercism/ruby" }
     author_username { "iHiD" }
     merged_by_username { "ErikSchierboom" }
-    state { :open }
+    state { :closed }
     data do
       {
         node_id:,

--- a/test/jobs/process_pull_request_update_job_test.rb
+++ b/test/jobs/process_pull_request_update_job_test.rb
@@ -69,51 +69,83 @@ class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
     end
   end
 
-  test "creates pull request" do
-    pull_request_update = {
-      action: 'closed',
-      author_username: 'user22',
-      url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
-      html_url: 'https://github.com/exercism/fsharp/pull/1347',
-      labels: %w[bug duplicate],
-      repo: 'exercism/fsharp',
-      node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
-      title: "The cat sat on the mat",
-      created_at: Time.parse("2019-05-15T15:20:33Z").utc,
-      number: 1347,
-      merged: true,
-      merged_at: Time.parse("2019-05-15T16:43:00Z").utc,
-      merged_by_username: 'merger11',
-      state: 'open'
-    }
+  %w[closed edited opened reopened labeled unlabeled].each do |action|
+    test "creates pull request when action is #{action}" do
+      pull_request_update = {
+        action:,
+        author_username: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        repo: 'exercism/fsharp',
+        node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+        title: "The cat sat on the mat",
+        created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+        number: 1347,
+        merged: true,
+        merged_at: Time.parse("2019-05-15T16:43:00Z").utc,
+        merged_by_username: 'merger11',
+        state: 'open'
+      }
 
-    reviews = [
-      { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
-        submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
-      { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
-        submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
-    ]
+      reviews = [
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
+          submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
+          submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
+      ]
 
-    RestClient.unstub(:get)
-    stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
-      to_return(status: 200, body: [
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', user: { login: "reviewer71" },
-          submitted_at: "2019-05-23T12:12:13Z" },
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', user: { login: "reviewer13" },
-          submitted_at: "2019-05-24T10:56:29Z" }
-      ].to_json, headers: { 'Content-Type' => 'application/json' })
+      RestClient.unstub(:get)
+      stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
+        to_return(status: 200, body: [
+          { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', user: { login: "reviewer71" },
+            submitted_at: "2019-05-23T12:12:13Z" },
+          { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', user: { login: "reviewer13" },
+            submitted_at: "2019-05-24T10:56:29Z" }
+        ].to_json, headers: { 'Content-Type' => 'application/json' })
 
-    ProcessPullRequestUpdateJob.perform_now(**pull_request_update)
+      ProcessPullRequestUpdateJob.perform_now(**pull_request_update)
 
-    pr = Github::PullRequest.find_by(node_id: pull_request_update[:node_id])
-    pull_request_update[:data] = pull_request_update.merge(reviews:)
-    assert_equal pull_request_update[:node_id], pr.node_id
-    assert_equal pull_request_update[:number], pr.number
-    assert_equal pull_request_update[:title], pr.title
-    assert_equal pull_request_update[:repo], pr.repo
-    assert_equal pull_request_update[:author_username], pr.author_username
-    assert_equal pull_request_update[:merged_by_username], pr.merged_by_username
-    assert_equal pull_request_update[:data], pr.data
+      pr = Github::PullRequest.find_by(node_id: pull_request_update[:node_id])
+      pull_request_update[:data] = pull_request_update.merge(reviews:)
+      assert_equal pull_request_update[:node_id], pr.node_id
+      assert_equal pull_request_update[:number], pr.number
+      assert_equal pull_request_update[:title], pr.title
+      assert_equal pull_request_update[:repo], pr.repo
+      assert_equal pull_request_update[:author_username], pr.author_username
+      assert_equal pull_request_update[:merged_by_username], pr.merged_by_username
+      assert_equal pull_request_update[:data], pr.data
+    end
+
+    test "updates pull request when action is #{action}" do
+      pull_request_update = {
+        action:,
+        author_username: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        repo: 'exercism/fsharp',
+        node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+        title: "The cat sat on the mat",
+        created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+        number: 1347,
+        merged: true,
+        merged_at: Time.parse("2019-05-15T16:43:00Z").utc,
+        merged_by_username: 'merger11',
+        state: 'open'
+      }
+
+      RestClient.unstub(:get)
+      stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
+        to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
+
+      pr = create(:github_pull_request,
+**pull_request_update.merge(reviews: []).slice(:node_id, :number, :title, :author_username, :merged_by_username, :repo, :data))
+
+      ProcessPullRequestUpdateJob.perform_now(**pull_request_update.merge(title: "New title"))
+
+      assert_equal "New title", pr.reload.title
+    end
   end
 
   test "creates pull request reviews" do

--- a/test/jobs/process_pull_request_update_job_test.rb
+++ b/test/jobs/process_pull_request_update_job_test.rb
@@ -1,71 +1,113 @@
 require "test_helper"
 
 class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
-  test "reputation tokens are awarded for pull request" do
-    action = 'closed'
-    author = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    repo = 'exercism/fsharp'
-    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
-    title = "The cat sat on the mat"
-    created_at = Time.parse("2019-05-15T15:20:33Z").utc
-    number = 1347
-    merged = false
-    merged_at = nil
-    merged_by = nil
-    state = 'open'
-    reviews = [
-      { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
-        submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
-      { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
-        submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
-    ]
+  %w[closed labeled unlabeled].each do |action|
+    test "reputation tokens are awarded when action is #{action}" do
+      author = 'user22'
+      url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
+      html_url = 'https://github.com/exercism/fsharp/pull/1347'
+      labels = %w[bug duplicate]
+      repo = 'exercism/fsharp'
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      title = "The cat sat on the mat"
+      created_at = Time.parse("2019-05-15T15:20:33Z").utc
+      number = 1347
+      merged = false
+      merged_at = nil
+      merged_by = nil
+      state = 'open'
+      reviews = [
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
+          submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
+          submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
+      ]
 
-    RestClient.unstub(:get)
-    stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
-      to_return(status: 200, body: [
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', user: { login: "reviewer71" },
-          submitted_at: "2019-05-23T12:12:13Z" },
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', user: { login: "reviewer13" },
-          submitted_at: "2019-05-24T10:56:29Z" }
-      ].to_json, headers: { 'Content-Type' => 'application/json' })
+      RestClient.unstub(:get)
+      stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
+        to_return(status: 200, body: [
+          { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', user: { login: "reviewer71" },
+            submitted_at: "2019-05-23T12:12:13Z" },
+          { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', user: { login: "reviewer13" },
+            submitted_at: "2019-05-24T10:56:29Z" }
+        ].to_json, headers: { 'Content-Type' => 'application/json' })
 
-    User::ReputationToken::AwardForPullRequest.expects(:call).with(
-      action:,
-      author_username: author,
-      url:,
-      html_url:,
-      labels:,
-      repo:,
-      node_id:,
-      title:,
-      created_at:,
-      number:,
-      merged:,
-      merged_at:,
-      merged_by_username: merged_by,
-      state:,
-      reviews:
-    )
+      User::ReputationToken::AwardForPullRequest.expects(:call).with(
+        action:,
+        author_username: author,
+        url:,
+        html_url:,
+        labels:,
+        repo:,
+        node_id:,
+        title:,
+        created_at:,
+        number:,
+        merged:,
+        merged_at:,
+        merged_by_username: merged_by,
+        state:,
+        reviews:
+      )
 
-    ProcessPullRequestUpdateJob.perform_now(
-      action:,
-      author_username: author,
-      url:,
-      html_url:,
-      labels:,
-      repo:,
-      node_id:,
-      title:,
-      created_at:,
-      number:,
-      merged:,
-      merged_at:,
-      merged_by_username: merged_by,
-      state:
-    )
+      ProcessPullRequestUpdateJob.perform_now(
+        action:,
+        author_username: author,
+        url:,
+        html_url:,
+        labels:,
+        repo:,
+        node_id:,
+        title:,
+        created_at:,
+        number:,
+        merged:,
+        merged_at:,
+        merged_by_username: merged_by,
+        state:
+      )
+    end
+  end
+
+  %w[edited opened reopened].each do |action|
+    test "reputation tokens are not awarded when action is #{action}" do
+      author = 'user22'
+      url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
+      html_url = 'https://github.com/exercism/fsharp/pull/1347'
+      labels = %w[bug duplicate]
+      repo = 'exercism/fsharp'
+      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
+      title = "The cat sat on the mat"
+      created_at = Time.parse("2019-05-15T15:20:33Z").utc
+      number = 1347
+      merged = false
+      merged_at = nil
+      merged_by = nil
+      state = 'open'
+
+      RestClient.unstub(:get)
+      stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
+        to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
+
+      User::ReputationToken::AwardForPullRequest.expects(:call).never
+
+      ProcessPullRequestUpdateJob.perform_now(
+        action:,
+        author_username: author,
+        url:,
+        html_url:,
+        labels:,
+        repo:,
+        node_id:,
+        title:,
+        created_at:,
+        number:,
+        merged:,
+        merged_at:,
+        merged_by_username: merged_by,
+        state:
+      )
+    end
   end
 
   test "creates pull request record" do

--- a/test/jobs/process_pull_request_update_job_test.rb
+++ b/test/jobs/process_pull_request_update_job_test.rb
@@ -3,25 +3,22 @@ require "test_helper"
 class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
   %w[closed labeled unlabeled].each do |action|
     test "reputation tokens are awarded when action is #{action}" do
-      author = 'user22'
-      url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-      html_url = 'https://github.com/exercism/fsharp/pull/1347'
-      labels = %w[bug duplicate]
-      repo = 'exercism/fsharp'
-      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
-      title = "The cat sat on the mat"
-      created_at = Time.parse("2019-05-15T15:20:33Z").utc
-      number = 1347
-      merged = false
-      merged_at = nil
-      merged_by = nil
-      state = 'open'
-      reviews = [
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
-          submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
-        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
-          submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
-      ]
+      pull_request_update = {
+        action:,
+        author_username: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        repo: 'exercism/fsharp',
+        node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+        title: "The cat sat on the mat",
+        created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+        number: 1347,
+        merged: false,
+        merged_at: nil,
+        merged_by_username: nil,
+        state: 'open'
+      }
 
       RestClient.unstub(:get)
       stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
@@ -32,59 +29,21 @@ class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
             submitted_at: "2019-05-24T10:56:29Z" }
         ].to_json, headers: { 'Content-Type' => 'application/json' })
 
-      User::ReputationToken::AwardForPullRequest.expects(:call).with(
-        action:,
-        author_username: author,
-        url:,
-        html_url:,
-        labels:,
-        repo:,
-        node_id:,
-        title:,
-        created_at:,
-        number:,
-        merged:,
-        merged_at:,
-        merged_by_username: merged_by,
-        state:,
-        reviews:
-      )
+      reviews = [
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
+          submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
+        { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI5', reviewer_username: "reviewer13",
+          submitted_at: Time.parse("2019-05-24T10:56:29Z").utc }
+      ]
 
-      ProcessPullRequestUpdateJob.perform_now(
-        action:,
-        author_username: author,
-        url:,
-        html_url:,
-        labels:,
-        repo:,
-        node_id:,
-        title:,
-        created_at:,
-        number:,
-        merged:,
-        merged_at:,
-        merged_by_username: merged_by,
-        state:
-      )
+      User::ReputationToken::AwardForPullRequest.expects(:call).with(**pull_request_update.merge(reviews:))
+
+      ProcessPullRequestUpdateJob.perform_now(**pull_request_update)
     end
   end
 
   %w[edited opened reopened].each do |action|
     test "reputation tokens are not awarded when action is #{action}" do
-      author = 'user22'
-      url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-      html_url = 'https://github.com/exercism/fsharp/pull/1347'
-      labels = %w[bug duplicate]
-      repo = 'exercism/fsharp'
-      node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
-      title = "The cat sat on the mat"
-      created_at = Time.parse("2019-05-15T15:20:33Z").utc
-      number = 1347
-      merged = false
-      merged_at = nil
-      merged_by = nil
-      state = 'open'
-
       RestClient.unstub(:get)
       stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
         to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
@@ -93,38 +52,41 @@ class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
 
       ProcessPullRequestUpdateJob.perform_now(
         action:,
-        author_username: author,
-        url:,
-        html_url:,
-        labels:,
-        repo:,
-        node_id:,
-        title:,
-        created_at:,
-        number:,
-        merged:,
-        merged_at:,
-        merged_by_username: merged_by,
-        state:
+        author: 'user22',
+        url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+        html_url: 'https://github.com/exercism/fsharp/pull/1347',
+        labels: %w[bug duplicate],
+        repo: 'exercism/fsharp',
+        node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+        title: "The cat sat on the mat",
+        created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+        number: 1347,
+        merged: false,
+        merged_at: nil,
+        merged_by: nil,
+        state: 'open'
       )
     end
   end
 
-  test "creates pull request record" do
-    action = 'closed'
-    author = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    repo = 'exercism/fsharp'
-    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
-    title = "The cat sat on the mat"
-    created_at = Time.parse("2019-05-15T15:20:33Z").utc
-    number = 1347
-    merged = true
-    merged_at = Time.parse("2019-05-15T16:43:00Z").utc
-    merged_by = 'merger11'
-    state = 'open'
+  test "creates pull request" do
+    pull_request_update = {
+      action: 'closed',
+      author_username: 'user22',
+      url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+      html_url: 'https://github.com/exercism/fsharp/pull/1347',
+      labels: %w[bug duplicate],
+      repo: 'exercism/fsharp',
+      node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+      title: "The cat sat on the mat",
+      created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+      number: 1347,
+      merged: true,
+      merged_at: Time.parse("2019-05-15T16:43:00Z").utc,
+      merged_by_username: 'merger11',
+      state: 'open'
+    }
+
     reviews = [
       { node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTk5ODA2NTI4', reviewer_username: "reviewer71",
         submitted_at: Time.parse("2019-05-23T12:12:13Z").utc },
@@ -141,66 +103,20 @@ class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
           submitted_at: "2019-05-24T10:56:29Z" }
       ].to_json, headers: { 'Content-Type' => 'application/json' })
 
-    ProcessPullRequestUpdateJob.perform_now(
-      action:,
-      author_username: author,
-      url:,
-      html_url:,
-      labels:,
-      repo:,
-      node_id:,
-      title:,
-      created_at:,
-      number:,
-      state:,
-      merged:,
-      merged_at:,
-      merged_by_username: merged_by
-    )
+    ProcessPullRequestUpdateJob.perform_now(**pull_request_update)
 
-    pr = Github::PullRequest.find_by(node_id:)
-    expected_data = {
-      url:,
-      repo:,
-      state:,
-      title:,
-      action:,
-      labels:,
-      merged:,
-      number:,
-      node_id:,
-      reviews:,
-      html_url:,
-      merged_at:,
-      created_at:,
-      author_username: author,
-      merged_by_username: merged_by
-    }
-    assert_equal node_id, pr.node_id
-    assert_equal number, pr.number
-    assert_equal title, pr.title
-    assert_equal repo, pr.repo
-    assert_equal author, pr.author_username
-    assert_equal merged_by, pr.merged_by_username
-    assert_equal expected_data, pr.data
+    pr = Github::PullRequest.find_by(node_id: pull_request_update[:node_id])
+    pull_request_update[:data] = pull_request_update.merge(reviews:)
+    assert_equal pull_request_update[:node_id], pr.node_id
+    assert_equal pull_request_update[:number], pr.number
+    assert_equal pull_request_update[:title], pr.title
+    assert_equal pull_request_update[:repo], pr.repo
+    assert_equal pull_request_update[:author_username], pr.author_username
+    assert_equal pull_request_update[:merged_by_username], pr.merged_by_username
+    assert_equal pull_request_update[:data], pr.data
   end
 
-  test "retrieves all reviews" do
-    action = 'closed'
-    author = 'user22'
-    url = 'https://api.github.com/repos/exercism/fsharp/pulls/1347'
-    html_url = 'https://github.com/exercism/fsharp/pull/1347'
-    labels = %w[bug duplicate]
-    repo = 'exercism/fsharp'
-    node_id = 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ'
-    title = "The cat sat on the mat"
-    created_at = Time.parse("2019-05-15T15:20:33Z").utc
-    number = 1347
-    merged = false
-    merged_at = nil
-    merged_by = nil
-    state = 'open'
-
+  test "creates pull request reviews" do
     RestClient.unstub(:get)
     stub_request(:get, "https://api.github.com/repos/exercism/fsharp/pulls/1347/reviews?per_page=100").
       to_return(
@@ -228,20 +144,20 @@ class ProcessPullRequestUpdateJobTest < ActiveJob::TestCase
       )
 
     ProcessPullRequestUpdateJob.perform_now(
-      action:,
-      author_username: author,
-      url:,
-      html_url:,
-      labels:,
-      repo:,
-      node_id:,
-      title:,
-      created_at:,
-      number:,
-      state:,
-      merged:,
-      merged_at:,
-      merged_by_username: merged_by
+      action: 'closed',
+      author_username: 'user22',
+      url: 'https://api.github.com/repos/exercism/fsharp/pulls/1347',
+      html_url: 'https://github.com/exercism/fsharp/pull/1347',
+      labels: %w[bug duplicate],
+      repo: 'exercism/fsharp',
+      node_id: 'MDExOlB1bGxSZXF1ZXN0NTgzMTI1NTaQ',
+      title: "The cat sat on the mat",
+      created_at: Time.parse("2019-05-15T15:20:33Z").utc,
+      number: 1347,
+      merged: false,
+      merged_at: nil,
+      merged_by_username: nil,
+      state: 'open'
     )
 
     assert_equal 3, Github::PullRequestReview.find_each.size

--- a/test/models/github/pull_request_test.rb
+++ b/test/models/github/pull_request_test.rb
@@ -8,4 +8,10 @@ class Github::PullRequestTest < ActiveSupport::TestCase
     assert_equal 2, pr.data[:number]
     assert_equal "MDExOlB1bGxSZXF1ZXN0Mzk0NTc4ODMz", pr.data[:node_id]
   end
+
+  test "state can be accessed using symbols" do
+    pr = create :github_pull_request, state: :open
+    pr.state = :closed
+    assert_equal :closed, pr.state
+  end
 end


### PR DESCRIPTION
To allow us to add metrics for pull requests that are opened, we'll also need to store open pull requests.
This also makes pull requests handling more in line with issues, which we already store if they're open.
