### PR TITLE
Store date of first feedback for exercise representation

### DIFF
--- a/app/commands/exercise/representation/submit_feedback.rb
+++ b/app/commands/exercise/representation/submit_feedback.rb
@@ -10,7 +10,7 @@ class Exercise
           representation.update(feedback_markdown:, feedback_type:, feedback_editor: mentor)
           award_reputation_token!(:automation_feedback_editor) unless mentor_is_author?
         else
-          representation.update(feedback_markdown:, feedback_type:, feedback_author: mentor)
+          representation.update(feedback_markdown:, feedback_type:, feedback_author: mentor, feedback_added_at: Time.now.utc)
           award_reputation_token!(:automation_feedback_author)
         end
 

--- a/db/migrate/20221006094545_add_feedback_added_at_to_exercise_representations.rb
+++ b/db/migrate/20221006094545_add_feedback_added_at_to_exercise_representations.rb
@@ -1,0 +1,13 @@
+class AddFeedbackAddedAtToExerciseRepresentations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :exercise_representations, :feedback_added_at, :datetime, null: true, if_not_exists: true
+
+    unless Rails.env.production?
+      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+        Exercise::Representation
+          .where.not(feedback_type: nil)
+          .update_all('feedback_added_at = updated_at')
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_05_115713) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_06_094545) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -255,21 +255,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_115713) do
     t.bigint "feedback_editor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "num_submissions", default: 1, null: false
-    t.datetime "last_submitted_at", default: -> { "CURRENT_TIMESTAMP(6)" }, null: false
+    t.integer "num_submissions", default: 0, null: false
+    t.datetime "last_shown_at"
+    t.datetime "last_submitted_at", default: "2022-08-17 08:10:01", null: false
     t.string "uuid", null: false
     t.bigint "track_id"
+    t.datetime "feedback_added_at"
     t.index ["exercise_id", "ast_digest"], name: "exercise_representations_unique", unique: true
     t.index ["exercise_id", "ast_digest"], name: "index_exercise_representations_on_exercise_id_and_ast_digest"
     t.index ["exercise_id"], name: "index_exercise_representations_on_exercise_id"
-    t.index ["feedback_author_id", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_author_exercise_last_submitted_at", order: { last_submitted_at: :desc }
-    t.index ["feedback_author_id", "exercise_id", "num_submissions"], name: "index_exercise_representation_author_exercise_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_author_id", "track_id", "last_submitted_at"], name: "index_exercise_representation_author_track_last_submitted_at", order: { last_submitted_at: :desc }
     t.index ["feedback_author_id", "track_id", "num_submissions"], name: "index_exercise_representation_author_track_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_author_id"], name: "index_exercise_representations_on_feedback_author_id"
     t.index ["feedback_editor_id"], name: "index_exercise_representations_on_feedback_editor_id"
-    t.index ["feedback_type", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_type_exercise_last_submitted_at", order: { last_submitted_at: :desc }
-    t.index ["feedback_type", "exercise_id", "num_submissions"], name: "index_exercise_representation_type_exercise_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_type", "track_id", "last_submitted_at"], name: "index_exercise_representation_type_track_last_submitted_at", order: { last_submitted_at: :desc }
     t.index ["feedback_type", "track_id", "num_submissions"], name: "index_exercise_representation_type_track_num_submissions", order: { num_submissions: :desc }
     t.index ["source_submission_id"], name: "index_exercise_representations_on_source_submission_id"
@@ -666,7 +664,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_115713) do
     t.integer "published_iteration_head_tests_status", default: 0, null: false
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
-    t.index ["exercise_id", "published_at"], name: "index_solutions_on_exercise_id_and_published_at"
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
     t.index ["num_stars", "id"], name: "solutions_popular_new", order: :desc
     t.index ["public_uuid"], name: "index_solutions_on_public_uuid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -255,19 +255,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_06_094545) do
     t.bigint "feedback_editor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "num_submissions", default: 0, null: false
-    t.datetime "last_shown_at"
-    t.datetime "last_submitted_at", default: "2022-08-17 08:10:01", null: false
+    t.integer "num_submissions", default: 1, null: false
+    t.datetime "last_submitted_at", default: -> { "CURRENT_TIMESTAMP(6)" }, null: false
     t.string "uuid", null: false
     t.bigint "track_id"
     t.datetime "feedback_added_at"
     t.index ["exercise_id", "ast_digest"], name: "exercise_representations_unique", unique: true
     t.index ["exercise_id", "ast_digest"], name: "index_exercise_representations_on_exercise_id_and_ast_digest"
     t.index ["exercise_id"], name: "index_exercise_representations_on_exercise_id"
+    t.index ["feedback_author_id", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_author_exercise_last_submitted_at", order: { last_submitted_at: :desc }
+    t.index ["feedback_author_id", "exercise_id", "num_submissions"], name: "index_exercise_representation_author_exercise_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_author_id", "track_id", "last_submitted_at"], name: "index_exercise_representation_author_track_last_submitted_at", order: { last_submitted_at: :desc }
     t.index ["feedback_author_id", "track_id", "num_submissions"], name: "index_exercise_representation_author_track_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_author_id"], name: "index_exercise_representations_on_feedback_author_id"
     t.index ["feedback_editor_id"], name: "index_exercise_representations_on_feedback_editor_id"
+    t.index ["feedback_type", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_type_exercise_last_submitted_at", order: { last_submitted_at: :desc }
+    t.index ["feedback_type", "exercise_id", "num_submissions"], name: "index_exercise_representation_type_exercise_num_submissions", order: { num_submissions: :desc }
     t.index ["feedback_type", "track_id", "last_submitted_at"], name: "index_exercise_representation_type_track_last_submitted_at", order: { last_submitted_at: :desc }
     t.index ["feedback_type", "track_id", "num_submissions"], name: "index_exercise_representation_type_track_num_submissions", order: { num_submissions: :desc }
     t.index ["source_submission_id"], name: "index_exercise_representations_on_source_submission_id"
@@ -664,6 +667,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_06_094545) do
     t.integer "published_iteration_head_tests_status", default: 0, null: false
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
+    t.index ["exercise_id", "published_at"], name: "index_solutions_on_exercise_id_and_published_at"
     t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
     t.index ["num_stars", "id"], name: "solutions_popular_new", order: :desc
     t.index ["public_uuid"], name: "index_solutions_on_public_uuid", unique: true

--- a/test/commands/exercise/representation/submit_feedback_test.rb
+++ b/test/commands/exercise/representation/submit_feedback_test.rb
@@ -7,13 +7,16 @@ class Exercise::Representation::SubmitFeedbackTest < ActiveSupport::TestCase
     feedback_markdown = 'Try _this_'
     feedback_type = :actionable
 
-    Exercise::Representation::SubmitFeedback.(mentor, representation, feedback_markdown, feedback_type)
+    freeze_time do
+      Exercise::Representation::SubmitFeedback.(mentor, representation, feedback_markdown, feedback_type)
 
-    representation.reload
-    assert_equal feedback_markdown, representation.feedback_markdown
-    assert_equal feedback_type, representation.feedback_type
-    assert_equal mentor, representation.feedback_author
-    assert_nil representation.feedback_editor
+      representation.reload
+      assert_equal feedback_markdown, representation.feedback_markdown
+      assert_equal feedback_type, representation.feedback_type
+      assert_equal mentor, representation.feedback_author
+      assert_nil representation.feedback_editor
+      assert_equal Time.now.utc, representation.feedback_added_at
+    end
   end
 
   test "adding feedback awards automation feedback author reputation token" do
@@ -39,8 +42,9 @@ class Exercise::Representation::SubmitFeedbackTest < ActiveSupport::TestCase
     editor = create :user
     feedback_markdown = 'Try _this_'
     feedback_type = :actionable
+    feedback_added_at = Time.zone.now - 2.minutes
     representation = create :exercise_representation, feedback_author: author, feedback_markdown: feedback_markdown,
-      feedback_type: feedback_type
+      feedback_type: feedback_type, feedback_added_at: feedback_added_at
 
     Exercise::Representation::SubmitFeedback.(editor, representation, feedback_markdown, feedback_type)
 
@@ -49,6 +53,7 @@ class Exercise::Representation::SubmitFeedbackTest < ActiveSupport::TestCase
     assert_equal feedback_type, representation.feedback_type
     assert_equal author, representation.feedback_author
     assert_equal editor, representation.feedback_editor
+    assert_equal feedback_added_at, representation.feedback_added_at
   end
 
   test "updating feedback awards automation feedback editor reputation token" do


### PR DESCRIPTION
- Add feedback_added_at column to exercise_representations table
- Set feedback_added_at value when feedback is first added
