### PR TITLE
Listen for workflow_run webhook events

### DIFF
--- a/app/commands/webhooks/process_workflow_run_update.rb
+++ b/app/commands/webhooks/process_workflow_run_update.rb
@@ -1,0 +1,10 @@
+class Webhooks::ProcessWorkflowRunUpdate
+  include Mandate
+
+  initialize_with params: Mandate::KWARGS
+
+  def call
+    return unless params[:action] == 'completed'
+    return unless params[:conclusion] == 'success'
+  end
+end

--- a/app/controllers/webhooks/workflow_run_updates_controller.rb
+++ b/app/controllers/webhooks/workflow_run_updates_controller.rb
@@ -1,0 +1,8 @@
+# This controller listens for Github workflow_run webhook events,
+# for which the "Workflow runs" event type must be enabled in GitHub.
+# See https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#workflow_run
+class Webhooks::WorkflowRunUpdatesController < Webhooks::GithubBaseController
+  def create
+    head :no_content
+  end
+end

--- a/app/controllers/webhooks/workflow_run_updates_controller.rb
+++ b/app/controllers/webhooks/workflow_run_updates_controller.rb
@@ -6,6 +6,8 @@ class Webhooks::WorkflowRunUpdatesController < Webhooks::GithubBaseController
     ::Webhooks::ProcessWorkflowRunUpdate.(
       # params[:action] does not work as it is populated by Rails with the action method name
       action: request.request_parameters[:action],
+      repo: params.dig(:repository, :full_name),
+      head_branch: params.dig(:workflow_run, :head_branch),
       path: params.dig(:workflow_run, :path),
       conclusion: params.dig(:workflow_run, :conclusion),
       referenced_workflows: params.dig(:workflow_run, :referenced_workflows).to_a.map { |workflow| workflow[:path] }

--- a/app/controllers/webhooks/workflow_run_updates_controller.rb
+++ b/app/controllers/webhooks/workflow_run_updates_controller.rb
@@ -3,6 +3,14 @@
 # See https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#workflow_run
 class Webhooks::WorkflowRunUpdatesController < Webhooks::GithubBaseController
   def create
+    ::Webhooks::ProcessWorkflowRunUpdate.(
+      # params[:action] does not work as it is populated by Rails with the action method name
+      action: request.request_parameters[:action],
+      path: params.dig(:workflow_run, :path),
+      conclusion: params.dig(:workflow_run, :conclusion),
+      referenced_workflows: params.dig(:workflow_run, :referenced_workflows).to_a.map { |workflow| workflow[:path] }
+    )
+
     head :no_content
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     resource :push_updates, only: [:create]
     resource :pull_request_updates, only: [:create]
     resource :organization_updates, only: [:create]
+    resource :workflow_run_updates, only: [:create]
   end
 
   # ##### #

--- a/test/commands/webhooks/process_workflow_run_update_test.rb
+++ b/test/commands/webhooks/process_workflow_run_update_test.rb
@@ -1,4 +1,4 @@
 require "test_helper"
 
-class Webhooks::ProcessWorkflowRunUpdateeTest < ActiveSupport::TestCase
+class Webhooks::ProcessWorkflowRunUpdateTest < ActiveSupport::TestCase
 end

--- a/test/commands/webhooks/process_workflow_run_update_test.rb
+++ b/test/commands/webhooks/process_workflow_run_update_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class Webhooks::ProcessWorkflowRunUpdateeTest < ActiveSupport::TestCase
+end

--- a/test/controllers/webhooks/workflow_run_updates_controller_test.rb
+++ b/test/controllers/webhooks/workflow_run_updates_controller_test.rb
@@ -1,0 +1,27 @@
+require_relative './base_test_case'
+
+class Webhooks::PullRequestUpdatesControllerTest < Webhooks::BaseTestCase
+  test "create: return 403 when signature is invalid" do
+    payload = { action: 'completed' }
+
+    invalid_headers = headers(payload)
+    invalid_headers['HTTP_X_HUB_SIGNATURE_256'] = "invalid_signature"
+
+    post webhooks_workflow_run_updates_path, headers: invalid_headers, as: :json, params: payload
+    assert_response :forbidden
+  end
+
+  test "create: return 200 when signature is valid" do
+    payload = { action: 'completed' }
+
+    post webhooks_workflow_run_updates_path, headers: headers(payload), as: :json, params: payload
+    assert_response :no_content
+  end
+
+  test "create: return 204 when ping event is sent" do
+    payload = { action: 'completed' }
+
+    post webhooks_workflow_run_updates_path, headers: headers(payload, event: 'ping'), as: :json, params: payload
+    assert_response :no_content
+  end
+end

--- a/test/controllers/webhooks/workflow_run_updates_controller_test.rb
+++ b/test/controllers/webhooks/workflow_run_updates_controller_test.rb
@@ -24,4 +24,26 @@ class Webhooks::PullRequestUpdatesControllerTest < Webhooks::BaseTestCase
     post webhooks_workflow_run_updates_path, headers: headers(payload, event: 'ping'), as: :json, params: payload
     assert_response :no_content
   end
+
+  test "create: processes payload" do
+    payload = {
+      action: 'completed',
+      workflow_run: {
+        path: '.github/workflows/deploy.yml',
+        conclusion: 'failure',
+        referenced_workflows: [
+          { path: 'deploy.yml' }
+        ]
+      }
+    }
+
+    Webhooks::ProcessWorkflowRunUpdate.expects(:call).with(
+      action: 'completed',
+      path: '.github/workflows/deploy.yml',
+      conclusion: 'failure',
+      referenced_workflows: ['deploy.yml']
+    )
+
+    post webhooks_workflow_run_updates_path, headers: headers(payload), as: :json, params: payload
+  end
 end

--- a/test/controllers/webhooks/workflow_run_updates_controller_test.rb
+++ b/test/controllers/webhooks/workflow_run_updates_controller_test.rb
@@ -29,16 +29,22 @@ class Webhooks::PullRequestUpdatesControllerTest < Webhooks::BaseTestCase
     payload = {
       action: 'completed',
       workflow_run: {
+        head_branch: 'main',
         path: '.github/workflows/deploy.yml',
         conclusion: 'failure',
         referenced_workflows: [
           { path: 'deploy.yml' }
         ]
+      },
+      repository: {
+        full_name: 'exercism/fsharp-representer'
       }
     }
 
     Webhooks::ProcessWorkflowRunUpdate.expects(:call).with(
       action: 'completed',
+      repo: 'exercism/fsharp-representer',
+      head_branch: 'main',
       path: '.github/workflows/deploy.yml',
       conclusion: 'failure',
       referenced_workflows: ['deploy.yml']


### PR DESCRIPTION
This PR allows us to listen to `workflow_run` events, which in turn lets us do things when e.g. tooling has deployed successfully.