### PR TITLE
Fix issue with exercise updates not triggering concept recount

### DIFF
--- a/app/commands/track/update_num_concepts.rb
+++ b/app/commands/track/update_num_concepts.rb
@@ -1,0 +1,23 @@
+class Track::UpdateNumConcepts
+  include Mandate
+
+  initialize_with :track
+
+  def call
+    # We're updating in a single query instead of two queries to avoid race-conditions
+    # and using read_committed to avoid deadlocks
+    ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
+      Track.where(id: track.id).update_all("num_concepts = (#{sql})")
+    end
+  end
+
+  memoize
+  def sql
+    Arel.sql(
+      Exercise::TaughtConcept.joins(:exercise).
+        where(exercise: { track: track.id, status: %i[beta active] }).
+        select("COUNT(DISTINCT(track_concept_id))").
+        to_sql
+    )
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -102,8 +102,8 @@ class Exercise < ApplicationRecord
 
   after_commit do
     if (saved_changes.keys & %w[id status]).present?
-      Track::UpdateNumExercises.defer(track)
-      Track::UpdateNumConcepts.defer(track)
+      Track::UpdateNumExercises.(track)
+      Track::UpdateNumConcepts.(track)
     end
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -101,7 +101,10 @@ class Exercise < ApplicationRecord
   end
 
   after_commit do
-    track.recache_num_exercises! if (saved_changes.keys & %w[id status]).present?
+    if (saved_changes.keys & %w[id status]).present?
+      Track::UpdateNumExercises.defer(track)
+      Track::UpdateNumConcepts.defer(track)
+    end
   end
 
   def status = super.to_sym

--- a/app/models/exercise/taught_concept.rb
+++ b/app/models/exercise/taught_concept.rb
@@ -3,16 +3,6 @@ class Exercise::TaughtConcept < ApplicationRecord
   belongs_to :concept, foreign_key: :track_concept_id # rubocop:disable Rails/InverseOf
 
   after_save_commit do
-    # We're updating in a single query instead of two queries to avoid race-conditions
-    # and using read_committed to avoid deadlocks
-    ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
-      concepts_count_sql = Arel.sql(
-        Exercise::TaughtConcept.joins(:exercise).
-          where(exercise: { track: exercise.track_id, status: %i[beta active] }).
-          select("COUNT(DISTINCT(track_concept_id))").
-          to_sql
-      )
-      Track.where(id: exercise.track_id).update_all("num_concepts = (#{concepts_count_sql})")
-    end
+    Track::UpdateNumConcepts.defer(exercise.track)
   end
 end

--- a/app/models/exercise/taught_concept.rb
+++ b/app/models/exercise/taught_concept.rb
@@ -3,6 +3,6 @@ class Exercise::TaughtConcept < ApplicationRecord
   belongs_to :concept, foreign_key: :track_concept_id # rubocop:disable Rails/InverseOf
 
   after_save_commit do
-    Track::UpdateNumConcepts.defer(exercise.track)
+    Track::UpdateNumConcepts.(exercise.track)
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -46,13 +46,6 @@ class Track < ApplicationRecord
     find_by(slug:)
   end
 
-  def recache_num_exercises!
-    filtered_exercises = exercises.where(status: %i[active beta])
-    filtered_exercises = filtered_exercises.where(type: PracticeExercise.to_s) unless course?
-
-    update_column(:num_exercises, filtered_exercises.count)
-  end
-
   def to_param = slug
 
   memoize

--- a/app/models/track/update_num_exercises.rb
+++ b/app/models/track/update_num_exercises.rb
@@ -1,0 +1,12 @@
+class Track::UpdateNumExercises
+  include Mandate
+
+  initialize_with :track
+
+  def call
+    filtered_exercises = track.exercises.where(status: %i[active beta])
+    filtered_exercises = filtered_exercises.where(type: PracticeExercise.to_s) unless track.course?
+
+    track.update_column(:num_exercises, filtered_exercises.count)
+  end
+end

--- a/test/commands/track/update_num_concepts_test.rb
+++ b/test/commands/track/update_num_concepts_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Track::UpdateNumConceptsTest < ActiveSupport::TestCase
+  test "num_concepts updated" do
+    track = create :track
+    c_1 = create :concept
+    c_2 = create :concept
+    c_3 = create :concept
+    c_4 = create :concept
+
+    # Sanity check
+    Track::UpdateNumConcepts.(track)
+    assert_equal 0, track.reload.num_concepts
+
+    ce_1 = create :concept_exercise, track: track, status: :active
+    create :exercise_taught_concept, exercise: ce_1, concept: c_1
+    Track::UpdateNumConcepts.(track)
+    assert_equal 1, track.reload.num_concepts
+
+    ce_2 = create :concept_exercise, track: track, status: :beta
+    create :exercise_taught_concept, exercise: ce_2, concept: c_2
+    Track::UpdateNumConcepts.(track)
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: duplicate taught concept should not count
+    ce_3 = create :concept_exercise, track: track, status: :active
+    create :exercise_taught_concept, exercise: ce_3, concept: c_2
+    Track::UpdateNumConcepts.(track)
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: taught concepts in other track should not count
+    ce_4 = create :concept_exercise, track: (create :track, :random_slug), status: :active
+    create :exercise_taught_concept, exercise: ce_4, concept: c_3
+    Track::UpdateNumConcepts.(track)
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: taught concept of wip exercise should not count
+    ce_5 = create :concept_exercise, track: track, status: :wip
+    create :exercise_taught_concept, exercise: ce_5, concept: c_4
+    Track::UpdateNumConcepts.(track)
+    assert_equal 2, track.reload.num_concepts
+
+    # Sanity check: taught concept of deprecated exercise should not count
+    ce_5 = create :concept_exercise, track: track, status: :deprecated
+    create :exercise_taught_concept, exercise: ce_5, concept: c_4
+    Track::UpdateNumConcepts.(track)
+    assert_equal 2, track.reload.num_concepts
+  end
+end

--- a/test/commands/track/update_num_exercises_test.rb
+++ b/test/commands/track/update_num_exercises_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class Track::UpdateNumExercisesTest < ActiveSupport::TestCase
+  test "recache_num_exercises!" do
+    track = create :track
+    Track::UpdateNumExercises.(track)
+    assert_equal 0, track.num_exercises
+
+    create :practice_exercise, track: track, status: :beta
+    Track::UpdateNumExercises.(track)
+    assert_equal 1, track.num_exercises
+
+    create :practice_exercise, track: track, status: :active
+    Track::UpdateNumExercises.(track)
+    assert_equal 2, track.reload.num_exercises
+
+    # Ignore wip practice exercises
+    create :practice_exercise, track: track, status: :wip
+    Track::UpdateNumExercises.(track)
+    assert_equal 2, track.reload.num_exercises
+
+    # Ignore deprecated practice exercises
+    create :practice_exercise, track: track, status: :deprecated
+    Track::UpdateNumExercises.(track)
+    assert_equal 2, track.reload.num_exercises
+
+    # Ignore concept exercises when the track does not have a course
+    track.update(course: false)
+    create :concept_exercise, track: track, status: :active
+    Track::UpdateNumExercises.(track)
+    assert_equal 2, track.reload.num_exercises
+
+    # Include concept exercises when the track has a course
+    track.update(course: true)
+    create :concept_exercise, track: track, status: :beta
+    Track::UpdateNumExercises.(track)
+    assert_equal 4, track.reload.num_exercises
+
+    # Ignore wip concept exercises
+    create :concept_exercise, track: track, status: :wip
+    Track::UpdateNumExercises.(track)
+    assert_equal 4, track.reload.num_exercises
+
+    # Ignore deprecated concept exercises
+    create :concept_exercise, track: track, status: :deprecated
+    Track::UpdateNumExercises.(track)
+    assert_equal 4, track.reload.num_exercises
+  end
+end

--- a/test/models/exercise/taught_concept_test.rb
+++ b/test/models/exercise/taught_concept_test.rb
@@ -11,43 +11,4 @@ class Exercise::TaughtConceptTest < ActiveSupport::TestCase
     assert_equal exercise, taught_concept.exercise
     assert_equal concept, taught_concept.concept
   end
-
-  test "num_concepts updated" do
-    track = create :track
-    c_1 = create :concept
-    c_2 = create :concept
-    c_3 = create :concept
-    c_4 = create :concept
-
-    # Sanity check
-    assert_equal 0, track.num_concepts
-
-    ce_1 = create :concept_exercise, track: track, status: :active
-    create :exercise_taught_concept, exercise: ce_1, concept: c_1
-    assert_equal 1, track.reload.num_concepts
-
-    ce_2 = create :concept_exercise, track: track, status: :beta
-    create :exercise_taught_concept, exercise: ce_2, concept: c_2
-    assert_equal 2, track.reload.num_concepts
-
-    # Sanity check: duplicate taught concept should not count
-    ce_3 = create :concept_exercise, track: track, status: :active
-    create :exercise_taught_concept, exercise: ce_3, concept: c_2
-    assert_equal 2, track.reload.num_concepts
-
-    # Sanity check: taught concepts in other track should not count
-    ce_4 = create :concept_exercise, track: (create :track, :random_slug), status: :active
-    create :exercise_taught_concept, exercise: ce_4, concept: c_3
-    assert_equal 2, track.reload.num_concepts
-
-    # Sanity check: taught concept of wip exercise should not count
-    ce_5 = create :concept_exercise, track: track, status: :wip
-    create :exercise_taught_concept, exercise: ce_5, concept: c_4
-    assert_equal 2, track.reload.num_concepts
-
-    # Sanity check: taught concept of deprecated exercise should not count
-    ce_5 = create :concept_exercise, track: track, status: :deprecated
-    create :exercise_taught_concept, exercise: ce_5, concept: c_4
-    assert_equal 2, track.reload.num_concepts
-  end
 end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -136,7 +136,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test "updates track num_exercises when created" do
     track = create :track
-    track.expects(:recache_num_exercises!).once
+    Track::UpdateNumExercises.expects(:defer).with(track)
     create :practice_exercise, track:
   end
 
@@ -144,7 +144,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    track.expects(:recache_num_exercises!).once
+    Track::UpdateNumExercises.expects(:defer).with(track)
     exercise.destroy
   end
 
@@ -152,7 +152,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    track.expects(:recache_num_exercises!).once
+    Track::UpdateNumExercises.expects(:defer).with(track)
     exercise.update(status: :beta)
   end
 
@@ -160,7 +160,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    track.expects(:recache_num_exercises!).never
+    Track::UpdateNumExercises.expects(:defer).with(track)
     exercise.update(title: 'something')
   end
 end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -136,7 +136,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test "updates track num_exercises when created" do
     track = create :track
-    Track::UpdateNumExercises.expects(:defer).with(track)
+    Track::UpdateNumExercises.expects(:call).with(track)
     create :practice_exercise, track:
   end
 
@@ -144,7 +144,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    Track::UpdateNumExercises.expects(:defer).with(track)
+    Track::UpdateNumExercises.expects(:call).with(track)
     exercise.destroy
   end
 
@@ -152,7 +152,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    Track::UpdateNumExercises.expects(:defer).with(track)
+    Track::UpdateNumExercises.expects(:call).with(track)
     exercise.update(status: :beta)
   end
 
@@ -160,7 +160,7 @@ class ExerciseTest < ActiveSupport::TestCase
     track = create :track
     exercise = create :practice_exercise, track: track
 
-    Track::UpdateNumExercises.expects(:defer).with(track)
+    Track::UpdateNumExercises.expects(:call).with(track)
     exercise.update(title: 'something')
   end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -176,44 +176,6 @@ class TrackTest < ActiveSupport::TestCase
     assert_nil Track.for_repo("exercism/configlet")
   end
 
-  test "recache_num_exercises!" do
-    track = create :track
-    track.recache_num_exercises!
-    assert_equal 0, track.num_exercises
-
-    create :practice_exercise, track: track, status: :beta
-    assert_equal 1, track.num_exercises
-
-    create :practice_exercise, track: track, status: :active
-    assert_equal 2, track.reload.num_exercises
-
-    # Ignore wip practice exercises
-    create :practice_exercise, track: track, status: :wip
-    assert_equal 2, track.reload.num_exercises
-
-    # Ignore deprecated practice exercises
-    create :practice_exercise, track: track, status: :deprecated
-    assert_equal 2, track.reload.num_exercises
-
-    # Ignore concept exercises when the track does not have a course
-    track.update(course: false)
-    create :concept_exercise, track: track, status: :active
-    assert_equal 2, track.reload.num_exercises
-
-    # Include concept exercises when the track has a course
-    track.update(course: true)
-    create :concept_exercise, track: track, status: :beta
-    assert_equal 4, track.reload.num_exercises
-
-    # Ignore wip concept exercises
-    create :concept_exercise, track: track, status: :wip
-    assert_equal 4, track.reload.num_exercises
-
-    # Ignore deprecated concept exercises
-    create :concept_exercise, track: track, status: :deprecated
-    assert_equal 4, track.reload.num_exercises
-  end
-
   test "representations" do
     track = create :track
     exercise_1 = create :practice_exercise, track: track


### PR DESCRIPTION
Currently, changing an exercise from wip to beta/active doesn't recache the number of concepts on a track. This fixes that, and also moves things into their own commands.