### PR TITLE
Track dashboard frontend patch

### DIFF
--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -286,8 +286,17 @@
     }
 
     .sticky {
+        .record-name {
+            @apply mb-0;
+        }
         .record-element {
-            @apply bg-white;
+            @apply bg-white items-center;
+        }
+    }
+
+    .record-value {
+        strong {
+            @apply mt-8 xl:mt-0;
         }
     }
 

--- a/app/css/pages/track-build.css
+++ b/app/css/pages/track-build.css
@@ -285,6 +285,12 @@
         @apply w-1-2;
     }
 
+    .sticky {
+        .record-element {
+            @apply bg-white;
+        }
+    }
+
     .record-row {
         @apply flex justify-between lg:items-center;
         @apply lg:flex-row flex-col;

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -4,7 +4,7 @@
   .lg-container.grid.grid-cols-3.gap-48.relative.mt-40
     .col-span-2
       %h1.text-h1.mb-12.text-48.font-bold.z-1
-        .highlight-text= @status.students.num_students
+        .highlight-text= number_with_delimiter(@status.students.num_students)
         students have developed their #{@track.title} skills.
       .grid.grid-cols-3.mb-32.gap-16
         .report-stat
@@ -104,7 +104,7 @@
                 .record-name
                   = render ViewComponents::ConceptIcon.new(concept, :small)
                   = concept.name
-                .record-value #{concept.num_students_learnt} learnt
+                .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
           %details
             %summary.--lightbulb
               #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
@@ -123,13 +123,13 @@
                   = exercise.title
                 .record-value
                   .record-element
-                    %strong= exercise.num_started
+                    %strong= number_with_delimiter(exercise.num_started)
                   .record-element
-                    %strong #{exercise.num_submitted} (avg. #{exercise.num_submitted_average})
+                    %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
                   .record-element
-                    %strong #{exercise.num_completed} (#{exercise.num_completed_percentage}%)
+                    %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
                   .record-element
-                    %strong #{exercise.num_mentoring_requests} (#{exercise.num_mentoring_requests_percentage}%)
+                    %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
         = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
@@ -272,13 +272,13 @@
                   = exercise.title
                 .record-value
                   .record-element
-                    %strong= exercise.num_started
+                    %strong= = number_with_delimiter(exercise.num_started)
                   .record-element
-                    %strong #{exercise.num_submitted} (avg. #{exercise.num_submitted_average})
+                    %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
                   .record-element
-                    %strong #{exercise.num_completed} (#{exercise.num_completed_percentage}%)
+                    %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
                   .record-element
-                    %strong #{exercise.num_mentoring_requests} (#{exercise.num_mentoring_requests_percentage}%)
+                    %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
         = render ReactComponents::Common::Credits.new(@status.practice_exercises.volunteers.users, @status.practice_exercises.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
@@ -295,16 +295,18 @@
         - @status.volunteers.users[0, 3].to_a.each do |volunteer|
           .contributor-credit-block
             .contributor
-              = avatar(volunteer)
+              = avatar(volunteer, css_class: "h-32 w-32")
               = volunteer.handle
             = render ViewComponents::Reputation.new(volunteer.reputation, flashy: true, size: :small)
 
         .inline-grid.grid-cols-6.gap-16.mt-20.mb-16
           - @status.volunteers.users[3..].to_a.each do |volunteer|
-            = avatar(volunteer)
+            = avatar(volunteer, css_class: "h-32 w-32")
           - if @status.volunteers.num_volunteers > @status.volunteers.users.size
             .col-span-2.self-center.leading-170.text-14.font-semibold.text-lightBlue
-              + #{@status.volunteers.num_volunteers - @status.volunteers.users.size} more
+              = link_to contributing_contributors_path(track_slug: @track.slug) do
+                + #{number_with_delimiter(@status.volunteers.num_volunteers - @status.volunteers.users.size)} more
+
 
         .rounded-8.py-16.px-20.bg-backgroundColorG
           %h6.text-h6.leading-150.mb-4 We 💙 our volunteers

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -109,7 +109,7 @@
             %summary.--lightbulb
               #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky.top-0.bg-white
+            .record-row.sticky.top-0
               .record-name
               .record-value
                 .record-element Started
@@ -258,7 +258,7 @@
             %summary.--practice-exercises
               #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky.top-0.bg-white
+            .record-row.sticky.top-0
               .record-name
               .record-value
                 .record-element Started
@@ -272,7 +272,7 @@
                   = exercise.title
                 .record-value
                   .record-element
-                    %strong= = number_with_delimiter(exercise.num_started)
+                    %strong= number_with_delimiter(exercise.num_started)
                   .record-element
                     %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
                   .record-element

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -2,7 +2,7 @@
 
   %header.absolute.top-0
   .lg-container.grid.grid-cols-3.gap-48.relative.mt-40
-    .col-span-2
+    .col-span-3.xl:col-span-2
       %h1.text-h1.mb-12.text-48.font-bold.z-1
         .highlight-text= number_with_delimiter(@status.students.num_students)
         students have developed their #{@track.title} skills.
@@ -109,8 +109,8 @@
             %summary.--lightbulb
               #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky.top-0
-              .record-name
+            .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
+              .record-name.mb-0
               .record-value
                 .record-element Started
                 .record-element Attempts
@@ -258,7 +258,7 @@
             %summary.--practice-exercises
               #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky.top-0
+            .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
               .record-name
               .record-value
                 .record-element Started
@@ -283,7 +283,7 @@
         = render ReactComponents::Common::Credits.new(@status.practice_exercises.volunteers.users, @status.practice_exercises.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
 
-    .col-span-1
+    .hidden.xl:block.col-span-1
       = ReactComponents::Impact::Map.new(track: @track)
       .rounded-8.p-24.shadow-baseZ1.bg-white
         .flex.items-center.mb-12

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -258,6 +258,7 @@ module.exports = {
     height: {
       auto: 'auto',
       arbitary: '1px',
+      32: '32px',
       48: '48px',
       100: '100%',
     },


### PR DESCRIPTION
#### - Add delimiters to big numbers

#### - Apply white background only for the column names.

Before:
<img width="908" alt="Screenshot 2022-11-28 at 11 22 17" src="https://user-images.githubusercontent.com/66035744/204253819-a47bb343-0fac-4bdc-afe3-6d6ef693816a.png">

After:
<img width="908" alt="Screenshot 2022-11-28 at 11 17 56" src="https://user-images.githubusercontent.com/66035744/204253663-2c726cfa-02d3-42bb-ab67-d9428ed143ab.png">

---

#### - Add fix height-width to avatars on volunteers panel

Before:
<img width="487" alt="Screenshot 2022-11-28 at 11 26 43" src="https://user-images.githubusercontent.com/66035744/204254716-de4f7d36-97ad-4b7d-a9ea-41ec4f743554.png">


After:
<img width="487" alt="Screenshot 2022-11-28 at 11 25 22" src="https://user-images.githubusercontent.com/66035744/204254617-f4e260ac-3878-49d4-8e19-09ff2193f10f.png">

#### - "+ 2578 more" is a link now to track contributors list

