### PR TITLE
Add 'Day of Month with ordinal' formatting on BadgeModal

### DIFF
--- a/app/javascript/components/modals/BadgeModal.tsx
+++ b/app/javascript/components/modals/BadgeModal.tsx
@@ -32,7 +32,7 @@ export const BadgeModal = ({
       <div className="earned-at">
         Earned on{' '}
         <time dateTime={badge.unlockedAt}>
-          {timeFormat(badge.unlockedAt, 'DD MMM YYYY')}
+          {timeFormat(badge.unlockedAt, 'Do MMM YYYY')}
         </time>
       </div>
       <div className="num-awardees text-p-base">
@@ -42,7 +42,7 @@ export const BadgeModal = ({
         {pluralize('has', badge.numAwardees)} earned this badge.
       </div>
       <div className="percentage-awardees">
-        That's <strong>{badge.percentageAwardees}%</strong> of all Exercism
+        That&apos;s <strong>{badge.percentageAwardees}%</strong> of all Exercism
         users
       </div>
     </Modal>

--- a/app/javascript/utils/date.ts
+++ b/app/javascript/utils/date.ts
@@ -4,7 +4,7 @@ import RelativeTime from 'dayjs/plugin/relativeTime'
 import pluralize from 'pluralize'
 dayjs.extend(RelativeTime)
 
-export function fromNow(date: ConfigType) {
+export function fromNow(date: ConfigType): string {
   const now = dayjs()
   const from = dayjs(date)
 

--- a/app/javascript/utils/time.ts
+++ b/app/javascript/utils/time.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs'
 import type { ConfigType } from 'dayjs'
 import RelativeTime from 'dayjs/plugin/relativeTime'
+import AdvancedFormat from 'dayjs/plugin/advancedFormat'
 import pluralize from 'pluralize'
 dayjs.extend(RelativeTime)
+dayjs.extend(AdvancedFormat)
 
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * 60


### PR DESCRIPTION
<img width="869" alt="Screenshot 2023-02-02 at 11 25 30" src="https://user-images.githubusercontent.com/66035744/216300270-e4877ca1-3746-40b3-9335-45f673c0c8b4.png">

Leaning on dayjs's [AdvancedFormat](https://day.js.org/docs/en/plugin/advanced-format) plugin