### PR TITLE
Replace 'build' typo with 'built'

### DIFF
--- a/app/views/community/show.html.haml
+++ b/app/views/community/show.html.haml
@@ -53,7 +53,7 @@
       .block
         = graphical_icon "podcast-gradient", css_class: "h-[48px] w-[48px] mb-16"
         %h2.text-h2.mb-8 Hear our Community Stories
-        %p.mb-24.text-p-large.text-textColor5 Listen to the stories of those who have build, contributed to, and learnt from Exercism.
+        %p.mb-24.text-p-large.text-textColor5 Listen to the stories of those who have built, contributed to, and learnt from Exercism.
 
         .grid.grid-cols-1.lg:grid-cols-3.gap-16
           - @community_stories.each do |community_story|


### PR DESCRIPTION
Typo fix for issue spotted on the website-copy repository: https://github.com/exercism/website-copy/issues/2245