### PR TITLE
Fix refreshing bug on Representation-tables

### DIFF
--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -92,7 +92,7 @@ export function useAutomation(
 
   const { status, resolvedData, latestData, isFetching } =
     usePaginatedRequestQuery<APIResponse>(
-      ['mentor-representations-list', request.endpoint, request.query],
+      ['mentor-representations-list', request],
       request
     )
 
@@ -124,7 +124,7 @@ export function useAutomation(
 
   // Automatically set a selected track based on query or the lack of it
   useEffect(() => {
-    // don't repeat 'find' on track change, only when page loads
+    // don't repeat `find` on track change, only when page loads
     if (tracks.length > 0 && selectedTrack === initialTrackData) {
       const foundTrack = tracks.find(
         (t: AutomationTrack) => t.slug == request.query.trackSlug


### PR DESCRIPTION
This PR takes care of these from this issue https://github.com/exercism/exercism/issues/6547:
- Fix bug that number of requests doesn't go down when representations have been provided.
- Fix this caching bug: https://www.loom.com/share/f50400a550484b2889693b911cdee80b?from_recorder=1&focus_title=1
