### PR TITLE
Track-dashboard chevrons

### DIFF
--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -66,7 +66,7 @@
             @apply before-icon;
             .summary-chevron {
                 @apply transition-all;
-                @apply filter-textColor6 leading-150;
+                @apply filter-textColor6;
                 height: 16px;
                 width: 16px;
                 @apply flex ml-auto;

--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -60,16 +60,16 @@
         }
 
         .usage-summary {
-            @apply label-large leading-150 flex items-center text-center;
+            @apply flex items-center;
+            @apply label-large leading-150;
             @apply cursor-pointer;
             @apply before-icon;
-            &:after {
-                content: url("icons/chevron-down.svg");
+            .summary-chevron {
                 @apply transition-all;
-                @apply filter-textColor6;
+                @apply filter-textColor6 leading-150;
                 height: 16px;
                 width: 16px;
-                @apply block ml-auto;
+                @apply flex ml-auto;
             }
         }
 
@@ -248,8 +248,8 @@
 
         details[open] {
             summary {
-                &:after {
-                    @apply -rotate-90 transition-all;
+                .summary-chevron {
+                    @apply rotate-90 transition-all;
                 }
             }
         }

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -96,7 +96,9 @@
           .usage-stats-header
             %h4 Usage statistics
           %details.mb-10
-            %summary.--syllabus #{@status.syllabus.concepts.num_concepts}/#{@status.syllabus.concepts.num_concepts_target} concepts created
+            %summary.--syllabus
+              #{@status.syllabus.concepts.num_concepts}/#{@status.syllabus.concepts.num_concepts_target} concepts created
+              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             - @status.syllabus.concepts.created.each do |concept|
               .record-row
                 .record-name
@@ -104,7 +106,9 @@
                   = concept.name
                 .record-value #{concept.num_students_learnt} learnt
           %details
-            %summary.--lightbulb #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
+            %summary.--lightbulb
+              #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
+              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky.top-0.bg-white
               .record-name
               .record-value
@@ -248,7 +252,9 @@
           .usage-stats-header
             %h4 Usage statistics
           %details
-            %summary.--practice-exercises #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
+            %summary.--practice-exercises
+              #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
+              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky.top-0.bg-white
               .record-name
               .record-value


### PR DESCRIPTION
Had a hard time centering/working with `::after` content chevrons, so replaced them with icons. It wasn't _perfectly_ centered until now.

![Screenshot 2022-11-16 at 10 41 35](https://user-images.githubusercontent.com/66035744/202146099-2834f411-13d2-4c1e-976c-34e56677c513.png)
