### PR TITLE
:lipstick: primary-reputation allow wrap for small screens

### DIFF
--- a/app/css/components/primary-reputation.css
+++ b/app/css/components/primary-reputation.css
@@ -5,7 +5,7 @@
     @apply relative flex px-8 items-center justify-center;
     @apply border-3 border-gradient;
 
-    @apply flex items-center justify-center;
+    @apply flex items-center justify-center flex-wrap;
     @apply text-16 leading-200 font-semibold;
     @apply px-16 rounded-100;
 


### PR DESCRIPTION
On small screens primary reputation badge does not display well:
![image](https://user-images.githubusercontent.com/16977446/224578646-d498993b-6eef-41d6-9b7f-1e5be81418b4.png)

This Pull Request fix this behavior by adding a `flex-wrap: wrap`:
![image](https://user-images.githubusercontent.com/16977446/224578682-7ab4f6cc-a41d-4bc8-b86c-02b16f974864.png)

