### PR TITLE
Add proper warning label to Representation, adjust spacing

### DIFF
--- a/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/AutomationRules.tsx
@@ -16,7 +16,7 @@ export default function AutomationRules({
 
   if (!guidance.representations) {
     return (
-      <p className="px-24 py-16 text-p-base">
+      <p className="px-24 mb-16 text-p-base">
         This representer doesn&apos;t have any guidance yet. Guidance notes are
         written by our maintainers to explain what normalizations occur during
         the representation process. If you are a maintainer, please help get
@@ -26,7 +26,7 @@ export default function AutomationRules({
   }
 
   return (
-    <div className="px-24 shadow-xsZ1v2 mb-24">
+    <div className="px-24 shadow-xsZ1v2 pt-12 pb-24">
       <h2 className="text-h4 mb-12">Please read before giving feedback</h2>
       <div
         dangerouslySetInnerHTML={{

--- a/app/javascript/components/mentoring/representation/right-pane/Considerations.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/Considerations.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@/components/common'
 import React from 'react'
 import { CompleteRepresentationData } from '../../../types'
 
@@ -6,22 +5,17 @@ export default function Considerations({
   guidance,
 }: Pick<CompleteRepresentationData, 'guidance'>): JSX.Element | null {
   return (
-    <p className="px-24 mt-16 text-p-base text-warning flex items-center">
-      <Icon
-        className="h-[16px] w-[16px] filter-orange mr-8"
-        icon="warning"
-        alt="Please read this"
-      />
-      Please read&nbsp;
+    <p className="flex items-center justify-center font-medium text-16 leading-[24px] py-8 px-16 border-2 border-orange rounded-8 bg-lightOrange text-lightBrown whitespace-nowrap my-16 mx-24">
+      Please&nbsp;
       <a
         href={guidance.links.representationFeedbackGuide}
         target="_blank"
         rel="noreferrer"
-        className="!text-warning underline"
+        className="!text-cautionLabel underline"
       >
-        this
+        read this
       </a>
-      &nbsp; before giving your first feedback.
+      &nbsp;before giving your first feedback.
     </p>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -202,6 +202,7 @@ module.exports = {
 
       muddy: '#6E82AA',
       caution: '#955D09',
+      cautionLabel: '#3E2705',
       color22: '#C8D5EF',
 
       commonBadge: 'rgb(var(--commonBadge-RGB))',


### PR DESCRIPTION
### Before:

<img width="647" alt="Screenshot 2022-10-04 at 13 42 42" src="https://user-images.githubusercontent.com/66035744/193811193-ea5ac611-eede-4900-b43f-0c5c803c3201.png">

### After:

<img width="640" alt="Screenshot 2022-10-04 at 13 42 56" src="https://user-images.githubusercontent.com/66035744/193811220-86beddfa-1526-4c1f-a2bc-a9f65ea142ab.png">
