### PR TITLE
Fix typo in gitignore for dump.rdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ app/javascript/.config/*
 !app/javascript/.config/.keep
 
 # Redis Database Backup
-dumb.rdb
+dump.rdb


### PR DESCRIPTION
Changes dumb.rdb to dump.rdb.
