### PR TITLE
Don't cause track exercises data to become stale due to criteria being empty

### DIFF
--- a/app/helpers/react_components/student/exercise_list.rb
+++ b/app/helpers/react_components/student/exercise_list.rb
@@ -12,18 +12,20 @@ module ReactComponents
 
       private
       def request
-        query = {
-          criteria: params[:criteria],
-          sideload: ["solutions"]
-        }.compact
-
         {
           endpoint: Exercism::Routes.api_track_exercises_path(track),
           options: {
-            initial_data: AssembleExerciseList.(current_user, track, query),
-            stale_time: 0
+            initial_data: AssembleExerciseList.(current_user, track, query)
           },
           query:
+        }
+      end
+
+      memoize
+      def query
+        {
+          criteria: params.fetch(:criteria, ''),
+          sideload: ["solutions"]
         }
       end
     end


### PR DESCRIPTION
The issue was not that there wasn't a stale time (there is by default), but that the criteria param is set to `nil` on the ruby side, but to an empty string on the React side (which is required for proper input handling)

Closes https://github.com/exercism/exercism/issues/6505
