### PR TITLE
Use Error suffix for InvalidCommunityVideoUrl error

### DIFF
--- a/app/commands/community_video/retrieve.rb
+++ b/app/commands/community_video/retrieve.rb
@@ -5,14 +5,14 @@ class CommunityVideo
     initialize_with :url
 
     def call
-      raise InvalidCommunityVideoUrl unless url.present?
+      raise InvalidCommunityVideoUrlError unless url.present?
 
       if youtube?
         CommunityVideo::RetrieveFromYoutube.(url)
       elsif vimeo?
         CommunityVideo::RetrieveFromVimeo.(url)
       else
-        raise InvalidCommunityVideoUrl
+        raise InvalidCommunityVideoUrlError
       end
     end
 

--- a/app/commands/community_video/retrieve_from_youtube.rb
+++ b/app/commands/community_video/retrieve_from_youtube.rb
@@ -22,7 +22,7 @@ class CommunityVideo
         thumbnail_url: snippet["thumbnails"]["standard"]["url"]
       )
     rescue StandardError
-      raise InvalidCommunityVideoUrl
+      raise InvalidCommunityVideoUrlError
     end
 
     def embed_url = "https://www.youtube.com/embed/#{youtube_id}"
@@ -32,7 +32,7 @@ class CommunityVideo
       resp = JSON.parse(RestClient.get(api_url).body)
 
       items = resp['items']
-      raise InvalidCommunityVideoUrl if items.blank?
+      raise InvalidCommunityVideoUrlError if items.blank?
 
       items.first['snippet']
     end

--- a/app/controllers/api/community_videos_controller.rb
+++ b/app/controllers/api/community_videos_controller.rb
@@ -4,7 +4,7 @@ module API
       video = CommunityVideo::Retrieve.(params[:video_url])
       serialized = video.attributes.slice(*%w[title platform channel_name channel_url thumbnail_url url])
       render json: { community_video: serialized }.to_json
-    rescue InvalidCommunityVideoUrl
+    rescue InvalidCommunityVideoUrlError
       render_400(:invalid_community_video_url)
     end
 
@@ -33,7 +33,7 @@ module API
       )
 
       render json: {}
-    rescue InvalidCommunityVideoUrl
+    rescue InvalidCommunityVideoUrlError
       render_400(:invalid_community_video_url)
     end
   end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -53,4 +53,4 @@ class InvalidMetricPeriodError < RuntimeError; end
 
 class InvalidMetricTypeError < RuntimeError; end
 
-class InvalidCommunityVideoUrl < RuntimeError; end
+class InvalidCommunityVideoUrlError < RuntimeError; end

--- a/test/commands/community_video/retrieve_test.rb
+++ b/test/commands/community_video/retrieve_test.rb
@@ -22,7 +22,7 @@ class CommunityVideo::RetrieveTest < ActiveSupport::TestCase
   end
 
   test "raises with unexpected url" do
-    assert_raises(InvalidCommunityVideoUrl) do
+    assert_raises(InvalidCommunityVideoUrlError) do
       CommunityVideo::Retrieve.("https://foo.bar")
     end
   end


### PR DESCRIPTION
This makes it consistent with other errors
