### PR TITLE
Reshape guidance in automation

### DIFF
--- a/app/css/ui-kit/text.css
+++ b/app/css/ui-kit/text.css
@@ -89,7 +89,7 @@
     }
 
     .text-radio-essential {
-        @apply text-16 font-semibold text-biggerBolderAndMorePurpleThanEver;
+        @apply text-14 font-semibold text-biggerBolderAndMorePurpleThanEver;
     }
 
     .text-gradient {

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -53,6 +53,11 @@ module ReactComponents
               Exercism::Routes.with_feedback_mentoring_automation_index_path
         end
 
+        memoize
+        def scratchpad
+          ScratchpadPage.new(about: exercise)
+        end
+
         delegate :track, :exercise, to: :representation
       end
     end

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -9,19 +9,15 @@ module ReactComponents
             representation: SerializeExerciseRepresentation.(representation),
             examples: examples_data,
             mentor: mentor_data,
+            mentor_solution:,
             guidance: {
+              representationsHtml: Markdown::Parse.(track.mentoring_representations).presence,
               exercise: exercise.mentoring_notes_content,
               track: track.mentoring_notes_content,
               exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
               links: {
                 improve_notes: exercise.mentoring_notes_edit_url
               }
-            },
-            mentor_solution:,
-            information: {
-              representations: Markdown::Parse.(track.mentoring_representations).presence,
-              exercise: exercise.mentoring_notes_content,
-              track: track.mentoring_notes_content
             },
             scratchpad: {
               is_introducer_hidden: true,

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -15,7 +15,7 @@ module ReactComponents
               track: track.mentoring_notes_content
             },
             scratchpad: {
-              is_introducer_hidden: current_user&.introducer_dismissed?("scratchpad"),
+              is_introducer_hidden: true,
               links: {
                 markdown: Exercism::Routes.doc_url(:mentoring, "markdown"),
                 hide_introducer: Exercism::Routes.hide_api_settings_introducer_path("scratchpad"),

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -10,6 +10,15 @@ module ReactComponents
             examples: examples_data,
             mentor: mentor_data,
             guidance: {
+              exercise: exercise.mentoring_notes_content,
+              track: track.mentoring_notes_content,
+              exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
+              links: {
+                improve_notes: exercise.mentoring_notes_edit_url
+              }
+            },
+            mentor_solution:,
+            information: {
               representations: Markdown::Parse.(track.mentoring_representations).presence,
               exercise: exercise.mentoring_notes_content,
               track: track.mentoring_notes_content
@@ -58,7 +67,27 @@ module ReactComponents
           ScratchpadPage.new(about: exercise)
         end
 
+        def mentor_solution
+          ms = ::Solution.for(current_user, exercise)
+          ms ? SerializeCommunitySolution.(ms) : nil
+        end
+
         delegate :track, :exercise, to: :representation
+
+        class SerializeExemplarFiles
+          include Mandate
+
+          initialize_with :files
+
+          def call
+            files.map do |filename, content|
+              {
+                filename: filename.gsub(%r{^\.meta/}, ''),
+                content:
+              }
+            end
+          end
+        end
       end
     end
   end

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -11,7 +11,7 @@ module ReactComponents
             mentor: mentor_data,
             mentor_solution:,
             guidance: {
-              representationsHtml: Markdown::Parse.(track.mentoring_representations).presence,
+              representations: Markdown::Parse.(track.mentoring_representations).presence,
               exercise: exercise.mentoring_notes_content,
               track: track.mentoring_notes_content,
               exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -10,9 +10,17 @@ module ReactComponents
             examples: examples_data,
             mentor: mentor_data,
             guidance: {
-              representations_html: Markdown::Parse.(track.mentoring_representations).presence,
-              track_mentoring_notes_html: track.mentoring_notes_content.presence,
-              exercise_mentoring_notes_html: exercise.mentoring_notes_content.presence
+              representations: Markdown::Parse.(track.mentoring_representations).presence,
+              exercise: exercise.mentoring_notes_content,
+              track: track.mentoring_notes_content
+            },
+            scratchpad: {
+              is_introducer_hidden: current_user&.introducer_dismissed?("scratchpad"),
+              links: {
+                markdown: Exercism::Routes.doc_url(:mentoring, "markdown"),
+                hide_introducer: Exercism::Routes.hide_api_settings_introducer_path("scratchpad"),
+                self: Exercism::Routes.api_scratchpad_page_path(scratchpad.category, scratchpad.title)
+              }
             },
             links: {
               success: Exercism::Routes.mentoring_automation_index_path,

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -16,7 +16,8 @@ module ReactComponents
               track: track.mentoring_notes_content,
               exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
               links: {
-                improve_notes: exercise.mentoring_notes_edit_url,
+                improve_exercise_guidance: exercise.mentoring_notes_edit_url,
+                improve_track_guidance: track.mentoring_notes_edit_url,
                 improve_representer_guidance: 'https://github.com/exercism/website-copy'
               }
             },

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -16,7 +16,8 @@ module ReactComponents
               track: track.mentoring_notes_content,
               exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
               links: {
-                improve_notes: exercise.mentoring_notes_edit_url
+                improve_notes: exercise.mentoring_notes_edit_url,
+                improve_representer_guidance: 'https://github.com/exercism/website-copy'
               }
             },
             scratchpad: {

--- a/app/helpers/react_components/mentoring/representations/representation.rb
+++ b/app/helpers/react_components/mentoring/representations/representation.rb
@@ -18,7 +18,7 @@ module ReactComponents
               links: {
                 improve_exercise_guidance: exercise.mentoring_notes_edit_url,
                 improve_track_guidance: track.mentoring_notes_edit_url,
-                improve_representer_guidance: 'https://github.com/exercism/website-copy'
+                improve_representer_guidance: "https://github.com/exercism/#{track.slug}/new/main?filename=exercises/shared/.docs/representations.md"
               }
             },
             scratchpad: {

--- a/app/helpers/react_components/mentoring/session.rb
+++ b/app/helpers/react_components/mentoring/session.rb
@@ -33,10 +33,12 @@ module ReactComponents
             ),
             mentor_solution:,
             exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
-            notes: exercise.mentoring_notes_content,
-            track_notes: track.mentoring_notes_content,
             out_of_date: solution.out_of_date?,
             download_command: solution.mentor_download_cmd,
+            guidance: {
+              exercise: exercise.mentoring_notes_content,
+              track: track.mentoring_notes_content
+            },
             scratchpad: {
               is_introducer_hidden: current_user&.introducer_dismissed?("scratchpad"),
               links: {

--- a/app/helpers/react_components/mentoring/session.rb
+++ b/app/helpers/react_components/mentoring/session.rb
@@ -33,12 +33,12 @@ module ReactComponents
             ),
             mentor_solution:,
             exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
-            out_of_date: solution.out_of_date?,
-            download_command: solution.mentor_download_cmd,
             guidance: {
               exercise: exercise.mentoring_notes_content,
               track: track.mentoring_notes_content
             },
+            out_of_date: solution.out_of_date?,
+            download_command: solution.mentor_download_cmd,
             scratchpad: {
               is_introducer_hidden: current_user&.introducer_dismissed?("scratchpad"),
               links: {

--- a/app/helpers/react_components/mentoring/session.rb
+++ b/app/helpers/react_components/mentoring/session.rb
@@ -35,7 +35,11 @@ module ReactComponents
             exemplar_files: SerializeExemplarFiles.(exercise.exemplar_files),
             guidance: {
               exercise: exercise.mentoring_notes_content,
-              track: track.mentoring_notes_content
+              track: track.mentoring_notes_content,
+              links: {
+                improve_exercise_guidance: exercise.mentoring_notes_edit_url,
+                improve_track_guidance: track.mentoring_notes_edit_url
+              }
             },
             out_of_date: solution.out_of_date?,
             download_command: solution.mentor_download_cmd,
@@ -64,7 +68,6 @@ module ReactComponents
         {
           mentor_dashboard: Exercism::Routes.mentoring_inbox_path,
           exercise: Exercism::Routes.track_exercise_path(track, exercise),
-          improve_notes: exercise.mentoring_notes_edit_url,
           mentoring_docs: Exercism::Routes.docs_section_path(:mentoring)
         }
       end

--- a/app/javascript/components/mentoring/Representation.tsx
+++ b/app/javascript/components/mentoring/Representation.tsx
@@ -16,7 +16,9 @@ export function Representation({
         leftMinWidth={550}
         rightMinWidth={625}
         id="mentoring-session"
-        left={<LeftPane links={data.links} data={data.representation} />}
+        left={
+          <LeftPane links={data.links} representation={data.representation} />
+        }
         right={<RightPane data={data} />}
       />
     </div>

--- a/app/javascript/components/mentoring/Session.tsx
+++ b/app/javascript/components/mentoring/Session.tsx
@@ -1,6 +1,6 @@
 import React, { useState, createContext, useCallback } from 'react'
 
-import { CommunitySolution, Student } from '../types'
+import { CommunitySolution, Guidance as GuidanceTypes, Student } from '../types'
 import { CloseButton } from './session/CloseButton'
 import { SessionInfo } from './session/SessionInfo'
 import { Guidance } from './session/Guidance'
@@ -58,7 +58,7 @@ export type SessionProps = {
   instructions: string
   tests: string
   userHandle: string
-  notes: string
+  guidance: Pick<GuidanceTypes, 'exercise'>
   outOfDate: boolean
   mentorSolution: CommunitySolution
   exemplarFiles: readonly MentoringSessionExemplarFile[]
@@ -85,7 +85,7 @@ export const Session = (props: SessionProps): JSX.Element => {
     instructions,
     tests,
     discussion,
-    notes,
+    guidance,
     mentorSolution,
     exemplarFiles,
     outOfDate,
@@ -203,7 +203,7 @@ export const Session = (props: SessionProps): JSX.Element => {
                 </Tab.Panel>
                 <Tab.Panel id="guidance" context={TabsContext}>
                   <Guidance
-                    notes={notes}
+                    notes={guidance.exercise}
                     mentorSolution={mentorSolution}
                     exemplarFiles={exemplarFiles}
                     language={track.highlightjsLanguage}

--- a/app/javascript/components/mentoring/Session.tsx
+++ b/app/javascript/components/mentoring/Session.tsx
@@ -58,7 +58,7 @@ export type SessionProps = {
   instructions: string
   tests: string
   userHandle: string
-  guidance: Pick<GuidanceTypes, 'exercise'>
+  guidance: SessionGuidance
   outOfDate: boolean
   mentorSolution: CommunitySolution
   exemplarFiles: readonly MentoringSessionExemplarFile[]
@@ -66,6 +66,11 @@ export type SessionProps = {
   scratchpad: Scratchpad
   downloadCommand: string
 }
+
+export type SessionGuidance = Pick<
+  GuidanceTypes,
+  'exercise' | 'track' | 'links'
+>
 
 export type TabIndex = 'discussion' | 'scratchpad' | 'guidance'
 
@@ -203,11 +208,11 @@ export const Session = (props: SessionProps): JSX.Element => {
                 </Tab.Panel>
                 <Tab.Panel id="guidance" context={TabsContext}>
                   <Guidance
-                    notes={guidance.exercise}
+                    guidance={guidance}
                     mentorSolution={mentorSolution}
                     exemplarFiles={exemplarFiles}
                     language={track.highlightjsLanguage}
-                    links={links}
+                    links={guidance.links}
                   />
                 </Tab.Panel>
                 {discussion ? (

--- a/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
+++ b/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
@@ -5,17 +5,20 @@ import RepresentationInfo from './RepresentationInfo'
 import { CompleteRepresentationData, RepresentationData } from '../../../types'
 
 export type PanesProps = {
-  data: RepresentationData
+  representation: RepresentationData
 } & Pick<CompleteRepresentationData, 'links'>
 
-export function LeftPane({ data, links }: PanesProps): JSX.Element {
+export function LeftPane({ representation, links }: PanesProps): JSX.Element {
   return (
     <>
       <header className="discussion-header">
         <CloseButton url={links.back} />
-        <RepresentationInfo exercise={data.exercise} track={data.track} />
+        <RepresentationInfo
+          exercise={representation.exercise}
+          track={representation.track}
+        />
       </header>
-      <IterationView representationData={data} />
+      <IterationView representationData={representation} />
     </>
   )
 }

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -4,7 +4,7 @@ import { CompleteRepresentationData } from '../../../types'
 export default function AutomationRules({
   guidance,
 }: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
-  if (!guidance.representationsHtml) {
+  if (!guidance.representations) {
     return null
   }
 
@@ -13,7 +13,7 @@ export default function AutomationRules({
       <h2 className="text-h4 mb-12">Please read before giving feedback</h2>
       <div
         dangerouslySetInnerHTML={{
-          __html: `<div class="c-textual-content --base">${guidance.representationsHtml}</div>`,
+          __html: `<div class="c-textual-content --base">${guidance.representations}</div>`,
         }}
       />
     </div>

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -20,8 +20,9 @@ export default function AutomationRules({
     return (
       <p className="px-24 py-16 text-p-base">
         This representer doesn&apos;t have any guidance yet. Guidance notes are
-        written by our community. Please help get them started for this exercise
-        by sending a {prLink}.
+        written by our maintainers to explain what normalizations occur during
+        the representation process. If you are a maintainer, please help get
+        them started for this representer by sending a {prLink}.
       </p>
     )
   }

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -4,8 +4,26 @@ import { CompleteRepresentationData } from '../../../types'
 export default function AutomationRules({
   guidance,
 }: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
+  console.log(guidance)
+
+  const prLink = (
+    <a
+      href={guidance.links.improveRepresenterGuidance}
+      target="_blank"
+      rel="noreferrer"
+    >
+      Pull Request on GitHub
+    </a>
+  )
+
   if (!guidance.representations) {
-    return null
+    return (
+      <p className="px-24 py-16 text-p-base">
+        This representer doesn&apos;t have any guidance yet. Guidance notes are
+        written by our community. Please help get them started for this exercise
+        by sending a {prLink}.
+      </p>
+    )
   }
 
   return (

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -4,7 +4,7 @@ import { CompleteRepresentationData } from '../../../types'
 export default function AutomationRules({
   guidance,
 }: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
-  if (guidance.representationsHtml === null) {
+  if (!guidance.representationsHtml) {
     return null
   }
 

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { CompleteRepresentationData } from '../../../types'
 
 export default function AutomationRules({
-  information,
-}: Pick<CompleteRepresentationData, 'information'>): JSX.Element | null {
-  if (!information.representationsHtml) {
+  guidance,
+}: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
+  if (!guidance.representationsHtml) {
     return null
   }
 
@@ -13,7 +13,7 @@ export default function AutomationRules({
       <h2 className="text-h4 mb-12">Please read before giving feedback</h2>
       <div
         dangerouslySetInnerHTML={{
-          __html: `<div class="c-textual-content --base">${information.representationsHtml}</div>`,
+          __html: `<div class="c-textual-content --base">${guidance.representationsHtml}</div>`,
         }}
       />
     </div>

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { CompleteRepresentationData } from '../../../types'
 
 export default function AutomationRules({
-  guidance,
-}: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
-  if (!guidance.representationsHtml) {
+  information,
+}: Pick<CompleteRepresentationData, 'information'>): JSX.Element | null {
+  if (!information.representationsHtml) {
     return null
   }
 
@@ -13,7 +13,7 @@ export default function AutomationRules({
       <h2 className="text-h4 mb-12">Please read before giving feedback</h2>
       <div
         dangerouslySetInnerHTML={{
-          __html: `<div class="c-textual-content --base">${guidance.representationsHtml}</div>`,
+          __html: `<div class="c-textual-content --base">${information.representationsHtml}</div>`,
         }}
       />
     </div>

--- a/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
@@ -12,8 +12,8 @@ export default function HowImportant({
   setFeedbackType,
 }: HowImportantProps): JSX.Element {
   return (
-    <div>
-      <h2 className="text-h4 mb-[10px]">How important is this?</h2>
+    <div class="mb-4">
+      <h2 className="text-h6 mb-8">How important is this?</h2>
       <RadioGroup
         feedbackType={feedbackType}
         setFeedbackType={setFeedbackType}

--- a/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
@@ -12,8 +12,8 @@ export default function HowImportant({
   setFeedbackType,
 }: HowImportantProps): JSX.Element {
   return (
-    <div className="px-24">
-      <h2 className="text-h4 mb-[10.5px]">How important is this?</h2>
+    <div className="px-24 overflow-auto">
+      <h2 className="text-h4 mb-[10px]">How important is this?</h2>
       <RadioGroup
         feedbackType={feedbackType}
         setFeedbackType={setFeedbackType}

--- a/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/HowImportant.tsx
@@ -12,7 +12,7 @@ export default function HowImportant({
   setFeedbackType,
 }: HowImportantProps): JSX.Element {
   return (
-    <div className="px-24 overflow-auto">
+    <div>
       <h2 className="text-h4 mb-[10px]">How important is this?</h2>
       <RadioGroup
         feedbackType={feedbackType}

--- a/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
@@ -76,9 +76,9 @@ export default function MentoringConversation({
         onPreviewClick={handlePreviewClick}
       />
 
-      <div className="mt-12 text-textColor6 bg-veryLightBlue py-4 px-8 rounded-5 leading-150">
+      {/*<div className="mt-12 text-textColor6 bg-veryLightBlue py-4 px-8 rounded-5 leading-150">
         We imported your last mentoring feedback to this solution above
-      </div>
+      </div>*/}
 
       <PreviewAutomationModal
         feedbackType={feedbackType}

--- a/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
@@ -42,8 +42,7 @@ export default function MentoringConversation({
     const { fetch } = sendRequest<{ html: string }>({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      // querySelector _may_ return undefined, but not in this case.
-      // probably there is a better way doing this
+      // querySelector may return undefined, but not in this case.
       endpoint: document.querySelector<HTMLMetaElement>(
         'meta[name="parse-markdown-url"]'
       )?.content,
@@ -67,7 +66,7 @@ export default function MentoringConversation({
   }, [generateHTML, value])
 
   return (
-    <div className="px-24">
+    <div>
       <RepresentationFeedbackEditor
         onChange={handleChange}
         value={value}

--- a/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/MentoringConversation.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { PreviewAutomationModal } from '../modals/PreviewAutomationModal'
 import { SubmittedAutomationModal } from '../modals/SubmittedAutomationModal'
-import { PrimaryButton } from '../common/PrimaryButton'
 import {
   CompleteRepresentationData,
   RepresentationFeedbackType,
@@ -20,7 +19,9 @@ export default function MentoringConversation({
   const [value, setValue] = useState(data.representation.feedbackMarkdown || '')
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false)
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false)
-  const [expanded, setExpanded] = useState(!!data.representation.feedbackMarkdown || false)
+  const [expanded, setExpanded] = useState(
+    !!data.representation.feedbackMarkdown || false
+  )
   const [html, setHtml] = useState('<p>Loading..</p>')
 
   const handleChange = useCallback((value) => setValue(value), [setValue])
@@ -73,24 +74,13 @@ export default function MentoringConversation({
         expanded={expanded}
         onFocus={() => handleExpansion(expanded)}
         onBlur={() => handleCompression(value)}
+        onPreviewClick={handlePreviewClick}
       />
 
-      <div className="mt-12 mb-20 text-textColor6 bg-veryLightBlue py-4 px-8 rounded-5 leading-150">
+      <div className="mt-12 text-textColor6 bg-veryLightBlue py-4 px-8 rounded-5 leading-150">
         We imported your last mentoring feedback to this solution above
       </div>
 
-      <div>
-        <PrimaryButton
-          disabled={!/[a-zA-Z0-9]/.test(value)}
-          className="px-[64px] py-[12px] mb-16 mr-24"
-          onClick={handlePreviewClick}
-        >
-          Preview & Submit
-        </PrimaryButton>
-      </div>
-      <div className="text-textColor6 ">
-        Remember, you can edit this feedback anytime after submission.
-      </div>
       <PreviewAutomationModal
         feedbackType={feedbackType}
         markdown={value}

--- a/app/javascript/components/mentoring/representation/right-pane/RadioButton.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RadioButton.tsx
@@ -17,11 +17,11 @@ export default function RadioButton({
   value: string
 }): JSX.Element {
   return (
-    <label className="c-radio-wrapper mb-[13px] hover:cursor-pointer">
+    <label className="c-radio-wrapper mb-8 hover:cursor-pointer">
       <input checked={checked} onChange={onChange} value={value} type="radio" />
       <div className="row text-radio-essential">
         <div className="c-radio mr-16" />
-        <div className="mr-[8.5px]">{label}</div>
+        <div className="mr-8">{label}</div>
         <ExercismTippy
           content={<InfoTooltip title={tooltip.title} body={tooltip.body} />}
         >

--- a/app/javascript/components/mentoring/representation/right-pane/RepresentationFeedbackEditor.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RepresentationFeedbackEditor.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react'
 import { MarkdownEditor } from '../../../common'
 import { MarkdownEditorHandle } from '../../../common/MarkdownEditor'
+import { PrimaryButton } from '../common/PrimaryButton'
 
 export function RepresentationFeedbackEditor({
   onChange,
@@ -14,12 +15,14 @@ export function RepresentationFeedbackEditor({
   expanded,
   onFocus,
   onBlur,
+  onPreviewClick,
 }: {
   onChange: (value: string) => void
   onFocus: MouseEventHandler<HTMLDivElement>
   onBlur: FocusEventHandler<HTMLDivElement>
   value: string
   expanded: boolean
+  onPreviewClick: () => void
 }): JSX.Element {
   const [editor, setEditor] = useState<MarkdownEditorHandle | null>(null)
 
@@ -49,6 +52,16 @@ export function RepresentationFeedbackEditor({
         editorDidMount={handleEditorDidMount}
         value={value}
       />
+
+      <div className="editor-footer">
+        <PrimaryButton
+          disabled={!/[a-zA-Z0-9]/.test(value)}
+          className="px-[18px] py-[12px] "
+          onClick={onPreviewClick}
+        >
+          Preview & Submit
+        </PrimaryButton>
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
@@ -17,9 +17,6 @@ export function RightPane({
       ? data.representation.feedbackType
       : 'essential'
   )
-
-  console.log(data)
-
   return (
     <div className="!h-100 flex flex-col justify-between">
       <UtilityTabs data={data} />

--- a/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
@@ -22,13 +22,11 @@ export function RightPane({
 
   return (
     <div className="!h-100 py-16 flex flex-col justify-between">
-      <div className="flex flex-col overflow-auto">
-        <UtilityTabs data={data} />
-        <HowImportant
-          feedbackType={feedbackType}
-          setFeedbackType={setFeedbackType}
-        />
-      </div>
+      <UtilityTabs data={data} />
+      <HowImportant
+        feedbackType={feedbackType}
+        setFeedbackType={setFeedbackType}
+      />
       <MentoringConversation feedbackType={feedbackType} data={data} />
     </div>
   )

--- a/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
@@ -21,13 +21,15 @@ export function RightPane({
   console.log(data)
 
   return (
-    <div className="!h-100 py-16 flex flex-col justify-between">
+    <div className="!h-100 flex flex-col justify-between">
       <UtilityTabs data={data} />
-      <HowImportant
-        feedbackType={feedbackType}
-        setFeedbackType={setFeedbackType}
-      />
-      <MentoringConversation feedbackType={feedbackType} data={data} />
+      <div className="comment-section --comment">
+        <HowImportant
+          feedbackType={feedbackType}
+          setFeedbackType={setFeedbackType}
+        />
+        <MentoringConversation feedbackType={feedbackType} data={data} />
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RightPane.tsx
@@ -3,9 +3,9 @@ import {
   CompleteRepresentationData,
   RepresentationFeedbackType,
 } from '../../../types'
-import AutomationRules from './AutomationRules'
 import HowImportant from './HowImportant'
 import MentoringConversation from './MentoringConversation'
+import { UtilityTabs } from './UtilityTabs'
 
 export function RightPane({
   data,
@@ -18,10 +18,12 @@ export function RightPane({
       : 'essential'
   )
 
+  console.log(data)
+
   return (
     <div className="!h-100 py-16 flex flex-col justify-between">
       <div className="flex flex-col overflow-auto">
-        <AutomationRules guidance={data.guidance} />
+        <UtilityTabs data={data} />
         <HowImportant
           feedbackType={feedbackType}
           setFeedbackType={setFeedbackType}

--- a/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
@@ -25,7 +25,7 @@ export function UtilityTabs({
       <div className="tabs" role="tablist">
         <Tab id="information" context={TabsContext}>
           <GraphicalIcon icon="comment" />
-          <Tab.Title text="information" />
+          <Tab.Title text="Information" />
         </Tab>
         <Tab id="scratchpad" context={TabsContext}>
           <GraphicalIcon icon="scratchpad" />

--- a/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import { Tab, GraphicalIcon } from '../../../common'
+import { CompleteRepresentationData } from '../../../types'
+import { TabsContext } from '../../Session'
+// import { Guidance } from '../../session/Guidance'
+import { Scratchpad } from '../../session/Scratchpad'
+import AutomationRules from './AutomationRules'
+
+type RepresentationTabIndex = 'information' | 'scratchpad' | 'guidance'
+
+export function UtilityTabs({
+  data,
+}: {
+  data: CompleteRepresentationData
+}): JSX.Element {
+  const [tab, setTab] = useState<RepresentationTabIndex>('information')
+
+  return (
+    <TabsContext.Provider
+      value={{
+        current: tab,
+        switchToTab: (id: string) => setTab(id as RepresentationTabIndex),
+      }}
+    >
+      <div className="tabs" role="tablist">
+        <Tab id="information" context={TabsContext}>
+          <GraphicalIcon icon="comment" />
+          <Tab.Title text="information" />
+        </Tab>
+        <Tab id="scratchpad" context={TabsContext}>
+          <GraphicalIcon icon="scratchpad" />
+          <Tab.Title text="Scratchpad" />
+        </Tab>
+        <Tab id="guidance" context={TabsContext}>
+          <GraphicalIcon icon="guidance" />
+          <Tab.Title text="Guidance" />
+        </Tab>
+      </div>
+      <Tab.Panel id="information" context={TabsContext}>
+        <AutomationRules guidance={data.guidance} />
+      </Tab.Panel>
+      <Tab.Panel id="scratchpad" context={TabsContext}>
+        <Scratchpad
+          scratchpad={data.scratchpad}
+          track={data.representation.track}
+          exercise={data.representation.exercise}
+        />
+      </Tab.Panel>
+      <Tab.Panel id="guidance" context={TabsContext}>
+        <div>Guidance is coming soon!</div>
+        {/* <Guidance
+          notes={notes}
+          mentorSolution={mentorSolution}
+          exemplarFiles={exemplarFiles}
+          language={track.highlightjsLanguage}
+          links={links}
+        /> */}
+      </Tab.Panel>
+    </TabsContext.Provider>
+  )
+}

--- a/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
@@ -38,7 +38,7 @@ export function UtilityTabs({
         </Tab>
       </div>
       <Tab.Panel id="information" context={TabsContext}>
-        <AutomationRules information={data.information} />
+        <AutomationRules guidance={data.guidance} />
       </Tab.Panel>
       <Tab.Panel id="scratchpad" context={TabsContext}>
         <Scratchpad
@@ -49,7 +49,7 @@ export function UtilityTabs({
       </Tab.Panel>
       <Tab.Panel id="guidance" context={TabsContext}>
         <Guidance
-          notes={''}
+          notes={data.guidance.exercise}
           mentorSolution={data.mentorSolution}
           exemplarFiles={data.guidance.exemplarFiles}
           language={data.representation.track.highlightjsLanguage}

--- a/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
@@ -49,7 +49,7 @@ export function UtilityTabs({
       </Tab.Panel>
       <Tab.Panel id="guidance" context={TabsContext}>
         <Guidance
-          notes={data.guidance.exercise}
+          guidance={data.guidance}
           mentorSolution={data.mentorSolution}
           exemplarFiles={data.guidance.exemplarFiles}
           language={data.representation.track.highlightjsLanguage}

--- a/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/UtilityTabs.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Tab, GraphicalIcon } from '../../../common'
 import { CompleteRepresentationData } from '../../../types'
 import { TabsContext } from '../../Session'
+import { Guidance } from '../../session/Guidance'
 // import { Guidance } from '../../session/Guidance'
 import { Scratchpad } from '../../session/Scratchpad'
 import AutomationRules from './AutomationRules'
@@ -37,7 +38,7 @@ export function UtilityTabs({
         </Tab>
       </div>
       <Tab.Panel id="information" context={TabsContext}>
-        <AutomationRules guidance={data.guidance} />
+        <AutomationRules information={data.information} />
       </Tab.Panel>
       <Tab.Panel id="scratchpad" context={TabsContext}>
         <Scratchpad
@@ -47,14 +48,13 @@ export function UtilityTabs({
         />
       </Tab.Panel>
       <Tab.Panel id="guidance" context={TabsContext}>
-        <div>Guidance is coming soon!</div>
-        {/* <Guidance
-          notes={notes}
-          mentorSolution={mentorSolution}
-          exemplarFiles={exemplarFiles}
-          language={track.highlightjsLanguage}
-          links={links}
-        /> */}
+        <Guidance
+          notes={''}
+          mentorSolution={data.mentorSolution}
+          exemplarFiles={data.guidance.exemplarFiles}
+          language={data.representation.track.highlightjsLanguage}
+          links={data.guidance.links}
+        />
       </Tab.Panel>
     </TabsContext.Provider>
   )

--- a/app/javascript/components/mentoring/session/Guidance.tsx
+++ b/app/javascript/components/mentoring/session/Guidance.tsx
@@ -28,7 +28,7 @@ const AccordionHeader = ({
   )
 }
 
-type Links = {
+export type Links = {
   improveNotes: string
 }
 

--- a/app/javascript/components/mentoring/session/Guidance.tsx
+++ b/app/javascript/components/mentoring/session/Guidance.tsx
@@ -3,11 +3,13 @@ import { Accordion } from '../../common/Accordion'
 import { MentorNotes } from './MentorNotes'
 import {
   CommunitySolution as CommunitySolutionProps,
+  GuidanceLinks,
   MentoringSessionExemplarFile,
 } from '../../types'
 import { CommunitySolution, GraphicalIcon } from '../../common'
 import { useHighlighting } from '../../../utils/highlight'
 import { ExemplarFilesList } from './guidance/ExemplarFilesList'
+import { SessionGuidance } from '../Session'
 
 const AccordionHeader = ({
   isOpen,
@@ -28,21 +30,17 @@ const AccordionHeader = ({
   )
 }
 
-export type Links = {
-  improveNotes: string
-}
-
 export type Props = {
-  notes: string
+  guidance: SessionGuidance
   mentorSolution?: CommunitySolutionProps
   exemplarFiles: readonly MentoringSessionExemplarFile[]
-  links: Links
+  links: GuidanceLinks
   language: string
   feedback?: any
 }
 
 export const Guidance = ({
-  notes,
+  guidance,
   mentorSolution,
   exemplarFiles,
   links,
@@ -56,7 +54,11 @@ export const Guidance = ({
       isOpen: exemplarFiles.length !== 0,
     },
     {
-      id: 'notes',
+      id: 'exercise-guidance',
+      isOpen: exemplarFiles.length === 0,
+    },
+    {
+      id: 'track-guidance',
       isOpen: exemplarFiles.length === 0,
     },
     {
@@ -120,10 +122,38 @@ export const Guidance = ({
           </Accordion.Panel>
         </Accordion>
       ) : null}
-      <Accordion id="notes" isOpen={isOpen('notes')} onClick={handleClick}>
-        <AccordionHeader isOpen={isOpen('notes')} title="Mentor notes" />
+      <Accordion
+        id="exercise-guidance"
+        isOpen={isOpen('exercise-guidance')}
+        onClick={handleClick}
+      >
+        <AccordionHeader
+          isOpen={isOpen('exercise-guidance')}
+          title="Exercise notes"
+        />
         <Accordion.Panel>
-          <MentorNotes notes={notes} improveUrl={links.improveNotes} />
+          <MentorNotes
+            notes={guidance.exercise}
+            guidanceType="exercise"
+            improveUrl={links.improveExerciseGuidance}
+          />
+        </Accordion.Panel>
+      </Accordion>
+      <Accordion
+        id="track-guidance"
+        isOpen={isOpen('track-guidance')}
+        onClick={handleClick}
+      >
+        <AccordionHeader
+          isOpen={isOpen('track-guidance')}
+          title="Track notes"
+        />
+        <Accordion.Panel>
+          <MentorNotes
+            notes={guidance.track}
+            guidanceType="track"
+            improveUrl={links.improveTrackGuidance}
+          />
         </Accordion.Panel>
       </Accordion>
       {mentorSolution ? (

--- a/app/javascript/components/mentoring/session/Guidance.tsx
+++ b/app/javascript/components/mentoring/session/Guidance.tsx
@@ -59,7 +59,7 @@ export const Guidance = ({
     },
     {
       id: 'track-guidance',
-      isOpen: exemplarFiles.length === 0,
+      isOpen: false,
     },
     {
       id: 'mentor-solution',

--- a/app/javascript/components/mentoring/session/MentorNotes.tsx
+++ b/app/javascript/components/mentoring/session/MentorNotes.tsx
@@ -3,9 +3,11 @@ import React from 'react'
 export const MentorNotes = ({
   notes,
   improveUrl,
+  guidanceType,
 }: {
   notes?: string
   improveUrl: string
+  guidanceType: 'track' | 'exercise' | 'representer'
 }): JSX.Element => {
   const prLink = (
     <a href={improveUrl} target="_blank" rel="noreferrer">
@@ -16,9 +18,9 @@ export const MentorNotes = ({
   if (!notes) {
     return (
       <p className="text-p-base">
-        This exercise doesn&apos;t have any mentoring notes yet. Mentoring notes
-        are written by our community. Please help get them started for this
-        exercise by sending a {prLink}.
+        This {guidanceType} doesn&apos;t have any mentoring notes yet. Mentoring
+        notes are written by our community. Please help get them started for
+        this exercise by sending a {prLink}.
       </p>
     )
   }

--- a/app/javascript/components/mentoring/session/Scratchpad.tsx
+++ b/app/javascript/components/mentoring/session/Scratchpad.tsx
@@ -12,6 +12,8 @@ import {
 import {
   MentorSessionTrack as Track,
   MentorSessionExercise as Exercise,
+  RepresentationTrack,
+  RepresentationExercise,
 } from '../../types'
 import { Scratchpad as ScratchpadProps } from '../Session'
 import { useMutation } from 'react-query'
@@ -26,8 +28,8 @@ export const Scratchpad = ({
   exercise,
 }: {
   scratchpad: ScratchpadProps
-  track: Track
-  exercise: Exercise
+  track: Track | RepresentationTrack
+  exercise: Exercise | RepresentationExercise
 }): JSX.Element => {
   const [content, setContent] = useState('')
   const [error, setError] = useState('')

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -476,18 +476,16 @@ export type CompleteRepresentationData = {
   mentor: Pick<User, 'avatarUrl' | 'handle'> & { name: string }
   mentorSolution: CommunitySolution
   links: { back: string; success: string }
-  information: {
-    representationsHtml?: string
-    trackMentoringNotesHtml?: string
-    exerciseMentoringNotesHtml?: string
-  }
-  guidance: {
-    exercise: any
-    track: any
-    exemplarFiles: any
-    links: GuidanceLinks
-  }
+  guidance: Guidance
   scratchpad: Scratchpad
+}
+
+export type Guidance = {
+  representationsHtml: string
+  exercise: string
+  track: string
+  exemplarFiles: MentoringSessionExemplarFile[]
+  links: GuidanceLinks
 }
 
 export type Contributor = {

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -2,7 +2,6 @@ import { Props as ConceptWidgetProps } from './common/ConceptWidget'
 import { Props as ExerciseWidgetProps } from './common/ExerciseWidget'
 import { DiscussionPostProps } from './mentoring/discussion/DiscussionPost'
 import { Scratchpad } from './mentoring/Session'
-import { Links as GuidanceLinks } from './mentoring/session/Guidance'
 
 export type Size = 'small' | 'large'
 
@@ -486,6 +485,12 @@ export type Guidance = {
   track: string
   exemplarFiles: MentoringSessionExemplarFile[]
   links: GuidanceLinks
+}
+
+export type GuidanceLinks = {
+  improveExerciseGuidance: string
+  improveTrackGuidance: string
+  improveRepresenterGuidance?: string
 }
 
 export type Contributor = {

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -1,6 +1,7 @@
 import { Props as ConceptWidgetProps } from './common/ConceptWidget'
 import { Props as ExerciseWidgetProps } from './common/ExerciseWidget'
 import { DiscussionPostProps } from './mentoring/discussion/DiscussionPost'
+import { Scratchpad } from './mentoring/Session'
 
 export type Size = 'small' | 'large'
 
@@ -435,10 +436,18 @@ export type MentoredTrack = {
   }
 }
 
+export type RepresentationExercise = Pick<
+  MentorSessionExercise,
+  'title' | 'iconUrl'
+>
+export type RepresentationTrack = Pick<
+  MentorSessionTrack,
+  'title' | 'iconUrl' | 'highlightjsLanguage'
+>
 export type Representation = {
   id: number
-  exercise: { title: string; iconUrl: string }
-  track: { title: string; iconUrl: string; highlightjsLanguage:string }
+  exercise: RepresentationExercise
+  track: RepresentationTrack
   numSubmissions: number
   feedbackHtml: string
   feedbackType: RepresentationFeedbackType | null
@@ -470,6 +479,7 @@ export type CompleteRepresentationData = {
     trackMentoringNotesHtml?: string
     exerciseMentoringNotesHtml?: string
   }
+  scratchpad: Scratchpad
 }
 
 export type Contributor = {

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -2,6 +2,7 @@ import { Props as ConceptWidgetProps } from './common/ConceptWidget'
 import { Props as ExerciseWidgetProps } from './common/ExerciseWidget'
 import { DiscussionPostProps } from './mentoring/discussion/DiscussionPost'
 import { Scratchpad } from './mentoring/Session'
+import { Links as GuidanceLinks } from './mentoring/session/Guidance'
 
 export type Size = 'small' | 'large'
 
@@ -473,11 +474,18 @@ export type CompleteRepresentationData = {
   representation: RepresentationData
   examples: Pick<RepresentationData, 'files' | 'instructions' | 'tests'>[]
   mentor: Pick<User, 'avatarUrl' | 'handle'> & { name: string }
+  mentorSolution: CommunitySolution
   links: { back: string; success: string }
-  guidance: {
+  information: {
     representationsHtml?: string
     trackMentoringNotesHtml?: string
     exerciseMentoringNotesHtml?: string
+  }
+  guidance: {
+    exercise: any
+    track: any
+    exemplarFiles: any
+    links: GuidanceLinks
   }
   scratchpad: Scratchpad
 }

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -481,7 +481,7 @@ export type CompleteRepresentationData = {
 }
 
 export type Guidance = {
-  representationsHtml: string
+  representations: string
   exercise: string
   track: string
   exemplarFiles: MentoringSessionExemplarFile[]

--- a/app/javascript/packs/internal.tsx
+++ b/app/javascript/packs/internal.tsx
@@ -24,6 +24,7 @@ import {
   MentoringSessionExemplarFile,
   SharePlatform,
   CompleteRepresentationData,
+  Guidance,
   // TrackContribution,
 } from '../components/types'
 
@@ -152,7 +153,9 @@ initReact({
       links={camelizeKeysAs<MentoringSessionLinks>(data.links)}
       request={camelizeKeysAs<MentorSessionRequest>(data.request)}
       scratchpad={camelizeKeysAs<MentoringSessionScratchpad>(data.scratchpad)}
-      notes={data.notes}
+      guidance={camelizeKeysAs<Pick<Guidance, 'exercise' | 'track'>>(
+        data.guidance
+      )}
       outOfDate={data.out_of_date}
       downloadCommand={data.download_command}
     />

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -27,7 +27,7 @@ class Track < ApplicationRecord
   delegate :head_sha, to: :git, prefix: :git
   delegate :representations, to: :git, prefix: :mentoring
   delegate :debugging_instructions, :representer_normalizations, to: :git
-  delegate :content, to: :mentoring_notes, prefix: :mentoring_notes
+  delegate :content, :edit_url, to: :mentoring_notes, prefix: :mentoring_notes
 
   def self.for!(param)
     return param if param.is_a?(Track)

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -6,7 +6,14 @@ module User::Roles
 
   def supermentor?
     # TODO: enable once we're ready for supermentors
-    return [38_366, 56_500, 76_721, 88_486, 91_576, 757_288].include?(id) if Rails.env.production?
+    # rubocop:disable Style/IfUnlessModifier
+    # rubocop:disable Style/NumericLiterals
+    if Rails.env.production?
+      return [38366, 56500, 76721, 88486, 91576, 757288].include?(id)
+    end
+    # rubocop:enable Style/IfUnlessModifier
+
+    # rubocop:enable Style/NumericLiterals
 
     roles.include?(:supermentor)
   end

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -6,11 +6,14 @@ module User::Roles
 
   def supermentor?
     # TODO: enable once we're ready for supermentors
-    # rubocop:disable Style/IfUnlessModifier Style/NumericLiterals
+    # rubocop:disable Style/IfUnlessModifier
+    # rubocop:disable Style/NumericLiterals
     if Rails.env.production?
-      return [38_366, 56_500, 76_721, 88_486, 91_576, 757_288].include?(id)
+      return [38366, 56500, 76721, 88486, 91576, 757288].include?(id)
     end
-    # rubocop:enable Style/IfUnlessModifier Style/NumericLiterals
+    # rubocop:enable Style/IfUnlessModifier
+
+    # rubocop:enable Style/NumericLiterals
 
     roles.include?(:supermentor)
   end

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -6,7 +6,7 @@ module User::Roles
 
   def supermentor?
     # TODO: enable once we're ready for supermentors
-    return false if Rails.env.production?
+    return [38_366, 56_500, 76_721, 88_486, 91_576, 757_288].include?(id) if Rails.env.production?
 
     roles.include?(:supermentor)
   end

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -6,14 +6,11 @@ module User::Roles
 
   def supermentor?
     # TODO: enable once we're ready for supermentors
-    # rubocop:disable Style/IfUnlessModifier
-    # rubocop:disable Style/NumericLiterals
+    # rubocop:disable Style/IfUnlessModifier Style/NumericLiterals
     if Rails.env.production?
-      return [38366, 56500, 76721, 88486, 91576, 757288].include?(id)
+      return [38_366, 56_500, 76_721, 88_486, 91_576, 757_288].include?(id)
     end
-    # rubocop:enable Style/IfUnlessModifier
-
-    # rubocop:enable Style/NumericLiterals
+    # rubocop:enable Style/IfUnlessModifier Style/NumericLiterals
 
     roles.include?(:supermentor)
   end

--- a/test/helpers/react_components/mentoring/session_test.rb
+++ b/test/helpers/react_components/mentoring/session_test.rb
@@ -42,8 +42,10 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         student: SerializeStudent.(student, mentor, relationship: nil, anonymous_mode: false, user_track:),
         mentor_solution: nil,
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
-        notes: "<p>These are notes for lasagna.</p>\n",
-        track_notes: "<p>Use Ruby wisely</p>\n",
+        guidance: {
+          exercise: "<p>These are notes for lasagna.</p>\n",
+          track: "<p>Use Ruby wisely</p>\n"
+        },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,
         scratchpad: {
@@ -115,8 +117,10 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
             content: exercise.exemplar_files.values.first
           }
         ],
-        notes: "<p>These are notes for lasagna.</p>\n",
-        track_notes: "<p>Use Ruby wisely</p>\n",
+        guidance: {
+          exercise: "<p>These are notes for lasagna.</p>\n",
+          track: "<p>Use Ruby wisely</p>\n"
+        },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,
         scratchpad: {
@@ -180,8 +184,10 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         student: SerializeStudent.(student, mentor, relationship: nil, anonymous_mode: false, user_track:),
         mentor_solution: nil,
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
-        notes: "<p>These are notes for lasagna.</p>\n",
-        track_notes: "<p>Use Ruby wisely</p>\n",
+        guidance: {
+          exercise: "<p>These are notes for lasagna.</p>\n",
+          track: "<p>Use Ruby wisely</p>\n"
+        },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,
         scratchpad: {

--- a/test/helpers/react_components/mentoring/session_test.rb
+++ b/test/helpers/react_components/mentoring/session_test.rb
@@ -44,7 +44,11 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
         guidance: {
           exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n"
+          track: "<p>Use Ruby wisely</p>\n",
+          links: {
+            improve_exercise_guidance: exercise.mentoring_notes_edit_url,
+            improve_track_guidance: track.mentoring_notes_edit_url
+          }
         },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,
@@ -119,7 +123,11 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         ],
         guidance: {
           exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n"
+          track: "<p>Use Ruby wisely</p>\n",
+          links: {
+            improve_exercise_guidance: exercise.mentoring_notes_edit_url,
+            improve_track_guidance: track.mentoring_notes_edit_url
+          }
         },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,
@@ -186,7 +194,11 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
         guidance: {
           exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n"
+          track: "<p>Use Ruby wisely</p>\n",
+          links: {
+            improve_exercise_guidance: exercise.mentoring_notes_edit_url,
+            improve_track_guidance: track.mentoring_notes_edit_url
+          }
         },
         out_of_date: false,
         download_command: solution.mentor_download_cmd,

--- a/test/helpers/react_components/mentoring/session_test.rb
+++ b/test/helpers/react_components/mentoring/session_test.rb
@@ -43,8 +43,8 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         mentor_solution: nil,
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
         guidance: {
-          exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n",
+          exercise: exercise.mentoring_notes_content,
+          track: track.mentoring_notes_content,
           links: {
             improve_exercise_guidance: exercise.mentoring_notes_edit_url,
             improve_track_guidance: track.mentoring_notes_edit_url
@@ -63,7 +63,6 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         links: {
           mentor_dashboard: Exercism::Routes.mentoring_inbox_path,
           exercise: Exercism::Routes.track_exercise_path(track, exercise),
-          improve_notes: exercise.mentoring_notes_edit_url,
           mentoring_docs: Exercism::Routes.docs_section_path(:mentoring)
         }
       }
@@ -122,8 +121,8 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
           }
         ],
         guidance: {
-          exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n",
+          exercise: exercise.mentoring_notes_content,
+          track: track.mentoring_notes_content,
           links: {
             improve_exercise_guidance: exercise.mentoring_notes_edit_url,
             improve_track_guidance: track.mentoring_notes_edit_url
@@ -142,7 +141,6 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         links: {
           mentor_dashboard: Exercism::Routes.mentoring_inbox_path,
           exercise: Exercism::Routes.track_exercise_path(track, exercise),
-          improve_notes: exercise.mentoring_notes_edit_url,
           mentoring_docs: Exercism::Routes.docs_section_path(:mentoring)
         }
       }
@@ -193,8 +191,8 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         mentor_solution: nil,
         exemplar_files: Session::SerializeExemplarFiles.(exercise.exemplar_files),
         guidance: {
-          exercise: "<p>These are notes for lasagna.</p>\n",
-          track: "<p>Use Ruby wisely</p>\n",
+          exercise: exercise.mentoring_notes_content,
+          track: track.mentoring_notes_content,
           links: {
             improve_exercise_guidance: exercise.mentoring_notes_edit_url,
             improve_track_guidance: track.mentoring_notes_edit_url
@@ -213,7 +211,6 @@ class ReactComponents::Mentoring::SessionTest < ReactComponentTestCase
         links: {
           mentor_dashboard: Exercism::Routes.mentoring_inbox_path,
           exercise: Exercism::Routes.track_exercise_path(track, exercise),
-          improve_notes: exercise.mentoring_notes_edit_url,
           mentoring_docs: Exercism::Routes.docs_section_path(:mentoring)
         }
       }

--- a/test/javascript/components/mentoring/Session.test.jsx
+++ b/test/javascript/components/mentoring/Session.test.jsx
@@ -20,6 +20,10 @@ import { expectConsoleError } from '../../support/silence-console'
 stubRange()
 stubIntersectionObserver()
 
+const guidance = {
+  exercise: '<p>These are notes for lasagna.</p>\n',
+}
+
 test('highlights currently selected iteration', async () => {
   const scratchpad = {
     links: {
@@ -73,6 +77,7 @@ test('highlights currently selected iteration', async () => {
         discussion={discussion}
         exemplarFiles={[]}
         links={{}}
+        guidance={guidance}
       />
     )
     userEvent.click(screen.getByRole('button', { name: 'Go to iteration 1' }))
@@ -136,6 +141,7 @@ test('shows back button', async () => {
       discussion={discussion}
       scratchpad={scratchpad}
       exemplarFiles={[]}
+      guidance={guidance}
     />
   )
   queryCache.cancelQueries()
@@ -203,6 +209,7 @@ test('hides latest label if on old iteration', async () => {
       discussion={discussion}
       scratchpad={scratchpad}
       exemplarFiles={[]}
+      guidance={guidance}
     />
   )
   await awaitPopper()
@@ -272,6 +279,7 @@ test('switches to posts tab when comment success', async () => {
       discussion={discussion}
       scratchpad={scratchpad}
       exemplarFiles={[]}
+      guidance={guidance}
     />
   )
 
@@ -351,6 +359,7 @@ test('switches tabs', async () => {
       discussion={discussion}
       scratchpad={scratchpad}
       exemplarFiles={[]}
+      guidance={guidance}
     />
   )
   userEvent.click(screen.getByRole('tab', { name: 'Scratchpad' }))
@@ -426,6 +435,7 @@ test('go to previous iteration', async () => {
         discussion={discussion}
         scratchpad={scratchpad}
         exemplarFiles={[]}
+        guidance={guidance}
       />
     )
   })
@@ -497,6 +507,7 @@ test('go to next iteration', async () => {
       discussion={discussion}
       scratchpad={scratchpad}
       exemplarFiles={[]}
+      guidance={guidance}
     />
   )
   userEvent.click(screen.getByRole('button', { name: 'Go to iteration 1' }))

--- a/test/javascript/components/mentoring/Session.test.jsx
+++ b/test/javascript/components/mentoring/Session.test.jsx
@@ -22,6 +22,11 @@ stubIntersectionObserver()
 
 const guidance = {
   exercise: '<p>These are notes for lasagna.</p>\n',
+  links: {
+    improveExerciseGuidance: 'https://exercism.org',
+    improveTrackGuidance: 'https://exercism.org',
+    improveRepresenterGuidance: 'https://exercism.org',
+  },
 }
 
 test('highlights currently selected iteration', async () => {

--- a/test/javascript/components/mentoring/session/Guidance.test.tsx
+++ b/test/javascript/components/mentoring/session/Guidance.test.tsx
@@ -7,10 +7,14 @@ import {
   Props,
 } from '../../../../../app/javascript/components/mentoring/session/Guidance'
 import { build } from '@jackfranklin/test-data-bot'
+import { SessionGuidance } from '../../../../../app/javascript/components/mentoring/Session'
 
 const buildProps = build<Props>({
   fields: {
-    notes: '<h1>Notes</h1>',
+    guidance: {
+      exercise: 'Helpful notes for a good lasagna',
+      track: 'Guidance for good Ruby mentoring',
+    },
     exemplarFiles: [],
     language: 'ruby',
     links: {},
@@ -20,10 +24,9 @@ const buildProps = build<Props>({
 test('how you solved the exercise is open by default', async () => {
   render(<Guidance {...buildProps()} feedback={{}} />)
 
-  expect(screen.getByRole('button', { name: 'Mentor notes' })).toHaveAttribute(
-    'aria-expanded',
-    'true'
-  )
+  expect(
+    screen.getByRole('button', { name: 'Exercise notes' })
+  ).toHaveAttribute('aria-expanded', 'true')
   expect(
     screen.getByRole('button', { name: 'Automated feedback' })
   ).toHaveAttribute('aria-expanded', 'false')
@@ -32,10 +35,10 @@ test('how you solved the exercise is open by default', async () => {
 test('open and close same accordion', async () => {
   render(<Guidance {...buildProps()} />)
 
-  userEvent.click(screen.getByRole('button', { name: 'Mentor notes' }))
+  userEvent.click(screen.getByRole('button', { name: 'Track notes' }))
 
   expect(
-    await screen.findByRole('button', { name: 'Mentor notes' })
+    await screen.findByRole('button', { name: 'Track notes' })
   ).toHaveAttribute('aria-expanded', 'false')
 })
 
@@ -44,25 +47,32 @@ test('only one accordion is open at a time', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Automated feedback' }))
 
-  expect(screen.getByRole('button', { name: 'Mentor notes' })).toHaveAttribute(
-    'aria-expanded',
-    'false'
-  )
+  expect(
+    screen.getByRole('button', { name: 'Exercise notes' })
+  ).toHaveAttribute('aria-expanded', 'false')
   expect(
     screen.getByRole('button', { name: 'Automated feedback' })
   ).toHaveAttribute('aria-expanded', 'true')
 })
 
 test('displays notes', async () => {
-  const notes = '<h2>Notes</h2>'
-  render(<Guidance {...buildProps()} notes={notes} />)
+  const guidance: SessionGuidance = {
+    exercise: '<h2>Notes</h2>',
+    track: '',
+    links: { improveExerciseGuidance: '', improveTrackGuidance: '' },
+  }
+  render(<Guidance {...buildProps()} guidance={guidance} />)
 
   expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument()
 })
 
 test('hides how you solved the solution if mentor solution is null', async () => {
-  const notes = '<h2>Notes</h2>'
-  render(<Guidance {...buildProps()} notes={notes} />)
+  const guidance: SessionGuidance = {
+    exercise: '<h2>Notes</h2>',
+    track: '',
+    links: { improveExerciseGuidance: '', improveTrackGuidance: '' },
+  }
+  render(<Guidance {...buildProps()} guidance={guidance} />)
 
   expect(
     screen.queryByRole('button', { name: 'How you solved the exercise' })

--- a/test/javascript/components/mentoring/session/Guidance.test.tsx
+++ b/test/javascript/components/mentoring/session/Guidance.test.tsx
@@ -35,10 +35,10 @@ test('how you solved the exercise is open by default', async () => {
 test('open and close same accordion', async () => {
   render(<Guidance {...buildProps()} />)
 
-  userEvent.click(screen.getByRole('button', { name: 'Track notes' }))
+  userEvent.click(screen.getByRole('button', { name: 'Exercise notes' }))
 
   expect(
-    await screen.findByRole('button', { name: 'Track notes' })
+    await screen.findByRole('button', { name: 'Exercise notes' })
   ).toHaveAttribute('aria-expanded', 'false')
 })
 

--- a/test/javascript/components/mentoring/session/MentorNotes.test.jsx
+++ b/test/javascript/components/mentoring/session/MentorNotes.test.jsx
@@ -4,7 +4,12 @@ import '@testing-library/jest-dom/extend-expect'
 import { MentorNotes } from '../../../../../app/javascript/components/mentoring/session/MentorNotes'
 
 test('shows CTA to contribute notes when notes isnt present', async () => {
-  render(<MentorNotes improveUrl="https://exercism.org/notes" />)
+  render(
+    <MentorNotes
+      improveUrl="https://exercism.org/notes"
+      guidanceType="exercise"
+    />
+  )
 
   expect(
     screen.getByText(/This exercise doesn't have any mentoring notes yet/)
@@ -19,6 +24,7 @@ test('shows CTA to improve notes when notes is present', async () => {
   render(
     <MentorNotes
       notes="<p>Mentor notes here</p>"
+      guidanceType="exercise"
       improveUrl="https://exercism.org/notes"
     />
   )

--- a/test/system/components/mentoring/discussion_test.rb
+++ b/test/system/components/mentoring/discussion_test.rb
@@ -473,8 +473,6 @@ module Components
           click_on "Exercise notes"
           assert_text "These are notes for lasagna"
           assert_link "Pull Request on GitHub", href: exercise.mentoring_notes_edit_url
-          click_on "Track notes"
-          assert_link "Pull Request on GitHub", href: exercise.mentoring_notes_edit_url
         end
       end
 

--- a/test/system/components/mentoring/discussion_test.rb
+++ b/test/system/components/mentoring/discussion_test.rb
@@ -453,7 +453,7 @@ module Components
         assert_no_text "Remove from Inbox"
       end
 
-      test "mentor sees mentor notes" do
+      test "mentor sees exercise guidance" do
         TestHelpers.use_website_copy_test_repo!
 
         mentor = create :user, handle: "author"
@@ -470,8 +470,10 @@ module Components
           sign_in!(mentor)
           visit mentoring_discussion_path(discussion)
           click_on "Guidance"
-          click_on "Mentor notes"
+          click_on "Exercise notes"
           assert_text "These are notes for lasagna"
+          assert_link "Pull Request on GitHub", href: exercise.mentoring_notes_edit_url
+          click_on "Track notes"
           assert_link "Pull Request on GitHub", href: exercise.mentoring_notes_edit_url
         end
       end


### PR DESCRIPTION
@dem4ron This:
- Adds the scratchpad to the representation JSON
- Unifies it's format with that of the existing mentoring UI (by changing both). 

You'll need to make changes to the work you've already done for the automation UI and also change the mentoring UI. The tests will also need updating, which you might like to try and do, or ask me to do (or pair with me on).

You can build on this branch, or you can cherry pick the commit onto your branch (Go to your branch and do `git fetch && git cherry-pick a955b32a04739df2b8a8530fa169dc11030fc1c9`)