### PR TITLE
Add channel url to community videos

### DIFF
--- a/app/commands/community_video/retrieve_from_youtube.rb
+++ b/app/commands/community_video/retrieve_from_youtube.rb
@@ -16,6 +16,8 @@ class CommunityVideo
         embed_id: youtube_id,
 
         channel_name: snippet["channelTitle"],
+        channel_url: "https://www.youtube.com/channel/#{snippet['channelId']}",
+
         thumbnail_url: snippet["thumbnails"]["standard"]["url"]
       )
     rescue StandardError

--- a/app/controllers/api/community_videos_controller.rb
+++ b/app/controllers/api/community_videos_controller.rb
@@ -2,7 +2,7 @@ module API
   class CommunityVideosController < BaseController
     def lookup
       video = CommunityVideo::Retrieve.(params[:video_url])
-      serialized = video.attributes.slice(*%w[title platform channel_name thumbnail_url url])
+      serialized = video.attributes.slice(*%w[title platform channel_name channel_url thumbnail_url url])
       render json: { community_video: serialized }.to_json
     rescue InvalidCommunityVideoUrl
       render_400(:invalid_community_video_url)

--- a/db/migrate/20221005100207_add_channel_url_to_community_videos.rb
+++ b/db/migrate/20221005100207_add_channel_url_to_community_videos.rb
@@ -1,0 +1,5 @@
+class AddChannelUrlToCommunityVideos < ActiveRecord::Migration[7.0]
+  def change
+    add_column :community_videos, :channel_url, :string, null: false, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_29_134810) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_05_100207) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_29_134810) do
     t.string "thumbnail_url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "channel_url", null: false
     t.index ["author_id"], name: "index_community_videos_on_author_id"
     t.index ["exercise_id"], name: "index_community_videos_on_exercise_id"
     t.index ["submitted_by_id"], name: "index_community_videos_on_submitted_by_id"

--- a/test/commands/community_video/retrieve_from_youtube_test.rb
+++ b/test/commands/community_video/retrieve_from_youtube_test.rb
@@ -14,6 +14,7 @@ class CommunityVideo::RetrieveFromYoutubeTest < ActiveSupport::TestCase
     assert_equal "hFZFjoX2cGg", video.watch_id
     assert_equal "hFZFjoX2cGg", video.embed_id
     assert_equal "Mark Rober", video.channel_name
+    assert_equal "https://www.youtube.com/channel/UCY1kMZp36IQSyNx_9h4mpCg", video.channel_url
     assert_equal "https://i.ytimg.com/vi/hFZFjoX2cGg/sddefault.jpg", video.thumbnail_url
   end
 

--- a/test/controllers/api/community_videos_controller_test.rb
+++ b/test/controllers/api/community_videos_controller_test.rb
@@ -23,6 +23,7 @@ class API::CommunitySolutionVideosControllerTest < API::BaseTestCase
         title: video.title,
         platform: video.platform.to_s,
         channel_name: video.channel_name,
+        channel_url: video.channel_url,
         thumbnail_url: video.thumbnail_url,
         url: video.url
       }

--- a/test/factories/community_videos.rb
+++ b/test/factories/community_videos.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     platform { :youtube }
     title { "something interesting" }
     thumbnail_url { "http://the.internet.com" }
+    channel_url { "https://youtube.com/watch/abcdefg" }
     channel_name { "a cool place for squirrels" }
     watch_id { "me-them" }
     embed_id { "me&them" }


### PR DESCRIPTION
- Add channel_url column to community videos
- Retrieve channel url for community videos
- Save channel_url for youtube videos
