### PR TITLE
Allow websockets from non-users

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,5 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
+    delegate :current_user, to: :connection
   end
 end

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,5 +1,7 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
+    # As we don't identify by current_user, we have
+    # to manually delegate to the connection here
     delegate :current_user, to: :connection
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,10 +1,15 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
-    identified_by :current_user
+    attr_accessor :current_user
+
+    identified_by :connection_identifier
 
     def connect
       self.current_user = env["warden"].user(:user)
-      self.current_user || reject_unauthorized_connection
+    end
+
+    def connection_identifier
+      current_user || SecureRandom.uuid
     end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -8,6 +8,9 @@ module ApplicationCable
       self.current_user = env["warden"].user(:user)
     end
 
+    # We don't require a user to be authenticated
+    # If they're not, we'll just generated a random
+    # one off id for this connection (browser tab)
     def connection_identifier
       current_user || SecureRandom.uuid
     end


### PR DESCRIPTION
Allow non-logged-in users to use websockets (e.g. for the impact page)