### PR TITLE
Remove empty Learn More section from Concept page

### DIFF
--- a/app/views/tracks/concepts/show.html.haml
+++ b/app/views/tracks/concepts/show.html.haml
@@ -55,9 +55,9 @@
             - else
               = raw Markdown::Parse.(@concept.introduction)
 
-          .links
-            %h3 Learn More
-            - if @concept.links.present?
+          - if @concept.links.present?
+            .links
+              %h3 Learn More
               %ul
                 - @concept.links.each do |link|
                   %li


### PR DESCRIPTION
## Before:

<img width="908" alt="Screenshot 2022-09-05 at 16 30 32" src="https://user-images.githubusercontent.com/66035744/188473513-05a36615-4c75-45a0-87a7-4d7c618a0601.png">

## After:
<img width="1055" alt="Screenshot 2022-09-05 at 16 34 48" src="https://user-images.githubusercontent.com/66035744/188473862-78e0010e-b0d1-4a09-a1cc-36c628586772.png">

## This should stay the same:
<img width="1042" alt="Screenshot 2022-09-05 at 16 35 53" src="https://user-images.githubusercontent.com/66035744/188473914-319d2a5f-97fd-4536-badd-90bf17178c00.png">


Closes https://github.com/exercism/exercism/issues/6539