### PR TITLE
Fix metrics

### DIFF
--- a/app/commands/metric/create.rb
+++ b/app/commands/metric/create.rb
@@ -3,16 +3,29 @@ class Metric::Create
 
   queue_as :metrics
 
-  initialize_with :type, :occurred_at, :params
+  def initialize(type, occurred_at, params)
+    @type = type
+    @occurred_at = occurred_at
+    @request_context = params.delete(:request_context) || {}
+    @params = params
+  end
 
   def call
     klass = "metrics/#{type}_metric".camelize.constantize
 
     klass.new(occurred_at:, params:).tap do |metric|
-      metric.country_code = Geocoder.search(metric.remote_ip).first&.country_code
+      metric.country_code = Geocoder.search(remote_ip).first&.country_code if metric.store_country_code? && remote_ip
       metric.save!
     rescue ActiveRecord::RecordNotUnique
       return klass.find_by!(uniqueness_key: metric.uniqueness_key)
     end
+  end
+
+  private
+  attr_reader :type, :occurred_at, :params, :request_context
+
+  memoize
+  def remote_ip
+    request_context[:remote_ip]
   end
 end

--- a/app/commands/metric/create.rb
+++ b/app/commands/metric/create.rb
@@ -25,7 +25,5 @@ class Metric::Create
   attr_reader :type, :occurred_at, :params, :request_context
 
   memoize
-  def remote_ip
-    request_context[:remote_ip]
-  end
+  def remote_ip = request_context[:remote_ip]
 end

--- a/app/commands/metric/queue.rb
+++ b/app/commands/metric/queue.rb
@@ -7,6 +7,7 @@ class Metric::Queue
     return if user&.ghost?
     return if user&.system?
 
+    attributes[:request_context] = Exercism.request_context
     Metric::Create.defer(type, occurred_at, **attributes)
   rescue StandardError => e
     # Don't crash if the creation fails, e.g. if sidekiq is down

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -13,7 +13,7 @@ class Metric < ApplicationRecord
 
   # By default, use the request's remote IP to determine the country code.
   # Metrics can opt-out by overriding this method and returning nil.
-  def remote_ip = Exercism.request_context[:remote_ip]
+  def store_country_code? = true
 
   # This maps
   # {discussion: Mentor::Discussion.find(186)}

--- a/app/models/metrics/merge_pull_request_metric.rb
+++ b/app/models/metrics/merge_pull_request_metric.rb
@@ -4,5 +4,5 @@ class Metrics::MergePullRequestMetric < Metric
   def guard_params = pull_request.id
 
   # Don't use the request's remote IP as that will always be GitHub's IP address
-  def remote_ip = nil
+  def store_country_code? = false
 end

--- a/app/models/metrics/open_issue_metric.rb
+++ b/app/models/metrics/open_issue_metric.rb
@@ -4,5 +4,5 @@ class Metrics::OpenIssueMetric < Metric
   def guard_params = issue.id
 
   # Don't use the request's remote IP as that will always be GitHub's IP address
-  def remote_ip = nil
+  def store_country_code? = false
 end

--- a/app/models/metrics/open_pull_request_metric.rb
+++ b/app/models/metrics/open_pull_request_metric.rb
@@ -4,5 +4,5 @@ class Metrics::OpenPullRequestMetric < Metric
   def guard_params = pull_request.id
 
   # Don't use the request's remote IP as that will always be GitHub's IP address
-  def remote_ip = nil
+  def store_country_code? = false
 end

--- a/test/commands/metric/create_test.rb
+++ b/test/commands/metric/create_test.rb
@@ -28,10 +28,10 @@ class Metric::CreateTest < ActiveSupport::TestCase
     remote_ip = '127.0.0.1'
     country_code = 'US'
 
-    Exercism.request_context = { remote_ip: }
+    request_context = { remote_ip: }
     Geocoder::Lookup::Test.add_stub(remote_ip, [{ 'country_code' => country_code }])
 
-    Metric::Create.(:submit_solution, Time.current, track:, user:, solution:)
+    Metric::Create.(:submit_solution, Time.current, track:, user:, solution:, request_context:)
 
     assert_equal 1, Metric.count
     assert_equal country_code, Metric.last.country_code

--- a/test/commands/metric/queue_test.rb
+++ b/test/commands/metric/queue_test.rb
@@ -6,7 +6,8 @@ class Metric::QueueTest < ActiveSupport::TestCase
     track = create :track
     user = create :user
 
-    assert_enqueued_with(job: MandateJob, args: [Metric::Create.name, :open_issue, Time.current, { track:, user:, issue: }]) do
+    assert_enqueued_with(job: MandateJob,
+      args: [Metric::Create.name, :open_issue, Time.current, { track:, user:, issue:, request_context: Exercism.request_context }]) do
       Metric::Queue.(:open_issue, Time.current, track:, user:, issue:)
     end
   end
@@ -15,7 +16,8 @@ class Metric::QueueTest < ActiveSupport::TestCase
     issue = create :github_issue
     track = create :track
 
-    assert_enqueued_with(job: MandateJob, args: [Metric::Create.name, :open_issue, Time.current, { track:, issue: }]) do
+    assert_enqueued_with(job: MandateJob,
+      args: [Metric::Create.name, :open_issue, Time.current, { track:, issue:, request_context: Exercism.request_context }]) do
       Metric::Queue.(:open_issue, Time.current, track:, issue:)
     end
   end
@@ -24,7 +26,9 @@ class Metric::QueueTest < ActiveSupport::TestCase
     issue = create :github_issue
     track = create :track
 
-    assert_enqueued_with(job: MandateJob, args: [Metric::Create.name, :open_issue, Time.current, { track:, user: nil, issue: }]) do
+    assert_enqueued_with(job: MandateJob,
+      args: [Metric::Create.name, :open_issue, Time.current,
+             { track:, user: nil, issue:, request_context: Exercism.request_context }]) do
       Metric::Queue.(:open_issue, Time.current, user: nil, track:, issue:)
     end
   end
@@ -33,7 +37,8 @@ class Metric::QueueTest < ActiveSupport::TestCase
     issue = create :github_issue
     user = create :user
 
-    assert_enqueued_with(job: MandateJob, args: [Metric::Create.name, :open_issue, Time.current, { user:, issue: }]) do
+    assert_enqueued_with(job: MandateJob,
+      args: [Metric::Create.name, :open_issue, Time.current, { user:, issue:, request_context: Exercism.request_context }]) do
       Metric::Queue.(:open_issue, Time.current, user:, issue:)
     end
   end
@@ -44,7 +49,7 @@ class Metric::QueueTest < ActiveSupport::TestCase
     user = create :user, :system
 
     assert_no_enqueued_jobs do
-      Metric::Queue.(:open_issue, Time.current, track:, user:, issue:)
+      Metric::Queue.(:open_issue, Time.current, track:, user:, issue:, request_context: Exercism.request_context)
     end
   end
 
@@ -54,7 +59,7 @@ class Metric::QueueTest < ActiveSupport::TestCase
     user = create :user, :ghost
 
     assert_no_enqueued_jobs do
-      Metric::Queue.(:open_issue, Time.current, track:, user:, issue:)
+      Metric::Queue.(:open_issue, Time.current, track:, user:, issue:, request_context: Exercism.request_context)
     end
   end
 
@@ -68,7 +73,7 @@ class Metric::QueueTest < ActiveSupport::TestCase
     Metric::Create.stubs(:defer).raises
 
     perform_enqueued_jobs do
-      Metric::Queue.(type, occurred_at, track:, user:, issue:)
+      Metric::Queue.(type, occurred_at, track:, user:, issue:, request_context: Exercism.request_context)
     end
 
     refute Metric.exists?

--- a/test/models/metrics/complete_solution_metric_test.rb
+++ b/test/models/metrics/complete_solution_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::CompleteSolutionTest < ActiveSupport::TestCase
       user = create :user, id: 3
       solution = create :concept_solution, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:complete_solution, occurred_at, solution:, track:, user:)
+      metric = Metric::Create.(:complete_solution, occurred_at, solution:, track:, user:, request_context:)
 
       assert_equal Metrics::CompleteSolutionMetric, metric.class
       assert_equal occurred_at, metric.occurred_at

--- a/test/models/metrics/finish_mentoring_metric_test.rb
+++ b/test/models/metrics/finish_mentoring_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::FinishMentoringTest < ActiveSupport::TestCase
       user = create :user, id: 3
       discussion = create :mentor_discussion, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:finish_mentoring, occurred_at, discussion:, track:, user:)
+      metric = Metric::Create.(:finish_mentoring, occurred_at, discussion:, track:, user:, request_context:)
 
       assert_equal Metrics::FinishMentoringMetric, metric.class
       assert_equal occurred_at, metric.occurred_at

--- a/test/models/metrics/publish_solution_metric_test.rb
+++ b/test/models/metrics/publish_solution_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::PublishSolutionTest < ActiveSupport::TestCase
       user = create :user, id: 3
       solution = create :concept_solution, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:publish_solution, occurred_at, solution:, track:, user:)
+      metric = Metric::Create.(:publish_solution, occurred_at, solution:, track:, user:, request_context:)
 
       assert_equal Metrics::PublishSolutionMetric, metric.class
       assert_equal occurred_at, metric.occurred_at

--- a/test/models/metrics/request_mentoring_metric_test.rb
+++ b/test/models/metrics/request_mentoring_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::RequestMentoringTest < ActiveSupport::TestCase
       user = create :user, id: 3
       request = create :mentor_request, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:request_mentoring, occurred_at, request:, track:, user:)
+      metric = Metric::Create.(:request_mentoring, occurred_at, request:, track:, user:, request_context:)
 
       assert_equal Metrics::RequestMentoringMetric, metric.class
       assert_equal occurred_at, metric.occurred_at

--- a/test/models/metrics/request_private_mentoring_metric_test.rb
+++ b/test/models/metrics/request_private_mentoring_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::RequestPrivateMentoringTest < ActiveSupport::TestCase
       user = create :user, id: 3
       request = create :mentor_request, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:request_private_mentoring, occurred_at, request:, track:, user:)
+      metric = Metric::Create.(:request_private_mentoring, occurred_at, request:, track:, user:, request_context:)
 
       assert_equal Metrics::RequestPrivateMentoringMetric, metric.class
       assert_equal occurred_at, metric.occurred_at

--- a/test/models/metrics/submit_solution_metric_test.rb
+++ b/test/models/metrics/submit_solution_metric_test.rb
@@ -7,8 +7,9 @@ class Metrics::SubmitSolutionTest < ActiveSupport::TestCase
       user = create :user, id: 3
       solution = create :concept_solution, id: 4
       occurred_at = Time.current - 5.seconds
+      request_context = { remote_ip: '127.0.0.1' }
 
-      metric = Metric::Create.(:submit_solution, occurred_at, solution:, track:, user:)
+      metric = Metric::Create.(:submit_solution, occurred_at, solution:, track:, user:, request_context:)
 
       assert_equal Metrics::SubmitSolutionMetric, metric.class
       assert_equal occurred_at, metric.occurred_at


### PR DESCRIPTION
By the time `Metric::Create` is called, it's in Sidekiq, which no-longer has access to the request as it was at the time of the user. This moves the extraction logic into `Queue` and then passing it explicitely into `Create`