### PR TITLE
Fix volunteer avatars bug

### DIFF
--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -326,7 +326,7 @@
 
         .inline-grid.grid-cols-6.gap-16.mt-20.mb-16
           - @status.volunteers.users[3..].to_a.each do |volunteer|
-            = avatar(volunteer, css_class: "h-32 w-32")
+            = avatar(volunteer, css_class: "h-32 w-32 bg-cover rounded-circle")
           - if @status.volunteers.num_volunteers > @status.volunteers.users.size
             .col-span-2.self-center.leading-170.text-14.font-semibold.text-lightBlue
               = link_to contributing_contributors_path(track_slug: @track.slug) do


### PR DESCRIPTION
I should use photos instead of avatar placeholder in dev env.. :/

This one should fix it, and make all of them look the same as the one I modified in the dev console.

<img width="423" alt="Screenshot 2022-12-07 at 21 05 03" src="https://user-images.githubusercontent.com/66035744/206284570-f77f5aa5-65ea-4762-b5b1-152c9636e137.png">
