### PR TITLE
Fix background highlight bug on code-pane

### DIFF
--- a/app/css/components/code-pane.css
+++ b/app/css/components/code-pane.css
@@ -2,7 +2,7 @@
     @apply overflow-auto;
 
     & code {
-        @apply block;
+        @apply flex;
         @apply py-8;
         & li {
             @apply flex;


### PR DESCRIPTION
Closes this issue: https://github.com/exercism/exercism/issues/6558

## UI Changes:

#### Instead of this:

<img width="1512" alt="Screenshot 2022-09-27 at 22 16 07" src="https://user-images.githubusercontent.com/66035744/192627104-7c61e448-8144-4ce8-aa3c-0118d8af7367.png">

#### I want this:

<img width="1512" alt="Screenshot 2022-09-27 at 22 12 54" src="https://user-images.githubusercontent.com/66035744/192627208-2d1cf389-ac68-4740-8a2e-964b2208e03d.png">
