### PR TITLE
[Update]: Update highlightjs-cobol package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fontfaceobserver": "^2.1.0",
     "global": "^4.4.0",
     "highlight.js": "^11.5.1",
-    "highlightjs-cobol": "^0.2.13",
+    "highlightjs-cobol": "^0.3.1",
     "highlightjs-sap-abap": "^0.2.0",
     "humps": "^2.0.1",
     "lang-julia": "^0.1.0",


### PR DESCRIPTION
Update the highlightjs-cobol package to the latest version from NPM:
https://www.npmjs.com/package/highlightjs-cobol

This version fixes the highlighting to work with fixed-form COBOL, which is the format that we're using for our COBOL track.