### PR TITLE
Add metric for joining track

### DIFF
--- a/app/commands/metric_period/search.rb
+++ b/app/commands/metric_period/search.rb
@@ -6,6 +6,7 @@ class MetricPeriod::Search
     open_issue_metric open_pull_request_metric merge_pull_request_metric
     start_solution_metric complete_solution_metric publish_solution_metric
     request_mentoring_metric request_private_mentoring_metric finish_mentoring_metric
+    join_track_metric
   ].freeze
 
   initialize_with :period_type, :options

--- a/app/commands/user_track/create.rb
+++ b/app/commands/user_track/create.rb
@@ -5,7 +5,13 @@ class UserTrack
     initialize_with :user, :track
 
     def call
-      ::UserTrack.create_or_find_by!(user:, track:)
+      ::UserTrack.create_or_find_by!(user:, track:).tap do |user_track|
+        log_metric!(user_track)
+      end
+    end
+
+    def log_metric!(user_track)
+      Metric::Queue.(:join_track, user_track.created_at, user_track:, track:, user:)
     end
   end
 end

--- a/app/models/metrics/join_track_metric.rb
+++ b/app/models/metrics/join_track_metric.rb
@@ -1,0 +1,5 @@
+class Metrics::JoinTrackMetric < Metric
+  params :user_track
+
+  def guard_params = user_track.id
+end

--- a/test/commands/user_track/create_test.rb
+++ b/test/commands/user_track/create_test.rb
@@ -14,6 +14,22 @@ class UserTrack::CreateTest < ActiveSupport::TestCase
     assert_equal track, ut.track
   end
 
+  test "adds metric" do
+    user = create :user
+    track = create :track
+
+    user_track = UserTrack::Create.(user, track)
+    perform_enqueued_jobs
+
+    assert_equal 1, Metric.count
+    metric = Metric.last
+    assert_equal Metrics::JoinTrackMetric, metric.class
+    assert_equal user_track.created_at, metric.occurred_at
+    assert_equal user_track, metric.user_track
+    assert_equal track, metric.track
+    assert_equal user, metric.user
+  end
+
   test "idempotent" do
     user = create :user
     track = create :track

--- a/test/factories/metrics.rb
+++ b/test/factories/metrics.rb
@@ -44,4 +44,8 @@ FactoryBot.define do
   factory :open_issue_metric, parent: :metric, class: 'Metrics::OpenIssueMetric' do
     params { { issue: create(:github_issue, :random) } }
   end
+
+  factory :join_track_metric, parent: :metric, class: 'Metrics::JoinTrackMetric' do
+    params { { user_track: create(:user_track, track:, user:) } }
+  end
 end

--- a/test/models/metrics/join_track_metric_test.rb
+++ b/test/models/metrics/join_track_metric_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Metrics::JoinTrackMetricTest < ActiveSupport::TestCase
+  test "create metric" do
+    freeze_time do
+      track = create :track, id: 2
+      user = create :user, id: 3
+      user_track = create :user_track, user: user, track: track, id: 4
+      occurred_at = Time.current - 5.seconds
+
+      metric = Metric::Create.(:join_track, occurred_at, user_track:, track:, user:)
+
+      assert_equal Metrics::JoinTrackMetric, metric.class
+      assert_equal occurred_at, metric.occurred_at
+      assert_equal user, metric.user
+      assert_equal track, metric.track
+      assert_equal "JoinTrackMetric|4", metric.uniqueness_key
+    end
+  end
+
+  test "correctly sets params" do
+    freeze_time do
+      user_track = create :user_track, id: 4
+
+      metric = Metric::Create.(:join_track, Time.current, user_track:)
+
+      expected = { "user_track" => "gid://website/UserTrack/4" }
+      assert_equal expected, metric.params
+    end
+  end
+
+  test "uniqueness_key is unique per issue" do
+    uniqueness_keys = Array.new(10) do
+      issue = create :github_issue, :random
+      Metric::Create.(:open_issue, Time.current, issue:)
+    end
+
+    assert_equal uniqueness_keys.uniq.size, uniqueness_keys.size
+  end
+
+  test "idempotent" do
+    issue = create :github_issue
+
+    assert_idempotent_command do
+      Metric::Create.(:open_issue, Time.utc(2012, 7, 25), issue:)
+    end
+  end
+end

--- a/test/models/metrics/join_track_metric_test.rb
+++ b/test/models/metrics/join_track_metric_test.rb
@@ -29,20 +29,20 @@ class Metrics::JoinTrackMetricTest < ActiveSupport::TestCase
     end
   end
 
-  test "uniqueness_key is unique per issue" do
+  test "uniqueness_key is unique per user track" do
     uniqueness_keys = Array.new(10) do
-      issue = create :github_issue, :random
-      Metric::Create.(:open_issue, Time.current, issue:)
+      user_track = create :user_track, track: create(:track, :random_slug)
+      Metric::Create.(:join_track, Time.current, user_track:)
     end
 
     assert_equal uniqueness_keys.uniq.size, uniqueness_keys.size
   end
 
   test "idempotent" do
-    issue = create :github_issue
+    user_track = create :user_track
 
     assert_idempotent_command do
-      Metric::Create.(:open_issue, Time.utc(2012, 7, 25), issue:)
+      Metric::Create.(:join_track, Time.utc(2012, 7, 25), user_track:)
     end
   end
 end


### PR DESCRIPTION
We can use this metric to calculate the build status page's data and on the impact page.

This should back-port the existing data (1.2M records):

```ruby
UserTrack.includes(:track, :user).find_in_batches do |batch|
  batch.each do |user_track|
    Metric::Create.(:join_track, user_track.created_at, user_track:, track: user_track.track, user: user_track.user)
  end
end
```
