### PR TITLE
cohorts: fix typo in headers

### DIFF
--- a/app/views/cohorts/show/_exhort_aug_22.html.haml
+++ b/app/views/cohorts/show/_exhort_aug_22.html.haml
@@ -15,7 +15,7 @@
         .content.flex.flex-col
           %h2.text-h4.mb-16.flex.items-center
             = graphical_icon "mentoring-gradient"
-            .text-gradient.ml-24 Tell more more!
+            .text-gradient.ml-24 Tell me more!
           %h3.text-h1
             %span What is the Exhort?
           %hr.c-divider.my-24

--- a/app/views/cohorts/show/_gohort_aug_22.html.haml
+++ b/app/views/cohorts/show/_gohort_aug_22.html.haml
@@ -15,7 +15,7 @@
         .content.flex.flex-col
           %h2.text-h4.mb-16.flex.items-center
             = graphical_icon "mentoring-gradient"
-            .text-gradient.ml-24 Tell more more!
+            .text-gradient.ml-24 Tell me more!
           %h3.text-h1
             %span What is the Gohort?
           %hr.c-divider.my-24


### PR DESCRIPTION
Fixes this:

![1](https://user-images.githubusercontent.com/45465154/180977669-8583f923-2b0b-4f2d-b6d6-9223858ae949.png)

https://exercism.org/cohorts/gohort-aug-22
https://exercism.org/cohorts/exhort-aug-22