### PR TITLE
Persist filters on Representation table

### DIFF
--- a/app/javascript/components/common/SearchInput.tsx
+++ b/app/javascript/components/common/SearchInput.tsx
@@ -44,7 +44,9 @@ export function SearchInput({
         className={INPUT_CLASSNAMES}
         style={{ all: 'unset' }}
         value={filter}
-        onChange={(e) => setFilter(e.target.value)}
+        onChange={(e) => {
+          setFilter(e.target.value)
+        }}
         placeholder={placeholder}
       />
     </div>

--- a/app/javascript/components/mentoring/Sorter.tsx
+++ b/app/javascript/components/mentoring/Sorter.tsx
@@ -11,8 +11,10 @@ export const Sorter = ({
   order,
   sortOptions,
   componentClassName,
+  setPage,
 }: {
   setOrder: (order: string) => void
+  setPage: (page: number) => void
   order: string
   sortOptions: readonly SortOption[]
   componentClassName?: string
@@ -21,8 +23,9 @@ export const Sorter = ({
   const setValue = useCallback(
     (option) => {
       setOrder(option.value)
+      setPage(1)
     },
-    [setOrder]
+    [setOrder, setPage]
   )
 
   return (

--- a/app/javascript/components/mentoring/automation/Representation.tsx
+++ b/app/javascript/components/mentoring/automation/Representation.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { TrackFilterList } from './TrackFilterList'
 import { Request } from '../../../hooks/request-query'
 import { AutomationStatus } from '../../types'
@@ -11,6 +11,7 @@ import { RepresentationList } from './RepresentationList'
 import { SortOption } from '../Inbox'
 import { error } from 'jquery'
 import { useAutomation } from './useAutomation'
+import { useStoredRepresentationQueries } from '../../../hooks/use-stored-queries'
 
 export type AutomationLinks = {
   withFeedback?: string
@@ -61,6 +62,7 @@ export function Representations({
     trackListStatus,
     tracks,
     criteria,
+    parsedQueries,
   } = useAutomation(
     representationsRequest,
     representationsWithFeedbackCount,
@@ -82,7 +84,15 @@ export function Representations({
             currentStatus={withFeedback ? 'with_feedback' : 'without_feedback'}
             setStatus={() => null}
           >
-            <a href={links.withoutFeedback}>Need feedback</a>
+            <a
+              href={
+                links.withoutFeedback !== undefined
+                  ? links.withoutFeedback + '?' + parsedQueries
+                  : undefined
+              }
+            >
+              Need feedback
+            </a>
 
             {/* TODO: re-enable once we've fixed performance */}
             {/* {resolvedData ? (
@@ -94,7 +104,15 @@ export function Representations({
             currentStatus={withFeedback ? 'with_feedback' : 'without_feedback'}
             setStatus={() => null}
           >
-            <a href={links.withFeedback}>Feedback submitted</a>
+            <a
+              href={
+                links.withFeedback !== undefined
+                  ? links.withFeedback + '?' + parsedQueries
+                  : undefined
+              }
+            >
+              Feedback submitted
+            </a>
             {resolvedData ? (
               <div className="count">{feedbackCount['with_feedback']}</div>
             ) : null}

--- a/app/javascript/components/mentoring/automation/Representation.tsx
+++ b/app/javascript/components/mentoring/automation/Representation.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { TrackFilterList } from './TrackFilterList'
 import { Request } from '../../../hooks/request-query'
 import { AutomationStatus } from '../../types'
@@ -69,6 +69,15 @@ export function Representations({
     tracksRequest,
     trackCacheKey,
     withFeedback
+  )
+
+  const handlePageResetOnInputChange = useCallback(
+    (input: string) => {
+      if (input.length === 3 || (criteria && input.length < criteria.length)) {
+        setPage(1)
+      }
+    },
+    [criteria, setPage]
   )
 
   return (
@@ -144,7 +153,10 @@ export function Representations({
           <div className="flex flex-row flex-grow justify-between">
             <SearchInput
               className="mr-24"
-              setFilter={setCriteria}
+              setFilter={(input) => {
+                setCriteria(input)
+                handlePageResetOnInputChange(input)
+              }}
               filter={criteria}
               placeholder="Filter by exercise (min 3 chars)"
             />

--- a/app/javascript/components/mentoring/automation/Representation.tsx
+++ b/app/javascript/components/mentoring/automation/Representation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { TrackFilterList } from './TrackFilterList'
 import { Request } from '../../../hooks/request-query'
 import { AutomationStatus } from '../../types'
@@ -11,7 +11,6 @@ import { RepresentationList } from './RepresentationList'
 import { SortOption } from '../Inbox'
 import { error } from 'jquery'
 import { useAutomation } from './useAutomation'
-import { useStoredRepresentationQueries } from '../../../hooks/use-stored-queries'
 
 export type AutomationLinks = {
   withFeedback?: string
@@ -87,7 +86,7 @@ export function Representations({
             <a
               href={
                 links.withoutFeedback !== undefined
-                  ? links.withoutFeedback + '?' + parsedQueries
+                  ? links.withoutFeedback + '?' + parsedQueries.withoutFeedback
                   : undefined
               }
             >
@@ -107,7 +106,7 @@ export function Representations({
             <a
               href={
                 links.withFeedback !== undefined
-                  ? links.withFeedback + '?' + parsedQueries
+                  ? links.withFeedback + '?' + parsedQueries.withFeedback
                   : undefined
               }
             >

--- a/app/javascript/components/mentoring/automation/Representation.tsx
+++ b/app/javascript/components/mentoring/automation/Representation.tsx
@@ -153,6 +153,7 @@ export function Representations({
               sortOptions={sortOptions}
               order={order}
               setOrder={setOrder}
+              setPage={setPage}
             />
           </div>
         </header>

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -92,7 +92,7 @@ export function useAutomation(
 
   const { status, resolvedData, latestData, isFetching } =
     usePaginatedRequestQuery<APIResponse>(
-      ['mentor-representations-list', request.endpoint, request.query],
+      ['mentor-representations-list', request],
       request
     )
 
@@ -124,7 +124,7 @@ export function useAutomation(
 
   // Automatically set a selected track based on query or the lack of it
   useEffect(() => {
-    // don't repeat 'find' on track change, only when page loads
+    // don't repeat `find` on track change, only when page loads
     if (tracks.length > 0 && selectedTrack === initialTrackData) {
       const foundTrack = tracks.find(
         (t: AutomationTrack) => t.slug == request.query.trackSlug

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -127,12 +127,7 @@ export function useAutomation(
       setCriteria('')
       setSelectedTrack(track)
 
-      setQuery({ ...request.query, trackSlug: track.slug, page: undefined })
-      setLocalQueries({
-        ...request.query,
-        trackSlug: track.slug,
-        page: undefined,
-      })
+      setQuery({ ...request.query, trackSlug: track.slug, page: 1 })
     },
     [setPage, setQuery, request.query]
   )
@@ -170,9 +165,9 @@ export function useAutomation(
   useLogger('default query', { ...request.query })
 
   useEffect(() => {
-    setLocalQueries({ ...request.query })
+    setLocalQueries({ ...request.query, trackSlug: tracks.slug })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [request, withFeedback, tracks])
+  }, [request])
 
   // Get the proper count number of automation requests for tabs
   const getFeedbackCount = useCallback(

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -113,7 +113,6 @@ export function useAutomation(
     const handler = setTimeout(() => {
       if (criteria.length > 2 || criteria === '') {
         setRequestCriteria(criteria)
-        setPage(1)
       }
     }, 300)
 

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -6,7 +6,6 @@ import {
   useState,
 } from 'react'
 import { QueryStatus } from 'react-query'
-import { useLogger } from '../../../hooks'
 import { usePaginatedRequestQuery, Request } from '../../../hooks/request-query'
 import { useHistory, removeEmpty } from '../../../hooks/use-history'
 import { ListState, useList } from '../../../hooks/use-list'
@@ -70,7 +69,9 @@ export function useAutomation(
   cacheKey: string,
   withFeedback: boolean
 ): returnMentoringAutomation {
-  const [checked, setChecked] = useState(false)
+  const [checked, setChecked] = useState(
+    representationsRequest.query?.onlyMentoredSolutions
+  )
   const [criteria, setCriteria] = useState(
     representationsRequest.query?.criteria || ''
   )
@@ -95,7 +96,7 @@ export function useAutomation(
 
   const { parsedQueries, setLocalQueries } = useStoredRepresentationQueries(
     withFeedback,
-    { ...request.query }
+    { criteria: '', page: 1 }
   )
   const [selectedTrack, setSelectedTrack] =
     useState<AutomationTrack>(initialTrackData)
@@ -128,8 +129,9 @@ export function useAutomation(
       setSelectedTrack(track)
 
       setQuery({ ...request.query, trackSlug: track.slug, page: 1 })
+      setLocalQueries({ ...request.query, trackSlug: track.slug })
     },
-    [setPage, setQuery, request.query]
+    [setPage, setQuery, request.query, setLocalQueries]
   )
 
   // Automatically set a selected track based on query or the lack of it
@@ -157,17 +159,15 @@ export function useAutomation(
       }
       setQuery(queryObject)
       setPage(1)
-      setChecked((checked) => !checked)
+      setChecked((checked: boolean) => !checked)
     },
     [request.query, setPage, setQuery]
   )
 
-  useLogger('default query', { ...request.query })
-
   useEffect(() => {
-    setLocalQueries({ ...request.query, trackSlug: tracks.slug })
+    setLocalQueries({ ...request.query })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [request])
+  }, [request, tracks])
 
   // Get the proper count number of automation requests for tabs
   const getFeedbackCount = useCallback(

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -96,7 +96,7 @@ export function useAutomation(
 
   const { parsedQueries, setLocalQueries } = useStoredRepresentationQueries(
     withFeedback,
-    { criteria: '', page: 1 }
+    { page: 1 }
   )
   const [selectedTrack, setSelectedTrack] =
     useState<AutomationTrack>(initialTrackData)
@@ -164,7 +164,7 @@ export function useAutomation(
   )
 
   useEffect(() => {
-    setLocalQueries({ ...request.query })
+    setLocalQueries(removeEmpty(request.query))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [request, tracks])
 

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -108,17 +108,19 @@ export function useAutomation(
     )
 
   // TODO: refactor this and probably all query with the debounce hook
+
   useEffect(() => {
     const handler = setTimeout(() => {
       if (criteria.length > 2 || criteria === '') {
         setRequestCriteria(criteria)
+        setPage(1)
       }
     }, 300)
 
     return () => {
       clearTimeout(handler)
     }
-  }, [setRequestCriteria, criteria])
+  }, [setRequestCriteria, criteria, setPage])
 
   useHistory({ pushOn: removeEmpty(request.query) })
 
@@ -167,10 +169,6 @@ export function useAutomation(
     setLocalQueries(removeEmpty(request.query))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [request, tracks])
-
-  useEffect(() => {
-    setPage(1)
-  }, [request.query.criteria, request.query.order, setPage])
 
   // Get the proper count number of automation requests for tabs
   const getFeedbackCount = useCallback(

--- a/app/javascript/components/mentoring/automation/useAutomation.tsx
+++ b/app/javascript/components/mentoring/automation/useAutomation.tsx
@@ -129,9 +129,8 @@ export function useAutomation(
       setSelectedTrack(track)
 
       setQuery({ ...request.query, trackSlug: track.slug, page: 1 })
-      setLocalQueries({ ...request.query, trackSlug: track.slug })
     },
-    [setPage, setQuery, request.query, setLocalQueries]
+    [setPage, setQuery, request.query]
   )
 
   // Automatically set a selected track based on query or the lack of it
@@ -164,17 +163,14 @@ export function useAutomation(
     [request.query, setPage, setQuery]
   )
 
-
   useEffect(() => {
     setLocalQueries({ ...request.query })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [request, tracks])
 
-
   useEffect(() => {
     setPage(1)
   }, [request.query.criteria, request.query.order, setPage])
-
 
   // Get the proper count number of automation requests for tabs
   const getFeedbackCount = useCallback(

--- a/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
+++ b/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
@@ -1,18 +1,52 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { CloseButton } from '../../session/CloseButton'
 import { IterationView } from './RepresentationIterationView'
 import RepresentationInfo from './RepresentationInfo'
 import { CompleteRepresentationData, RepresentationData } from '../../../types'
+import { useLogger } from '../../../../hooks'
+import { useLocalStorage } from '../../../../utils/use-storage'
+import { decamelize, decamelizeKeys } from 'humps'
 
 export type PanesProps = {
   representation: RepresentationData
 } & Pick<CompleteRepresentationData, 'links'>
 
 export function LeftPane({ representation, links }: PanesProps): JSX.Element {
+  const backlink = useMemo(() => {
+    const backLinkArray = links.back.split('/')
+    const withoutFeedback = backLinkArray[backLinkArray.length - 1]
+
+    const storedItem =
+      localStorage.getItem(
+        `representation-${
+          withoutFeedback === 'without_feedback'
+            ? 'without_feedback'
+            : 'with_feedback'
+        }-queries`
+      ) || ''
+
+    let parsed
+    try {
+      parsed = JSON.parse(storedItem)
+    } catch {
+      parsed = {}
+    }
+
+    const decamelized = decamelizeKeys(parsed)
+    const storedQuery = new URLSearchParams(
+      decamelized as unknown as URLSearchParams
+    )
+
+    console.log('STORED Q:', storedQuery)
+
+    return `${links.back}${
+      storedQuery.getAll.length > 0 ? `?${storedQuery}` : ''
+    }`
+  }, [links])
   return (
     <>
       <header className="discussion-header">
-        <CloseButton url={links.back} />
+        <CloseButton url={backlink} />
         <RepresentationInfo
           exercise={representation.exercise}
           track={representation.track}

--- a/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
+++ b/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
@@ -9,17 +9,20 @@ export type PanesProps = {
   representation: RepresentationData
 } & Pick<CompleteRepresentationData, 'links'>
 
+const INIT_DATA = {
+  page: 1,
+  criteria: '',
+}
+
 export function LeftPane({ representation, links }: PanesProps): JSX.Element {
-  const backLinkArray = links.back.split('/')
-  const withFeedback = backLinkArray.pop() === 'with_feedback'
-  const initData = {
-    page: 1,
-    criteria: '',
-    trackSlug: 'csharp',
-  }
+  const withFeedback = useMemo(() => {
+    const backLinkArray = links.back.split('/')
+    return backLinkArray.pop() === 'with_feedback'
+  }, [links])
+
   const { parsedQueries } = useStoredRepresentationQueries(
     withFeedback,
-    initData
+    INIT_DATA
   )
 
   const backlink = useMemo(() => {

--- a/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
+++ b/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
@@ -3,46 +3,40 @@ import { CloseButton } from '../../session/CloseButton'
 import { IterationView } from './RepresentationIterationView'
 import RepresentationInfo from './RepresentationInfo'
 import { CompleteRepresentationData, RepresentationData } from '../../../types'
-import { useLogger } from '../../../../hooks'
-import { useLocalStorage } from '../../../../utils/use-storage'
-import { decamelize, decamelizeKeys } from 'humps'
+import { useStoredRepresentationQueries } from '../../../../hooks/use-stored-queries'
 
 export type PanesProps = {
   representation: RepresentationData
 } & Pick<CompleteRepresentationData, 'links'>
 
 export function LeftPane({ representation, links }: PanesProps): JSX.Element {
+  const backLinkArray = links.back.split('/')
+  const withFeedback = backLinkArray.pop() === 'with_feedback'
+  const initData = {
+    page: 1,
+    criteria: '',
+    trackSlug: 'csharp',
+  }
+  const { parsedQueries } = useStoredRepresentationQueries(
+    withFeedback,
+    initData
+  )
+
   const backlink = useMemo(() => {
-    const backLinkArray = links.back.split('/')
-    const withoutFeedback = backLinkArray[backLinkArray.length - 1]
-
-    const storedItem =
-      localStorage.getItem(
-        `representation-${
-          withoutFeedback === 'without_feedback'
-            ? 'without_feedback'
-            : 'with_feedback'
-        }-queries`
-      ) || ''
-
-    let parsed
-    try {
-      parsed = JSON.parse(storedItem)
-    } catch {
-      parsed = {}
-    }
-
-    const decamelized = decamelizeKeys(parsed)
-    const storedQuery = new URLSearchParams(
-      decamelized as unknown as URLSearchParams
+    return (
+      links.back +
+      '?' +
+      (withFeedback
+        ? parsedQueries.withFeedback
+        : parsedQueries.withoutFeedback)
     )
+  }, [
+    links.back,
+    parsedQueries.withFeedback,
+    parsedQueries.withoutFeedback,
+    withFeedback,
+  ])
 
-    console.log('STORED Q:', storedQuery)
-
-    return `${links.back}${
-      storedQuery.getAll.length > 0 ? `?${storedQuery}` : ''
-    }`
-  }, [links])
   return (
     <>
       <header className="discussion-header">
@@ -56,3 +50,33 @@ export function LeftPane({ representation, links }: PanesProps): JSX.Element {
     </>
   )
 }
+
+// const backlink = useMemo(() => {
+//   const storedItem =
+//     localStorage.getItem(
+//       `representation-${
+//         withoutFeedback === 'without_feedback'
+//           ? 'without_feedback'
+//           : 'with_feedback'
+//       }-queries`
+//     ) || ''
+
+// let parsed
+// try {
+//   parsed = JSON.parse(storedItem)
+// } catch {
+//   parsed = {}
+// }
+
+// console.log("")
+// const decamelized = decamelizeKeys(parsed)
+// const storedQuery = new URLSearchParams(
+//   decamelized as unknown as URLSearchParams
+// )
+
+// console.log('STORED Q:', storedQuery)
+
+// return `${links.back}${
+//   storedQuery.getAll.length > 0 ? `?${storedQuery}` : ''
+// }`
+// }, [links])

--- a/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
+++ b/app/javascript/components/mentoring/representation/left-pane/LeftPane.tsx
@@ -53,33 +53,3 @@ export function LeftPane({ representation, links }: PanesProps): JSX.Element {
     </>
   )
 }
-
-// const backlink = useMemo(() => {
-//   const storedItem =
-//     localStorage.getItem(
-//       `representation-${
-//         withoutFeedback === 'without_feedback'
-//           ? 'without_feedback'
-//           : 'with_feedback'
-//       }-queries`
-//     ) || ''
-
-// let parsed
-// try {
-//   parsed = JSON.parse(storedItem)
-// } catch {
-//   parsed = {}
-// }
-
-// console.log("")
-// const decamelized = decamelizeKeys(parsed)
-// const storedQuery = new URLSearchParams(
-//   decamelized as unknown as URLSearchParams
-// )
-
-// console.log('STORED Q:', storedQuery)
-
-// return `${links.back}${
-//   storedQuery.getAll.length > 0 ? `?${storedQuery}` : ''
-// }`
-// }, [links])

--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -4,8 +4,6 @@ import { CompleteRepresentationData } from '../../../types'
 export default function AutomationRules({
   guidance,
 }: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
-  console.log(guidance)
-
   const prLink = (
     <a
       href={guidance.links.improveRepresenterGuidance}

--- a/app/javascript/hooks/use-list.ts
+++ b/app/javascript/hooks/use-list.ts
@@ -2,12 +2,14 @@ import { useReducer, useCallback, Reducer } from 'react'
 import { Request } from './request-query'
 
 export type ListState = Request & {
-  query: {
-    page: number
-    criteria?: string
-    tags?: string[]
-    trackSlug?: string
-  }
+  query: ListQuery
+}
+
+export type ListQuery = {
+  page: number
+  criteria?: string
+  tags?: string[]
+  trackSlug?: string
 }
 
 type ListAction =

--- a/app/javascript/hooks/use-stored-queries.tsx
+++ b/app/javascript/hooks/use-stored-queries.tsx
@@ -1,0 +1,43 @@
+import { useLocalStorage } from '../utils/use-storage'
+import { ListQuery } from './use-list'
+import { decamelizeKeys } from 'humps'
+
+export type RepresentationParsedQueries = {
+  withFeedback: string
+  withoutFeedback: string
+}
+
+export function useStoredRepresentationQueries(
+  withFeedback: boolean,
+  initData: ListQuery
+): {
+  parsedQueries: RepresentationParsedQueries
+  setLocalQueries: (value: ListQuery) => void
+} {
+  const [, setLocalQueries] = useLocalStorage(
+    withFeedback
+      ? 'representation-with_feedback-queries'
+      : 'representation-without_feedback-queries',
+    initData
+  )
+
+  const [withFeedbackQueries] = useLocalStorage(
+    'representation-with_feedback-queries',
+    initData
+  )
+  const [withoutFeedbackQueries] = useLocalStorage(
+    'representation-without_feedback-queries',
+    initData
+  )
+
+  const parsedQueries = {
+    withFeedback: new URLSearchParams(
+      decamelizeKeys(withFeedbackQueries) as URLSearchParams
+    ).toString(),
+    withoutFeedback: new URLSearchParams(
+      decamelizeKeys(withoutFeedbackQueries) as URLSearchParams
+    ).toString(),
+  }
+
+  return { parsedQueries, setLocalQueries }
+}

--- a/app/javascript/hooks/use-stored-queries.tsx
+++ b/app/javascript/hooks/use-stored-queries.tsx
@@ -1,5 +1,4 @@
 import { useLocalStorage } from '../utils/use-storage'
-import { ListQuery } from './use-list'
 import { decamelizeKeys } from 'humps'
 
 export type RepresentationParsedQueries = {
@@ -9,10 +8,10 @@ export type RepresentationParsedQueries = {
 
 export function useStoredRepresentationQueries(
   withFeedback: boolean,
-  initData: ListQuery
+  initData: Record<string, unknown>
 ): {
   parsedQueries: RepresentationParsedQueries
-  setLocalQueries: (value: ListQuery) => void
+  setLocalQueries: (value: Record<string, unknown>) => void
 } {
   const [, setLocalQueries] = useLocalStorage(
     withFeedback


### PR DESCRIPTION
part of this issue: https://github.com/exercism/exercism/issues/6547

Queries are stored in local storage. 
- This makes it available to persist state of filters while switching from one table to another. (If you don't like this, it can be disabled.) Clicking on the **Automation** button opens up an unfiltered state of the table, since it is opened from Ruby. However **Feedback submitted** button opens up your previously saved filter results.
- When clicking on *X*, the table will be loaded in with your previous  filters.
