### PR TITLE
Allow more attributes in markdown

### DIFF
--- a/app/commands/markdown/parse.rb
+++ b/app/commands/markdown/parse.rb
@@ -49,7 +49,7 @@ class Markdown::Parse
     Markdown::RenderHTML.(doc, nofollow_links:, heading_ids:)
   end
 
-  ALLOWED_ATTRIBUTE_NAMES = %w[id href target rel class].freeze
+  ALLOWED_ATTRIBUTE_NAMES = %w[id href target rel class width height alt src].freeze
   ALLOWED_TOOLTIP_TYPES = %w[concept exercise].freeze
   private_constant :ALLOWED_ATTRIBUTE_NAMES, :ALLOWED_TOOLTIP_TYPES
 end

--- a/test/commands/markdown/parse_test.rb
+++ b/test/commands/markdown/parse_test.rb
@@ -47,10 +47,17 @@ Done')
     assert_equal expected.chomp, actual.chomp
   end
 
-  test "sanitizes data tags" do
+  test "sanitizes data- attributes" do
     expected = '<div>test</div>'
 
     actual = Markdown::Parse.('<div data-react-id="abd" data-react-data="{}" --hydrated>test</div>')
+    assert_equal expected.chomp, actual.chomp
+  end
+
+  test "does not sanitize allowed attributes" do
+    expected = '<div id="first" href="#" target="_blank" class="button" src="test.com" alt="lovely" width="80" height="50">test</div>'
+
+    actual = Markdown::Parse.('<div id="first" href="#" target="_blank" class="button" src="test.com" alt="lovely" width="80" height="50">test</div>') # rubocop:disable Layout/LineLength
     assert_equal expected.chomp, actual.chomp
   end
 


### PR DESCRIPTION
This fixes the issue where the icons on the docs page are not shown
