### PR TITLE
Improve performance of contributors page by a bazillion percent.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn pretty-quick --staged
+bin/rubocop-quick
+bin/haml-lint-quick
+bin/eslint-quick

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -11,7 +11,7 @@ class User::ReputationToken
     # By reducing it down to n queries, we have a steady performance that's at the very low
     # end of the range (~0.5s sum for all the queries)
     # 2. We cache the values per user and invalidate the cache when a new reputation token is
-    # added, so although this is n+1 in the worst case - we're never really actually there.
+    # added, so although this is n queries in the worst case - we're never really actually there.
     def initialize(user_ids, period: nil, earned_since: nil, track_id: nil, category: nil)
       @single_user = user_ids.is_a?(Integer)
       @user_ids = Array(user_ids)

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -7,7 +7,7 @@ class User::ReputationToken
     # This does n queries (where n is number of users).
     # This is theoretically terrible but actually works out to be much more performant for two reasons:
     # 1. MySQL's index performance ranges from 0.05s to 33s (!!) depending on how dispersed the indexes pages
-    # are. First page load therefore takes 33s and subsequent ones are pretty instant. 
+    # are. First website page load therefore takes 33s and subsequent ones are pretty instant. 
     # By reducing it down to n queries, we have a steady performance that's at the very low
     # end of the range (~0.5s sum for all the queries)
     # 2. We cache the values per user and invalidate the cache when a new reputation token is

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -7,7 +7,7 @@ class User::ReputationToken
     # This does n queries (where n is number of users).
     # This is theoretically terrible but actually works out to be much more performant for two reasons:
     # 1. MySQL's index performance ranges from 0.05s to 33s (!!) depending on how dispersed the indexes pages
-    # are. First website page load therefore takes 33s and subsequent ones are pretty instant. 
+    # are. First website page load therefore takes 33s and subsequent ones are pretty instant.
     # By reducing it down to n queries, we have a steady performance that's at the very low
     # end of the range (~0.5s sum for all the queries)
     # 2. We cache the values per user and invalidate the cache when a new reputation token is
@@ -78,10 +78,10 @@ class User::ReputationToken
       base = base.where(track_id:) if track_id
       base = base.group(:type)
       base = base.select('type, COUNT(value) AS num, SUM(value) AS total')
- 
-      user_ids.each_with_object({}) do |user_id, hash|
-        hash[user_id] = with_cache(user_id) do
-          query = base.where(user_id: user_id)
+
+      user_ids.index_with do |user_id|
+        with_cache(user_id) do
+          query = base.where(user_id:)
           ActiveRecord::Base.connection.select_all(query)
         end
       end

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -4,6 +4,14 @@ class User::ReputationToken
     include ActionView::Helpers::TextHelper
     include ActionView::Helpers::NumberHelper
 
+    # This does n queries (where n is number of users).
+    # This is theoretically terrible but actually works out to be much more performant for two reasons:
+    # 1. MySQL's index performance ranges from 0.05s to 33s (!!) depending on how dispersed the indexes pages
+    # are. First page load therefore takes 33s and subsequent ones are pretty instant. 
+    # By reducing it down to n queries, we have a steady performance that's at the very low
+    # end of the range (~0.5s sum for all the queries)
+    # 2. We cache the values per user and invalidate the cache when a new reputation token is
+    # added, so although this is n+1 in the worst case - we're never really actually there.
     def initialize(user_ids, period: nil, earned_since: nil, track_id: nil, category: nil)
       @single_user = user_ids.is_a?(Integer)
       @user_ids = Array(user_ids)
@@ -30,10 +38,8 @@ class User::ReputationToken
 
     memoize
     def data
-      user_ids.each_with_object({}) do |user_id, data|
-        user_tuples = tuples.select { |t| t['user_id'] == user_id }.
-          index_by { |t| t['type'] }.
-          transform_keys { |k| k.split("::").last }
+      tuples.each.with_object({}) do |(user_id, user_tuples), data|
+        user_tuples = user_tuples.index_by { |t| t['type'] }.transform_keys { |k| k.split("::").last }
 
         code_contributions = user_tuples.dig("CodeContributionToken", 'num')
         code_reviews = user_tuples.dig("CodeReviewToken", 'num')
@@ -66,13 +72,19 @@ class User::ReputationToken
 
     memoize
     def tuples
-      ts = User::ReputationToken.where(user_id: user_ids)
-      ts = ts.where(category:) if category
-      ts = ts.where('earned_on >= ?', earned_since) if earned_since
-      ts = ts.where(track_id:) if track_id
-      ts = ts.group(:user_id, :type).select("user_id, type, COUNT(*) as num, SUM(value) as total")
-
-      ActiveRecord::Base.connection.select_all(ts.to_sql)
+      base = User::ReputationToken
+      base = base.where(category:) if category
+      base = base.where('earned_on >= ?', earned_since) if earned_since
+      base = base.where(track_id:) if track_id
+      base = base.group(:type)
+      base = base.select('type, COUNT(value) AS num, SUM(value) AS total')
+ 
+      user_ids.each_with_object({}) do |user_id, hash|
+        hash[user_id] = with_cache(user_id) do
+          query = base.where(user_id: user_id)
+          ActiveRecord::Base.connection.select_all(query)
+        end
+      end
     end
 
     private
@@ -80,5 +92,17 @@ class User::ReputationToken
 
     Data = Struct.new(:activity, :reputation)
     private_constant :Data
+
+    def with_cache(user)
+      user_key = User::ReputationToken.cache_hash_for(user)
+      value_key = ["contextual", earned_since, track_id, category].join("|")
+      redis = Exercism.redis_tooling_client
+      val = redis.hget(user_key, value_key)
+      return JSON.parse(val) if val
+
+      yield.tap do |val|
+        redis.hset(user_key, value_key, val.to_json)
+      end
+    end
   end
 end

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -89,7 +89,6 @@ class User::ReputationToken
 
     private
     attr_reader :user_ids, :single_user, :earned_since, :track_id, :category
-    
 
     Data = Struct.new(:activity, :reputation)
     private_constant :Data

--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -89,6 +89,7 @@ class User::ReputationToken
 
     private
     attr_reader :user_ids, :single_user, :earned_since, :track_id, :category
+    
 
     Data = Struct.new(:activity, :reputation)
     private_constant :Data

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -1,9 +1,7 @@
 class User::ReputationToken < ApplicationRecord
   include IsParamaterisedSTI
 
-  def self.cache_hash_for(user_id)
-    "users/#{user_id}/reputation"
-  end
+  def self.cache_hash_for(user_id) = "users/#{user_id}/reputation"
 
   self.class_suffix = :token
   self.i18n_category = :user_reputation_tokens

--- a/app/models/user/reputation_token.rb
+++ b/app/models/user/reputation_token.rb
@@ -1,6 +1,10 @@
 class User::ReputationToken < ApplicationRecord
   include IsParamaterisedSTI
 
+  def self.cache_hash_for(user_id)
+    "users/#{user_id}/reputation"
+  end
+
   self.class_suffix = :token
   self.i18n_category = :user_reputation_tokens
 
@@ -41,6 +45,9 @@ class User::ReputationToken < ApplicationRecord
     ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
       User.where(id: user.id).update_all(reputation: summing_sql)
     end
+
+    # Invalidate reputation cache for this user
+    Exercism.redis_tooling_client.del(self.class.cache_hash_for(user_id))
   end
 
   def params=(hash)

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "eslint-plugin-react-hooks": "^4.1.2",
     "eslint-plugin-testing-library": "^4.1.2",
     "flush-promises": "^1.0.2",
-    "husky": "^4.2.5",
+    "husky": "^8.0.0",
     "isomorphic-fetch": "^3.0.0",
     "jest": "27",
     "msw": "^0.21.2",
@@ -137,11 +137,7 @@
     "test": "jest",
     "test-watch": "jest --watchAll",
     "build:css": "postcss ./app/css/application.postcss.css -o .built-assets/website.css",
-    "build": "./app/javascript/esbuild.js"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged && bin/rubocop-quick && bin/haml-lint-quick && bin/eslint-quick"
-    }
+    "build": "./app/javascript/esbuild.js",
+    "prepare": "husky install"
   }
 }

--- a/test/commands/user/reputation_token/calculate_contextual_data_test.rb
+++ b/test/commands/user/reputation_token/calculate_contextual_data_test.rb
@@ -108,4 +108,50 @@ class User::ReputationToken::CalculateContextualDataTest < ActiveSupport::TestCa
     assert_equal "3 solutions mentored", data.activity
     assert_equal 15, data.reputation
   end
+
+  test "check we use activerecord select_all (for cache check below)" do
+    freeze_time do
+      user = create :user
+      create :user_code_contribution_reputation_token, user: user, earned_on: Time.zone.today
+
+      ActiveRecord::Base.connection.expects(:select_all).once.returns([])
+      User::ReputationToken::CalculateContextualData.(user.id, period: :week)
+    end
+  end
+
+  test "check we use cache" do
+    freeze_time do
+      user = create :user
+      create :user_code_contribution_reputation_token, user: user, earned_on: Time.zone.today
+
+      data = User::ReputationToken::CalculateContextualData.(user.id, period: :week)
+      assert_equal "1 PR created", data.activity
+      assert_equal 12, data.reputation
+
+      ActiveRecord::Base.connection.expects(:select_all).never
+
+      data = User::ReputationToken::CalculateContextualData.(user.id, period: :week)
+      assert_equal "1 PR created", data.activity
+      assert_equal 12, data.reputation
+    end
+  end
+
+  test "check cache is invalidated when a new token is created" do
+    freeze_time do
+      user = create :user
+      create :user_code_contribution_reputation_token, user: user, earned_on: Time.zone.today
+
+      data = User::ReputationToken::CalculateContextualData.(user.id, period: :week)
+      assert_equal "1 PR created", data.activity
+      assert_equal 12, data.reputation
+
+      # Create a second token
+      create :user_code_contribution_reputation_token, user: user, earned_on: Time.zone.today
+
+      data = User::ReputationToken::CalculateContextualData.(user.id, period: :week)
+      assert_equal "2 PRs created", data.activity
+      assert_equal 24, data.reputation
+    end
+  end
+
 end

--- a/test/commands/user/reputation_token/calculate_contextual_data_test.rb
+++ b/test/commands/user/reputation_token/calculate_contextual_data_test.rb
@@ -153,5 +153,4 @@ class User::ReputationToken::CalculateContextualDataTest < ActiveSupport::TestCa
       assert_equal 24, data.reputation
     end
   end
-
 end


### PR DESCRIPTION
This changes the calculation of contextual data to use n queries (where n is number of users) rather than 1 nice big optimised query.

This is theoretically terrible but actually works out to be much more performant for two reasons:
1. MySQL's index performance ranges from 0.05s to 33s (!!) depending on how dispersed the indexes pages are. First website page load therefore takes 33s and subsequent ones are pretty instant. By reducing it down to n queries, we have a steady performance that's at the very low end of the range (~0.5s sum for all the queries)
2. We cache the values per user and invalidate the cache when a new reputation token is added, so although this is n queries in the worst case - we're never really actually there.
 