### PR TITLE
Hide concept exercises when learning mode disabled

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -47,8 +47,8 @@ class Track < ApplicationRecord
   end
 
   def recache_num_exercises!
-    filtered_exercises = course ? exercises : practice_exercises
-    filtered_exercises = filtered_exercises.where(status: %i[active beta])
+    filtered_exercises = exercises.where(status: %i[active beta])
+    filtered_exercises = filtered_exercises.where(type: PracticeExercise.model_name.name) unless course?
 
     update_column(:num_exercises, filtered_exercises.count)
   end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -48,7 +48,7 @@ class Track < ApplicationRecord
 
   def recache_num_exercises!
     filtered_exercises = exercises.where(status: %i[active beta])
-    filtered_exercises = filtered_exercises.where(type: PracticeExercise.model_name.name) unless course?
+    filtered_exercises = filtered_exercises.where(type: PracticeExercise.to_s) unless course?
 
     update_column(:num_exercises, filtered_exercises.count)
   end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -47,7 +47,10 @@ class Track < ApplicationRecord
   end
 
   def recache_num_exercises!
-    update_column(:num_exercises, exercises.where(status: %i[active beta]).count)
+    filtered_exercises = course ? exercises : practice_exercises
+    filtered_exercises = filtered_exercises.where(status: %i[active beta])
+
+    update_column(:num_exercises, filtered_exercises.count)
   end
 
   def to_param = slug

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -81,6 +81,7 @@ class UserTrack < ApplicationRecord
     status = %i[active beta]
     status << :wip if maintainer?
 
+    exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course?
     exercises.where(status:).or(exercises.where(id: solutions.select(:exercise_id)))
   end
 

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -81,7 +81,7 @@ class UserTrack < ApplicationRecord
     status = %i[active beta]
     status << :wip if maintainer?
 
-    exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course? || maintainer?
+    exercises = exercises.where(type: PracticeExercise.to_s) unless track.course? || maintainer?
     exercises.where(status:).or(exercises.where(id: solutions.select(:exercise_id)))
   end
 

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -159,6 +159,8 @@ class UserTrack < ApplicationRecord
 
   memoize
   def maintainer?
+    return true if user.staff? || user.admin?
+
     user.maintainer? && user.github_team_memberships.where(team_name: track.github_team_name).exists?
   end
 

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -81,7 +81,7 @@ class UserTrack < ApplicationRecord
     status = %i[active beta]
     status << :wip if maintainer?
 
-    exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course?
+    exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course? || maintainer?
     exercises.where(status:).or(exercises.where(id: solutions.select(:exercise_id)))
   end
 

--- a/app/models/user_track/external.rb
+++ b/app/models/user_track/external.rb
@@ -49,6 +49,7 @@ class UserTrack
     end
 
     def enabled_exercises(exercises)
+      exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course?
       exercises.where(status: %i[active beta])
     end
 

--- a/app/models/user_track/external.rb
+++ b/app/models/user_track/external.rb
@@ -49,7 +49,7 @@ class UserTrack
     end
 
     def enabled_exercises(exercises)
-      exercises = exercises.where(type: PracticeExercise.model_name.name) unless track.course?
+      exercises = exercises.where(type: PracticeExercise.to_s) unless track.course?
       exercises.where(status: %i[active beta])
     end
 

--- a/test/commands/user_track/generate_summary_data/exercises_available_test.rb
+++ b/test/commands/user_track/generate_summary_data/exercises_available_test.rb
@@ -299,6 +299,29 @@ class UserTrack::GenerateSummaryData::ExercisesUnlockedTest < ActiveSupport::Tes
     assert_equal [wip_practice_exercise, hello_world], summary.unlocked_practice_exercises
   end
 
+  test "concept exercises are only available when track has course" do
+    track = create :track
+    concept_exercise = create :concept_exercise, :random_slug, track: track
+    practice_exercise = create :practice_exercise, :random_slug, track: track
+
+    user = create :user
+    user_track = create :user_track, track: track, user: user
+    hw_solution = create :hello_world_solution, :completed, track: track, user: user
+    hello_world = hw_solution.exercise
+
+    track.update(course: false)
+    summary = summary_for(user_track)
+    assert_equal [practice_exercise, hello_world], summary.unlocked_exercises
+    assert_empty summary.unlocked_concept_exercises
+    assert_equal [practice_exercise, hello_world], summary.unlocked_practice_exercises
+
+    track.update(course: true)
+    summary = summary_for(user_track)
+    assert_equal [concept_exercise, practice_exercise, hello_world], summary.unlocked_exercises
+    assert_equal [concept_exercise], summary.unlocked_concept_exercises
+    assert_equal [practice_exercise, hello_world], summary.unlocked_practice_exercises
+  end
+
   private
   def summary_for(user_track)
     user_track = UserTrack.find(user_track.id)

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -184,11 +184,34 @@ class TrackTest < ActiveSupport::TestCase
     create :practice_exercise, track: track, status: :beta
     assert_equal 1, track.num_exercises
 
-    create :concept_exercise, track: track, status: :active
-    assert_equal 2, track.num_exercises
+    create :practice_exercise, track: track, status: :active
+    assert_equal 2, track.reload.num_exercises
 
+    # Ignore wip practice exercises
     create :practice_exercise, track: track, status: :wip
-    assert_equal 2, track.num_exercises
+    assert_equal 2, track.reload.num_exercises
+
+    # Ignore deprecated practice exercises
+    create :practice_exercise, track: track, status: :deprecated
+    assert_equal 2, track.reload.num_exercises
+
+    # Ignore concept exercises when the track does not have a course
+    track.update(course: false)
+    create :concept_exercise, track: track, status: :active
+    assert_equal 2, track.reload.num_exercises
+
+    # Include concept exercises when the track has a course
+    track.update(course: true)
+    create :concept_exercise, track: track, status: :beta
+    assert_equal 4, track.reload.num_exercises
+
+    # Ignore wip concept exercises
+    create :concept_exercise, track: track, status: :wip
+    assert_equal 4, track.reload.num_exercises
+
+    # Ignore deprecated concept exercises
+    create :concept_exercise, track: track, status: :deprecated
+    assert_equal 4, track.reload.num_exercises
   end
 
   test "representations" do

--- a/test/models/user_track/external_test.rb
+++ b/test/models/user_track/external_test.rb
@@ -87,7 +87,6 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
 
   test "exercises" do
     track = create :track
-    user_track = UserTrack::External.new(track)
 
     create :concept_exercise, :random_slug, track: track, status: :wip
     beta_concept_exercise = create :concept_exercise, :random_slug, track: track, status: :beta
@@ -100,9 +99,19 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
     create :practice_exercise, :random_slug, track: track, status: :deprecated
 
     # wip and deprecated exercises are not included
+    track.update(course: true)
+    user_track = UserTrack::External.new(track)
     assert_equal [
       beta_concept_exercise,
       active_concept_exercise,
+      beta_practice_exercise,
+      active_practice_exercise
+    ].map(&:slug).sort, user_track.exercises.map(&:slug).sort
+
+    # concept exercises are excluded when track does not have course
+    track.update(course: false)
+    user_track = UserTrack::External.new(track)
+    assert_equal [
       beta_practice_exercise,
       active_practice_exercise
     ].map(&:slug).sort, user_track.exercises.map(&:slug).sort
@@ -110,7 +119,6 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
 
   test "concept_exercises" do
     track = create :track
-    user_track = UserTrack::External.new(track)
 
     create :concept_exercise, :random_slug, track: track, status: :wip
     beta_concept_exercise = create :concept_exercise, :random_slug, track: track, status: :beta
@@ -121,15 +129,21 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
     create :practice_exercise, :random_slug, track: track
 
     # wip and deprecated exercises are not included
+    track.update(course: true)
+    user_track = UserTrack::External.new(track)
     assert_equal [
       beta_concept_exercise,
       active_concept_exercise
     ].map(&:slug).sort, user_track.concept_exercises.map(&:slug).sort
+
+    # concept exercises are excluded when track does not have course
+    track.update(course: false)
+    user_track = UserTrack::External.new(track)
+    assert_empty user_track.concept_exercises
   end
 
   test "practice_exercises" do
     track = create :track
-    user_track = UserTrack::External.new(track)
 
     create :practice_exercise, :random_slug, track: track, status: :wip
     beta_practice_exercise = create :practice_exercise, :random_slug, track: track, status: :beta
@@ -140,6 +154,16 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
     create :concept_exercise, :random_slug, track: track
 
     # wip and deprecated exercises are not included
+    track.update(course: true)
+    user_track = UserTrack::External.new(track)
+    assert_equal [
+      beta_practice_exercise,
+      active_practice_exercise
+    ].map(&:slug).sort, user_track.practice_exercises.map(&:slug).sort
+
+    # practice exercises are included when track does not have course
+    track.update(course: false)
+    user_track = UserTrack::External.new(track)
     assert_equal [
       beta_practice_exercise,
       active_practice_exercise


### PR DESCRIPTION
- Calculate track's num_exercises based on course?
- Add published scope to exercise
- Add available exercise methods to track
- Use exercise filtering for external user track
- Simplify tests for external user track
- Add started scope on exercise
- Use started scope in user_track
- Add available scope to exercise
- Use available scope in user_track

Closes https://github.com/exercism/exercism/issues/6559