### PR TITLE
Fix typo in contribution task tooltips

### DIFF
--- a/app/javascript/components/tooltips/task-tooltip/ActionInfo.tsx
+++ b/app/javascript/components/tooltips/task-tooltip/ActionInfo.tsx
@@ -23,7 +23,7 @@ const ActionDetails = ({ action }: { action: TaskAction }): JSX.Element => {
           <h3>
             This task requires you to <strong>create</strong> something new.
           </h3>
-          <p>This means you’ll be bulding something from scratch.</p>
+          <p>This means you’ll be building something from scratch.</p>
         </>
       )
     case 'fix':
@@ -33,7 +33,7 @@ const ActionDetails = ({ action }: { action: TaskAction }): JSX.Element => {
             This task requires you to <strong>fix</strong> something broken.
           </h3>
           <p>
-            This means you’ll be bulding taking something that's currently not
+            This means you’ll be taking something that's currently not
             working and fixing it.
           </p>
         </>


### PR DESCRIPTION
The 'create' tooltip said bulding, and the 'fix' tooltip
was copy/pasted and had the same error.

I removed the word altogether in the 'fix' tooltip for better flow.

Closes https://github.com/exercism/exercism/issues/6439