### PR TITLE
Add syntax highlighting for Zig in editor

### DIFF
--- a/app/javascript/components/misc/CodeMirror/languageCompartment.ts
+++ b/app/javascript/components/misc/CodeMirror/languageCompartment.ts
@@ -40,6 +40,10 @@ export const loadLanguageCompartment = async (
       const { wren } = await import('@exercism/codemirror-lang-wren')
       return compartment.of(wren())
     }
+    case 'zig': {
+      const { rust: zig } = await import('@codemirror/lang-rust')
+      return compartment.of(zig())
+    }
 
     // Legacy
     case 'abap': {


### PR DESCRIPTION
Commit https://github.com/exercism/website/commit/e2f0e7726ed0b78902d95dd0c4146daffd8360c0 added Zig syntax highlighting for highlightjs, but not the online editor.

Closes: https://github.com/exercism/exercism/issues/6670

---

Please check:

- That this PR isn't completely broken. I may be modifying the wrong file. I attempted to adapt the `reasonml` part from line 35. I confirm that it is common to use Rust syntax highlighting for Zig when Zig support is missing.
- That we can't trivially use a Zig language mode instead.

Please feel free to take over on this PR, or close it in favor of another one.

---

Currently, I see:

![1](https://user-images.githubusercontent.com/45465154/224487773-845f6dfb-c027-4e25-9dc3-0ab2ba7d7730.png)
