### PR TITLE
Fix test summary overflow bug

### DIFF
--- a/app/css/components/test-run.css
+++ b/app/css/components/test-run.css
@@ -200,6 +200,7 @@
             & .--summary-inner {
                 @apply flex items-center;
                 @apply py-10 px-24;
+                @apply overflow-y-scroll;
             }
 
             & .--status {
@@ -231,7 +232,7 @@
                     @apply font-bold text-darkGray uppercase leading-huge mb-8;
                 }
                 & pre {
-                    @apply bg-backgroundColorB py-16 px-20 whitespace-pre-wrap rounded-8;
+                    @apply bg-backgroundColorB py-16 px-20 whitespace-pre-wrap overflow-y-auto rounded-8;
                 }
             }
         }

--- a/app/css/components/test-run.css
+++ b/app/css/components/test-run.css
@@ -200,7 +200,6 @@
             & .--summary-inner {
                 @apply flex items-center;
                 @apply py-10 px-24;
-                @apply overflow-y-scroll;
             }
 
             & .--status {


### PR DESCRIPTION
Will resolve this issue: https://github.com/exercism/exercism/issues/6544

## Parts of the problem:

<img width="720" alt="Screenshot 2022-09-15 at 12 38 17" src="https://user-images.githubusercontent.com/66035744/190425200-17488326-9084-45f2-a486-02e84e2333a1.png">

![Screenshot 2022-09-15 at 15 47 54](https://user-images.githubusercontent.com/66035744/190425231-d4fb75ee-b62a-417d-8ae0-d520bdc9ee4e.png)

### One possible solution:
![Screenshot 2022-09-15 at 15 49 00](https://user-images.githubusercontent.com/66035744/190425390-fb665360-f699-4cda-9963-2c7c74e7d5b1.png)

I think this one looks fine for the body of test summary.

#### Apply scroll to title too?

![Screenshot 2022-09-15 at 16 03 29](https://user-images.githubusercontent.com/66035744/190425410-70a159c9-33f2-43bd-afaf-27fddfe66c20.png)

But these have too many scrollbars. Maybe a responsive UI would be good here. But still what happens when there is a sentence_written_with_underscores_and_digested_as_one_word. Ellipsis is a solution