### PR TITLE
Materialize track on submission tooling jobs

### DIFF
--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -115,7 +115,7 @@ class Track::UpdateBuildStatus
   memoize
   def test_runner_version = [
     1,
-    Submission::TestRun.joins(submission: :exercise).where(submission: { exercises: { track: } }).order(id: :desc).pick(:version).to_i
+    Submission::TestRun.where(track:).order(id: :desc).pick(:version).to_i
   ].max
 
   def test_runner_version_target
@@ -126,7 +126,7 @@ class Track::UpdateBuildStatus
 
   def representer
     {
-      num_runs: Submission::Representation.joins(submission: :exercise).where(submission: { exercises: { track: } }).count,
+      num_runs: Submission::Representation.where(track:).count,
       num_comments: representer_num_submissions_with_feedback,
       display_rate_percentage: representer_display_rate_percentage,
       volunteers: serialize_tooling_volunteers(track.representer_repo_url),
@@ -155,8 +155,8 @@ class Track::UpdateBuildStatus
 
   def analyzer
     {
-      num_runs: Submission::Analysis.joins(submission: :exercise).where(submission: { exercises: { track: } }).count,
-      num_comments: Submission::Analysis.joins(submission: :exercise).where(submission: { exercises: { track: } }).sum(:num_comments),
+      num_runs: Submission::Analysis.where(track:).count,
+      num_comments: Submission::Analysis.where(track:).sum(:num_comments),
       display_rate_percentage: analyzer_display_rate_percentage,
       volunteers: serialize_tooling_volunteers(track.analyzer_repo_url),
       health: analyzer_health

--- a/app/models/submission/analysis.rb
+++ b/app/models/submission/analysis.rb
@@ -5,12 +5,17 @@ class Submission::Analysis < ApplicationRecord
   serialize :data, JSON
 
   belongs_to :submission
+  belongs_to :track
 
   scope :ops_successful, -> { where(ops_status: 200) }
   scope :with_comments, -> { where('num_comments > 0') }
 
   before_create do
     self.num_comments = self.comment_blocks.size
+  end
+
+  before_validation on: :create do
+    self.track = submission.track unless track
   end
 
   memoize

--- a/app/models/submission/representation.rb
+++ b/app/models/submission/representation.rb
@@ -10,6 +10,7 @@ class Submission::Representation < ApplicationRecord
 
   belongs_to :submission
   belongs_to :mentored_by, optional: true, class_name: "User"
+  belongs_to :track
 
   has_one :solution, through: :submission
   has_one :iteration, through: :submission
@@ -25,6 +26,10 @@ class Submission::Representation < ApplicationRecord
   before_create do
     self.ast_digest = self.class.digest_ast(ast) unless self.ast_digest
     self.ops_status = OPS_STATUS_ERRORED if self.ast_digest.blank?
+  end
+
+  before_validation on: :create do
+    self.track = submission.track unless track
   end
 
   delegate :has_feedback?, to: :exercise_representation

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -4,6 +4,7 @@ class Submission::TestRun < ApplicationRecord
 
   serialize :raw_results, JSON
 
+  belongs_to :track
   belongs_to :submission
   has_one :exercise, through: :submission
 
@@ -29,6 +30,10 @@ class Submission::TestRun < ApplicationRecord
         exercise, git_sha: self.git_sha
       )
     end
+  end
+
+  before_validation on: :create do
+    self.track = submission.track unless track
   end
 
   def status = super.try(&:to_sym)

--- a/db/migrate/20221115122417_add_track_to_submission_analyses.rb
+++ b/db/migrate/20221115122417_add_track_to_submission_analyses.rb
@@ -1,0 +1,14 @@
+class AddTrackToSubmissionAnalyses < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :submission_analyses, :track, null: true, foreign_key: true, if_not_exists: true
+    add_index :submission_analyses, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
+
+    unless Rails.env.production?
+      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+        Submission::Analysis.includes(submission: :track).find_each do |analysis|
+          analysis.update(track_id: analysis.submission.track.id)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20221115122417_add_track_to_submission_analyses.rb
+++ b/db/migrate/20221115122417_add_track_to_submission_analyses.rb
@@ -5,8 +5,10 @@ class AddTrackToSubmissionAnalyses < ActiveRecord::Migration[7.0]
 
     unless Rails.env.production?
       Submission::Analysis.includes(submission: :track).find_in_batches do |batch|
-        batch.each do |analysis|
-          analysis.update(track_id: analysis.submission.track.id)
+        ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+          batch.each do |analysis|
+            analysis.update(track_id: analysis.submission.track.id)
+          end
         end
       end
     end

--- a/db/migrate/20221115122417_add_track_to_submission_analyses.rb
+++ b/db/migrate/20221115122417_add_track_to_submission_analyses.rb
@@ -4,8 +4,8 @@ class AddTrackToSubmissionAnalyses < ActiveRecord::Migration[7.0]
     add_index :submission_analyses, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
 
     unless Rails.env.production?
-      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
-        Submission::Analysis.includes(submission: :track).find_each do |analysis|
+      Submission::Analysis.includes(submission: :track).find_in_batches do |batch|
+        batch.each do |analysis|
           analysis.update(track_id: analysis.submission.track.id)
         end
       end

--- a/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
+++ b/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
@@ -4,9 +4,9 @@ class AddTrackToSubmissionTestRuns < ActiveRecord::Migration[7.0]
     add_index :submission_test_runs, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
 
     unless Rails.env.production?
-      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
-        Submission::TestRun.includes(submission: :track).find_each do |testrun|
-          testrun.update(track_id: testrun.submission.track.id)
+      Submission::TestRun.includes(submission: :track).find_in_batches do |batch|
+        batch.each do |test_run|
+          test_run.update(track_id: test_run.submission.track.id)
         end
       end
     end

--- a/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
+++ b/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
@@ -5,8 +5,10 @@ class AddTrackToSubmissionTestRuns < ActiveRecord::Migration[7.0]
 
     unless Rails.env.production?
       Submission::TestRun.includes(submission: :track).find_in_batches do |batch|
-        batch.each do |test_run|
-          test_run.update(track_id: test_run.submission.track.id)
+        ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+          batch.each do |test_run|
+            test_run.update(track_id: test_run.submission.track.id)
+          end
         end
       end
     end

--- a/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
+++ b/db/migrate/20221115123455_add_track_to_submission_test_runs.rb
@@ -1,0 +1,14 @@
+class AddTrackToSubmissionTestRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :submission_test_runs, :track, null: true, foreign_key: true, if_not_exists: true
+    add_index :submission_test_runs, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
+
+    unless Rails.env.production?
+      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+        Submission::TestRun.includes(submission: :track).find_each do |testrun|
+          testrun.update(track_id: testrun.submission.track.id)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20221115123459_add_track_to_submission_representations.rb
+++ b/db/migrate/20221115123459_add_track_to_submission_representations.rb
@@ -5,8 +5,10 @@ class AddTrackToSubmissionRepresentations < ActiveRecord::Migration[7.0]
 
     unless Rails.env.production?
       Submission::Representation.includes(submission: :track).find_in_batches do |batch|
-        batch.each do |representation|
-          representation.update(track_id: representation.submission.track.id)
+        ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+          batch.each do |representation|
+            representation.update(track_id: representation.submission.track.id)
+          end
         end
       end
     end

--- a/db/migrate/20221115123459_add_track_to_submission_representations.rb
+++ b/db/migrate/20221115123459_add_track_to_submission_representations.rb
@@ -4,8 +4,8 @@ class AddTrackToSubmissionRepresentations < ActiveRecord::Migration[7.0]
     add_index :submission_representations, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
 
     unless Rails.env.production?
-      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
-        Submission::Representation.includes(submission: :track).find_each do |representation|
+      Submission::Representation.includes(submission: :track).find_in_batches do |batch|
+        batch.each do |representation|
           representation.update(track_id: representation.submission.track.id)
         end
       end

--- a/db/migrate/20221115123459_add_track_to_submission_representations.rb
+++ b/db/migrate/20221115123459_add_track_to_submission_representations.rb
@@ -1,0 +1,14 @@
+class AddTrackToSubmissionRepresentations < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :submission_representations, :track, null: true, foreign_key: true, if_not_exists: true
+    add_index :submission_representations, %i[track_id id], order: {track_id: :asc, id: :desc}, unique: false, if_not_exists: true
+
+    unless Rails.env.production?
+      ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+        Submission::Representation.includes(submission: :track).find_each do |representation|
+          representation.update(track_id: representation.submission.track.id)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_03_092412) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_123459) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -773,7 +773,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_092412) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "num_comments", limit: 1, default: 0, null: false
+    t.bigint "track_id"
     t.index ["submission_id"], name: "index_submission_analyses_on_submission_id"
+    t.index ["track_id", "id"], name: "index_submission_analyses_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id"], name: "index_submission_analyses_on_track_id"
   end
 
   create_table "submission_files", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -795,9 +798,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_092412) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "mentored_by_id"
+    t.bigint "track_id"
     t.index ["mentored_by_id"], name: "index_submission_representations_on_mentored_by_id"
     t.index ["submission_id", "ast_digest"], name: "index_submission_representations_on_submission_id_and_ast_digest"
     t.index ["submission_id"], name: "index_submission_representations_on_submission_id"
+    t.index ["track_id", "id"], name: "index_submission_representations_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -814,7 +820,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_092412) do
     t.datetime "updated_at", null: false
     t.string "git_important_files_hash", limit: 50
     t.string "git_sha", limit: 50
+    t.bigint "track_id"
     t.index ["submission_id"], name: "index_submission_test_runs_on_submission_id"
+    t.index ["track_id", "id"], name: "index_submission_test_runs_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id"], name: "index_submission_test_runs_on_track_id"
     t.index ["uuid"], name: "index_submission_test_runs_on_uuid", unique: true
   end
 
@@ -1222,10 +1231,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_092412) do
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
   add_foreign_key "solutions", "users"
   add_foreign_key "submission_analyses", "submissions"
+  add_foreign_key "submission_analyses", "tracks"
   add_foreign_key "submission_files", "submissions"
   add_foreign_key "submission_representations", "submissions"
+  add_foreign_key "submission_representations", "tracks"
   add_foreign_key "submission_representations", "users", column: "mentored_by_id"
   add_foreign_key "submission_test_runs", "submissions"
+  add_foreign_key "submission_test_runs", "tracks"
   add_foreign_key "submissions", "solutions"
   add_foreign_key "track_concept_authorships", "track_concepts"
   add_foreign_key "track_concept_authorships", "users"

--- a/test/models/submission/analysis_test.rb
+++ b/test/models/submission/analysis_test.rb
@@ -226,4 +226,11 @@ class Submission::AnalysisTest < ActiveSupport::TestCase
 
     assert_equal [analysis_1, analysis_2], Submission::Analysis.with_comments
   end
+
+  test "track: inferred from submission" do
+    submission = create :submission
+    analysis = create :submission_analysis, submission: submission
+
+    assert_equal submission.track, analysis.track
+  end
 end

--- a/test/models/submission/representation_test.rb
+++ b/test/models/submission/representation_test.rb
@@ -47,4 +47,11 @@ class Submission::RepresentationTest < ActiveSupport::TestCase
 
     assert_equal exercise_representation, representation.reload.exercise_representation
   end
+
+  test "track: inferred from submission" do
+    submission = create :submission
+    representation = create :submission_representation, submission: submission
+
+    assert_equal submission.track, representation.track
+  end
 end

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -209,4 +209,11 @@ class Submission::TestRunTest < ActiveSupport::TestCase
   end
 
   # TODO: - Add a test for if the raw_results is empty
+
+  test "track: inferred from submission" do
+    submission = create :submission
+    test_run = create :submission_test_run, submission: submission
+
+    assert_equal submission.track, test_run.track
+  end
 end


### PR DESCRIPTION
- Add track to submission_{analyses/representations/test_run} including index
- Store track with submission {analyses,representations,test_runs} model
- Use track field for filtering submission analyses/test_runs/representations
