### PR TITLE
Track dashboard small changes

### DIFF
--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -256,36 +256,18 @@
     }
 
     .track-header {
-        display: grid;
-        @apply gap-x-48 gap-y-8 mb-16;
-        grid-template-areas:
-            "a c"
-            "b c";
-        @apply self-center;
-
         h3 {
-            grid-area: a;
             @apply track-leader;
         }
         p {
-            grid-area: b;
             @apply text-16 text-textColor5 leading-150;
-        }
-
-        .learn-more-new-tab {
-            grid-area: c;
-            place-self: center;
         }
     }
 
     .learn-more-new-tab {
-        @apply text-16 text-textColor6 font-semibold whitespace-nowrap leading-150 items-center;
-
-        &:after {
-            content: url("icons/new-tab.svg");
+        @apply text-16 text-textColor6 font-semibold whitespace-nowrap leading-150 flex items-center;
+        img {
             @apply filter-textColor6 ml-12;
-            width: 12px;
-            height: 12px;
         }
     }
 

--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -307,9 +307,9 @@
             @apply text-label-timestamp flex font-semibold;
             .record-element {
                 @apply grid w-[128px] gap-2;
-                @apply text-12 font-normal;
+                @apply text-14 font-normal;
                 strong {
-                    @apply text-14 font-semibold;
+                    @apply font-semibold;
                 }
             }
         }

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -70,7 +70,7 @@
           %h2.text-h2 Build
           %p.text-18.text-textColor1.leading-150 Use your knowledge to build the #{@track.title} track itself
 
-        = link_to contributing_contributors_path(track_slug: @track.slug), class: "people hidden lg:flex " do
+        = link_to contributing_contributors_path(track_slug: @track.slug), class: "people hidden lg:flex items-center" do
           .c-faces.mr-16
             - @track.top_contributors[0, 3].map do |author|
               .face= avatar(author)

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -78,11 +78,13 @@
             .contributors.text-textColor1.font-medium.mb-2= pluralize(@track.num_code_contributors, "contributor")
 
       .track-team-group
-        .track-header
-          %h3.--syllabus-gradient Create the #{@track.title} syllabus
+        .track-header.mb-16
+          .flex.items-center.justify-between.mb-8
+            %h3.--syllabus-gradient Create the #{@track.title} syllabus
+            = link_to doc_path(:building, "tracks/syllabus"), class: "learn-more-new-tab" do
+              Learn More
+              = graphical_icon "new-tab"
           %p Help create the track syllabus: is a set of concepts and learning exercises put together to teach foundational elements of the programming language.
-          = link_to doc_path(:building, "tracks/syllabus"), class: "learn-more-new-tab" do
-            Learn More
 
         - if @status.syllabus.concepts.num_concepts < @status.syllabus.concepts.num_concepts_target
           .action-required
@@ -122,11 +124,13 @@
         = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
       .track-team-group
-        .track-header
-          %h3.--test-runner-gradient Build Test Runners
+        .track-header.mb-16
+          .flex.items-center.justify-between.mb-8
+            %h3.--test-runner-gradient Build Test Runners
+            = link_to doc_path(:building, "tooling/test-runners"), class: "learn-more-new-tab" do
+              Learn More
+              = graphical_icon "new-tab"
           %p Create Test Runners that have the single responsibility of taking a solution, running all tests and returning a standardized output.
-          = link_to doc_path(:building, "tooling/test-runners"), class: "learn-more-new-tab" do
-            Learn More
 
         - if @status.test_runner.health == "missing"
           .action-required
@@ -159,11 +163,13 @@
         = render ReactComponents::Common::Credits.new(@status.test_runner.volunteers.users, @status.test_runner.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
       .track-team-group
-        .track-header
-          %h3.--analyzer-gradient Build Analyzers
+        .track-header.mb-16
+          .flex.items-center.justify-between.mb-8
+            %h3.--analyzer-gradient Build Analyzers
+            = link_to doc_path(:building, "tooling/analyzers"), class: "learn-more-new-tab" do
+              Learn More
+              = graphical_icon "new-tab"
           %p Build an Analyzer for #{@track.title}: Exercism's analyzers automatically assess student's submissions and provide mentor-style commentary.
-          = link_to doc_path(:building, "tooling/analyzers"), class: "learn-more-new-tab" do
-            Learn More
 
         - if @status.analyzer.health == "missing"
           .action-required
@@ -189,11 +195,13 @@
         = render ReactComponents::Common::Credits.new(@status.analyzer.volunteers.users, @status.analyzer.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
       .track-team-group
-        .track-header
-          %h3.--representer-gradient Build Representers
+        .track-header.mb-16
+          .flex.items-center.justify-between.mb-8
+            %h3.--representer-gradient Build Representers
+            = link_to doc_path(:building, "tooling/representers"), class: "learn-more-new-tab" do
+              Learn More
+              = graphical_icon "new-tab"
           %p Build a Representer: a bit of code that has the single responsibility of taking a solution and returning a normalized representation of it.
-          = link_to doc_path(:building, "tooling/representers"), class: "learn-more-new-tab" do
-            Learn More
 
         - if @status.representer.health == "missing"
           .action-required
@@ -220,11 +228,13 @@
 
 
       .track-team-group
-        .track-header
-          %h3.--practice-exercises-gradient Create Practice Exercises
+        .track-header.mb-16
+          .flex.items-center.justify-between.mb-8
+            %h3.--practice-exercises-gradient Create Practice Exercises
+            = link_to doc_path(:building, "tracks/new/add-initial-exercises"), class: "learn-more-new-tab" do
+              Learn More
+              = graphical_icon "new-tab"
           %p Practice Exercises are exercises designed to allow students to solve an arbitrary problem, with the aim of them making use of the concepts they have learned so far.
-          = link_to doc_path(:building, "tracks/new/add-initial-exercises"), class: "learn-more-new-tab" do
-            Learn More
 
         - if @status.practice_exercises.num_exercises < @status.practice_exercises.num_exercises_target
           .action-required

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -105,6 +105,12 @@
                 .record-value #{concept.num_students_learnt} learnt
           %details
             %summary.--lightbulb #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
+            .record-row.sticky.top-0.bg-white
+              .record-name
+              .record-value
+                .record-element Started
+                .record-element Attempts
+                .record-element Completions
             - @status.syllabus.concept_exercises.created.each do |exercise|
               .record-row
                 .record-name
@@ -113,13 +119,10 @@
                 .record-value
                   .record-element
                     %strong= exercise.num_started
-                    Started
                   .record-element
                     %strong #{exercise.num_submitted} (avg. #{exercise.num_submitted_average})
-                    = 'Attempt'.pluralize(exercise.num_submitted)
                   .record-element
                     %strong #{exercise.num_completed} (#{exercise.num_completed_percentage}%)
-                    = 'Completition'.pluralize(exercise.num_completed)
 
         = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
@@ -247,6 +250,12 @@
             %h4 Usage statistics
           %details
             %summary.--practice-exercises #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
+            .record-row.sticky.top-0.bg-white
+              .record-name
+              .record-value
+                .record-element Started
+                .record-element Attempts
+                .record-element Completions
             - @status.practice_exercises.created.each do |exercise|
               .record-row
                 .record-name
@@ -255,13 +264,10 @@
                 .record-value
                   .record-element
                     %strong= exercise.num_started
-                    Started
                   .record-element
                     %strong #{exercise.num_submitted} (avg. #{exercise.num_submitted_average})
-                    = 'Attempt'.pluralize(exercise.num_submitted)
                   .record-element
                     %strong #{exercise.num_completed} (#{exercise.num_completed_percentage}%)
-                    = 'Completition'.pluralize(exercise.num_completed)
 
         = render ReactComponents::Common::Credits.new(@status.practice_exercises.volunteers.users, @status.practice_exercises.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 


### PR DESCRIPTION
Fixed contributor alignment next to Build header.

<img width="951" alt="Screenshot 2022-11-11 at 10 19 49" src="https://user-images.githubusercontent.com/66035744/201308129-a10a946f-b5d2-4338-bc24-d835b5e551ba.png">

Put Learn More next to the title of tooling sections
<img width="951" alt="Screenshot 2022-11-11 at 10 20 35" src="https://user-images.githubusercontent.com/66035744/201308263-0733c374-8f22-44fb-b66f-d4a30fa9d739.png">

Added sticky column names

<img width="905" alt="Screenshot 2022-11-11 at 10 21 33" src="https://user-images.githubusercontent.com/66035744/201308483-4a9b07bd-7047-4e77-9952-538127205e80.png">
<img width="905" alt="Screenshot 2022-11-11 at 10 21 23" src="https://user-images.githubusercontent.com/66035744/201308507-00dea838-4ae0-40e2-aa51-13f6101f9ffe.png">
