### PR TITLE
Remove n+1 from track page

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -11,7 +11,7 @@ class Exercise < ApplicationRecord
     deprecated: 3
   }
 
-  belongs_to :track, counter_cache: :num_exercises
+  belongs_to :track
 
   has_many :solutions, dependent: :destroy
   has_many :submissions, through: :solutions
@@ -68,6 +68,10 @@ class Exercise < ApplicationRecord
       Exercise::MarkSolutionsAsOutOfDateInIndex.defer(self)
       Exercise::QueueSolutionHeadTestRuns.defer(self)
     end
+  end
+
+  after_commit do
+    track.recache_num_exercises! if (saved_changes.keys & %w[id status]).present?
   end
 
   def status

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -38,6 +38,10 @@ class Track < ApplicationRecord
     find_by(slug:)
   end
 
+  def recache_num_exercises!
+    update_column(:num_exercises, exercises.where(status: %i[active beta]).count)
+  end
+
   def to_param
     slug
   end

--- a/app/models/user_track/external.rb
+++ b/app/models/user_track/external.rb
@@ -10,7 +10,7 @@ class UserTrack
       @track = track
     end
 
-    delegate :concepts, :num_concepts, :updated_at,
+    delegate :concepts, :num_exercises, :num_concepts, :updated_at,
       to: :track
     delegate :title, to: :track, prefix: true
 
@@ -127,10 +127,6 @@ class UserTrack
     ###############################
     # Exercises aggregate methods #
     ###############################
-
-    def num_exercises
-      exercises.size
-    end
 
     def num_completed_exercises
       0

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -133,4 +133,34 @@ class ExerciseTest < ActiveSupport::TestCase
       exercise.update!(position: 2)
     end
   end
+
+  test "updates track num_exercises when created" do
+    track = create :track
+    track.expects(:recache_num_exercises!).once
+    create :practice_exercise, track:
+  end
+
+  test "updates track num_exercises when deleted" do
+    track = create :track
+    exercise = create :practice_exercise, track: track
+
+    track.expects(:recache_num_exercises!).once
+    exercise.destroy
+  end
+
+  test "updates track num_exercises when status column changed" do
+    track = create :track
+    exercise = create :practice_exercise, track: track
+
+    track.expects(:recache_num_exercises!).once
+    exercise.update(status: :beta)
+  end
+
+  test "doesn't update track num_exercises when other column changed" do
+    track = create :track
+    exercise = create :practice_exercise, track: track
+
+    track.expects(:recache_num_exercises!).never
+    exercise.update(title: 'something')
+  end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -175,4 +175,19 @@ class TrackTest < ActiveSupport::TestCase
   test ".for_repo with non-track or track tooling repo" do
     assert_nil Track.for_repo("exercism/configlet")
   end
+
+  test "recache_num_exercises!" do
+    track = create :track
+    track.recache_num_exercises!
+    assert_equal 0, track.num_exercises
+
+    create :practice_exercise, track: track, status: :beta
+    assert_equal 1, track.num_exercises
+
+    create :concept_exercise, track: track, status: :active
+    assert_equal 2, track.num_exercises
+
+    create :practice_exercise, track: track, status: :wip
+    assert_equal 2, track.num_exercises
+  end
 end


### PR DESCRIPTION
I can't see any reason why we can't delegate to the db column here and avoid an n+1 lookup