### PR TITLE
Support Linux in bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-hivemind Procfile.dev
+case $(uname -s) in
+    Linux)
+        overmind start -f Procfile.dev
+        ;;
+    Darwin)
+        hivemind Procfile.dev
+        ;;
+    *)
+        >&2 echo "Unsupported platform"
+        exit 1
+esac


### PR DESCRIPTION
With this PR, the bin/dev binary supports running on both MacOS and Linux.

We need this as `hivemind` is only supported on MacOS, whereas on Linux you'd use `overmind`.
