### PR TITLE
Replace link to kytrinyx.com

### DIFF
--- a/app/views/about/team.html.haml
+++ b/app/views/about/team.html.haml
@@ -43,12 +43,12 @@
             = image_tag "team/katrina.jpg", alt: "An image of Katrina", class: "avatar"
             .details
               %h3
-                = link_to "Katrina Owen", "https://kytrinyx.com", target: "_blank", rel: 'noopener'
+                = link_to "Katrina Owen", "https://exercism.github.io/kytrinyx/", target: "_blank", rel: 'noopener'
               .handle Co-founder &amp; Director
               %p Katrina is the original creator of Exercism. She is co-author of #{link_to '99 Bottles of OOP', 'https://sandimetz.com/99bottles'}. Polyglot developer and Ruby Hero award winner, with a degree in Molecular Biology. Cares deeply about open-source and contributes to several projects outside of Exercism.
               %ul.links
                 %li
-                  = link_to "https://kytrinyx.com", target: "_blank", rel: 'noopener' do
+                  = link_to "https://exercism.github.io/kytrinyx/", target: "_blank", rel: 'noopener' do
                     = graphical_icon "link"
                     %span Katrina's Personal Site
 

--- a/app/views/components/footer/shared.html.haml
+++ b/app/views/components/footer/shared.html.haml
@@ -96,6 +96,6 @@
     .company.mb-16.md:mb-0.md:mr-32
       Exercism is not-for-profit organisation registered in the UK with company number
       #{link_to '11733062', 'https://find-and-update.company-information.service.gov.uk/company/11733062'}.
-      Its trustees are #{link_to 'Katrina Owen', 'https://www.kytrinyx.com/'} and #{link_to 'Jeremy Walker', 'https://ihid.info/'}.
+      Its trustees are #{link_to 'Katrina Owen', 'https://exercism.github.io/kytrinyx/'} and #{link_to 'Jeremy Walker', 'https://ihid.info/'}.
     .copyright.md:ml-auto
       © #{Date.current.year} Exercism


### PR DESCRIPTION
I don't have a personal website anymore.
I have a very simple resume page up on github apps, though.
Let's link to that.

Closes https://github.com/exercism/exercism/issues/6412