### PR TITLE
Tweak build status page

### DIFF
--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -273,6 +273,7 @@ class Track::UpdateBuildStatus
     {
       num_active_target: practice_exercises_num_exercises_target,
       active: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
+      deprecated: deprecated_practice_exercises.map { |exercise| serialize_exercise(exercise) },
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       foregone: foregone_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       volunteers: practice_exercises_volunteers,
@@ -315,6 +316,9 @@ class Track::UpdateBuildStatus
 
   memoize
   def active_practice_exercises = track.practice_exercises.where(status: %i[active beta]).order(:position).to_a
+
+  memoize
+  def deprecated_practice_exercises = track.practice_exercises.where(status: :deprecated).order(:title).to_a
 
   def average_number_per_day(query, model)
     first_id = query.where("#{model.table_name}.created_at >= ?", Time.current - NUM_DAYS_FOR_AVERAGE.days).pick(:id)

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -287,14 +287,14 @@ class Track::UpdateBuildStatus
 
   memoize
   def unimplemented_practice_exercises
-    Track::RetrieveUnimplementedPracticeExercises.(track).sort_by(&:slug)
+    Track::RetrieveUnimplementedPracticeExercises.(track).sort_by(&:title)
   end
 
   memoize
   def num_unimplemented_practice_exercises = unimplemented_practice_exercises.size
 
   memoize
-  def foregone_practice_exercises = track.foregone_exercises.sort_by(&:slug)
+  def foregone_practice_exercises = track.foregone_exercises.sort_by(&:title)
 
   memoize
   def num_foregone_practice_exercises = foregone_practice_exercises.size

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -231,7 +231,6 @@ class Track::UpdateBuildStatus
 
   def concepts
     {
-      num_concepts: taught_concepts.size,
       num_concepts_target:,
       active: taught_concepts.map { |concept| serialize_concept(concept) }
     }
@@ -261,7 +260,6 @@ class Track::UpdateBuildStatus
 
   def concept_exercises
     {
-      num_exercises: active_concept_exercises.size,
       num_exercises_target: concept_exercises_num_exercises_target,
       active: active_concept_exercises.map { |exercise| serialize_exercise(exercise) }
     }
@@ -273,7 +271,6 @@ class Track::UpdateBuildStatus
 
   def practice_exercises
     {
-      num_exercises: active_practice_exercises.size,
       num_exercises_target: practice_exercises_num_exercises_target,
       active: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -261,7 +261,8 @@ class Track::UpdateBuildStatus
   def concept_exercises
     {
       num_active_target: concept_exercises_num_exercises_target,
-      active: active_concept_exercises.map { |exercise| serialize_exercise(exercise) }
+      active: active_concept_exercises.map { |exercise| serialize_exercise(exercise) },
+      deprecated: deprecated_concept_exercises.map { |exercise| serialize_exercise(exercise) }
     }
   end
 
@@ -313,6 +314,9 @@ class Track::UpdateBuildStatus
 
   memoize
   def active_concept_exercises = track.concept_exercises.where(status: %i[active beta]).order(:position).to_a
+
+  memoize
+  def deprecated_concept_exercises = track.concept_exercises.where(status: :deprecated).order(:title).to_a
 
   memoize
   def active_practice_exercises = track.practice_exercises.where(status: %i[active beta]).order(:position).to_a

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -278,7 +278,6 @@ class Track::UpdateBuildStatus
       created: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
       num_unimplemented: num_unimplemented_practice_exercises,
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
-      num_foregone: num_foregone_practice_exercises,
       foregone: foregone_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       volunteers: practice_exercises_volunteers,
       health: practice_exercises_health
@@ -295,9 +294,6 @@ class Track::UpdateBuildStatus
 
   memoize
   def foregone_practice_exercises = track.foregone_exercises.sort_by(&:title)
-
-  memoize
-  def num_foregone_practice_exercises = foregone_practice_exercises.size
 
   def practice_exercises_num_exercises_target
     max_target = track.num_exercises + num_unimplemented_practice_exercises

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -276,7 +276,6 @@ class Track::UpdateBuildStatus
       num_exercises: active_practice_exercises.size,
       num_exercises_target: practice_exercises_num_exercises_target,
       created: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
-      num_unimplemented: num_unimplemented_practice_exercises,
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       foregone: foregone_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       volunteers: practice_exercises_volunteers,
@@ -290,13 +289,10 @@ class Track::UpdateBuildStatus
   end
 
   memoize
-  def num_unimplemented_practice_exercises = unimplemented_practice_exercises.size
-
-  memoize
   def foregone_practice_exercises = track.foregone_exercises.sort_by(&:title)
 
   def practice_exercises_num_exercises_target
-    max_target = track.num_exercises + num_unimplemented_practice_exercises
+    max_target = track.num_exercises + unimplemented_practice_exercises.size
 
     NUM_PRACTICE_EXERCISES_TARGETS.find { |target| active_practice_exercises.size < target } || max_target
   end

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -233,7 +233,7 @@ class Track::UpdateBuildStatus
     {
       num_concepts: taught_concepts.size,
       num_concepts_target:,
-      created: taught_concepts.map { |concept| serialize_concept(concept) }
+      active: taught_concepts.map { |concept| serialize_concept(concept) }
     }
   end
 
@@ -263,7 +263,7 @@ class Track::UpdateBuildStatus
     {
       num_exercises: active_concept_exercises.size,
       num_exercises_target: concept_exercises_num_exercises_target,
-      created: active_concept_exercises.map { |exercise| serialize_exercise(exercise) }
+      active: active_concept_exercises.map { |exercise| serialize_exercise(exercise) }
     }
   end
 
@@ -275,7 +275,7 @@ class Track::UpdateBuildStatus
     {
       num_exercises: active_practice_exercises.size,
       num_exercises_target: practice_exercises_num_exercises_target,
-      created: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
+      active: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       foregone: foregone_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       volunteers: practice_exercises_volunteers,

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -231,12 +231,12 @@ class Track::UpdateBuildStatus
 
   def concepts
     {
-      num_concepts_target:,
+      num_active_target: num_taught_concepts_target,
       active: taught_concepts.map { |concept| serialize_concept(concept) }
     }
   end
 
-  def num_concepts_target
+  def num_taught_concepts_target
     NUM_CONCEPTS_TARGETS.find { |target| taught_concepts.size < target } || taught_concepts.size
   end
 
@@ -260,7 +260,7 @@ class Track::UpdateBuildStatus
 
   def concept_exercises
     {
-      num_exercises_target: concept_exercises_num_exercises_target,
+      num_active_target: concept_exercises_num_exercises_target,
       active: active_concept_exercises.map { |exercise| serialize_exercise(exercise) }
     }
   end
@@ -271,7 +271,7 @@ class Track::UpdateBuildStatus
 
   def practice_exercises
     {
-      num_exercises_target: practice_exercises_num_exercises_target,
+      num_active_target: practice_exercises_num_exercises_target,
       active: active_practice_exercises.map { |exercise| serialize_exercise(exercise) },
       unimplemented: unimplemented_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },
       foregone: foregone_practice_exercises.map { |exercise| serialize_prob_specs_exercise(exercise) },

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -290,7 +290,7 @@ class Track::UpdateBuildStatus
   def foregone_practice_exercises = track.foregone_exercises.sort_by(&:title)
 
   def practice_exercises_num_exercises_target
-    max_target = track.num_exercises + unimplemented_practice_exercises.size
+    max_target = active_practice_exercises.size + unimplemented_practice_exercises.size
 
     NUM_PRACTICE_EXERCISES_TARGETS.find { |target| active_practice_exercises.size < target } || max_target
   end

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -102,7 +102,7 @@
               %h4 Usage statistics
             %details.mb-10
               %summary.--syllabus
-                #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_active_target} concepts created
+                #{@status.syllabus.concepts.active.size} concepts created
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               - @status.syllabus.concepts.active.each do |concept|
                 .record-row
@@ -257,7 +257,7 @@
             %h4 Usage statistics
           %details
             %summary.--practice-exercises
-              #{@status.practice_exercises.active.size}/#{@status.practice_exercises.num_active_target} practice exercises created
+              #{@status.practice_exercises.active.size} practice exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
               .record-name

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -255,6 +255,7 @@
         - unless @status.practice_exercises.health == "missing"
           .usage-stats-header
             %h4 Usage statistics
+
           - if @status.practice_exercises.active.size.positive?
             %details
               %summary.--practice-exercises
@@ -268,6 +269,34 @@
                   .record-element Completions
                   .record-element Mentoring requests
               - @status.practice_exercises.active.each do |exercise|
+                .record-row
+                  .record-name
+                    = exercise_icon exercise
+                    = exercise.title
+                  .record-value
+                    .record-element
+                      %strong= number_with_delimiter(exercise.num_started)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
+
+
+          - if @status.practice_exercises.deprecated.size.positive?
+            %details.mt-10
+              %summary.--practice-exercises
+                #{@status.practice_exercises.deprecated.size} practice exercises deprecated
+                = graphical_icon 'chevron-right', css_class: 'summary-chevron'
+              .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
+                .record-name
+                .record-value
+                  .record-element Started
+                  .record-element Attempts
+                  .record-element Completions
+                  .record-element Mentoring requests
+              - @status.practice_exercises.deprecated.each do |exercise|
                 .record-row
                   .record-name
                     = exercise_icon exercise
@@ -299,7 +328,7 @@
           - if @status.practice_exercises.foregone.size.positive?
             %details.mt-10
               %summary.--practice-exercises
-                #{@status.practice_exercises.foregone.size} practice #{'exercise'.pluralize(@status.practice_exercises.foregone.size)} foregone
+                #{@status.practice_exercises.foregone.size} foregone practice #{'exercise'.pluralize(@status.practice_exercises.foregone.size)}
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               - @status.practice_exercises.foregone.each do |exercise|
                 .record-row

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -279,6 +279,20 @@
                   .record-element
                     %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
+          - if @status.practice_exercises.deprecated.size.positive?
+            %details.mt-10
+              %summary.--practice-exercises
+                #{@status.practice_exercises.deprecated.size} deprecated practice #{'exercise'.pluralize(@status.practice_exercises.deprecated.size)}
+                = graphical_icon 'chevron-right', css_class: 'summary-chevron'
+              - @status.practice_exercises.deprecated.each do |exercise|
+                .record-row
+                  .record-name
+                    = exercise_icon exercise
+                    = exercise.title
+                  .record-value
+                    .record-element
+                      = external_link_to "View data", exercise.links.self, class: 'external-link'
+
           - if @status.practice_exercises.unimplemented.size.positive?
             %details.mt-10
               %summary.--practice-exercises

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -89,9 +89,9 @@
               Learn More
           %p Help create the track syllabus: is a set of concepts and learning exercises put together to teach foundational elements of the programming language.
 
-        - if @status.syllabus.concepts.active.size < @status.syllabus.concepts.num_concepts_target
+        - if @status.syllabus.concepts.active.size < @status.syllabus.concepts.num_active_target
           .action-required
-            Next goal: Create a complete syllabus with at least #{@status.syllabus.concepts.num_concepts_target} concepts.
+            Next goal: Create a complete syllabus with at least #{@status.syllabus.concepts.num_active_target} concepts.
             = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
               Find out more.
 
@@ -100,7 +100,7 @@
             %h4 Usage statistics
           %details.mb-10
             %summary.--syllabus
-              #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_concepts_target} concepts created
+              #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_active_target} concepts created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             - @status.syllabus.concepts.active.each do |concept|
               .record-row
@@ -244,9 +244,9 @@
               Learn More
           %p Practice Exercises are exercises designed to allow students to solve an arbitrary problem, with the aim of them making use of the concepts they have learned so far.
 
-        - if @status.practice_exercises.active.size < @status.practice_exercises.num_exercises_target
+        - if @status.practice_exercises.active.size < @status.practice_exercises.num_active_target
           .action-required
-            Next goal: Implement #{%w[exemplar health].include?(@status.practice_exercises.health) ? '' : 'at least '}#{@status.practice_exercises.num_exercises_target} practice exercises.
+            Next goal: Implement #{%w[exemplar health].include?(@status.practice_exercises.health) ? '' : 'at least '}#{@status.practice_exercises.num_active_target} practice exercises.
             = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
               Find out more.
 
@@ -255,7 +255,7 @@
             %h4 Usage statistics
           %details
             %summary.--practice-exercises
-              #{@status.practice_exercises.active.size}/#{@status.practice_exercises.num_exercises_target} practice exercises created
+              #{@status.practice_exercises.active.size}/#{@status.practice_exercises.num_active_target} practice exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
               .record-name

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -255,45 +255,32 @@
         - unless @status.practice_exercises.health == "missing"
           .usage-stats-header
             %h4 Usage statistics
-          %details
-            %summary.--practice-exercises
-              #{@status.practice_exercises.active.size} practice exercises created
-              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
-              .record-name
-              .record-value
-                .record-element Started
-                .record-element Attempts
-                .record-element Completions
-                .record-element Mentoring requests
-            - @status.practice_exercises.active.each do |exercise|
-              .record-row
-                .record-name
-                  = exercise_icon exercise
-                  = exercise.title
-                .record-value
-                  .record-element
-                    %strong= number_with_delimiter(exercise.num_started)
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
-
-          - if @status.practice_exercises.deprecated.size.positive?
-            %details.mt-10
+          - if @status.practice_exercises.active.size.positive?
+            %details
               %summary.--practice-exercises
-                #{@status.practice_exercises.deprecated.size} deprecated practice #{'exercise'.pluralize(@status.practice_exercises.deprecated.size)}
+                #{@status.practice_exercises.active.size} practice exercises created
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-              - @status.practice_exercises.deprecated.each do |exercise|
+              .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
+                .record-name
+                .record-value
+                  .record-element Started
+                  .record-element Attempts
+                  .record-element Completions
+                  .record-element Mentoring requests
+              - @status.practice_exercises.active.each do |exercise|
                 .record-row
                   .record-name
                     = exercise_icon exercise
                     = exercise.title
                   .record-value
                     .record-element
-                      = external_link_to "View data", exercise.links.self, class: 'external-link'
+                      %strong= number_with_delimiter(exercise.num_started)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
           - if @status.practice_exercises.unimplemented.size.positive?
             %details.mt-10

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -102,7 +102,7 @@
             %summary.--syllabus
               #{@status.syllabus.concepts.num_concepts}/#{@status.syllabus.concepts.num_concepts_target} concepts created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            - @status.syllabus.concepts.created.each do |concept|
+            - @status.syllabus.concepts.active.each do |concept|
               .record-row
                 .record-name
                   = render ViewComponents::ConceptIcon.new(concept, :small)
@@ -119,7 +119,7 @@
                 .record-element Attempts
                 .record-element Completions
                 .record-element Mentoring requests
-            - @status.syllabus.concept_exercises.created.each do |exercise|
+            - @status.syllabus.concept_exercises.active.each do |exercise|
               .record-row
                 .record-name
                   = exercise_icon exercise
@@ -264,7 +264,7 @@
                 .record-element Attempts
                 .record-element Completions
                 .record-element Mentoring requests
-            - @status.practice_exercises.created.each do |exercise|
+            - @status.practice_exercises.active.each do |exercise|
               .record-row
                 .record-name
                   = exercise_icon exercise

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -279,10 +279,10 @@
                   .record-element
                     %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
-          - if @status.practice_exercises.num_unimplemented.positive?
+          - if @status.practice_exercises.unimplemented.size.positive?
             %details.mt-10
               %summary.--practice-exercises
-                #{@status.practice_exercises.num_unimplemented} unimplemented practice #{'exercise'.pluralize(@status.practice_exercises.num_unimplemented)}
+                #{@status.practice_exercises.unimplemented.size} unimplemented practice #{'exercise'.pluralize(@status.practice_exercises.unimplemented.size)}
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               - @status.practice_exercises.unimplemented.each do |exercise|
                 .record-row

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -89,7 +89,7 @@
               Learn More
           %p Help create the track syllabus: is a set of concepts and learning exercises put together to teach foundational elements of the programming language.
 
-        - if @status.syllabus.concepts.num_concepts < @status.syllabus.concepts.num_concepts_target
+        - if @status.syllabus.concepts.active.size < @status.syllabus.concepts.num_concepts_target
           .action-required
             Next goal: Create a complete syllabus with at least #{@status.syllabus.concepts.num_concepts_target} concepts.
             = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
@@ -100,7 +100,7 @@
             %h4 Usage statistics
           %details.mb-10
             %summary.--syllabus
-              #{@status.syllabus.concepts.num_concepts}/#{@status.syllabus.concepts.num_concepts_target} concepts created
+              #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_concepts_target} concepts created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             - @status.syllabus.concepts.active.each do |concept|
               .record-row
@@ -110,7 +110,7 @@
                 .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
           %details
             %summary.--lightbulb
-              #{@status.syllabus.concept_exercises.num_exercises} learning exercises created
+              #{@status.syllabus.concept_exercises.active.size} learning exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
               .record-name.mb-0
@@ -244,7 +244,7 @@
               Learn More
           %p Practice Exercises are exercises designed to allow students to solve an arbitrary problem, with the aim of them making use of the concepts they have learned so far.
 
-        - if @status.practice_exercises.num_exercises < @status.practice_exercises.num_exercises_target
+        - if @status.practice_exercises.active.size < @status.practice_exercises.num_exercises_target
           .action-required
             Next goal: Implement #{%w[exemplar health].include?(@status.practice_exercises.health) ? '' : 'at least '}#{@status.practice_exercises.num_exercises_target} practice exercises.
             = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
@@ -255,7 +255,7 @@
             %h4 Usage statistics
           %details
             %summary.--practice-exercises
-              #{@status.practice_exercises.num_exercises}/#{@status.practice_exercises.num_exercises_target} practice exercises created
+              #{@status.practice_exercises.active.size}/#{@status.practice_exercises.num_exercises_target} practice exercises created
               = graphical_icon 'chevron-right', css_class: 'summary-chevron'
             .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
               .record-name

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -40,8 +40,9 @@
           .flex.flex-col.mr-40
             .tooling-status-label Building
             .tooling-status-group
-              %div{ 'tooling-status': @status.syllabus.health, 'aria-label': "Syllabus status for #{@track.title}", 'data-tooltip-type': 'tooling', 'data-endpoint': Exercism::Routes.syllabus_tooltip_track_build_path(@track) }
-                = graphical_icon 'syllabus'
+              - if @track.course?
+                %div{ 'tooling-status': @status.syllabus.health, 'aria-label': "Syllabus status for #{@track.title}", 'data-tooltip-type': 'tooling', 'data-endpoint': Exercism::Routes.syllabus_tooltip_track_build_path(@track) }
+                  = graphical_icon 'syllabus'
               %div{ 'tooling-status': @status.test_runner.health, 'aria-label': "Status of the test runner for #{@track.title}", 'data-tooltip-type': 'tooling', 'data-endpoint': Exercism::Routes.test_runner_tooltip_track_build_path(@track) }
                 = graphical_icon 'test-runner'
               %div{ 'tooling-status': @status.analyzer.health, 'aria-label': "Status of the analyzer for #{@track.title}", 'data-tooltip-type': 'tooling', 'data-endpoint': Exercism::Routes.analyzer_tooltip_track_build_path(@track) }
@@ -81,60 +82,61 @@
           .stats.text-16
             .contributors.text-textColor1.font-medium.mb-2= pluralize(@track.num_code_contributors, "contributor")
 
-      .track-team-group
-        .track-header.mb-16
-          .flex.items-center.justify-between.mb-8
-            %h3.--syllabus-gradient Create the #{@track.title} syllabus
-            = link_to doc_path(:building, "tracks/syllabus"), class: "learn-more-new-tab" do
-              Learn More
-          %p Help create the track syllabus: is a set of concepts and learning exercises put together to teach foundational elements of the programming language.
+      - if @track.course?
+        .track-team-group
+          .track-header.mb-16
+            .flex.items-center.justify-between.mb-8
+              %h3.--syllabus-gradient Create the #{@track.title} syllabus
+              = link_to doc_path(:building, "tracks/syllabus"), class: "learn-more-new-tab" do
+                Learn More
+            %p Help create the track syllabus: is a set of concepts and learning exercises put together to teach foundational elements of the programming language.
 
-        - if @status.syllabus.concepts.active.size < @status.syllabus.concepts.num_active_target
-          .action-required
-            Next goal: Create a complete syllabus with at least #{@status.syllabus.concepts.num_active_target} concepts.
-            = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
-              Find out more.
+          - if @status.syllabus.concepts.active.size < @status.syllabus.concepts.num_active_target
+            .action-required
+              Next goal: Create a complete syllabus with at least #{@status.syllabus.concepts.num_active_target} concepts.
+              = link_to doc_path(:building, "tracks/syllabus/next-exercises") do
+                Find out more.
 
-        - unless @status.syllabus.health == "missing"
-          .usage-stats-header
-            %h4 Usage statistics
-          %details.mb-10
-            %summary.--syllabus
-              #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_active_target} concepts created
-              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            - @status.syllabus.concepts.active.each do |concept|
-              .record-row
-                .record-name
-                  = render ViewComponents::ConceptIcon.new(concept, :small)
-                  = concept.name
-                .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
-          %details
-            %summary.--lightbulb
-              #{@status.syllabus.concept_exercises.active.size} learning exercises created
-              = graphical_icon 'chevron-right', css_class: 'summary-chevron'
-            .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
-              .record-name.mb-0
-              .record-value
-                .record-element Started
-                .record-element Attempts
-                .record-element Completions
-                .record-element Mentoring requests
-            - @status.syllabus.concept_exercises.active.each do |exercise|
-              .record-row
-                .record-name
-                  = exercise_icon exercise
-                  = exercise.title
+          - unless @status.syllabus.health == "missing"
+            .usage-stats-header
+              %h4 Usage statistics
+            %details.mb-10
+              %summary.--syllabus
+                #{@status.syllabus.concepts.active.size}/#{@status.syllabus.concepts.num_active_target} concepts created
+                = graphical_icon 'chevron-right', css_class: 'summary-chevron'
+              - @status.syllabus.concepts.active.each do |concept|
+                .record-row
+                  .record-name
+                    = render ViewComponents::ConceptIcon.new(concept, :small)
+                    = concept.name
+                  .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
+            %details
+              %summary.--lightbulb
+                #{@status.syllabus.concept_exercises.active.size} learning exercises created
+                = graphical_icon 'chevron-right', css_class: 'summary-chevron'
+              .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
+                .record-name.mb-0
                 .record-value
-                  .record-element
-                    %strong= number_with_delimiter(exercise.num_started)
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
-                  .record-element
-                    %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
+                  .record-element Started
+                  .record-element Attempts
+                  .record-element Completions
+                  .record-element Mentoring requests
+              - @status.syllabus.concept_exercises.active.each do |exercise|
+                .record-row
+                  .record-name
+                    = exercise_icon exercise
+                    = exercise.title
+                  .record-value
+                    .record-element
+                      %strong= number_with_delimiter(exercise.num_started)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
+                    .record-element
+                      %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
-        = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
+          = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 
       .track-team-group
         .track-header.mb-16

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -293,10 +293,10 @@
                     .record-element
                       = external_link_to "View data", exercise.links.self, class: 'external-link'
 
-          - if @status.practice_exercises.num_foregone.positive?
+          - if @status.practice_exercises.foregone.size.positive?
             %details.mt-10
               %summary.--practice-exercises
-                #{@status.practice_exercises.num_foregone} practice #{'exercise'.pluralize(@status.practice_exercises.num_foregone)} foregone
+                #{@status.practice_exercises.foregone.size} practice #{'exercise'.pluralize(@status.practice_exercises.foregone.size)} foregone
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               - @status.practice_exercises.foregone.each do |exercise|
                 .record-row

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -100,6 +100,7 @@
           - unless @status.syllabus.health == "missing"
             .usage-stats-header
               %h4 Usage statistics
+
             %details.mb-10
               %summary.--syllabus
                 #{@status.syllabus.concepts.active.size} concepts being taught
@@ -110,6 +111,7 @@
                     = render ViewComponents::ConceptIcon.new(concept, :small)
                     = concept.name
                   .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
+
             %details
               %summary.--lightbulb
                 #{@status.syllabus.concept_exercises.active.size} active learning exercises
@@ -135,6 +137,33 @@
                       %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
                     .record-element
                       %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
+
+            - if @status.syllabus.concept_exercises.deprecated.size.positive?
+              %details.mt-10
+                %summary.--lightbulb
+                  #{@status.syllabus.concept_exercises.deprecated.size} deprecated learning exercises
+                  = graphical_icon 'chevron-right', css_class: 'summary-chevron'
+                .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
+                  .record-name.mb-0
+                  .record-value
+                    .record-element Started
+                    .record-element Attempts
+                    .record-element Completions
+                    .record-element Mentoring requests
+                - @status.syllabus.concept_exercises.deprecated.each do |exercise|
+                  .record-row
+                    .record-name
+                      = exercise_icon exercise
+                      = exercise.title
+                    .record-value
+                      .record-element
+                        %strong= number_with_delimiter(exercise.num_started)
+                      .record-element
+                        %strong #{number_with_delimiter(exercise.num_submitted)} (avg. #{exercise.num_submitted_average})
+                      .record-element
+                        %strong #{number_with_delimiter(exercise.num_completed)} (#{exercise.num_completed_percentage}%)
+                      .record-element
+                        %strong #{number_with_delimiter(exercise.num_mentoring_requests)} (#{exercise.num_mentoring_requests_percentage}%)
 
           = render ReactComponents::Common::Credits.new(@status.syllabus.volunteers.users, @status.syllabus.volunteers.num_users, 'contributor', 0, '', css_class: 'font-semibold')
 

--- a/app/views/tracks/build/show.html.haml
+++ b/app/views/tracks/build/show.html.haml
@@ -102,7 +102,7 @@
               %h4 Usage statistics
             %details.mb-10
               %summary.--syllabus
-                #{@status.syllabus.concepts.active.size} concepts created
+                #{@status.syllabus.concepts.active.size} concepts being taught
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               - @status.syllabus.concepts.active.each do |concept|
                 .record-row
@@ -112,7 +112,7 @@
                   .record-value #{number_with_delimiter(concept.num_students_learnt)} learnt
             %details
               %summary.--lightbulb
-                #{@status.syllabus.concept_exercises.active.size} learning exercises created
+                #{@status.syllabus.concept_exercises.active.size} active learning exercises
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
                 .record-name.mb-0
@@ -259,7 +259,7 @@
           - if @status.practice_exercises.active.size.positive?
             %details
               %summary.--practice-exercises
-                #{@status.practice_exercises.active.size} practice exercises created
+                #{@status.practice_exercises.active.size} active practice exercises
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
                 .record-name
@@ -287,7 +287,7 @@
           - if @status.practice_exercises.deprecated.size.positive?
             %details.mt-10
               %summary.--practice-exercises
-                #{@status.practice_exercises.deprecated.size} practice exercises deprecated
+                #{@status.practice_exercises.deprecated.size} deprecated practice exercises
                 = graphical_icon 'chevron-right', css_class: 'summary-chevron'
               .record-row.sticky{ class: 'top-[106px] z-1 lg:top-0' }
                 .record-name

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -281,6 +281,30 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     assert_equal expected_active, track.build_status.syllabus.concept_exercises.active
   end
 
+  test "syllabus: concept_exercises: deprecated" do
+    track = create :track
+
+    deprecated_exercise = create :concept_exercise, track: track, status: :deprecated
+
+    Track::UpdateBuildStatus.(track)
+
+    assert_equal 1, track.build_status.syllabus.concept_exercises.deprecated.size
+    expected = {
+      slug: deprecated_exercise.slug,
+      title: deprecated_exercise.title,
+      icon_url: deprecated_exercise.icon_url,
+      num_started: 0,
+      num_submitted: 0,
+      num_submitted_average: 0.0,
+      num_completed: 0,
+      num_completed_percentage: 0,
+      num_mentoring_requests: 0,
+      num_mentoring_requests_percentage: 0.0,
+      links: { self: "/tracks/ruby/exercises/#{deprecated_exercise.slug}" }
+    }.to_obj
+    assert_includes track.build_status.syllabus.concept_exercises.deprecated, expected
+  end
+
   test "syllabus: concept_exercises: num_active_target" do
     track = create :track
     Track::UpdateBuildStatus.(track)
@@ -392,15 +416,15 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
   test "practice_exercises: deprecated" do
     track = create :track
 
-    deprecated = create :practice_exercise, track: track, status: :deprecated
+    deprecated_exercise = create :practice_exercise, track: track, status: :deprecated
 
     Track::UpdateBuildStatus.(track)
 
     assert_equal 1, track.build_status.practice_exercises.deprecated.size
     expected = {
-      slug: deprecated.slug,
-      title: deprecated.title,
-      icon_url: deprecated.icon_url,
+      slug: deprecated_exercise.slug,
+      title: deprecated_exercise.title,
+      icon_url: deprecated_exercise.icon_url,
       num_started: 0,
       num_submitted: 0,
       num_submitted_average: 0.0,
@@ -408,7 +432,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
       num_completed_percentage: 0,
       num_mentoring_requests: 0,
       num_mentoring_requests_percentage: 0.0,
-      links: { self: "/tracks/ruby/exercises/#{deprecated.slug}" }
+      links: { self: "/tracks/ruby/exercises/#{deprecated_exercise.slug}" }
     }.to_obj
     assert_includes track.build_status.practice_exercises.deprecated, expected
   end

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -178,7 +178,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     Track::UpdateBuildStatus.(track)
 
-    assert_equal 3, track.build_status.syllabus.concepts.num_concepts
+    assert_equal 3, track.build_status.syllabus.concepts.active.size
     assert_equal 10, track.build_status.syllabus.concepts.num_concepts_target
     expected_active = [
       { slug: c_2.slug, name: c_2.name, num_students_learnt: 1 },
@@ -249,7 +249,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     Track::UpdateBuildStatus.(track)
 
-    assert_equal 2, track.build_status.syllabus.concept_exercises.num_exercises
+    assert_equal 2, track.build_status.syllabus.concept_exercises.active.size
     expected_active = [
       {
         slug: ce_2.slug,
@@ -357,7 +357,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     Track::UpdateBuildStatus.(track)
 
-    assert_equal 2, track.build_status.practice_exercises.num_exercises
+    assert_equal 2, track.build_status.practice_exercises.active.size
     expected_active = [
       {
         slug: pe_3.slug,

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -389,6 +389,30 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     assert_equal expected_active, track.build_status.practice_exercises.active
   end
 
+  test "practice_exercises: deprecated" do
+    track = create :track
+
+    deprecated = create :practice_exercise, track: track, status: :deprecated
+
+    Track::UpdateBuildStatus.(track)
+
+    assert_equal 1, track.build_status.practice_exercises.deprecated.size
+    expected = {
+      slug: deprecated.slug,
+      title: deprecated.title,
+      icon_url: deprecated.icon_url,
+      num_started: 0,
+      num_submitted: 0,
+      num_submitted_average: 0.0,
+      num_completed: 0,
+      num_completed_percentage: 0,
+      num_mentoring_requests: 0,
+      num_mentoring_requests_percentage: 0.0,
+      links: { self: "/tracks/ruby/exercises/#{deprecated.slug}" }
+    }.to_obj
+    assert_includes track.build_status.practice_exercises.deprecated, expected
+  end
+
   test "practice_exercises: unimplemented" do
     track = create :track
 

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -180,12 +180,12 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     assert_equal 3, track.build_status.syllabus.concepts.num_concepts
     assert_equal 10, track.build_status.syllabus.concepts.num_concepts_target
-    expected_created = [
+    expected_active = [
       { slug: c_2.slug, name: c_2.name, num_students_learnt: 1 },
       { slug: c_4.slug, name: c_4.name, num_students_learnt: 3 },
       { slug: c_3.slug, name: c_3.name, num_students_learnt: 3 }
     ].map(&:to_obj)
-    assert_equal expected_created, track.build_status.syllabus.concepts.created
+    assert_equal expected_active, track.build_status.syllabus.concepts.active
   end
 
   test "syllabus: concepts: num_concepts_target" do
@@ -250,7 +250,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     Track::UpdateBuildStatus.(track)
 
     assert_equal 2, track.build_status.syllabus.concept_exercises.num_exercises
-    expected_created = [
+    expected_active = [
       {
         slug: ce_2.slug,
         title: ce_2.title,
@@ -278,7 +278,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
         links: { self: "/tracks/ruby/exercises/#{ce_3.slug}" }
       }
     ].map(&:to_obj)
-    assert_equal expected_created, track.build_status.syllabus.concept_exercises.created
+    assert_equal expected_active, track.build_status.syllabus.concept_exercises.active
   end
 
   test "syllabus: concept_exercises: num_exercises_target" do
@@ -358,7 +358,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     Track::UpdateBuildStatus.(track)
 
     assert_equal 2, track.build_status.practice_exercises.num_exercises
-    expected_created = [
+    expected_active = [
       {
         slug: pe_3.slug,
         title: pe_3.title,
@@ -386,7 +386,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
         links: { self: "/tracks/ruby/exercises/#{pe_2.slug}" }
       }
     ].map(&:to_obj)
-    assert_equal expected_created, track.build_status.practice_exercises.created
+    assert_equal expected_active, track.build_status.practice_exercises.active
   end
 
   test "practice_exercises: unimplemented" do
@@ -394,7 +394,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     Track::UpdateBuildStatus.(track)
 
-    assert_equal 126, track.build_status.practice_exercises.num_unimplemented
+    assert_equal 126, track.build_status.practice_exercises.unimplemented.size
     expected = {
       slug: "zebra-puzzle",
       title: "Zebra Puzzle",

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -179,7 +179,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     Track::UpdateBuildStatus.(track)
 
     assert_equal 3, track.build_status.syllabus.concepts.active.size
-    assert_equal 10, track.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 10, track.build_status.syllabus.concepts.num_active_target
     expected_active = [
       { slug: c_2.slug, name: c_2.name, num_students_learnt: 1 },
       { slug: c_4.slug, name: c_4.name, num_students_learnt: 3 },
@@ -188,30 +188,30 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     assert_equal expected_active, track.build_status.syllabus.concepts.active
   end
 
-  test "syllabus: concepts: num_concepts_target" do
+  test "syllabus: concepts: num_active_target" do
     track = create :track
     Track::UpdateBuildStatus.(track)
-    assert_equal 10, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 10, track.reload.build_status.syllabus.concepts.num_active_target
 
     create_list(:exercise_taught_concept, 10, exercise: create(:concept_exercise, track:))
     Track::UpdateBuildStatus.(track)
-    assert_equal 20, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 20, track.reload.build_status.syllabus.concepts.num_active_target
 
     create_list(:exercise_taught_concept, 10, exercise: create(:concept_exercise, track:))
     Track::UpdateBuildStatus.(track)
-    assert_equal 30, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 30, track.reload.build_status.syllabus.concepts.num_active_target
 
     create_list(:exercise_taught_concept, 10, exercise: create(:concept_exercise, track:))
     Track::UpdateBuildStatus.(track)
-    assert_equal 40, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 40, track.reload.build_status.syllabus.concepts.num_active_target
 
     create_list(:exercise_taught_concept, 10, exercise: create(:concept_exercise, track:))
     Track::UpdateBuildStatus.(track)
-    assert_equal 50, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 50, track.reload.build_status.syllabus.concepts.num_active_target
 
     create_list(:exercise_taught_concept, 26, exercise: create(:concept_exercise, track:))
     Track::UpdateBuildStatus.(track)
-    assert_equal 66, track.reload.build_status.syllabus.concepts.num_concepts_target
+    assert_equal 66, track.reload.build_status.syllabus.concepts.num_active_target
   end
 
   test "syllabus: concept_exercises" do
@@ -281,30 +281,30 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     assert_equal expected_active, track.build_status.syllabus.concept_exercises.active
   end
 
-  test "syllabus: concept_exercises: num_exercises_target" do
+  test "syllabus: concept_exercises: num_active_target" do
     track = create :track
     Track::UpdateBuildStatus.(track)
-    assert_equal 10, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 10, track.reload.build_status.syllabus.concept_exercises.num_active_target
 
     create_list(:concept_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 20, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 20, track.reload.build_status.syllabus.concept_exercises.num_active_target
 
     create_list(:concept_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 30, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 30, track.reload.build_status.syllabus.concept_exercises.num_active_target
 
     create_list(:concept_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 40, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 40, track.reload.build_status.syllabus.concept_exercises.num_active_target
 
     create_list(:concept_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 50, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 50, track.reload.build_status.syllabus.concept_exercises.num_active_target
 
     create_list(:concept_exercise, 26, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 66, track.reload.build_status.syllabus.concept_exercises.num_exercises_target
+    assert_equal 66, track.reload.build_status.syllabus.concept_exercises.num_active_target
   end
 
   test "syllabus: health" do
@@ -447,32 +447,43 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
     assert_includes track.build_status.practice_exercises.foregone, expected
   end
 
-  test "practice_exercises: num_exercises_target" do
+  test "practice_exercises: num_active_target" do
     track = create :track
     Track::UpdateBuildStatus.(track)
-    assert_equal 10, track.reload.build_status.practice_exercises.num_exercises_target
+    assert_equal 10, track.reload.build_status.practice_exercises.num_active_target
 
     create_list(:practice_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 20, track.reload.build_status.practice_exercises.num_exercises_target
+    assert_equal 20, track.reload.build_status.practice_exercises.num_active_target
 
     create_list(:practice_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 30, track.reload.build_status.practice_exercises.num_exercises_target
+    assert_equal 30, track.reload.build_status.practice_exercises.num_active_target
 
     create_list(:practice_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 40, track.reload.build_status.practice_exercises.num_exercises_target
+    assert_equal 40, track.reload.build_status.practice_exercises.num_active_target
 
     create_list(:practice_exercise, 10, track:)
     Track::UpdateBuildStatus.(track)
-    assert_equal 50, track.reload.build_status.practice_exercises.num_exercises_target
+    assert_equal 50, track.reload.build_status.practice_exercises.num_active_target
 
     create_list(:practice_exercise, 30, track:)
     Track::UpdateBuildStatus.(track)
 
-    num_unimplemented = Track::RetrieveUnimplementedPracticeExercises.(track.reload).size
-    assert_equal track.num_exercises + num_unimplemented, track.reload.build_status.practice_exercises.num_exercises_target
+    # Sanity check: concept exercises don't count
+    create_list(:concept_exercise, 3, track:)
+    Track::UpdateBuildStatus.(track)
+
+    # Sanity check: wip practice exercises don't count
+    create_list(:practice_exercise, 2, status: :wip, track:)
+    Track::UpdateBuildStatus.(track)
+
+    # Sanity check: deprecated practice exercises don't count
+    create_list(:practice_exercise, 2, status: :deprecated, track:)
+    Track::UpdateBuildStatus.(track)
+
+    assert_equal 195, track.reload.build_status.practice_exercises.num_active_target
   end
 
   test "practice_exercises: volunteers" do

--- a/test/commands/track/update_build_status_test.rb
+++ b/test/commands/track/update_build_status_test.rb
@@ -411,7 +411,7 @@ class Track::UpdateBuildStatusTest < ActiveSupport::TestCase
 
     Track::UpdateBuildStatus.(track)
 
-    assert_equal 2, track.build_status.practice_exercises.num_foregone
+    assert_equal 2, track.build_status.practice_exercises.foregone.size
     expected = {
       slug: "alphametics",
       title: "Alphametics",


### PR DESCRIPTION
- Sort foregone/unimplemented exercises by title in build status
- Inline num_foregone
- Inline num_unimplemented
- Use better name for active entities
- Inline active entities size
- Normalize naming
- Show deprecated exercises
- Add tests for num active target
- Don't show syllabus info on build page if track does not have course
