### PR TITLE
Fix overflow and height of snippets on Approaches

### DIFF
--- a/app/javascript/components/track/approaches-elements/ApproachSnippet.tsx
+++ b/app/javascript/components/track/approaches-elements/ApproachSnippet.tsx
@@ -21,8 +21,13 @@ export function ApproachSnippet({
         className="border-1 border-lightGray rounded-8 p-16 mb-16"
         ref={codeBlockRef}
       >
+        {/* 
+        show 8 lines of code in code block:
+        (14 * 1.6) * 8 = 
+        179.20000000000002 
+        */}
         <code
-          className={`${track.slug} block max-h-[134px] overflow-hidden `}
+          className={`${track.slug} block max-h-[180px] overflow-hidden `}
           style={{ textOverflow: 'ellipsis' }}
         >
           {approach.snippet}

--- a/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
+++ b/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
@@ -16,7 +16,7 @@ export function ArticleSnippet({ article }: { article: Article }): JSX.Element {
         ref={codeBlockRef}
       >
         <div
-          className="c-cli-walkthrough overflow-hidden block"
+          className="overflow-hidden block"
           dangerouslySetInnerHTML={{ __html: article.snippetHtml }}
           style={{
             textOverflow: 'ellipsis',

--- a/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
+++ b/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
@@ -16,8 +16,12 @@ export function ArticleSnippet({ article }: { article: Article }): JSX.Element {
         ref={codeBlockRef}
       >
         <div
-          className="c-cli-walkthrough"
+          className="c-cli-walkthrough overflow-hidden block"
           dangerouslySetInnerHTML={{ __html: article.snippetHtml }}
+          style={{
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
         />
       </pre>
       <h5 className="text-h5 mb-2">{article.title}</h5>
@@ -28,6 +32,7 @@ export function ArticleSnippet({ article }: { article: Article }): JSX.Element {
         bottomLabel={'contributor'}
         bottomCount={article.numContributors}
         users={article.users}
+        className="text-textColor1 font-semibold text-14"
       />
     </a>
   )

--- a/app/views/tracks/approaches/show.html.haml
+++ b/app/views/tracks/approaches/show.html.haml
@@ -58,7 +58,7 @@
         - @other_approaches.each do |other_approach|
           = link_to Exercism::Routes.track_exercise_approach_path(@track, @exercise, other_approach[:slug]), class: "bg-white shadow-base rounded-8 px-20 py-16 flex flex-col" do
             %pre.border-1.border-lightGray.rounded-8.p-16.mb-16
-              %code.block.overflow-hidden{ class: "lang-#{@track.highlightjs_language} h-[158px]", style: "text-overflow:ellipsis" }
+              %code.block.overflow-hidden{ class: "lang-#{@track.highlightjs_language} h-[180px]", style: "text-overflow:ellipsis" }
                 = other_approach[:snippet]
             %h5.text-h5.mb-2
               = other_approach[:title]


### PR DESCRIPTION
# UI changes:

### shows 8 lines of code in a snippet.
<img width="571" alt="Screenshot 2022-11-01 at 12 28 55" src="https://user-images.githubusercontent.com/66035744/199223843-9800c813-9705-4ef8-8b55-e532b400e628.png">

### gets rid of overflowing
<img width="571" alt="Screenshot 2022-11-01 at 12 31 34" src="https://user-images.githubusercontent.com/66035744/199223864-6f8a9092-d7f4-415b-9533-51dac5fc2863.png">

