### PR TITLE
Change `overscroll-behaviour` on `body`

### DIFF
--- a/app/css/defaults.css
+++ b/app/css/defaults.css
@@ -8,7 +8,7 @@ body {
        when the scrollbar appears or disappears. */
     overflow-y: scroll;
     overflow-x: auto;
-    overscroll-behavior: contain;
+    overscroll-behavior-y: none;
     -webkit-overflow-scrolling: touch;
     -ms-overflow-style: -ms-autohiding-scrollbar;
 }


### PR DESCRIPTION
https://github.com/exercism/exercism/issues/6679

I see no reason for `overscroll-behaviour` to be specified as `contain` on `body`. 

If we want to prevent scroll-chaining, it should be specified on a child element (a modal/dialog) instead of a parent element.
It is only important to use it on the `body` element if we want to prevent a user from scrolling beyond (overscrolling) the page on the y-axis - using a touchpad/touchscreen - which creates that rubber band effect.

It can be either removed or applied as `none` on the y-axis.

Here I do the latter.