### PR TITLE
Link completed concepts to concept description

### DIFF
--- a/app/css/pages/exercise-show.css
+++ b/app/css/pages/exercise-show.css
@@ -38,6 +38,9 @@
 
         & .progressed-concepts {
             @apply mb-16;
+            & .c-react-wrapper-student-exercise-status-dot {
+                @apply ml-8;
+            }
         }
         & .c-prominent-link {
             @apply mb-24;

--- a/app/javascript/components/modals/complete-exercise-modal/ExerciseCompletedModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/ExerciseCompletedModal.tsx
@@ -95,8 +95,8 @@ export const ExerciseCompletedModal = ({
           </>
         ) : (
           <div className="info">
-            Once you've practiced some more {track.title}, come back to this
-            exercise and see if you can make it even better.
+            Once youv&apos;e practiced some more {track.title}, come back to
+            this exercise and see if you can make it even better.
           </div>
         )}
 
@@ -115,7 +115,7 @@ export const ExerciseCompletedModal = ({
       cover={true}
       open={open}
       className="m-completed-exercise c-completed-exercise-progress"
-      onClose={() => {}}
+      onClose={() => null}
       {...props}
     >
       <>

--- a/app/javascript/components/modals/complete-exercise-modal/ExerciseCompletedModal.tsx
+++ b/app/javascript/components/modals/complete-exercise-modal/ExerciseCompletedModal.tsx
@@ -95,7 +95,7 @@ export const ExerciseCompletedModal = ({
           </>
         ) : (
           <div className="info">
-            Once youv&apos;e practiced some more {track.title}, come back to
+            Once you&apos;ve practiced some more {track.title}, come back to
             this exercise and see if you can make it even better.
           </div>
         )}

--- a/app/views/tracks/exercises/show/_concepts_section.html.haml
+++ b/app/views/tracks/exercises/show/_concepts_section.html.haml
@@ -4,14 +4,15 @@
   %h2 You’ve learnt #{pluralize exercise.taught_concepts.size, 'concept'} by completing this exercise.
   .progressed-concepts
     - exercise.taught_concepts.includes(:concept_exercises, :practice_exercises).each do |concept|
-      .concept
-        = render ViewComponents::ConceptIcon.new(concept, :medium)
-        .name= concept.name
-        .exercises
-          - user_track.concept_exercises_for_concept(concept).each do |exercise|
-            = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
-          - user_track.practice_exercises_for_concept(concept).each do |exercise|
-            = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
+      = link_to(Exercism::Routes.track_concept_path(track, concept)) do
+        .concept
+          = render ViewComponents::ConceptIcon.new(concept, :medium)
+          .name= concept.name
+          .exercises
+            - user_track.concept_exercises_for_concept(concept).each do |exercise|
+              = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
+            - user_track.practice_exercises_for_concept(concept).each do |exercise|
+              = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
 
   = render ViewComponents::ProminentLink.new("See how your concept map has changed", track_concepts_path(track), with_bg: true)
 

--- a/app/views/tracks/exercises/show/_concepts_section.html.haml
+++ b/app/views/tracks/exercises/show/_concepts_section.html.haml
@@ -4,15 +4,14 @@
   %h2 You’ve learnt #{pluralize exercise.taught_concepts.size, 'concept'} by completing this exercise.
   .progressed-concepts
     - exercise.taught_concepts.includes(:concept_exercises, :practice_exercises).each do |concept|
-      = link_to(Exercism::Routes.track_concept_path(track, concept)) do
-        .concept
-          = render ViewComponents::ConceptIcon.new(concept, :medium)
-          .name= concept.name
-          .exercises
-            - user_track.concept_exercises_for_concept(concept).each do |exercise|
-              = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
-            - user_track.practice_exercises_for_concept(concept).each do |exercise|
-              = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
+      = link_to(Exercism::Routes.track_concept_path(track, concept), class: 'concept') do
+        = render ViewComponents::ConceptIcon.new(concept, :medium)
+        .name= concept.name
+        .exercises
+          - user_track.concept_exercises_for_concept(concept).each do |exercise|
+            = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
+          - user_track.practice_exercises_for_concept(concept).each do |exercise|
+            = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)
 
   = render ViewComponents::ProminentLink.new("See how your concept map has changed", track_concepts_path(track), with_bg: true)
 

--- a/app/views/tracks/exercises/show/_concepts_section.html.haml
+++ b/app/views/tracks/exercises/show/_concepts_section.html.haml
@@ -4,9 +4,10 @@
   %h2 You’ve learnt #{pluralize exercise.taught_concepts.size, 'concept'} by completing this exercise.
   .progressed-concepts
     - exercise.taught_concepts.includes(:concept_exercises, :practice_exercises).each do |concept|
-      = link_to(Exercism::Routes.track_concept_path(track, concept), class: 'concept') do
-        = render ViewComponents::ConceptIcon.new(concept, :medium)
-        .name= concept.name
+      .concept
+        = link_to Exercism::Routes.track_concept_path(track, concept), class: "flex items-center" do
+          = render ViewComponents::ConceptIcon.new(concept, :medium)
+          .name= concept.name
         .exercises
           - user_track.concept_exercises_for_concept(concept).each do |exercise|
             = ReactComponents::Student::ExerciseStatusDot.new(exercise, user_track)


### PR DESCRIPTION
Will resolve this issue: https://github.com/exercism/exercism/issues/6548

@iHiD, this is not really related to this PR, but I wonder if there should be a gap between exercise dots.

<img width="1512" alt="Screenshot 2022-09-20 at 11 50 09" src="https://user-images.githubusercontent.com/66035744/191232045-ac34c7f2-20bd-4fea-81d7-91a461846b0a.png">

<img width="1512" alt="Screenshot 2022-09-20 at 11 58 07" src="https://user-images.githubusercontent.com/66035744/191232205-4a95833b-b345-4301-b755-4dbed3ca70ea.png">
