### PR TITLE
Optimize build status queries

### DIFF
--- a/app/assemblers/combine_authors_and_contributors.rb
+++ b/app/assemblers/combine_authors_and_contributors.rb
@@ -10,12 +10,12 @@ class CombineAuthorsAndContributors
   end
 
   private
-  def randomize(users, limit)
+  def randomize(users, num_users)
     if users.is_a?(ActiveRecord::Relation)
-      ids = users.pluck(:id).shuffle.take(limit)
-      users.where(id: ids).to_a
+      ids = users.pluck(:id).shuffle.take(num_users)
+      users.includes(:profile).where(id: ids).to_a
     else
-      users.shuffle.take(limit)
+      users.shuffle.take(num_users)
     end
   end
 end

--- a/app/assemblers/combine_authors_and_contributors.rb
+++ b/app/assemblers/combine_authors_and_contributors.rb
@@ -15,7 +15,7 @@ class CombineAuthorsAndContributors
   private
   def randomize(users, num_users)
     if users.is_a?(ActiveRecord::Relation)
-      ids = users.pluck(user_id_column).shuffle.take(num_users)
+      ids = users.distinct.pluck(user_id_column).shuffle.take(num_users)
       User.with_attached_avatar.includes(:profile).where(id: ids).to_a
     else
       users.shuffle.take(num_users)

--- a/app/assemblers/combine_authors_and_contributors.rb
+++ b/app/assemblers/combine_authors_and_contributors.rb
@@ -1,21 +1,22 @@
 class CombineAuthorsAndContributors
   include Mandate
 
-  initialize_with :authors, :contributors, limit: 3
+  initialize_with :authors, :contributors, limit: 3, user_id_column: :id
 
   def call
     users = randomize(authors, limit)
-    users += randomize(contributors, limit - users.count)
+
+    updated_limit = limit - users.count
+    users += randomize(contributors, updated_limit) if updated_limit.positive?
+
     users
   end
 
   private
   def randomize(users, num_users)
-    return [] unless num_users.positive?
-
     if users.is_a?(ActiveRecord::Relation)
-      ids = users.pluck(:id).shuffle.take(num_users)
-      User.includes(:profile).where(id: ids).to_a
+      ids = users.pluck(user_id_column).shuffle.take(num_users)
+      User.with_attached_avatar.includes(:profile).where(id: ids).to_a
     else
       users.shuffle.take(num_users)
     end

--- a/app/assemblers/combine_authors_and_contributors.rb
+++ b/app/assemblers/combine_authors_and_contributors.rb
@@ -11,9 +11,11 @@ class CombineAuthorsAndContributors
 
   private
   def randomize(users, num_users)
+    return [] unless num_users.positive?
+
     if users.is_a?(ActiveRecord::Relation)
       ids = users.pluck(:id).shuffle.take(num_users)
-      users.includes(:profile).where(id: ids).to_a
+      User.includes(:profile).where(id: ids).to_a
     else
       users.shuffle.take(num_users)
     end

--- a/app/assemblers/combine_authors_and_contributors.rb
+++ b/app/assemblers/combine_authors_and_contributors.rb
@@ -15,8 +15,8 @@ class CombineAuthorsAndContributors
   private
   def randomize(users, num_users)
     if users.is_a?(ActiveRecord::Relation)
-      ids = users.distinct.pluck(user_id_column).shuffle.take(num_users)
-      User.with_attached_avatar.includes(:profile).where(id: ids).to_a
+      ids = users.distinct.order("RAND()").select(user_id_column)
+      User.with_attached_avatar.includes(:profile).where(id: ids).limit(num_users).to_a
     else
       users.shuffle.take(num_users)
     end

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -218,11 +218,11 @@ class Track::UpdateBuildStatus
   end
 
   def syllabus_volunteers
-    authors = User.with_attached_avatar.where(id: Concept::Authorship.where(concept: taught_concepts).select(:user_id)).
-      or(User.with_attached_avatar.where(id: Exercise::Authorship.where(exercise: active_concept_exercises).select(:user_id)))
+    authors = User.where(id: Concept::Authorship.where(concept: taught_concepts).select(:user_id)).
+      or(User.where(id: Exercise::Authorship.where(exercise: active_concept_exercises).select(:user_id)))
 
-    contributors = User.with_attached_avatar.where(id: Concept::Contributorship.where(concept: taught_concepts).select(:user_id)).
-      or(User.with_attached_avatar.where(id: Exercise::Contributorship.where(exercise: active_concept_exercises).select(:user_id)))
+    contributors = User.where(id: Concept::Contributorship.where(concept: taught_concepts).select(:user_id)).
+      or(User.where(id: Exercise::Contributorship.where(exercise: active_concept_exercises).select(:user_id)))
 
     serialize_volunteers(authors, contributors)
   end
@@ -292,12 +292,10 @@ class Track::UpdateBuildStatus
   end
 
   def practice_exercises_volunteers
-    authors = User.with_attached_avatar.where(id:
-      Exercise::Authorship.where(exercise: active_practice_exercises).select(:user_id))
-    contributors = User.with_attached_avatar.where(id:
-      Exercise::Contributorship.where(exercise: active_practice_exercises).select(:user_id))
+    authors = Exercise::Authorship.where(exercise: active_practice_exercises)
+    contributors = Exercise::Contributorship.where(exercise: active_practice_exercises)
 
-    serialize_volunteers(authors, contributors)
+    serialize_volunteers(authors, contributors, user_id_column: :user_id)
   end
 
   memoize
@@ -365,17 +363,15 @@ class Track::UpdateBuildStatus
   end
 
   def serialize_tooling_volunteers(repo_url)
-    authors = User.with_attached_avatar.where(id: track.reputation_tokens.where(category: :building).where('external_url LIKE ?',
-      "#{repo_url}/%").select(:user_id))
-    volunteers = User.with_attached_avatar.where(id: track.reputation_tokens.where(category: :maintaining).where('external_url LIKE ?',
-      "#{repo_url}/%").select(:user_id))
-    serialize_volunteers(authors, volunteers)
+    authors = track.reputation_tokens.where(category: :building).where('external_url LIKE ?', "#{repo_url}/%")
+    contributors = track.reputation_tokens.where(category: :maintaining).where('external_url LIKE ?', "#{repo_url}/%")
+    serialize_volunteers(authors, contributors, user_id_column: :user_id)
   end
 
-  def serialize_volunteers(authors, contributors)
+  def serialize_volunteers(authors, contributors, user_id_column: :id)
     {
-      users: SerializeAuthorOrContributors.(CombineAuthorsAndContributors.(authors, contributors)),
-      num_users: User.where(id: authors.select(:id) + contributors.select(:id)).count
+      users: SerializeAuthorOrContributors.(CombineAuthorsAndContributors.(authors, contributors, user_id_column:)),
+      num_users: User.where(id: authors.select(user_id_column)).or(User.where(id: contributors.select(user_id_column))).count
     }
   end
 

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -86,7 +86,7 @@ class Track::UpdateBuildStatus
 
   def mentor_discussions
     {
-      num_discussions: track.mentor_discussions.count
+      num_discussions: Mentor::Discussion.joins(:request).where(request: { track: }).count
     }
   end
 

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -72,8 +72,13 @@ class Track::UpdateBuildStatus
   def submissions
     {
       num_submissions:,
-      num_submissions_per_day: average_number_per_day(track.submissions, Submission)
+      num_submissions_per_day:
     }
+  end
+
+  def num_submissions_per_day
+    query = MetricPeriod::Day.where(metric_type: Metrics::SubmitSubmissionMetric.name, track:)
+    average(query.sum(:count), query.count)
   end
 
   memoize

--- a/db/migrate/20221124094828_add_build_status_indexes.rb
+++ b/db/migrate/20221124094828_add_build_status_indexes.rb
@@ -4,6 +4,7 @@ class AddBuildStatusIndexes < ActiveRecord::Migration[7.0]
       add_index :mentor_requests, %i[track_id exercise_id], if_not_exists: true
       add_index :user_reputation_tokens, %i[track_id category external_url], name: 'index_user_reputation_tokens_on_track_id_category_external_url', if_not_exists: true
       add_index :submission_analyses, %i[track_id num_comments], if_not_exists: true
+      add_index :submissions, %i[track_id tests_status], if_not_exists: true
     end
   end
 end

--- a/db/migrate/20221124094828_add_build_status_indexes.rb
+++ b/db/migrate/20221124094828_add_build_status_indexes.rb
@@ -1,5 +1,8 @@
 class AddBuildStatusIndexes < ActiveRecord::Migration[7.0]
   def change
-    add_index :mentor_requests, %i[track_id exercise_id]
+    unless Rails.env.production?
+      add_index :mentor_requests, %i[track_id exercise_id], if_not_exists: true
+      add_index :user_reputation_tokens, %i[track_id category external_url], name: 'index_user_reputation_tokens_on_track_id_category_external_url', if_not_exists: true
+    end
   end
 end

--- a/db/migrate/20221124094828_add_build_status_indexes.rb
+++ b/db/migrate/20221124094828_add_build_status_indexes.rb
@@ -3,6 +3,7 @@ class AddBuildStatusIndexes < ActiveRecord::Migration[7.0]
     unless Rails.env.production?
       add_index :mentor_requests, %i[track_id exercise_id], if_not_exists: true
       add_index :user_reputation_tokens, %i[track_id category external_url], name: 'index_user_reputation_tokens_on_track_id_category_external_url', if_not_exists: true
+      add_index :submission_analyses, %i[track_id num_comments], if_not_exists: true
     end
   end
 end

--- a/db/migrate/20221124094828_add_build_status_indexes.rb
+++ b/db/migrate/20221124094828_add_build_status_indexes.rb
@@ -1,0 +1,5 @@
+class AddBuildStatusIndexes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :mentor_requests, %i[track_id exercise_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -777,6 +777,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_094828) do
     t.bigint "track_id"
     t.index ["submission_id"], name: "index_submission_analyses_on_submission_id"
     t.index ["track_id", "id"], name: "index_submission_analyses_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id", "num_comments"], name: "index_submission_analyses_on_track_id_and_num_comments"
     t.index ["track_id"], name: "index_submission_analyses_on_track_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_18_125948) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_24_094828) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -564,6 +564,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_125948) do
     t.index ["status", "exercise_id"], name: "index_mentor_requests_on_status_and_exercise_id"
     t.index ["status", "track_id"], name: "index_mentor_requests_on_status_and_track_id"
     t.index ["student_id"], name: "index_mentor_requests_on_student_id"
+    t.index ["track_id", "exercise_id"], name: "index_mentor_requests_on_track_id_and_exercise_id"
     t.index ["track_id", "status"], name: "index_mentor_requests_on_track_id_and_status"
     t.index ["track_id"], name: "index_mentor_requests_on_track_id"
     t.index ["uuid"], name: "index_mentor_requests_on_uuid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -843,6 +843,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_094828) do
     t.string "git_important_files_hash", limit: 50
     t.integer "track_id", limit: 2
     t.index ["solution_id"], name: "index_submissions_on_solution_id"
+    t.index ["track_id", "tests_status"], name: "index_submissions_on_track_id_and_tests_status"
     t.index ["track_id"], name: "index_submissions_on_track_id"
     t.index ["uuid"], name: "index_submissions_on_uuid", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1069,6 +1069,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_094828) do
     t.datetime "updated_at", null: false
     t.index ["earned_on"], name: "sweeper"
     t.index ["exercise_id"], name: "index_user_reputation_tokens_on_exercise_id"
+    t.index ["track_id", "category", "external_url"], name: "index_user_reputation_tokens_on_track_id_category_external_url"
     t.index ["track_id"], name: "index_user_reputation_tokens_on_track_id"
     t.index ["uniqueness_key", "user_id"], name: "index_user_reputation_tokens_on_uniqueness_key_and_user_id", unique: true
     t.index ["user_id", "earned_on", "type"], name: "index_user_reputation_tokens_query_3"


### PR DESCRIPTION
- Calculate num_submissions per day from metrics
- Optimize query for num_discussions
- Add index on [track_id, exercise_id] for mentor_requests
- Add index on [track_id, exercise_id] for mentor_requests
- Add index on [track_id, category, external_url] for user_reputation_tokens
- Add index on [track_id, num_comments] for submission_analyses
- Add index on [track_id, tests_status] for submissions
- Include profile in author/contributor combining
- Short-circuit combining authors and contributors
