### PR TITLE
Tweak webservers init to offset connection spikes and calm git down

### DIFF
--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -134,6 +134,7 @@ module Git
         cmd = [
           "git clone",
           "--bare",
+          "-c core.sharedRepository=true",
           ("--single-branch" if branch_ref == MAIN_BRANCH_REF),
           repo_url,
           repo_dir

--- a/bin/start_sidekiq
+++ b/bin/start_sidekiq
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+
+# Path to the application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+# We want to guard against failures at each stage of this
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  # As EFS files are owned by different users in different places
+  # we need to tell libgit to be less stressed about user conflicts.
+  Track.pluck(:slug).each do |slug|
+    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
+  end
+
+  # Finally we get the actual server running
+  system! "bundle exec sidekiq"
+end

--- a/bin/start_sidekiq
+++ b/bin/start_sidekiq
@@ -14,7 +14,7 @@ FileUtils.chdir APP_ROOT do
   # we need to tell libgit to be less stressed about user conflicts.
   # Any instance of "fatal: detected dubious ownership in repository" 
   # means that this hasn't worked properly.
-  system! "ls -1 /mnt/efs/repos | xargs -p -L1 git config --global --add safe.directory"
+  system! "ls -1 -d /mnt/efs/repos/* | xargs -L1 git config --global --add safe.directory"
 
   # Finally we get the actual sidekiq running
   system! "bundle exec sidekiq"

--- a/bin/start_sidekiq
+++ b/bin/start_sidekiq
@@ -12,10 +12,10 @@ end
 FileUtils.chdir APP_ROOT do
   # As EFS files are owned by different users in different places
   # we need to tell libgit to be less stressed about user conflicts.
-  Track.pluck(:slug).each do |slug|
-    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
-  end
+  # Any instance of "fatal: detected dubious ownership in repository" 
+  # means that this hasn't worked properly.
+  system! "ls -1 /mnt/efs/repos | xargs -p -L1 git config --global --add safe.directory"
 
-  # Finally we get the actual server running
+  # Finally we get the actual sidekiq running
   system! "bundle exec sidekiq"
 end

--- a/bin/start_webserver
+++ b/bin/start_webserver
@@ -16,9 +16,9 @@ FileUtils.chdir APP_ROOT do
 
   # As EFS files are owned by different users in different places
   # we need to tell libgit to be less stressed about user conflicts.
-  # Any instance of "fatal: detected dubious ownership in repository" 
+  # Any instance of "fatal: detected dubious ownership in repository"
   # means that this hasn't worked properly.
-  system! "ls -1 /mnt/efs/repos | xargs -p -L1 git config --global --add safe.directory"
+  system! "ls -1 -d /mnt/efs/repos/* | xargs -L1 git config --global --add safe.directory"
 
   # Warm the local cache of EFS to avoid big read spikes as users start to hit the website.
   system! 'bundle exec bin/rails runner "Track.find_each{|t|begin;t.git.config;rescue;end}"'

--- a/bin/start_webserver
+++ b/bin/start_webserver
@@ -21,4 +21,10 @@ FileUtils.chdir APP_ROOT do
 
   # Finally we get the actual server running
   system! "bundle exec bin/rails server -e production -b '0.0.0.0' -p 3000"
+
+  # As EFS files are owned by different users in different places
+  # we need to tell libgit to be less stressed about user conflicts.
+  Track.pluck(:slug).each do |slug|
+    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}}")
+  end
 end

--- a/bin/start_webserver
+++ b/bin/start_webserver
@@ -16,9 +16,9 @@ FileUtils.chdir APP_ROOT do
 
   # As EFS files are owned by different users in different places
   # we need to tell libgit to be less stressed about user conflicts.
-  Track.pluck(:slug).each do |slug|
-    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
-  end
+  # Any instance of "fatal: detected dubious ownership in repository" 
+  # means that this hasn't worked properly.
+  system! "ls -1 /mnt/efs/repos | xargs -p -L1 git config --global --add safe.directory"
 
   # Warm the local cache of EFS to avoid big read spikes as users start to hit the website.
   system! 'bundle exec bin/rails runner "Track.find_each{|t|begin;t.git.config;rescue;end}"'

--- a/bin/start_webserver
+++ b/bin/start_webserver
@@ -14,6 +14,12 @@ FileUtils.chdir APP_ROOT do
   # We do this via this helper script to sleep and retry on conurrent failures
   system! 'bundle exec bin/rails runner lib/run_migrations_with_concurrent_guard.rb'
 
+  # As EFS files are owned by different users in different places
+  # we need to tell libgit to be less stressed about user conflicts.
+  Track.pluck(:slug).each do |slug|
+    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
+  end
+
   # Warm the local cache of EFS to avoid big read spikes as users start to hit the website.
   system! 'bundle exec bin/rails runner "Track.find_each{|t|begin;t.git.config;rescue;end}"'
   system! 'bundle exec bin/rails runner "Git::WebsiteCopy.new.walkthrough"'
@@ -21,10 +27,4 @@ FileUtils.chdir APP_ROOT do
 
   # Finally we get the actual server running
   system! "bundle exec bin/rails server -e production -b '0.0.0.0' -p 3000"
-
-  # As EFS files are owned by different users in different places
-  # we need to tell libgit to be less stressed about user conflicts.
-  Track.pluck(:slug).each do |slug|
-    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
-  end
 end

--- a/bin/start_webserver
+++ b/bin/start_webserver
@@ -25,6 +25,6 @@ FileUtils.chdir APP_ROOT do
   # As EFS files are owned by different users in different places
   # we need to tell libgit to be less stressed about user conflicts.
   Track.pluck(:slug).each do |slug|
-    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}}")
+    system("git config --global --add safe.directory /mnt/efs/repos/#{slug}")
   end
 end

--- a/docker/rails.Dockerfile
+++ b/docker/rails.Dockerfile
@@ -37,10 +37,13 @@ COPY . ./
 RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
 # This compiles the assets
-# During deployment the assets are copied from this image and 
+# During deployment the assets are copied from this image and
 # uploaded into s3. The assets left on the machine are not actually
 # used leave the assets on here.
 RUN bundle exec rails r bin/monitor-manifest
 RUN bundle exec rails assets:precompile
+
+RUN groupadd -g 2222 exercism-git
+RUN usermod -a -G exercism-git root
 
 ENTRYPOINT bin/start_webserver

--- a/lib/run_migrations_with_concurrent_guard.rb
+++ b/lib/run_migrations_with_concurrent_guard.rb
@@ -2,6 +2,10 @@
 # for any concurrent failures;
 
 begin
+  # Offset all the different rails c's against each other over 30secs
+  # Put it in this begin so it keeps on happening on each retry.
+  sleep(rand * 30)
+
   migrations = ActiveRecord::Migration.new.migration_context.migrations
   ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::SchemaMigration).migrate
 
@@ -12,6 +16,5 @@ rescue ActiveRecord::ConcurrentMigrationError
   # because eventually Fargate will just time the machine out.
 
   Rails.logger.info "Concurrent migration detected. Waiting to try again."
-  sleep(5)
   retry
 end


### PR DESCRIPTION
This primarily aims to fix the git issue.

For each repo, we need to run the following on Bastion.
```
cd /mnt/efs/repos/ruby
sudo chgrp -R exercism-git .
sudo chmod -R g+w .
sudo chmod g-w objects/pack/*
sudo find -type d -exec chmod g+s {} +
git config core.sharedRepository true
```

And also this to fix future repos:
```
cd /mnt/efs/repos/
sudo chgrp exercism-git .
sudo chmod g+s
```

We can safely do this before deploying this branch, but it won't fix the issues until we do.