### PR TITLE
Remove new-tab icon from Approach page

### DIFF
--- a/app/css/defaults.css
+++ b/app/css/defaults.css
@@ -46,7 +46,6 @@ body {
 /**************/
 /* Containers */
 /**************/
-.xs-container,
 .sm-container,
 .md-container,
 .lg-container {
@@ -54,10 +53,6 @@ body {
     @apply mx-auto;
 }
 
-.xs-container {
-    max-width: 840px;
-    padding: 0 var(--container-padding-x);
-}
 .sm-container {
     max-width: 1056px;
     padding: 0 var(--container-padding-x);

--- a/app/css/defaults.css
+++ b/app/css/defaults.css
@@ -46,6 +46,7 @@ body {
 /**************/
 /* Containers */
 /**************/
+.xs-container,
 .sm-container,
 .md-container,
 .lg-container {
@@ -53,6 +54,10 @@ body {
     @apply mx-auto;
 }
 
+.xs-container {
+    max-width: 840px;
+    padding: 0 var(--container-padding-x);
+}
 .sm-container {
     max-width: 1056px;
     padding: 0 var(--container-padding-x);

--- a/app/helpers/react_components/track/approach.rb
+++ b/app/helpers/react_components/track/approach.rb
@@ -1,9 +1,0 @@
-module ReactComponents
-  module Track
-    class Approach < ReactComponent
-      def to_s
-        super("track-approach", {})
-      end
-    end
-  end
-end

--- a/app/javascript/components/track/Approach.tsx
+++ b/app/javascript/components/track/Approach.tsx
@@ -1,5 +1,0 @@
-import React from 'react'
-
-export function Approach(): JSX.Element {
-  return <div>hello from react </div>
-}

--- a/app/javascript/components/track/index.ts
+++ b/app/javascript/components/track/index.ts
@@ -2,5 +2,4 @@ export { ExerciseCommunitySolutionsList } from './ExerciseCommunitySolutionsList
 export { ExerciseMakersButton } from './ExerciseMakersButton'
 export { ConceptMakersButton } from './ConceptMakersButton'
 export { DigDeeper as DigDeeper } from './DigDeeper'
-export { Approach } from './Approach'
 export { UnlockHelpButton } from './UnlockHelpButton'

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -185,7 +185,6 @@ export const mappings = {
   'track-dig-deeper': (data: DigDeeperProps) => (
     <TrackComponents.DigDeeper data={camelizeKeysAs<DigDeeperProps>(data)} />
   ),
-  'track-approach': (data: any) => <TrackComponents.Approach />,
 
   'unlock-help-button': (data: { unlock_url: string }): JSX.Element => (
     <TrackComponents.UnlockHelpButton unlockUrl={data.unlock_url} />

--- a/app/views/tracks/approaches/show.html.haml
+++ b/app/views/tracks/approaches/show.html.haml
@@ -21,7 +21,7 @@
           %span.text-textColor6
             Published at
             = format_date(@approach.created_at)
-  .xs-container.mb-32.md:mb-48
+  .md-container.mb-32.md:mb-48
     %article.shadow-lgZ1.bg-backgroundColorA.rounded-8
       .share-bar.border-b-1.border-borderColor6.py-12.md:py-16.px-24.md:px-32.flex.items-center
         = graphical_icon "lightbulb", category: :graphics, css_class: "main-graphic hidden md:block"

--- a/app/views/tracks/approaches/show.html.haml
+++ b/app/views/tracks/approaches/show.html.haml
@@ -21,7 +21,7 @@
           %span.text-textColor6
             Published at
             = format_date(@approach.created_at)
-  .md-container.mb-32.md:mb-48
+  .xs-container.mb-32.md:mb-48
     %article.shadow-lgZ1.bg-backgroundColorA.rounded-8
       .share-bar.border-b-1.border-borderColor6.py-12.md:py-16.px-24.md:px-32.flex.items-center
         = graphical_icon "lightbulb", category: :graphics, css_class: "main-graphic hidden md:block"

--- a/app/views/tracks/approaches/show.html.haml
+++ b/app/views/tracks/approaches/show.html.haml
@@ -5,14 +5,12 @@
 #page-approaches-show.pb-80
   %header.pt-24.md:pt-32.pb-32{ class: 'md:pb-[158px]' }
     .md-container.flex.flex-col.md:flex-row-reverse.items-center
-      -# .c-shapes.c-shapes-1{ class: 'gap-[48px]' }
       = link_to Exercism::Routes.track_exercise_path(@track, @exercise), class: "py-8 px-24 bg-gray border-2 border-gradient-bgGray rounded-100 flex flex-row items-center h-[68px]" do
         = track_icon @track, css_class: 'h-[40px] w-[40px] mr-12'
         = exercise_icon @exercise, css_class: 'h-[48px] w-[48px] mr-12'
         .flex.flex-col.mr-24
           .text-h5.whitespace-nowrap= @exercise.title
           .textColor-6.font-normal.leading-150.text-16 in #{@track.title}
-        = graphical_icon "new-tab", css_class: "filter-textColor6 w-[16px] h-[16px]"
 
       .block.flex-grow
         %h1.text-h0.mb-8.md:mb-8= @approach.title


### PR DESCRIPTION
This PR removes some dead code, and removes a misleading new tab icon, as the button opens the link in the same tab.