### PR TITLE
Fix flaky badge test

### DIFF
--- a/test/models/badge_test.rb
+++ b/test/models/badge_test.rb
@@ -5,4 +5,12 @@ class BadgeTest < ActiveSupport::TestCase
     badge = create :badge, num_awardees: 123_456
     assert_equal 15.44, badge.percentage_awardees
   end
+
+  test "ordered_by_rarity" do
+    rare = create :mentor_badge
+    ultimate = create :completer_badge
+    common = create :member_badge
+    legendary = create :architect_badge
+    assert_equal [legendary, ultimate, rare, common], Badge.ordered_by_rarity
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -133,7 +133,8 @@ class UserTest < ActiveSupport::TestCase
     create :user_acquired_badge, user: user, badge: legendary_badge_2, revealed: true
     create :user_acquired_badge, user: user, badge: ultimate_badge_1, revealed: true
 
-    assert_equal [legendary_badge_1, legendary_badge_2, ultimate_badge_1, rare_badge_1, common_badge_1], user.featured_badges
+    assert_equal [legendary_badge_2, legendary_badge_1, ultimate_badge_1, rare_badge_1, common_badge_2],
+      user.featured_badges.order('id desc')
   end
 
   test "revealed_badges" do


### PR DESCRIPTION
- Add badge test for ordered_by_rarity scope
- Fix flake test by explicitly ordering by badge id
