### PR TITLE
Don't create Stripe payments when email is on block domain list

### DIFF
--- a/app/commands/donations/payment_intent/create.rb
+++ b/app/commands/donations/payment_intent/create.rb
@@ -31,7 +31,11 @@ module Donations
       end
 
       private
-      def invalid_user_or_email? = User::BlockDomain.blocked?(user_or_email)
+      def invalid_user_or_email?
+        user_or_email.is_a?(User) ?
+          User::BlockDomain.blocked?(user:) :
+          User::BlockDomain.blocked?(email: user_or_email)
+      end
 
       memoize
       def user

--- a/app/commands/donations/payment_intent/create.rb
+++ b/app/commands/donations/payment_intent/create.rb
@@ -9,7 +9,14 @@ module Donations
       initialize_with :user_or_email, :type, :amount_in_cents
 
       def call
-        return if invalid_user_or_email?
+        if invalid_user_or_email?
+          begin
+            raise "Invalid user or email trying to make donation: #{user_or_email}"
+          rescue StandardError => e
+            Bugsnag.notify(e)
+            return
+          end
+        end
 
         customer_id = user ?
           Donations::Customer::CreateForUser.(user) :

--- a/app/commands/donations/payment_intent/create.rb
+++ b/app/commands/donations/payment_intent/create.rb
@@ -9,6 +9,8 @@ module Donations
       initialize_with :user_or_email, :type, :amount_in_cents
 
       def call
+        return if invalid_user_or_email?
+
         customer_id = user ?
           Donations::Customer::CreateForUser.(user) :
           Donations::Customer::CreateForEmail.(user_or_email)
@@ -20,6 +22,9 @@ module Donations
           CreateForPayment.(customer_id, amount_in_cents)
         end
       end
+
+      private
+      def invalid_user_or_email? = User::BlockDomain.blocked?(user_or_email)
 
       memoize
       def user

--- a/app/commands/donations/payment_intent/create.rb
+++ b/app/commands/donations/payment_intent/create.rb
@@ -10,12 +10,8 @@ module Donations
 
       def call
         if invalid_user_or_email?
-          begin
-            raise "Invalid user or email trying to make donation: #{user_or_email}"
-          rescue StandardError => e
-            Bugsnag.notify(e)
-            return
-          end
+          Bugsnag.notify(PaymentIntentError.new("Invalid user or email trying to make donation: #{user_or_email}"))
+          return
         end
 
         customer_id = user ?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,7 +280,7 @@ class User < ApplicationRecord
 
   def confirmed? = super && !disabled? && !blocked?
   def disabled? = !!disabled_at
-  def blocked? = User::BlockDomain.blocked?(self)
+  def blocked? = User::BlockDomain.blocked?(user: self)
 
   def github_auth? = uid.present?
   def captcha_required? = !github_auth? && Time.current - created_at < 2.days

--- a/app/models/user/block_domain.rb
+++ b/app/models/user/block_domain.rb
@@ -1,7 +1,8 @@
 class User::BlockDomain < ApplicationRecord
-  def self.blocked?(user_or_email)
-    email = user_or_email.is_a?(User) ? user_or_email.email : user_or_email
-    domain = Mail::Address.new(email).domain
+  def self.blocked?(user: nil, email: nil)
+    raise "Specify either user or email" unless user || email
+
+    domain = Mail::Address.new(email || user.email).domain
     User::BlockDomain.where(domain:).exists?
   end
 end

--- a/app/models/user/block_domain.rb
+++ b/app/models/user/block_domain.rb
@@ -1,6 +1,7 @@
 class User::BlockDomain < ApplicationRecord
-  def self.blocked?(user)
-    domain = Mail::Address.new(user.email).domain
+  def self.blocked?(user_or_email)
+    email = user_or_email.is_a?(User) ? user_or_email.email : user_or_email
+    domain = Mail::Address.new(email).domain
     User::BlockDomain.where(domain:).exists?
   end
 end

--- a/test/commands/donations/payment_intent/create_test.rb
+++ b/test/commands/donations/payment_intent/create_test.rb
@@ -1,0 +1,78 @@
+require_relative '../test_base'
+
+class Donations::PaymentIntent::CreateTest < Donations::TestBase
+  test "creates payment correctly" do
+    customer_id = SecureRandom.uuid
+    user = create :user, stripe_customer_id: customer_id
+    type = 'payment'
+    amount_in_cents = '1200'
+    payment_intent = mock
+
+    Stripe::Customer.expects(:retrieve).with(customer_id).once
+    Stripe::PaymentIntent.expects(:create).with(
+      customer: customer_id,
+      amount: amount_in_cents,
+      currency: 'usd',
+      setup_future_usage: 'off_session'
+    ).returns(payment_intent)
+
+    actual = Donations::PaymentIntent::Create.(user, type, amount_in_cents)
+    assert_equal payment_intent, actual
+  end
+
+  test "creates subscription correctly" do
+    customer_id = SecureRandom.uuid
+    user = create :user, stripe_customer_id: customer_id
+    type = 'subscription'
+    amount_in_cents = '1200'
+    payment_intent = mock
+    stripe_subscription = mock_stripe_subscription(nil, nil, payment_intent:)
+
+    Stripe::Customer.expects(:retrieve).with(customer_id).once
+    Stripe::Subscription.expects(:create).with(
+      customer: customer_id,
+      items: [{
+        price_data: {
+          unit_amount: amount_in_cents,
+          currency: 'usd',
+          product: Exercism.secrets.stripe_recurring_product_id,
+          recurring: {
+            interval: 'month'
+          }
+        }
+      }],
+      payment_behavior: 'default_incomplete',
+      expand: ['latest_invoice.payment_intent']
+    ).returns(stripe_subscription)
+
+    actual = Donations::PaymentIntent::Create.(user, type, amount_in_cents)
+    assert_equal payment_intent, actual
+  end
+
+  test "don't create Stripe payment intent when user's email uses blocked domain" do
+    customer_id = SecureRandom.uuid
+    block_domain = create :user_block_domain
+    user = create :user, stripe_customer_id: customer_id, email: "#{SecureRandom.uuid}@#{block_domain.domain}"
+    type = 'payment'
+    amount_in_cents = '1200'
+
+    Stripe::Customer.expects(:create).never
+    Stripe::PaymentIntent.expects(:create).never
+    Stripe::Subscription.expects(:create).never
+
+    assert_nil Donations::PaymentIntent::Create.(user, type, amount_in_cents)
+  end
+
+  test "don't create Stripe payment intent when email uses blocked domain" do
+    block_domain = create :user_block_domain
+    email = "#{SecureRandom.uuid}@#{block_domain.domain}"
+    type = 'payment'
+    amount_in_cents = '1200'
+
+    Stripe::Customer.expects(:create).never
+    Stripe::PaymentIntent.expects(:create).never
+    Stripe::Subscription.expects(:create).never
+
+    assert_nil Donations::PaymentIntent::Create.(email, type, amount_in_cents)
+  end
+end

--- a/test/commands/donations/payment_intent/create_test.rb
+++ b/test/commands/donations/payment_intent/create_test.rb
@@ -75,4 +75,19 @@ class Donations::PaymentIntent::CreateTest < Donations::TestBase
 
     assert_nil Donations::PaymentIntent::Create.(email, type, amount_in_cents)
   end
+
+  test "log error in bugsnag when email uses blocked domain" do
+    block_domain = create :user_block_domain
+    email = "#{SecureRandom.uuid}@#{block_domain.domain}"
+    type = 'payment'
+    amount_in_cents = '1200'
+
+    Stripe::Customer.expects(:create).never
+    Stripe::PaymentIntent.expects(:create).never
+    Stripe::Subscription.expects(:create).never
+
+    Bugsnag.expects(:notify).once
+
+    assert_nil Donations::PaymentIntent::Create.(email, type, amount_in_cents)
+  end
 end

--- a/test/models/user/block_domain_test.rb
+++ b/test/models/user/block_domain_test.rb
@@ -4,18 +4,24 @@ class User::BlockDomainTest < ActiveSupport::TestCase
   test "blocked? with user" do
     user = create :user, email: 'test@invalid.org'
 
-    refute User::BlockDomain.blocked?(user)
+    refute User::BlockDomain.blocked?(user:)
 
     create :user_block_domain, domain: 'invalid.org'
-    assert User::BlockDomain.blocked?(user)
+    assert User::BlockDomain.blocked?(user:)
   end
 
   test "blocked? with email" do
     email = 'test@invalid.org'
 
-    refute User::BlockDomain.blocked?(email)
+    refute User::BlockDomain.blocked?(email:)
 
     create :user_block_domain, domain: 'invalid.org'
-    assert User::BlockDomain.blocked?(email)
+    assert User::BlockDomain.blocked?(email:)
+  end
+
+  test "raises when called without email or user" do
+    assert_raises do
+      User::BlockDomain.blocked?
+    end
   end
 end

--- a/test/models/user/block_domain_test.rb
+++ b/test/models/user/block_domain_test.rb
@@ -1,12 +1,21 @@
 require "test_helper"
 
 class User::BlockDomainTest < ActiveSupport::TestCase
-  test "blocked?" do
+  test "blocked? with user" do
     user = create :user, email: 'test@invalid.org'
 
     refute User::BlockDomain.blocked?(user)
 
     create :user_block_domain, domain: 'invalid.org'
     assert User::BlockDomain.blocked?(user)
+  end
+
+  test "blocked? with email" do
+    email = 'test@invalid.org'
+
+    refute User::BlockDomain.blocked?(email)
+
+    create :user_block_domain, domain: 'invalid.org'
+    assert User::BlockDomain.blocked?(email)
   end
 end


### PR DESCRIPTION
- Allow testing blocked domain with email string
- Don't create Stripe payment intents when email is on blocked domain
