### PR TITLE
Add docker setup to bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+docker run -dp 3042:8080 -p 3040:4566 -p 3041:4566 localstack/localstack
+docker run -dp 9200:9200 -e "discovery.type=single-node" opensearchproject/opensearch:1.1.0
 hivemind Procfile.dev


### PR DESCRIPTION
I figure it's useful to have this. If the containers are already there the first two lines just error and continue.

I'd also love to get `setup_local_exercism_aws` in there too, but as that relies on waiting for docker, and it should open happen once, it's harder.