### PR TITLE
Add gradient background to upsell-section

### DIFF
--- a/app/css/pages/track-about.css
+++ b/app/css/pages/track-about.css
@@ -310,7 +310,10 @@
         }
     }
     & .upsell-section {
-        @apply bg-backgroundColorA;
+        background: linear-gradient(
+            var(--backgroundColorA),
+            var(--backgroundColorB)
+        );
         @apply pt-64;
 
         & .container {


### PR DESCRIPTION
Issue: https://github.com/exercism/exercism/issues/6409
This PR adds a gradient background to upsell-section.

<img width="1511" alt="Screenshot 2023-04-05 at 12 29 43" src="https://user-images.githubusercontent.com/66035744/230055771-e3edcf7a-c943-47f2-9256-609fd8216a82.png">
<img width="1511" alt="Screenshot 2023-04-05 at 12 30 04" src="https://user-images.githubusercontent.com/66035744/230055744-c25d0d44-b64d-4511-8d72-5893a959f2d6.png">
<img width="1511" alt="Screenshot 2023-04-05 at 12 30 01" src="https://user-images.githubusercontent.com/66035744/230055747-b1ea44af-5a7e-4610-83c1-86fddf4650a8.png">
<img width="1511" alt="Screenshot 2023-04-05 at 12 29 55" src="https://user-images.githubusercontent.com/66035744/230055751-a796e403-da2c-44b4-87b0-0457e119a8e0.png">
