### PR TITLE
Increase tolerance for community solution searching

### DIFF
--- a/app/commands/solution/search_community_solutions.rb
+++ b/app/commands/solution/search_community_solutions.rb
@@ -108,7 +108,7 @@ class Solution
       [value].flatten
     end
 
-    TIMEOUT = '100ms'.freeze
+    TIMEOUT = '400ms'.freeze
     private_constant :TIMEOUT
 
     class Fallback


### PR DESCRIPTION
When this value is hit, the actual SQL takes over 20s (!!) to execute, so I'd rather be more tolerant on the search index.