### PR TITLE
Refactor common logic to filters in solution API controller

### DIFF
--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -127,18 +127,16 @@ module API
 
     private
     def use_solution
-      begin
-        @solution = Solution.find_by!(uuid: params[:uuid])
-      rescue ActiveRecord::RecordNotFound
-        return render_solution_not_found
-      end
+      @solution = Solution.find_by!(uuid: params[:uuid])
 
-      return render_solution_not_accessible unless @solution.user_id == current_user.id
+      render_solution_not_accessible unless @solution.user_id == current_user.id
+    rescue ActiveRecord::RecordNotFound
+      render_solution_not_found
     end
 
     def use_user_track
       @user_track = UserTrack.for(current_user, @solution.track)
-      return render_404(:track_not_joined) if @user_track.external?
+      render_404(:track_not_joined) if @user_track.external?
     end
 
     def respond_with_authored_solution(solution)

--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -138,14 +138,5 @@ module API
       @user_track = UserTrack.for(current_user, @solution.track)
       render_404(:track_not_joined) if @user_track.external?
     end
-
-    def respond_with_authored_solution(solution)
-      solution.sync_git! unless solution.downloaded?
-
-      render json: SerializeSolutionForCLI.(solution, current_user)
-
-      # Only set this if we've not 500'd
-      solution.update(downloaded_at: Time.current)
-    end
   end
 end


### PR DESCRIPTION
I found some duplication in the solutions API controller whilst working on the unlock_help button, and thought I'd dry it up a bit.

- Refactor use_solution logic into before_action
- Refactor use_user_track logic into before_action
