### PR TITLE
Remove use of threads

### DIFF
--- a/test/commands/cohort/join_test.rb
+++ b/test/commands/cohort/join_test.rb
@@ -45,10 +45,15 @@ class Cohort::JoinTest < ActiveSupport::TestCase
     cohort = create :cohort, capacity: 10
     member_count = cohort.capacity * 10
 
+    # We're testing that when multiple people try to join
+    # at the same time, the number of enrolled members never
+    # exceeds the cohort's capacity
     threads = Array.new(member_count) do
       Thread.new do
-        user = create :user
-        Cohort::Join.(user, cohort, 'Hi')
+        Rails.application.executor.wrap do
+          user = create :user
+          Cohort::Join.(user, cohort, 'Hi')
+        end
       end
     end
     threads.map(&:join)


### PR DESCRIPTION
Rails isn't threadsafe without doing work (especially about ActiveRecord connection sharing), so this is resulting in sporadic errors.