### PR TITLE
Allow maintainers to do WIP exercises in the editor

### DIFF
--- a/app/commands/user_track/generate_summary_data.rb
+++ b/app/commands/user_track/generate_summary_data.rb
@@ -28,6 +28,8 @@ class UserTrack
     private
     attr_reader :exercises_data, :concepts_hash
 
+    delegate :user, to: :user_track
+
     memoize
     def exercises_hash
       exercises_data.transform_values do |exercise|
@@ -66,10 +68,14 @@ class UserTrack
     end
 
     def generate_exercises_data!
-      exercises = (
-        user_track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a +
-        user_track.practice_exercises.includes(:practiced_concepts, :prerequisites).to_a
-      ).freeze
+      if user.maintainer?
+        exercises = track.exercises.to_a.freeze
+      else
+        exercises = (
+          user_track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a +
+          user_track.practice_exercises.includes(:practiced_concepts, :prerequisites).to_a
+        ).freeze
+      end
 
       @exercises_data = exercises.each_with_object({}) do |exercise, data|
         prerequisite_concept_slugs = exercise.prerequisites.pluck(:slug)

--- a/app/commands/user_track/generate_summary_data.rb
+++ b/app/commands/user_track/generate_summary_data.rb
@@ -28,8 +28,6 @@ class UserTrack
     private
     attr_reader :exercises_data, :concepts_hash
 
-    delegate :user, to: :user_track
-
     memoize
     def exercises_hash
       exercises_data.transform_values do |exercise|
@@ -68,14 +66,10 @@ class UserTrack
     end
 
     def generate_exercises_data!
-      if user.maintainer?
-        exercises = track.exercises.to_a.freeze
-      else
-        exercises = (
-          user_track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a +
-          user_track.practice_exercises.includes(:practiced_concepts, :prerequisites).to_a
-        ).freeze
-      end
+      exercises = (
+        user_track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a +
+        user_track.practice_exercises.includes(:practiced_concepts, :prerequisites).to_a
+      ).freeze
 
       @exercises_data = exercises.each_with_object({}) do |exercise, data|
         prerequisite_concept_slugs = exercise.prerequisites.pluck(:slug)

--- a/app/css/components/exercise-status-tag.css
+++ b/app/css/components/exercise-status-tag.css
@@ -19,6 +19,10 @@
         }
     }
 
+    &.--wip {
+        @apply border-warningBtnBorder bg-warning;
+        @apply text-white;
+    }
     &.--in-progress {
         @apply border-lightBlue bg-veryLightBlue;
         @apply text-lightBlue;

--- a/app/helpers/view_components/track/exercise_status_tag.rb
+++ b/app/helpers/view_components/track/exercise_status_tag.rb
@@ -4,6 +4,8 @@ module ViewComponents
       initialize_with :exercise, :user_track
 
       def to_s
+        return tag.div("Work In Progress", class: 'c-exercise-status-tag --wip') if exercise.wip?
+
         status = user_track.exercise_status(exercise).to_sym
         case status
         when :available

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -122,7 +122,7 @@ class Track < ApplicationRecord
     git.foregone_exercises.map { |slug| ProblemSpecifications::Exercise.new(slug) }
   end
 
-  def team_name = slug
+  def github_team_name = slug
 
   CATGEORIES = {
     paradigm: "Paradigm",

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -122,6 +122,8 @@ class Track < ApplicationRecord
     git.foregone_exercises.map { |slug| ProblemSpecifications::Exercise.new(slug) }
   end
 
+  def team_name = slug
+
   CATGEORIES = {
     paradigm: "Paradigm",
     typing: "Typing",

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -158,7 +158,7 @@ class UserTrack < ApplicationRecord
 
   memoize
   def maintainer?
-    user.maintainer? && user.github_team_memberships.where(team_name: track.team_name).exists?
+    user.maintainer? && user.github_team_memberships.where(team_name: track.github_team_name).exists?
   end
 
   private

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -78,6 +78,12 @@ class UserTrack < ApplicationRecord
   end
 
   def enabled_exercises(exercises)
+    # This should really be "If the user a maintainer FOR THIS TRACK".
+    # I don't know how well we keep that up to date. If we do, then
+    # let's take that approach and refine it a bit. Otherwise let's
+    # consider if we want this brute-force approach for all maintainers.
+    return exercises if user.maintainer?
+
     exercises.where(status: %i[active beta]).or(exercises.where(id: solutions.select(:exercise_id)))
   end
 

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -79,12 +79,7 @@ class UserTrack < ApplicationRecord
 
   def enabled_exercises(exercises)
     status = %i[active beta]
-
-    # This should really be "If the user a maintainer FOR THIS TRACK".
-    # I don't know how well we keep that up to date. If we do, then
-    # let's take that approach and refine it a bit. Otherwise let's
-    # consider if we want this brute-force approach for all maintainers.
-    status << :wip if user.maintainer?
+    status << :wip if maintainer?
 
     exercises.where(status:).or(exercises.where(id: solutions.select(:exercise_id)))
   end
@@ -159,6 +154,11 @@ class UserTrack < ApplicationRecord
     reload
     self.summary_key = nil
     @summary = nil
+  end
+
+  memoize
+  def maintainer?
+    user.maintainer? && user.github_team_memberships.where(team_name: track.team_name).exists?
   end
 
   private

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -78,13 +78,15 @@ class UserTrack < ApplicationRecord
   end
 
   def enabled_exercises(exercises)
+    status = %i[active beta]
+
     # This should really be "If the user a maintainer FOR THIS TRACK".
     # I don't know how well we keep that up to date. If we do, then
     # let's take that approach and refine it a bit. Otherwise let's
     # consider if we want this brute-force approach for all maintainers.
-    return exercises if user.maintainer?
+    status << :wip if user.maintainer?
 
-    exercises.where(status: %i[active beta]).or(exercises.where(id: solutions.select(:exercise_id)))
+    exercises.where(status:).or(exercises.where(id: solutions.select(:exercise_id)))
   end
 
   def external? = false

--- a/app/models/user_track/external.rb
+++ b/app/models/user_track/external.rb
@@ -17,6 +17,7 @@ class UserTrack
     def user = nil
     def tutorial_exercise_completed? = false
     def anonymous_during_mentoring? = true
+    def maintainer? = false
 
     memoize
     def exercises

--- a/test/commands/user_track/generate_summary_data/exercises_available_test.rb
+++ b/test/commands/user_track/generate_summary_data/exercises_available_test.rb
@@ -286,7 +286,7 @@ class UserTrack::GenerateSummaryData::ExercisesUnlockedTest < ActiveSupport::Tes
     wip_practice_exercise = create :practice_exercise, :random_slug, track: track, status: :wip
 
     user = create :user, roles: [:maintainer], uid: '1232134'
-    create :github_team_member, user_id: user.uid, team_name: track.team_name
+    create :github_team_member, user_id: user.uid, team_name: track.github_team_name
     user_track = create :user_track, track: track, user: user
     hw_solution = create :hello_world_solution, :completed, track: track, user: user
     hello_world = hw_solution.exercise

--- a/test/commands/user_track/generate_summary_data/exercises_available_test.rb
+++ b/test/commands/user_track/generate_summary_data/exercises_available_test.rb
@@ -285,7 +285,8 @@ class UserTrack::GenerateSummaryData::ExercisesUnlockedTest < ActiveSupport::Tes
     wip_concept_exercise = create :concept_exercise, :random_slug, track: track, status: :wip
     wip_practice_exercise = create :practice_exercise, :random_slug, track: track, status: :wip
 
-    user = create :user, roles: [:maintainer]
+    user = create :user, roles: [:maintainer], uid: '1232134'
+    create :github_team_member, user_id: user.uid, team_name: track.team_name
     user_track = create :user_track, track: track, user: user
     hw_solution = create :hello_world_solution, :completed, track: track, user: user
     hello_world = hw_solution.exercise

--- a/test/commands/user_track/generate_summary_data/exercises_available_test.rb
+++ b/test/commands/user_track/generate_summary_data/exercises_available_test.rb
@@ -278,8 +278,24 @@ class UserTrack::GenerateSummaryData::ExercisesUnlockedTest < ActiveSupport::Tes
     assert_equal [beta_concept_exercise, active_concept_exercise, deprecated_concept_exercise], summary.unlocked_concept_exercises
     assert_equal [beta_practice_exercise, active_practice_exercise, deprecated_practice_exercise, hello_world],
       summary.unlocked_practice_exercises
+  end
 
-    # TODO: (Optional): show wip exercises for maintainers
+  test "maintainers can see WIP exercises" do
+    track = create :track
+    wip_concept_exercise = create :concept_exercise, :random_slug, track: track, status: :wip
+    wip_practice_exercise = create :practice_exercise, :random_slug, track: track, status: :wip
+
+    user = create :user, roles: [:maintainer]
+    user_track = create :user_track, track: track, user: user
+    hw_solution = create :hello_world_solution, :completed, track: track, user: user
+    hello_world = hw_solution.exercise
+
+    summary = summary_for(user_track)
+
+    # Test that the :wip and :deprecated exercises are not shown
+    assert_equal [wip_concept_exercise, wip_practice_exercise, hello_world], summary.unlocked_exercises
+    assert_equal [wip_concept_exercise], summary.unlocked_concept_exercises
+    assert_equal [wip_practice_exercise, hello_world], summary.unlocked_practice_exercises
   end
 
   private

--- a/test/helpers/view_components/track/exercise_status_tag_test.rb
+++ b/test/helpers/view_components/track/exercise_status_tag_test.rb
@@ -21,14 +21,22 @@ class ViewComponents::Track::ExerciseStatusTagTest < ActionView::TestCase
     assert_tag(:published, "Published", "published")
   end
 
+  test "wip" do
+    exercise = create :practice_exercise, status: :wip
+    expected = tag.div("Work In Progress", class: "c-exercise-status-tag --wip")
+    assert_equal expected, render(ViewComponents::Track::ExerciseStatusTag.new(exercise, nil))
+  end
+
   test "external" do
+    exercise = mock(wip?: false)
     user_track = mock(exercise_status: :external)
-    assert_equal "", render(ViewComponents::Track::ExerciseStatusTag.new(nil, user_track))
+    assert_equal "", render(ViewComponents::Track::ExerciseStatusTag.new(exercise, user_track))
   end
 
   def assert_tag(status, text, css_class)
+    exercise = mock(wip?: false)
     user_track = mock(exercise_status: status)
     expected = tag.div(text, class: "c-exercise-status-tag --#{css_class}")
-    assert_equal expected, render(ViewComponents::Track::ExerciseStatusTag.new(nil, user_track))
+    assert_equal expected, render(ViewComponents::Track::ExerciseStatusTag.new(exercise, user_track))
   end
 end

--- a/test/models/user_track/external_test.rb
+++ b/test/models/user_track/external_test.rb
@@ -5,6 +5,7 @@ class UserTrack::ExternalTest < ActiveSupport::TestCase
     ut = UserTrack::External.new(mock)
     assert ut.external?
     assert_empty ut.learnt_concepts
+    refute ut.maintainer?
 
     assert ut.exercise_unlocked?(nil)
     refute ut.exercise_completed?(nil)

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -594,7 +594,7 @@ class UserTrackTest < ActiveSupport::TestCase
       active_practice_exercise
     ].map(&:slug).sort, user_track.exercises.map(&:slug).sort
 
-    create :github_team_member, user_id: user.uid, team_name: track.team_name
+    create :github_team_member, user_id: user.uid, team_name: track.github_team_name
 
     # wip exercises are included
     assert_equal [
@@ -888,7 +888,7 @@ class UserTrackTest < ActiveSupport::TestCase
     user.update(roles: [:maintainer])
     refute user_track.reload.maintainer?
 
-    create :github_team_member, user_id: user.uid, team_name: track.team_name
+    create :github_team_member, user_id: user.uid, team_name: track.github_team_name
     assert user_track.reload.maintainer?
   end
 end


### PR DESCRIPTION
The issue was that for non-maintainers the exercises where never even getting to the user_track summary in the first place.

There's two commits here. The second improvement is probably more correct. There's a comment that needs addressing before we can merge, and I need to check if this breaks tests elsewhere.