### PR TITLE
Add error handler when image is missing on Update thread

### DIFF
--- a/app/javascript/components/common/imageErrorHandler.tsx
+++ b/app/javascript/components/common/imageErrorHandler.tsx
@@ -8,7 +8,7 @@ const missingImageErrorHandler = (
   missingImage: string
 ) => {
   const el = e.target as HTMLImageElement
-  if ((el.src = missingImage)) {
+  if (el.src === missingImage) {
     return
   }
   el.onerror = null
@@ -17,8 +17,8 @@ const missingImageErrorHandler = (
 
 export const missingExerciseIconErrorHandler = (
   e: React.SyntheticEvent<HTMLImageElement, Event>
-) => missingImageErrorHandler(e, missingExerciseIcon)
+): void => missingImageErrorHandler(e, missingExerciseIcon)
 
 export const missingTrackIconErrorHandler = (
   e: React.SyntheticEvent<HTMLImageElement, Event>
-) => missingImageErrorHandler(e, missingTrackIcon)
+): void => missingImageErrorHandler(e, missingTrackIcon)

--- a/app/javascript/components/common/site-updates-list/SiteUpdateIcon.tsx
+++ b/app/javascript/components/common/site-updates-list/SiteUpdateIcon.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ConceptIcon } from '../ConceptIcon'
 import { TrackIcon } from '../TrackIcon'
 import { SiteUpdate as SiteUpdateProps, SiteUpdateContext } from '../../types'
+import { missingExerciseIconErrorHandler } from '../imageErrorHandler'
 
 export const SiteUpdateIcon = ({
   context,
@@ -17,7 +18,13 @@ export const SiteUpdateIcon = ({
     case 'update':
       switch (icon.type) {
         case 'image':
-          return <img className="c-icon" src={icon.url} />
+          return (
+            <img
+              className="c-icon"
+              src={icon.url}
+              onError={missingExerciseIconErrorHandler}
+            />
+          )
         case 'concept':
           return <ConceptIcon size="large" name={icon.data} />
       }


### PR DESCRIPTION
Solves this issue: https://github.com/exercism/website/issues/3510

<img width="1504" alt="Screenshot 2023-03-02 at 14 23 58" src="https://user-images.githubusercontent.com/66035744/222441226-88bab3b9-c48c-4f25-b833-fcb4f731b782.png">
