### PR TITLE
Allow representation comments to be celebratory

### DIFF
--- a/app/javascript/components/mentoring/representation/right-pane/RadioGroup.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RadioGroup.tsx
@@ -27,6 +27,14 @@ const RADIO_DATA = [
       body: 'Student is not prompted to action this before proceeding, entirely a low-value enhancement.',
     },
   },
+  {
+    label: 'Celebratory',
+    value: 'celebratory',
+    tooltip: {
+      title: 'If you mark this as Celebratory',
+      body: 'Student is not prompted to action this before proceeding, congratules the student on their solution.',
+    },
+  },
 ]
 export default function RadioGroup({
   feedbackType,

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -468,6 +468,7 @@ export type RepresentationFeedbackType =
   | 'essential'
   | 'actionable'
   | 'non_actionable'
+  | 'celebratory'
 
 export type CompleteRepresentationData = {
   representation: RepresentationData

--- a/app/models/exercise/representation.rb
+++ b/app/models/exercise/representation.rb
@@ -9,7 +9,7 @@ class Exercise::Representation < ApplicationRecord
   belongs_to :track, optional: true
   has_one :solution, through: :source_submission
 
-  enum feedback_type: { essential: 0, actionable: 1, non_actionable: 2 }, _prefix: :feedback
+  enum feedback_type: { essential: 0, actionable: 1, non_actionable: 2, celebratory: 3 }, _prefix: :feedback
 
   has_many :submission_representations,
     class_name: "Submission::Representation",
@@ -38,17 +38,10 @@ class Exercise::Representation < ApplicationRecord
     submission_representations.count
   end
 
-  def has_essential_feedback?
-    has_feedback? && feedback_essential?
-  end
-
-  def has_actionable_feedback?
-    has_feedback? && feedback_actionable?
-  end
-
-  def has_non_actionable_feedback?
-    has_feedback? && feedback_non_actionable?
-  end
+  def has_essential_feedback? = has_feedback? && feedback_essential?
+  def has_actionable_feedback? = has_feedback? && feedback_actionable?
+  def has_non_actionable_feedback? = has_feedback? && feedback_non_actionable?
+  def has_celebratory_feedback? = has_feedback? && feedback_celebratory?
 
   def has_feedback?
     [feedback_markdown, feedback_author_id, feedback_type].all?(&:present?)

--- a/test/models/exercise/representation_test.rb
+++ b/test/models/exercise/representation_test.rb
@@ -19,19 +19,29 @@ class Exercise::RepresentationTest < ActiveSupport::TestCase
   test "has_essential_feedback?" do
     refute create(:exercise_representation, feedback_type: :essential).has_essential_feedback?
     refute create(:exercise_representation, :with_feedback, feedback_type: :actionable).has_essential_feedback?
+    refute create(:exercise_representation, :with_feedback, feedback_type: :celebratory).has_essential_feedback?
     assert create(:exercise_representation, :with_feedback, feedback_type: :essential).has_essential_feedback?
   end
 
   test "has_actionable_feedback?" do
     refute create(:exercise_representation, feedback_type: :actionable).has_actionable_feedback?
     refute create(:exercise_representation, :with_feedback, feedback_type: :essential).has_actionable_feedback?
+    refute create(:exercise_representation, :with_feedback, feedback_type: :celebratory).has_actionable_feedback?
     assert create(:exercise_representation, :with_feedback, feedback_type: :actionable).has_actionable_feedback?
   end
 
   test "has_non_actionable_feedback?" do
     refute create(:exercise_representation, feedback_type: :non_actionable).has_non_actionable_feedback?
     refute create(:exercise_representation, :with_feedback, feedback_type: :actionable).has_non_actionable_feedback?
+    refute create(:exercise_representation, :with_feedback, feedback_type: :celebratory).has_non_actionable_feedback?
     assert create(:exercise_representation, :with_feedback, feedback_type: :non_actionable).has_non_actionable_feedback?
+  end
+
+  test "has_celebratory_feedback?" do
+    refute create(:exercise_representation, feedback_type: :non_actionable).has_celebratory_feedback?
+    refute create(:exercise_representation, :with_feedback, feedback_type: :actionable).has_celebratory_feedback?
+    refute create(:exercise_representation, :with_feedback, feedback_type: :non_actionable).has_celebratory_feedback?
+    assert create(:exercise_representation, :with_feedback, feedback_type: :celebratory).has_celebratory_feedback?
   end
 
   test "num_times_used" do

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -77,12 +77,12 @@ class SubmissionTest < ActiveSupport::TestCase
     submission = Submission.find(submission.id)
     assert_nil submission.exercise_representation
 
-    # Missing exercise_reprsentation
+    # Missing exercise_representation
     sr.update!(ops_status: 200)
     submission = Submission.find(submission.id)
     assert_nil submission.exercise_representation
 
-    # er present
+    # exercise_representation present
     er = create :exercise_representation, exercise: submission.exercise, ast_digest: sr.ast_digest
     submission = Submission.find(submission.id)
     assert_equal er, submission.exercise_representation
@@ -125,6 +125,13 @@ class SubmissionTest < ActiveSupport::TestCase
     assert submission.has_essential_automated_feedback?
     refute submission.has_actionable_automated_feedback?
     refute submission.has_non_actionable_automated_feedback?
+
+    er.update!(feedback_type: :celebratory)
+    submission = Submission.find(submission.id)
+    refute submission.automated_feedback_pending?
+    refute submission.has_essential_automated_feedback?
+    refute submission.has_actionable_automated_feedback?
+    assert submission.has_non_actionable_automated_feedback?
 
     # Present only if there is actual feedback on analysis
     submission = create :submission, representation_status: :queued, analysis_status: :completed


### PR DESCRIPTION
- Add celebratory status to representation feedback type
- Verify that celebratory representer comments count as non_actionable for submission
- Allow adding celebratory comment for representation
