### PR TITLE
Perf tweaks

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -20,7 +20,7 @@ class AboutController < ApplicationController
 
   private
   def use_num_individual_supporters
-    @num_individual_supporters = User::AcquiredBadge.joins(:user).includes(:user).
+    @num_individual_supporters = User::AcquiredBadge.includes(:user).
       where(badge_id: Badge.find_by_slug!("supporter")). # rubocop:disable Rails/DynamicFindBy
       count
   end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,6 +1,12 @@
 class SitemapsController < ApplicationController
   skip_before_action :authenticate_user!
 
+  around_action do |_, action|
+    ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+      action.()
+    end
+  end
+
   def robots_txt
     render html: "User-agent: * Allow: /"
   end


### PR DESCRIPTION
Three more performance updates.

- The first one should insulate us from any locking pain. 
- The second should speed up the query as less data will be used. 
- The third one knocks about 25ms off our power-users' requests.