### PR TITLE
Change the "Open an issue" link in the footer

### DIFF
--- a/app/views/components/footer/shared.html.haml
+++ b/app/views/components/footer/shared.html.haml
@@ -89,7 +89,8 @@
       .col.hidden.md:block.mt-32.xl:mt-0
         %h3.text-h6 Want to add a language track to Exercism?
         %p.text-p-base
-          = link_to "Start a new topic in the forum", "https://forum.exercism.org/c/exercism/4"
+          Start a new topic
+          = link_to "in the forum", "https://forum.exercism.org/c/exercism/4"
           and let's discuss it.
   %hr
   .legals.mt-24.md:mt-32.mb-32.md:mb-40.flex.md:items-center.flex-col.md:flex-row

--- a/app/views/components/footer/shared.html.haml
+++ b/app/views/components/footer/shared.html.haml
@@ -89,7 +89,7 @@
       .col.hidden.md:block.mt-32.xl:mt-0
         %h3.text-h6 Want to add a language track to Exercism?
         %p.text-p-base
-          = link_to "Open an issue", "https://github.com/exercism/exercism/issues/new?title=Create%20new%20track%20for%20[LANGUAGE]"
+          = link_to "Start a new topic in the forum", "https://forum.exercism.org/c/exercism/4"
           and let's discuss it.
   %hr
   .legals.mt-24.md:mt-32.mb-32.md:mb-40.flex.md:items-center.flex-col.md:flex-row


### PR DESCRIPTION
This changes the link text to "Start a new topic in the forum"

It just links to the exercism category. 
There is a URL to jump straight to the "create a new topic" dialog: https://forum.exercism.org/new-topic?category=exercism
I think it's best to allow people to look around before they decide to actually create a new topic; perhaps they'll find their topic already exists.

If we choose to do the Create dialog, there are parameters to pre-populate the title and body: https://meta.discourse.org/t/create-a-link-to-start-a-new-topic-with-pre-filled-information/28074
Although I did read some opinions in the discourse forum about not making things too easy to create new topics, for fear of a flood of spam.

Also, is the top-level Exercism category the right place, or would a (new or existing) subcategory be better?