### PR TITLE
Update the schema from production

### DIFF
--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -177,8 +177,8 @@ class UserTrack < ApplicationRecord
     return @summary if @summary
 
     digest = Digest::SHA1.hexdigest(File.read(Rails.root.join('app', 'commands', 'user_track', 'generate_summary_data.rb')))
-    track_updated_at = association(:track).loaded? ? track.updated_at : Track.where(id: track_id).pick(:updated_at)
-    expected_key = "#{track_updated_at.to_f}:#{updated_at.to_f}:#{digest}"
+    track_last_touched_at = association(:track).loaded? ? track.last_touched_at : Track.where(id: track_id).pick(:last_touched_at)
+    expected_key = "#{track_last_touched_at.to_f}:#{last_touched_at.to_f}:#{digest}"
 
     if summary_key != expected_key
       # It is important to use update_columns here

--- a/db/migrate/20230430144945_use_precious_on_user_tracks_last_touched_at.rb
+++ b/db/migrate/20230430144945_use_precious_on_user_tracks_last_touched_at.rb
@@ -1,0 +1,5 @@
+class UsePreciousOnUserTracksLastTouchedAt < ActiveRecord::Migration[7.0]
+  def change
+    change_column :user_tracks, :last_touched_at, :datetime, precision: 6, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["changelog_entry_id"], name: "index_changelog_entry_tweets_on_changelog_entry_id"
   end
 
-  create_table "cohort_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "cohort_memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "introduction", null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_cohort_memberships_on_user_id"
   end
 
-  create_table "cohorts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "cohorts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "track_id", null: false
     t.string "slug", null: false
     t.string "name", null: false
@@ -134,7 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_cohorts_on_track_id"
   end
 
-  create_table "community_stories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "community_stories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "interviewer_id", null: false
     t.bigint "interviewee_id", null: false
     t.string "uuid", null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_community_stories_on_uuid", unique: true
   end
 
-  create_table "community_videos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "community_videos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "track_id"
     t.bigint "exercise_id"
     t.bigint "author_id"
@@ -177,7 +177,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
-  create_table "contributor_team_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "contributor_team_memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "contributor_team_id", null: false
     t.bigint "user_id", null: false
     t.boolean "visible", default: true, null: false
@@ -189,7 +189,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_contributor_team_memberships_on_user_id"
   end
 
-  create_table "contributor_teams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "contributor_teams", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "track_id"
     t.string "github_name", null: false
     t.integer "type", limit: 1, default: 0, null: false
@@ -243,7 +243,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 
-  create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "subscription_id"
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
@@ -258,7 +258,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_donations_payments_on_user_id"
   end
 
-  create_table "donations_subscriptions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "donations_subscriptions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
     t.datetime "created_at", null: false
@@ -271,7 +271,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_donations_subscriptions_on_user_id"
   end
 
-  create_table "exercise_approach_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_approach_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -281,7 +281,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_approach_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -291,7 +291,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_contributorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -301,7 +301,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -311,7 +311,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_contributorships_on_user_id"
   end
 
-  create_table "exercise_approaches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_approaches", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -325,7 +325,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_exercise_approaches_on_uuid"
   end
 
-  create_table "exercise_article_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_article_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -335,7 +335,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_article_authorships_on_user_id"
   end
 
-  create_table "exercise_article_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_article_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -345,7 +345,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_article_contributorships_on_user_id"
   end
 
-  create_table "exercise_articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercise_articles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -584,7 +584,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_github_tasks_on_uuid", unique: true
   end
 
-  create_table "github_team_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "github_team_members", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "user_id", null: false
     t.string "team_name", null: false
     t.datetime "created_at", null: false
@@ -637,7 +637,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "iterations_uuid"
   end
 
-  create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.string "email_communication_preferences_key", null: false
     t.boolean "test_sent", default: false, null: false
@@ -787,7 +787,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_mentors_on_track_id"
   end
 
-  create_table "metric_period_days", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "metric_period_days", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "day", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -798,7 +798,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_days_on_track_id"
   end
 
-  create_table "metric_period_minutes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "metric_period_minutes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "minute", limit: 2, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -809,7 +809,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_minutes_on_track_id"
   end
 
-  create_table "metric_period_months", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "metric_period_months", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "month", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -820,7 +820,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_months_on_track_id"
   end
 
-  create_table "metrics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "metrics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.text "params", null: false
     t.bigint "track_id"
@@ -1038,7 +1038,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_solutions_on_uuid"
   end
 
-  create_table "streaming_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "streaming_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
     t.datetime "starts_at", null: false
@@ -1314,14 +1314,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "fk_rails_0d66c22f4c"
   end
 
-  create_table "user_block_domains", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_block_domains", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "domain", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["domain"], name: "index_user_block_domains_on_domain", unique: true
   end
 
-  create_table "user_challenges", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_challenges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "challenge_id", null: false
     t.datetime "created_at", null: false
@@ -1375,7 +1375,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_user_email_logs_on_user_id", unique: true
   end
 
-  create_table "user_mailshots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "mailshot_slug"
     t.integer "email_status", limit: 1, default: 0, null: false
@@ -1412,7 +1412,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_user_notifications_on_uuid", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "auto_update_exercises", default: true, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1413,7 +1413,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.boolean "auto_update_exercises", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "theme"
     t.index ["user_id"], name: "index_user_preferences_on_user_id", unique: true
   end
 
@@ -1552,7 +1551,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.datetime "first_donated_at"
     t.string "discord_uid"
     t.integer "insiders_status", limit: 1, default: 0, null: false
-    t.integer "flair", limit: 1
     t.string "paypal_payer_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
@@ -1648,6 +1646,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   add_foreign_key "cohorts", "tracks"
   add_foreign_key "community_stories", "users", column: "interviewee_id"
   add_foreign_key "community_stories", "users", column: "interviewer_id"
+  add_foreign_key "community_videos", "exercises"
+  add_foreign_key "community_videos", "tracks"
   add_foreign_key "community_videos", "users", column: "author_id"
   add_foreign_key "community_videos", "users", column: "submitted_by_id"
   add_foreign_key "contributor_team_memberships", "contributor_teams"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -26,14 +26,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -52,24 +52,64 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["type"], name: "index_badges_on_type", unique: true
   end
 
+  create_table "blog_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "blog_post_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "blog_comment_id"
+    t.text "content", size: :long, null: false
+    t.text "html", size: :long, null: false
+    t.boolean "edited", default: false, null: false
+    t.text "previous_content"
+    t.boolean "deleted", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["blog_comment_id"], name: "fk_rails_de25ffa957"
+    t.index ["blog_post_id"], name: "fk_rails_ccd98ed6ee"
+    t.index ["user_id"], name: "fk_rails_a2e6f28c3a"
+  end
+
   create_table "blog_posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "author_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
     t.string "category", null: false
-    t.datetime "published_at", null: false
+    t.datetime "published_at", precision: nil, null: false
     t.string "title", null: false
-    t.text "description"
     t.string "marketing_copy", limit: 280
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "image_url"
+    t.text "description"
     t.string "youtube_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["author_id"], name: "index_blog_posts_on_author_id"
-    t.index ["uuid"], name: "index_blog_posts_on_uuid", unique: true
+    t.bigint "author_id", null: false
+    t.index ["author_id"], name: "fk_rails_b88cda424b"
+    t.index ["published_at"], name: "index_blog_posts_on_published_at"
+    t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
   end
 
-  create_table "cohort_memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "changelog_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "created_by_id", null: false
+    t.string "title", null: false
+    t.text "details_markdown"
+    t.string "referenceable_type"
+    t.bigint "referenceable_id"
+    t.string "info_url"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "published_at", precision: nil
+    t.text "details_html"
+    t.string "referenceable_key"
+    t.index ["created_by_id"], name: "index_changelog_entries_on_created_by_id"
+    t.index ["referenceable_type", "referenceable_id"], name: "index_changelog_entries_on_referenceable"
+  end
+
+  create_table "changelog_entry_tweets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "changelog_entry_id", null: false
+    t.text "copy", null: false
+    t.integer "status", default: 0, null: false
+    t.index ["changelog_entry_id"], name: "index_changelog_entry_tweets_on_changelog_entry_id"
+  end
+
+  create_table "cohort_memberships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "introduction", null: false
     t.datetime "created_at", null: false
@@ -81,7 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_cohort_memberships_on_user_id"
   end
 
-  create_table "cohorts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "cohorts", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "track_id", null: false
     t.string "slug", null: false
     t.string "name", null: false
@@ -94,7 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_cohorts_on_track_id"
   end
 
-  create_table "community_stories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "community_stories", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "interviewer_id", null: false
     t.bigint "interviewee_id", null: false
     t.string "uuid", null: false
@@ -113,7 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_community_stories_on_uuid", unique: true
   end
 
-  create_table "community_videos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "community_videos", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "track_id"
     t.bigint "exercise_id"
     t.bigint "author_id"
@@ -137,6 +177,55 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
+  create_table "contributor_team_memberships", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "contributor_team_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "visible", default: true, null: false
+    t.integer "seniority", limit: 1, default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contributor_team_id", "user_id"], name: "index_contributor_team_memberships_on_team_id_and_user_id", unique: true
+    t.index ["contributor_team_id"], name: "index_contributor_team_memberships_on_contributor_team_id"
+    t.index ["user_id"], name: "index_contributor_team_memberships_on_user_id"
+  end
+
+  create_table "contributor_teams", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "track_id"
+    t.string "github_name", null: false
+    t.integer "type", limit: 1, default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["github_name"], name: "index_contributor_teams_on_github_name", unique: true
+    t.index ["track_id"], name: "index_contributor_teams_on_track_id"
+  end
+
+  create_table "contributors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "github_username", null: false
+    t.string "avatar_url", null: false
+    t.integer "num_contributions", default: 0, null: false
+    t.boolean "is_maintainer", default: false, null: false
+    t.boolean "is_core", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "github_id", null: false
+    t.index ["is_maintainer", "is_core", "num_contributions"], name: "main_find_idx"
+  end
+
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -154,35 +243,35 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 
-  create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "donations_payments", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "subscription_id"
-    t.string "external_id", null: false
-    t.string "external_receipt_url"
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "email_status", limit: 1, default: 0, null: false
     t.integer "provider", limit: 1, default: 0, null: false
+    t.string "external_id", null: false
+    t.string "external_receipt_url"
     t.index ["external_id", "provider"], name: "index_donations_payments_on_external_id_and_provider", unique: true
     t.index ["subscription_id"], name: "index_donations_payments_on_subscription_id"
     t.index ["user_id"], name: "index_donations_payments_on_user_id"
   end
 
-  create_table "donations_subscriptions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "donations_subscriptions", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "external_id", null: false
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "email_status", limit: 1, default: 0, null: false
     t.integer "status", limit: 1, default: 0, null: false
     t.integer "provider", limit: 1, default: 0, null: false
+    t.string "external_id", null: false
     t.index ["external_id", "provider"], name: "index_donations_subscriptions_on_external_id_and_provider", unique: true
     t.index ["user_id"], name: "index_donations_subscriptions_on_user_id"
   end
 
-  create_table "exercise_approach_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_approach_authorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -192,7 +281,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_approach_contributorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -202,7 +291,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_contributorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -212,7 +301,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -222,7 +311,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_contributorships_on_user_id"
   end
 
-  create_table "exercise_approaches", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_approaches", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -236,7 +325,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_exercise_approaches_on_uuid"
   end
 
-  create_table "exercise_article_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_article_authorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -246,7 +335,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_article_authorships_on_user_id"
   end
 
-  create_table "exercise_article_contributorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_article_contributorships", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -256,7 +345,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_exercise_article_contributorships_on_user_id"
   end
 
-  create_table "exercise_articles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "exercise_articles", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -323,28 +412,29 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.bigint "feedback_editor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "num_submissions", default: 1, null: false
+    t.integer "num_submissions", limit: 3, default: 1, null: false
     t.datetime "last_submitted_at", default: -> { "CURRENT_TIMESTAMP(6)" }, null: false
-    t.string "uuid", null: false
     t.bigint "track_id"
+    t.string "uuid"
     t.datetime "feedback_added_at"
     t.integer "representer_version", limit: 2, default: 1, null: false
     t.integer "exercise_version", limit: 2, default: 1, null: false
     t.integer "draft_feedback_type", limit: 1
     t.text "draft_feedback_markdown"
-    t.string "exercise_id_and_ast_digest_idx_cache"
+    t.index ["ast_digest"], name: "index_exercise_representations_on_ast_digest"
     t.index ["exercise_id", "ast_digest", "representer_version", "exercise_version"], name: "exercise_representations_guard", unique: true
-    t.index ["exercise_id_and_ast_digest_idx_cache", "id"], name: "index_sub_rep", order: { id: :desc }
-    t.index ["feedback_author_id", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_author_exercise_last_submitted_at", order: { last_submitted_at: :desc }
-    t.index ["feedback_author_id", "exercise_id", "num_submissions"], name: "index_exercise_representation_author_exercise_num_submissions", order: { num_submissions: :desc }
-    t.index ["feedback_author_id", "track_id", "last_submitted_at"], name: "index_exercise_representation_author_track_last_submitted_at", order: { last_submitted_at: :desc }
-    t.index ["feedback_author_id", "track_id", "num_submissions"], name: "index_exercise_representation_author_track_num_submissions", order: { num_submissions: :desc }
+    t.index ["feedback_author_id", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_author_exercise_last_submitted_at"
+    t.index ["feedback_author_id", "exercise_id", "num_submissions"], name: "index_exercise_representation_author_exercise_num_submissions"
+    t.index ["feedback_author_id", "track_id", "last_submitted_at"], name: "index_exercise_representation_author_track_last_submitted_at"
     t.index ["feedback_author_id"], name: "index_exercise_representations_on_feedback_author_id"
     t.index ["feedback_editor_id"], name: "index_exercise_representations_on_feedback_editor_id"
-    t.index ["feedback_type", "track_id", "last_submitted_at"], name: "index_exercise_representation_type_track_last_submitted_at", order: { last_submitted_at: :desc }
-    t.index ["feedback_type", "track_id", "num_submissions"], name: "index_exercise_representation_type_track_num_submissions", order: { num_submissions: :desc }
+    t.index ["feedback_type", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_type_exercise_last_submitted_at"
+    t.index ["feedback_type", "exercise_id", "num_submissions"], name: "index_exercise_representation_type_exercise_num_submissions"
+    t.index ["feedback_type", "track_id", "last_submitted_at"], name: "index_exercise_representation_type_track_last_submitted_at"
+    t.index ["feedback_type", "track_id", "num_submissions"], name: "index_exercise_representation_type_track_num_submissions"
     t.index ["source_submission_id"], name: "index_exercise_representations_on_source_submission_id"
     t.index ["track_id"], name: "index_exercise_representations_on_track_id"
+    t.index ["uuid"], name: "index_exercise_representations_on_uuid", unique: true
   end
 
   create_table "exercise_taught_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -357,40 +447,65 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_concept_id"], name: "index_exercise_taught_concepts_on_track_concept_id"
   end
 
+  create_table "exercise_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "exercise_id", null: false
+    t.bigint "topic_id", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["exercise_id"], name: "fk_rails_0e58b87007"
+    t.index ["topic_id"], name: "fk_rails_0e642b953e"
+  end
+
   create_table "exercises", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "track_id", null: false
     t.string "uuid", null: false
-    t.string "type", null: false
     t.string "slug", null: false
     t.string "title", null: false
-    t.string "blurb", limit: 350, null: false
-    t.integer "difficulty", limit: 1, default: 1, null: false
-    t.integer "status", limit: 1, default: 0, null: false
+    t.text "blurb"
+    t.integer "difficulty", default: 1, null: false
+    t.integer "position"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "median_wait_time"
+    t.integer "status", limit: 1, default: 2, null: false
+    t.string "icon_name", null: false
+    t.string "type", null: false
     t.string "git_sha", null: false
     t.string "synced_to_git_sha", null: false
     t.string "git_important_files_hash", null: false
-    t.integer "position", null: false
-    t.string "icon_name", null: false
-    t.integer "median_wait_time"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "has_test_runner", default: false, null: false
     t.integer "num_published_solutions", default: 0, null: false
     t.boolean "has_approaches", default: false, null: false
     t.index ["track_id", "uuid"], name: "index_exercises_on_track_id_and_uuid", unique: true
-    t.index ["track_id"], name: "index_exercises_on_track_id"
-    t.index ["uuid"], name: "index_exercises_on_uuid"
+    t.index ["track_id"], name: "fk_rails_a796d89c21"
+  end
+
+  create_table "flipper_features", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "friendly_id_slugs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "slug", null: false
+    t.string "slug", limit: 190, null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
-    t.string "scope"
-    t.datetime "created_at"
-    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, length: { slug: 70, scope: 70 }
-    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", length: { slug: 140 }
-    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+    t.string "scope", limit: 190
+    t.datetime "created_at", precision: nil
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
   create_table "github_issue_labels", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -409,7 +524,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.integer "status", limit: 1, default: 0, null: false
     t.string "repo", null: false
     t.string "opened_by_username"
-    t.datetime "opened_at", null: false
+    t.datetime "opened_at", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["node_id"], name: "index_github_issues_on_node_id", unique: true
@@ -453,7 +568,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.string "repo", null: false
     t.string "issue_url", null: false
     t.string "opened_by_username"
-    t.datetime "opened_at", null: false
+    t.datetime "opened_at", precision: nil, null: false
     t.integer "action", limit: 1, default: 0
     t.integer "knowledge", limit: 1, default: 0
     t.integer "area", limit: 1, default: 0
@@ -467,7 +582,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_github_tasks_on_uuid", unique: true
   end
 
-  create_table "github_team_members", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "github_team_members", charset: "utf8mb4", force: :cascade do |t|
     t.string "user_id", null: false
     t.string "team_name", null: false
     t.datetime "created_at", null: false
@@ -475,21 +590,52 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id", "team_name"], name: "index_github_team_members_on_user_id_and_team_name", unique: true
   end
 
-  create_table "iterations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "ignored_solution_mentorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "solution_id", null: false
-    t.bigint "submission_id", null: false
-    t.string "uuid", null: false
-    t.integer "idx", limit: 1, null: false
-    t.string "snippet", limit: 1500
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "num_loc"
-    t.index ["solution_id"], name: "index_iterations_on_solution_id"
-    t.index ["submission_id"], name: "index_iterations_on_submission_id", unique: true
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["solution_id"], name: "fk_rails_31331ef022"
+    t.index ["user_id"], name: "fk_rails_7b8f6c3112"
   end
 
-  create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "infrastructure_test_runner_versions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "test_runner_id", null: false
+    t.string "slug", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_infrastructure_test_runner_versions_on_slug", unique: true
+    t.index ["test_runner_id"], name: "fk_rails_63c05336de"
+  end
+
+  create_table "infrastructure_test_runners", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "language_slug", null: false
+    t.integer "timeout_ms", null: false
+    t.string "version_slug"
+    t.integer "num_processors", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "iterations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "solution_type", default: "Solution", null: false
+    t.string "legacy_uuid"
+    t.bigint "submission_id", null: false
+    t.string "uuid", null: false
+    t.datetime "deleted_at", precision: nil
+    t.integer "idx", limit: 1, null: false
+    t.string "snippet", limit: 1500
+    t.integer "num_loc"
+    t.index ["solution_id"], name: "fk_rails_5d9f1bf4bd"
+    t.index ["submission_id"], name: "index_iterations_on_submission_id", unique: true
+    t.index ["uuid"], name: "iterations_uuid"
+  end
+
+  create_table "mailshots", charset: "utf8mb4", force: :cascade do |t|
     t.string "slug", null: false
     t.string "email_communication_preferences_key", null: false
     t.boolean "test_sent", default: false, null: false
@@ -503,6 +649,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_mailshots_on_slug", unique: true
+  end
+
+  create_table "maintainers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "track_id", null: false
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.string "avatar_url", null: false
+    t.string "github_username", null: false
+    t.string "link_text"
+    t.string "link_url"
+    t.text "bio"
+    t.boolean "visible", default: true, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "alumnus"
+    t.index ["track_id"], name: "fk_rails_ed46fd11a4"
+    t.index ["user_id"], name: "fk_rails_5b1168410c"
   end
 
   create_table "mentor_discussion_posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -523,31 +686,33 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   end
 
   create_table "mentor_discussions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.bigint "solution_id", null: false
     t.bigint "mentor_id", null: false
-    t.bigint "request_id", null: false
-    t.integer "status", limit: 1, default: 0, null: false
-    t.integer "rating", limit: 1
+    t.bigint "solution_id", null: false
+    t.integer "rating"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "awaiting_mentor_since", precision: nil
+    t.datetime "mentor_reminder_sent_at", precision: nil
+    t.string "uuid", null: false
+    t.datetime "requires_student_action_since", precision: nil
     t.integer "num_posts", limit: 3, default: 0, null: false
     t.boolean "anonymous_mode", default: false, null: false
-    t.datetime "awaiting_student_since"
-    t.datetime "awaiting_mentor_since"
-    t.datetime "mentor_reminder_sent_at"
-    t.datetime "finished_at"
+    t.datetime "awaiting_student_since", precision: nil
+    t.bigint "request_id", null: false
+    t.integer "status", limit: 1, default: 0, null: false
+    t.datetime "finished_at", precision: nil
     t.integer "finished_by", limit: 1
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "external", default: false, null: false
     t.index ["mentor_id", "status"], name: "index_mentor_discussions_on_mentor_id_and_status"
-    t.index ["request_id"], name: "index_mentor_discussions_on_request_id"
-    t.index ["solution_id"], name: "index_mentor_discussions_on_solution_id"
+    t.index ["request_id"], name: "fk_rails_38162d0a13"
+    t.index ["solution_id"], name: "fk_rails_704ccdde73"
+    t.index ["uuid"], name: "index_mentor_discussions_on_uuid", unique: true
   end
 
   create_table "mentor_request_locks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "request_id", null: false
     t.bigint "locked_by_id", null: false
-    t.datetime "locked_until", null: false
+    t.datetime "locked_until", precision: nil, null: false
     t.index ["request_id", "locked_by_id"], name: "index_mentor_request_locks_on_request_id_and_locked_by_id"
     t.index ["request_id"], name: "index_mentor_request_locks_on_request_id"
   end
@@ -598,7 +763,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.text "content", null: false
     t.boolean "revealed", default: false, null: false
     t.boolean "published", default: true, null: false
-    t.datetime "deleted_at"
+    t.datetime "deleted_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["discussion_id"], name: "index_mentor_testimonials_on_discussion_id", unique: true
@@ -607,7 +772,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_mentor_testimonials_on_uuid"
   end
 
-  create_table "metric_period_days", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "mentors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "track_id", null: false
+    t.string "name", null: false
+    t.string "avatar_url"
+    t.string "github_username", null: false
+    t.string "link_text"
+    t.string "link_url"
+    t.text "bio"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["track_id"], name: "index_mentors_on_track_id"
+  end
+
+  create_table "metric_period_days", charset: "utf8mb4", force: :cascade do |t|
     t.integer "day", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -618,7 +796,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_days_on_track_id"
   end
 
-  create_table "metric_period_minutes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "metric_period_minutes", charset: "utf8mb4", force: :cascade do |t|
     t.integer "minute", limit: 2, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -629,7 +807,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_minutes_on_track_id"
   end
 
-  create_table "metric_period_months", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "metric_period_months", charset: "utf8mb4", force: :cascade do |t|
     t.integer "month", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -640,7 +818,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["track_id"], name: "index_metric_period_months_on_track_id"
   end
 
-  create_table "metrics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "metrics", charset: "utf8mb4", force: :cascade do |t|
     t.string "type", null: false
     t.text "params", null: false
     t.bigint "track_id"
@@ -674,6 +852,70 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_problem_reports_on_user_id"
   end
 
+  create_table "reactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "emotion", null: false
+    t.text "comment"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["solution_id"], name: "fk_rails_51c7d8b8ad"
+    t.index ["user_id"], name: "fk_rails_9f02fc96a0"
+  end
+
+  create_table "repo_update_fetches", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.timestamp "completed_at"
+    t.bigint "repo_update_id", null: false
+    t.string "host", limit: 190, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["repo_update_id", "host"], name: "index_repo_update_fetches_on_repo_update_id_and_host", unique: true
+    t.index ["repo_update_id"], name: "index_repo_update_fetches_on_repo_update_id"
+  end
+
+  create_table "repo_updates", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.timestamp "synced_at"
+    t.string "slug", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "research_experiment_solutions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "experiment_id", null: false
+    t.string "uuid", null: false
+    t.bigint "exercise_id", null: false
+    t.string "git_sha", null: false
+    t.string "git_slug", null: false
+    t.datetime "started_at", precision: nil
+    t.datetime "finished_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "difficulty_rating"
+    t.index ["exercise_id"], name: "fk_rails_1be696c295"
+    t.index ["experiment_id"], name: "fk_rails_8f6bde7fee"
+    t.index ["user_id", "experiment_id", "exercise_id"], name: "research_solutions_uniq", unique: true
+  end
+
+  create_table "research_experiments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "slug", null: false
+    t.string "repo_url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_research_experiments_on_slug"
+  end
+
+  create_table "research_user_experiments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "experiment_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.json "survey"
+    t.index ["experiment_id"], name: "fk_rails_809b029224"
+    t.index ["user_id", "experiment_id"], name: "index_research_user_experiments_on_user_id_and_experiment_id", unique: true
+  end
+
   create_table "scratchpad_pages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "about_type", null: false
     t.bigint "about_id", null: false
@@ -696,7 +938,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.bigint "exercise_id"
     t.bigint "author_id"
     t.bigint "pull_request_id"
-    t.datetime "published_at", null: false
+    t.datetime "published_at", precision: nil, null: false
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -711,70 +953,90 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   end
 
   create_table "solution_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
     t.bigint "solution_id", null: false
     t.bigint "user_id", null: false
-    t.text "content_markdown", null: false
-    t.text "content_html", null: false
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["solution_id"], name: "index_solution_comments_on_solution_id"
+    t.text "content_markdown", size: :long, null: false
+    t.text "content_html", size: :long, null: false
+    t.boolean "edited", default: false, null: false
+    t.text "previous_content"
+    t.boolean "deleted", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "uuid", null: false
+    t.index ["solution_id"], name: "fk_rails_f34a457d42"
     t.index ["user_id"], name: "index_solution_comments_on_user_id"
     t.index ["uuid"], name: "index_solution_comments_on_uuid", unique: true
+  end
+
+  create_table "solution_locks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "locked_until", precision: nil, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["solution_id"], name: "fk_rails_d2575804da"
+    t.index ["user_id"], name: "fk_rails_7c200d25d8"
   end
 
   create_table "solution_stars", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "solution_id", null: false
     t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["solution_id", "user_id"], name: "index_solution_stars_on_solution_id_and_user_id", unique: true
-    t.index ["solution_id"], name: "index_solution_stars_on_solution_id"
     t.index ["user_id"], name: "index_solution_stars_on_user_id"
   end
 
   create_table "solutions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "type", null: false
-    t.string "unique_key", null: false
     t.bigint "user_id", null: false
-    t.bigint "exercise_id", null: false
-    t.bigint "published_iteration_id"
     t.string "uuid", null: false
-    t.string "public_uuid", null: false
-    t.string "git_slug", null: false
+    t.bigint "exercise_id", null: false
     t.string "git_sha", null: false
-    t.string "git_important_files_hash", null: false
+    t.string "git_slug", null: false
+    t.bigint "approved_by_id"
+    t.datetime "downloaded_at", precision: nil
+    t.datetime "completed_at", precision: nil
+    t.datetime "published_at", precision: nil
+    t.integer "num_reactions", default: 0, null: false
+    t.text "reflection"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "mentoring_requested_at", precision: nil
+    t.boolean "show_on_profile", default: false, null: false
+    t.boolean "allow_comments", default: false, null: false
+    t.integer "num_comments", limit: 2, default: 0, null: false
+    t.integer "num_stars", limit: 2, default: 0, null: false
+    t.integer "num_views", limit: 3, default: 0, null: false
+    t.integer "num_loc", limit: 3
+    t.bigint "published_iteration_id"
     t.integer "status", limit: 1, default: 0, null: false
     t.string "iteration_status"
-    t.boolean "allow_comments", default: true, null: false
-    t.datetime "last_iterated_at"
-    t.integer "num_iterations", limit: 1, default: 0, null: false
-    t.string "snippet", limit: 1500
-    t.datetime "downloaded_at"
-    t.datetime "completed_at"
-    t.datetime "published_at"
     t.integer "mentoring_status", limit: 1, default: 0, null: false
-    t.integer "num_views", limit: 3, default: 0, null: false
-    t.integer "num_stars", limit: 3, default: 0, null: false
-    t.integer "num_comments", limit: 3, default: 0, null: false
-    t.integer "num_loc", limit: 3
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "snippet", limit: 1500
+    t.integer "num_iterations", limit: 1, default: 0, null: false
+    t.string "type", null: false
+    t.string "public_uuid", null: false
+    t.datetime "last_iterated_at", precision: nil
+    t.string "git_important_files_hash", null: false
+    t.string "unique_key", null: false
     t.integer "published_iteration_head_tests_status", default: 0, null: false
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
-    t.index ["exercise_id", "status", "num_stars"], name: "solutions_ex_stat_stars", order: { status: :desc, num_stars: :desc }
-    t.index ["exercise_id"], name: "index_solutions_on_exercise_id"
-    t.index ["num_stars", "id"], name: "solutions_popular_new", order: :desc
-    t.index ["public_uuid"], name: "index_solutions_on_public_uuid", unique: true
-    t.index ["published_iteration_id"], name: "index_solutions_on_published_iteration_id"
+    t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
+    t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_1"
+    t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_2"
+    t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "id"], name: "mentor_selection_idx_3"
+    t.index ["exercise_id", "status", "num_stars"], name: "solutions_ex_stat_stars"
+    t.index ["exercise_id"], name: "fk_rails_8c0841e614"
+    t.index ["num_stars", "id"], name: "solutions_popular_new"
+    t.index ["public_uuid"], name: "solutions_public_uuid"
+    t.index ["published_iteration_id"], name: "fk_rails_16788386df"
     t.index ["unique_key"], name: "index_solutions_on_unique_key", unique: true
     t.index ["user_id", "exercise_id"], name: "index_solutions_on_user_id_and_exercise_id"
-    t.index ["uuid"], name: "index_solutions_on_uuid", unique: true
+    t.index ["uuid"], name: "index_solutions_on_uuid"
   end
 
-  create_table "streaming_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "streaming_events", charset: "utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
     t.datetime "starts_at", null: false
@@ -787,16 +1049,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["starts_at", "ends_at"], name: "index_streaming_events_on_starts_at_and_ends_at"
   end
 
-  create_table "submission_ai_help_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "submission_id", null: false
-    t.string "source", null: false
-    t.text "advice_markdown", null: false
-    t.text "advice_html", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["submission_id"], name: "fk_rails_76b9473637"
-  end
-
   create_table "submission_analyses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
     t.integer "ops_status", limit: 2, null: false
@@ -807,7 +1059,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.integer "num_comments", limit: 1, default: 0, null: false
     t.bigint "track_id"
     t.index ["submission_id"], name: "index_submission_analyses_on_submission_id"
-    t.index ["track_id", "id"], name: "index_submission_analyses_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id", "id"], name: "index_submission_analyses_on_track_id_and_id"
     t.index ["track_id", "num_comments"], name: "index_submission_analyses_on_track_id_and_num_comments"
     t.index ["track_id"], name: "index_submission_analyses_on_track_id"
   end
@@ -815,11 +1067,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   create_table "submission_files", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "submission_id", null: false
     t.string "filename", null: false
-    t.string "digest", null: false
+    t.binary "file_contents"
+    t.text "digest", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "uri", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["submission_id"], name: "index_submission_files_on_submission_id"
+    t.index ["submission_id"], name: "fk_rails_d1aca45f2f"
   end
 
   create_table "submission_representations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -831,13 +1084,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "mentored_by_id"
+    t.bigint "mentor_id"
     t.bigint "track_id"
-    t.string "exercise_id_and_ast_digest_idx_cache"
-    t.index ["exercise_id_and_ast_digest_idx_cache"], name: "index_ex_rep"
+    t.index ["ast_digest"], name: "index_submission_representations_on_ast_digest"
+    t.index ["mentor_id"], name: "index_submission_representations_on_mentor_id"
     t.index ["mentored_by_id"], name: "index_submission_representations_on_mentored_by_id"
     t.index ["submission_id", "ast_digest"], name: "index_submission_representations_on_submission_id_and_ast_digest"
     t.index ["submission_id"], name: "index_submission_representations_on_submission_id"
-    t.index ["track_id", "id"], name: "index_submission_representations_on_track_id_and_id", order: { id: :desc }
+    t.index ["track_id", "id"], name: "index_submission_representations_on_track_id_and_id"
     t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
@@ -855,10 +1109,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.datetime "updated_at", null: false
     t.string "git_important_files_hash", limit: 50
     t.string "git_sha", limit: 50
-    t.bigint "track_id"
+    t.integer "track_id", limit: 2
+    t.index ["git_important_files_hash", "submission_id"], name: "submissions-test-runs-git-optimiser-2"
+    t.index ["git_sha", "submission_id"], name: "submissions-test-runs-git-optimiser-1"
+    t.index ["submission_id", "git_sha"], name: "submissions-test-runs-git-optimiser-3"
     t.index ["submission_id"], name: "index_submission_test_runs_on_submission_id"
-    t.index ["track_id", "id"], name: "index_submission_test_runs_on_track_id_and_id", order: { id: :desc }
-    t.index ["track_id"], name: "index_submission_test_runs_on_track_id"
+    t.index ["track_id", "id"], name: "index_submission_test_runs_on_track_id_and_id"
     t.index ["uuid"], name: "index_submission_test_runs_on_uuid", unique: true
   end
 
@@ -876,11 +1132,82 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.string "git_important_files_hash", limit: 50
     t.integer "track_id", limit: 2
     t.integer "exercise_id", limit: 3
+    t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
+    t.index ["git_sha", "solution_id", "git_important_files_hash"], name: "submissions-git-optimiser-1"
     t.index ["solution_id"], name: "index_submissions_on_solution_id"
     t.index ["track_id", "exercise_id"], name: "index_submissions_on_track_id_and_exercise_id"
     t.index ["track_id", "tests_status"], name: "index_submissions_on_track_id_and_tests_status"
     t.index ["track_id"], name: "index_submissions_on_track_id"
     t.index ["uuid"], name: "index_submissions_on_uuid", unique: true
+  end
+
+  create_table "team_invitations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.bigint "invited_by_id", null: false
+    t.string "email", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "token", null: false
+    t.index ["invited_by_id"], name: "fk_rails_654806c772"
+    t.index ["team_id", "email"], name: "index_team_invitations_on_team_id_and_email", unique: true
+  end
+
+  create_table "team_memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "admin", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["team_id", "user_id"], name: "index_team_memberships_on_team_id_and_user_id", unique: true
+    t.index ["team_id"], name: "fk_rails_61c29b529e"
+    t.index ["user_id"], name: "fk_rails_5aba9331a7"
+  end
+
+  create_table "team_solutions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "team_id", null: false
+    t.string "uuid", null: false
+    t.bigint "exercise_id", null: false
+    t.string "git_sha", null: false
+    t.string "git_slug", null: false
+    t.boolean "needs_feedback", default: false, null: false
+    t.boolean "has_unseen_feedback", default: false, null: false
+    t.integer "num_iterations", default: 0, null: false
+    t.datetime "downloaded_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["exercise_id"], name: "fk_rails_ba74ecfdce"
+    t.index ["team_id"], name: "fk_rails_1c8d2e5b15"
+    t.index ["user_id", "team_id", "exercise_id"], name: "index_team_solutions_on_user_id_and_team_id_and_exercise_id", unique: true
+  end
+
+  create_table "teams", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.text "description"
+    t.string "token", null: false
+    t.boolean "url_join_allowed", default: true, null: false
+    t.index ["slug"], name: "index_teams_on_slug", unique: true
+    t.index ["token"], name: "index_teams_on_token", unique: true
+  end
+
+  create_table "testimonials", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "track_id"
+    t.string "headline", null: false
+    t.text "content", null: false
+    t.string "byline", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["track_id"], name: "fk_rails_c5eac2171d"
+  end
+
+  create_table "topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "track_concept_authorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -919,17 +1246,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   create_table "tracks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.string "title", null: false
-    t.string "blurb", limit: 400, null: false
     t.string "repo_url", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.boolean "active", default: true, null: false
+    t.integer "median_wait_time"
+    t.string "blurb", limit: 400, null: false
     t.string "synced_to_git_sha", null: false
+    t.json "tags"
     t.integer "num_exercises", limit: 3, default: 0, null: false
     t.integer "num_concepts", limit: 3, default: 0, null: false
-    t.json "tags"
-    t.boolean "active", default: true, null: false
     t.integer "num_students", default: 0, null: false
-    t.integer "median_wait_time"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "course", default: false, null: false
     t.boolean "has_test_runner", default: false, null: false
     t.boolean "has_representer", default: false, null: false
@@ -959,7 +1286,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.bigint "exercise_id"
     t.bigint "solution_id"
     t.text "params", null: false
-    t.datetime "occurred_at", null: false
+    t.datetime "occurred_at", precision: nil, null: false
     t.string "uniqueness_key", null: false
     t.integer "version", null: false
     t.text "rendering_data_cache", null: false
@@ -975,21 +1302,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   create_table "user_auth_tokens", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "token", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "active", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["token"], name: "index_user_auth_tokens_on_token", unique: true
-    t.index ["user_id"], name: "index_user_auth_tokens_on_user_id"
+    t.index ["user_id", "active"], name: "index_user_auth_tokens_on_user_id_and_active"
+    t.index ["user_id"], name: "fk_rails_0d66c22f4c"
   end
 
-  create_table "user_block_domains", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_block_domains", charset: "utf8mb4", force: :cascade do |t|
     t.string "domain", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["domain"], name: "index_user_block_domains_on_domain", unique: true
   end
 
-  create_table "user_challenges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_challenges", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "challenge_id", null: false
     t.datetime "created_at", null: false
@@ -1000,18 +1328,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
 
   create_table "user_communication_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "token"
-    t.boolean "email_on_mentor_started_discussion_notification", default: true, null: false
     t.boolean "email_on_mentor_replied_to_discussion_notification", default: true, null: false
     t.boolean "email_on_student_replied_to_discussion_notification", default: true, null: false
     t.boolean "email_on_student_added_iteration_notification", default: true, null: false
-    t.boolean "email_on_new_solution_comment_for_solution_user_notification", default: true, null: false
-    t.boolean "email_on_new_solution_comment_for_other_commenter_notification", default: true, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "receive_product_updates", default: true, null: false
     t.boolean "email_on_remind_mentor", default: true, null: false
+    t.boolean "email_on_new_solution_comment_for_solution_user_notification", default: true, null: false
+    t.boolean "email_on_new_solution_comment_for_other_commenter_notification", default: true, null: false
     t.boolean "email_on_mentor_heartbeat", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "token"
+    t.boolean "email_on_remind_about_solution", default: true, null: false
+    t.boolean "email_on_mentor_started_discussion_notification", default: true, null: false
     t.boolean "email_on_general_update_notification", default: true, null: false
     t.boolean "email_on_acquired_badge_notification", default: true, null: false
     t.boolean "email_on_nudge_notification", default: true, null: false
@@ -1020,8 +1349,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.boolean "email_on_automated_feedback_added_notification", default: true, null: false
     t.boolean "email_about_fundraising_campaigns", default: true, null: false
     t.boolean "email_about_events", default: true, null: false
-    t.index ["token"], name: "index_user_communication_preferences_on_token", unique: true
-    t.index ["user_id"], name: "index_user_communication_preferences_on_user_id"
+    t.index ["token"], name: "index_user_communication_preferences_on_token"
+    t.index ["user_id"], name: "fk_rails_65642a5510"
   end
 
   create_table "user_dismissed_introducers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1033,7 +1362,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["user_id"], name: "index_user_dismissed_introducers_on_user_id"
   end
 
-  create_table "user_mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_email_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "mentor_heartbeat_sent_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "remind_about_solution_sent_at", precision: nil
+    t.index ["user_id"], name: "index_user_email_logs_on_user_id", unique: true
+  end
+
+  create_table "user_mailshots", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "mailshot_slug"
     t.integer "email_status", limit: 1, default: 0, null: false
@@ -1042,7 +1380,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.bigint "mailshot_id", null: false
     t.index ["email_status"], name: "index_user_mailshots_on_email_status"
     t.index ["mailshot_id"], name: "fk_rails_9ddeeadfc0"
-    t.index ["user_id", "mailshot_id"], name: "index_user_mailshots_on_user_id_and_mailshot_id"
+    t.index ["user_id", "mailshot_id"], name: "index_user_mailshots_on_user_id_and_mailshot_id", unique: true
     t.index ["user_id"], name: "index_user_mailshots_on_user_id"
   end
 
@@ -1059,7 +1397,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.integer "email_status", limit: 1, default: 0, null: false
     t.string "uniqueness_key", null: false
     t.text "rendering_data_cache", null: false
-    t.datetime "read_at"
+    t.datetime "read_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_id"], name: "index_user_notifications_on_exercise_id"
@@ -1070,7 +1408,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["uuid"], name: "index_user_notifications_on_uuid", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "auto_update_exercises", default: true, null: false
     t.datetime "created_at", null: false
@@ -1081,13 +1419,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
 
   create_table "user_profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
+    t.string "display_name"
     t.string "twitter"
     t.string "website"
     t.string "github"
     t.string "linkedin"
     t.string "medium"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["user_id"], name: "fk_rails_e424190865"
     t.index ["user_id"], name: "index_user_profiles_on_user_id", unique: true
   end
 
@@ -1130,6 +1470,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["earned_on"], name: "sweeper"
     t.index ["exercise_id"], name: "index_user_reputation_tokens_on_exercise_id"
     t.index ["track_id", "category", "external_url"], name: "index_user_reputation_tokens_on_track_id_category_external_url"
+    t.index ["track_id"], name: "index_user_reputation_tokens_on_track_id"
     t.index ["uniqueness_key", "user_id"], name: "index_user_reputation_tokens_on_uniqueness_key_and_user_id", unique: true
     t.index ["user_id", "category"], name: "index_user_reputation_tokens_on_user_id_and_category"
     t.index ["user_id", "earned_on", "type"], name: "index_user_reputation_tokens_query_3"
@@ -1143,64 +1484,68 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   create_table "user_track_mentorships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "track_id", null: false
+    t.text "bio"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "last_viewed", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "num_finished_discussions", limit: 3, default: 0, null: false
-    t.index ["track_id"], name: "index_user_track_mentorships_on_track_id"
+    t.index ["track_id"], name: "fk_rails_4a81f96f88"
     t.index ["user_id", "track_id"], name: "index_user_track_mentorships_on_user_id_and_track_id", unique: true
-    t.index ["user_id"], name: "index_user_track_mentorships_on_user_id"
+    t.index ["user_id"], name: "fk_rails_283ecc719a"
   end
 
   create_table "user_tracks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "track_id", null: false
-    t.text "summary_data", null: false
-    t.string "summary_key"
-    t.boolean "practice_mode", default: false, null: false
     t.boolean "anonymous_during_mentoring", default: false, null: false
-    t.datetime "last_touched_at", null: false
+    t.string "avatar_url"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "summary_key"
+    t.text "summary_data"
+    t.datetime "last_touched_at", precision: nil, null: false
+    t.boolean "practice_mode", default: false, null: false
     t.text "objectives"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["track_id"], name: "index_user_tracks_on_track_id"
-    t.index ["user_id", "track_id"], name: "index_user_tracks_on_user_id_and_track_id", unique: true
-    t.index ["user_id"], name: "index_user_tracks_on_user_id"
+    t.index ["track_id", "user_id"], name: "index_user_tracks_on_track_id_and_user_id", unique: true
+    t.index ["user_id"], name: "fk_rails_99e944edbc"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "handle", null: false
     t.string "name", null: false
+    t.string "handle", limit: 190, null: false
+    t.string "avatar_url"
+    t.text "bio"
+    t.string "email", limit: 190, default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token", limit: 190
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
+    t.string "confirmation_token", limit: 190
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
+    t.string "unconfirmed_email"
     t.string "provider"
     t.string "uid"
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.datetime "accepted_privacy_policy_at"
-    t.datetime "accepted_terms_at"
-    t.datetime "became_mentor_at"
-    t.datetime "deleted_at"
-    t.datetime "joined_research_at"
+    t.boolean "admin", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "accepted_privacy_policy_at", precision: nil
+    t.datetime "accepted_terms_at", precision: nil
+    t.boolean "dark_code_theme", default: false, null: false
+    t.boolean "default_allow_comments"
+    t.datetime "deleted_at", precision: nil
+    t.datetime "joined_research_at", precision: nil
     t.string "github_username"
-    t.integer "reputation", default: 0, null: false
-    t.json "roles"
-    t.text "bio"
-    t.string "avatar_url"
     t.string "location"
     t.string "pronouns"
-    t.integer "num_solutions_mentored", limit: 3, default: 0, null: false
-    t.integer "mentor_satisfaction_percentage", limit: 1
+    t.integer "reputation", default: 0, null: false
     t.string "stripe_customer_id"
     t.integer "total_donated_in_cents", default: 0
     t.boolean "active_donation_subscription", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.json "roles"
+    t.integer "num_solutions_mentored", limit: 3, default: 0, null: false
+    t.integer "mentor_satisfaction_percentage", limit: 1
+    t.datetime "became_mentor_at", precision: nil
     t.boolean "show_on_supporters_page", default: true, null: false
     t.datetime "disabled_at"
     t.date "last_visited_on"
@@ -1212,12 +1557,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page", order: { first_donated_at: :desc }
+    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page"
     t.index ["github_username"], name: "index_users_on_github_username", unique: true
     t.index ["handle"], name: "index_users_on_handle", unique: true
     t.index ["insiders_status"], name: "index_users_on_insiders_status"
     t.index ["last_visited_on"], name: "index_users_on_last_visited_on"
-    t.index ["paypal_payer_id"], name: "index_users_on_paypal_payer_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -1225,8 +1569,79 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  create_table "v2_discussion_posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "iteration_id", null: false
+    t.bigint "user_id"
+    t.text "content", size: :long, null: false
+    t.text "html", size: :long, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.boolean "edited", default: false, null: false
+    t.text "previous_content", size: :long
+    t.boolean "deleted", default: false, null: false
+    t.string "type"
+    t.index ["iteration_id"], name: "fk_rails_f58a02b68e"
+  end
+
+  create_table "v2_iteration_analyses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "iteration_id", null: false
+    t.string "ops_status", null: false
+    t.json "analysis"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "website_error"
+    t.string "analysis_status"
+    t.index ["iteration_id"], name: "fk_rails_c60c42383b"
+  end
+
+  create_table "v2_notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "about_type"
+    t.bigint "about_id"
+    t.string "trigger_type"
+    t.bigint "trigger_id"
+    t.string "type"
+    t.text "content"
+    t.text "link"
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["about_type", "about_id"], name: "about"
+    t.index ["user_id", "read"], name: "index_v2_notifications_on_user_id_and_read"
+    t.index ["user_id"], name: "fk_rails_b080fb4855"
+  end
+
+  create_table "v2_submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "submission_id", null: false
+    t.string "results_status"
+    t.text "message"
+    t.json "tests"
+    t.json "results"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "ops_status", limit: 2, null: false
+    t.text "ops_message"
+    t.index ["submission_id"], name: "fk_rails_3812c45ada"
+  end
+
+  create_table "v2_submissions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.boolean "tested", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "uuid", null: false
+    t.json "filenames", null: false
+    t.string "solution_type", null: false
+    t.index ["solution_id", "id"], name: "index_v2_submissions_on_solution_id_and_id"
+    t.index ["solution_type", "solution_id"], name: "index_v2_submissions_on_solution_type_and_solution_id"
+    t.index ["tested", "id"], name: "index_v2_submissions_on_tested_and_id"
+    t.index ["uuid"], name: "index_v2_submissions_on_uuid", unique: true
+  end
+
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "blog_comments", "blog_comments"
+  add_foreign_key "blog_comments", "blog_posts"
+  add_foreign_key "blog_comments", "users"
   add_foreign_key "blog_posts", "users", column: "author_id"
   add_foreign_key "cohort_memberships", "cohorts"
   add_foreign_key "cohort_memberships", "users"
@@ -1235,6 +1650,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   add_foreign_key "community_stories", "users", column: "interviewer_id"
   add_foreign_key "community_videos", "users", column: "author_id"
   add_foreign_key "community_videos", "users", column: "submitted_by_id"
+  add_foreign_key "contributor_team_memberships", "contributor_teams"
+  add_foreign_key "contributor_team_memberships", "users"
+  add_foreign_key "contributor_teams", "tracks"
   add_foreign_key "documents", "tracks"
   add_foreign_key "donations_payments", "donations_subscriptions", column: "subscription_id"
   add_foreign_key "donations_payments", "users"
@@ -1268,12 +1686,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   add_foreign_key "exercise_representations", "users", column: "feedback_editor_id"
   add_foreign_key "exercise_taught_concepts", "exercises"
   add_foreign_key "exercise_taught_concepts", "track_concepts"
+  add_foreign_key "exercise_topics", "topics"
   add_foreign_key "exercises", "tracks"
   add_foreign_key "github_issue_labels", "github_issues"
   add_foreign_key "github_pull_request_reviews", "github_pull_requests"
   add_foreign_key "github_tasks", "tracks"
-  add_foreign_key "iterations", "solutions"
-  add_foreign_key "iterations", "submissions"
+  add_foreign_key "ignored_solution_mentorships", "solutions"
+  add_foreign_key "ignored_solution_mentorships", "users"
+  add_foreign_key "infrastructure_test_runner_versions", "infrastructure_test_runners", column: "test_runner_id"
+  add_foreign_key "maintainers", "tracks"
+  add_foreign_key "maintainers", "users"
   add_foreign_key "mentor_discussion_posts", "iterations"
   add_foreign_key "mentor_discussion_posts", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_discussion_posts", "users"
@@ -1287,31 +1709,37 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   add_foreign_key "mentor_testimonials", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_testimonials", "users", column: "mentor_id"
   add_foreign_key "mentor_testimonials", "users", column: "student_id"
+  add_foreign_key "mentors", "tracks"
   add_foreign_key "problem_reports", "exercises"
   add_foreign_key "problem_reports", "tracks"
   add_foreign_key "problem_reports", "users"
+  add_foreign_key "repo_update_fetches", "repo_updates"
+  add_foreign_key "research_experiment_solutions", "exercises"
+  add_foreign_key "research_experiment_solutions", "research_experiments", column: "experiment_id"
+  add_foreign_key "research_user_experiments", "research_experiments", column: "experiment_id"
   add_foreign_key "scratchpad_pages", "users"
   add_foreign_key "site_updates", "exercises"
   add_foreign_key "site_updates", "github_pull_requests", column: "pull_request_id"
   add_foreign_key "site_updates", "tracks"
   add_foreign_key "site_updates", "users", column: "author_id"
   add_foreign_key "solution_comments", "solutions"
-  add_foreign_key "solution_comments", "users"
-  add_foreign_key "solution_stars", "solutions"
-  add_foreign_key "solution_stars", "users"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
   add_foreign_key "solutions", "users"
-  add_foreign_key "submission_ai_help_records", "submissions"
   add_foreign_key "submission_analyses", "submissions"
   add_foreign_key "submission_analyses", "tracks"
   add_foreign_key "submission_files", "submissions"
   add_foreign_key "submission_representations", "submissions"
-  add_foreign_key "submission_representations", "tracks"
+  add_foreign_key "submission_representations", "users", column: "mentor_id"
   add_foreign_key "submission_representations", "users", column: "mentored_by_id"
   add_foreign_key "submission_test_runs", "submissions"
-  add_foreign_key "submission_test_runs", "tracks"
   add_foreign_key "submissions", "solutions"
+  add_foreign_key "team_invitations", "teams"
+  add_foreign_key "team_invitations", "users", column: "invited_by_id"
+  add_foreign_key "team_memberships", "teams"
+  add_foreign_key "team_solutions", "exercises"
+  add_foreign_key "team_solutions", "teams"
+  add_foreign_key "testimonials", "tracks"
   add_foreign_key "track_concept_authorships", "track_concepts"
   add_foreign_key "track_concept_authorships", "users"
   add_foreign_key "track_concept_contributorships", "track_concepts"
@@ -1340,4 +1768,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   add_foreign_key "user_track_mentorships", "users"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
+  add_foreign_key "v2_submission_test_runs", "v2_submissions", column: "submission_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_01_181339) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["changelog_entry_id"], name: "index_changelog_entry_tweets_on_changelog_entry_id"
   end
 
-  create_table "cohort_memberships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "cohort_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "introduction", null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_cohort_memberships_on_user_id"
   end
 
-  create_table "cohorts", charset: "utf8mb4", force: :cascade do |t|
+  create_table "cohorts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "track_id", null: false
     t.string "slug", null: false
     t.string "name", null: false
@@ -134,7 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["track_id"], name: "index_cohorts_on_track_id"
   end
 
-  create_table "community_stories", charset: "utf8mb4", force: :cascade do |t|
+  create_table "community_stories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "interviewer_id", null: false
     t.bigint "interviewee_id", null: false
     t.string "uuid", null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_community_stories_on_uuid", unique: true
   end
 
-  create_table "community_videos", charset: "utf8mb4", force: :cascade do |t|
+  create_table "community_videos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "track_id"
     t.bigint "exercise_id"
     t.bigint "author_id"
@@ -177,7 +177,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
-  create_table "contributor_team_memberships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "contributor_team_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "contributor_team_id", null: false
     t.bigint "user_id", null: false
     t.boolean "visible", default: true, null: false
@@ -189,7 +189,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_contributor_team_memberships_on_user_id"
   end
 
-  create_table "contributor_teams", charset: "utf8mb4", force: :cascade do |t|
+  create_table "contributor_teams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "track_id"
     t.string "github_name", null: false
     t.integer "type", limit: 1, default: 0, null: false
@@ -243,7 +243,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 
-  create_table "donations_payments", charset: "utf8mb4", force: :cascade do |t|
+  create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "subscription_id"
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
@@ -258,7 +258,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_donations_payments_on_user_id"
   end
 
-  create_table "donations_subscriptions", charset: "utf8mb4", force: :cascade do |t|
+  create_table "donations_subscriptions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.decimal "amount_in_cents", precision: 10, scale: 2, null: false
     t.datetime "created_at", null: false
@@ -271,7 +271,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_donations_subscriptions_on_user_id"
   end
 
-  create_table "exercise_approach_authorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_approach_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -281,7 +281,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_approach_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_contributorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_approach_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_approach_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -291,7 +291,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_approach_contributorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_approach_introduction_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -301,7 +301,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_authorships_on_user_id"
   end
 
-  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_approach_introduction_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -311,7 +311,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_approach_introduction_contributorships_on_user_id"
   end
 
-  create_table "exercise_approaches", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_approaches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -325,7 +325,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_exercise_approaches_on_uuid"
   end
 
-  create_table "exercise_article_authorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_article_authorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -335,7 +335,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_article_authorships_on_user_id"
   end
 
-  create_table "exercise_article_contributorships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_article_contributorships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -345,7 +345,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_exercise_article_contributorships_on_user_id"
   end
 
-  create_table "exercise_articles", charset: "utf8mb4", force: :cascade do |t|
+  create_table "exercise_articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "exercise_id", null: false
     t.string "uuid", null: false
     t.string "slug", null: false
@@ -421,8 +421,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.integer "exercise_version", limit: 2, default: 1, null: false
     t.integer "draft_feedback_type", limit: 1
     t.text "draft_feedback_markdown"
+    t.string "exercise_id_and_ast_digest_idx_cache"
     t.index ["ast_digest"], name: "index_exercise_representations_on_ast_digest"
     t.index ["exercise_id", "ast_digest", "representer_version", "exercise_version"], name: "exercise_representations_guard", unique: true
+    t.index ["exercise_id_and_ast_digest_idx_cache", "id"], name: "index_sub_rep", order: { id: :desc }
     t.index ["feedback_author_id", "exercise_id", "last_submitted_at"], name: "index_exercise_representation_author_exercise_last_submitted_at"
     t.index ["feedback_author_id", "exercise_id", "num_submissions"], name: "index_exercise_representation_author_exercise_num_submissions"
     t.index ["feedback_author_id", "track_id", "last_submitted_at"], name: "index_exercise_representation_author_track_last_submitted_at"
@@ -582,7 +584,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_github_tasks_on_uuid", unique: true
   end
 
-  create_table "github_team_members", charset: "utf8mb4", force: :cascade do |t|
+  create_table "github_team_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "user_id", null: false
     t.string "team_name", null: false
     t.datetime "created_at", null: false
@@ -635,7 +637,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "iterations_uuid"
   end
 
-  create_table "mailshots", charset: "utf8mb4", force: :cascade do |t|
+  create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.string "email_communication_preferences_key", null: false
     t.boolean "test_sent", default: false, null: false
@@ -785,7 +787,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["track_id"], name: "index_mentors_on_track_id"
   end
 
-  create_table "metric_period_days", charset: "utf8mb4", force: :cascade do |t|
+  create_table "metric_period_days", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "day", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -796,7 +798,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["track_id"], name: "index_metric_period_days_on_track_id"
   end
 
-  create_table "metric_period_minutes", charset: "utf8mb4", force: :cascade do |t|
+  create_table "metric_period_minutes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "minute", limit: 2, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -807,7 +809,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["track_id"], name: "index_metric_period_minutes_on_track_id"
   end
 
-  create_table "metric_period_months", charset: "utf8mb4", force: :cascade do |t|
+  create_table "metric_period_months", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "month", limit: 1, default: 0, null: false
     t.string "metric_type", null: false
     t.bigint "track_id"
@@ -818,7 +820,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["track_id"], name: "index_metric_period_months_on_track_id"
   end
 
-  create_table "metrics", charset: "utf8mb4", force: :cascade do |t|
+  create_table "metrics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "type", null: false
     t.text "params", null: false
     t.bigint "track_id"
@@ -1036,7 +1038,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_solutions_on_uuid"
   end
 
-  create_table "streaming_events", charset: "utf8mb4", force: :cascade do |t|
+  create_table "streaming_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
     t.datetime "starts_at", null: false
@@ -1086,7 +1088,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.bigint "mentored_by_id"
     t.bigint "mentor_id"
     t.bigint "track_id"
+    t.string "exercise_id_and_ast_digest_idx_cache"
     t.index ["ast_digest"], name: "index_submission_representations_on_ast_digest"
+    t.index ["exercise_id_and_ast_digest_idx_cache"], name: "index_ex_rep"
     t.index ["mentor_id"], name: "index_submission_representations_on_mentor_id"
     t.index ["mentored_by_id"], name: "index_submission_representations_on_mentored_by_id"
     t.index ["submission_id", "ast_digest"], name: "index_submission_representations_on_submission_id_and_ast_digest"
@@ -1310,14 +1314,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "fk_rails_0d66c22f4c"
   end
 
-  create_table "user_block_domains", charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_block_domains", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "domain", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["domain"], name: "index_user_block_domains_on_domain", unique: true
   end
 
-  create_table "user_challenges", charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_challenges", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "challenge_id", null: false
     t.datetime "created_at", null: false
@@ -1371,7 +1375,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["user_id"], name: "index_user_email_logs_on_user_id", unique: true
   end
 
-  create_table "user_mailshots", charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_mailshots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "mailshot_slug"
     t.integer "email_status", limit: 1, default: 0, null: false
@@ -1408,11 +1412,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.index ["uuid"], name: "index_user_notifications_on_uuid", unique: true
   end
 
-  create_table "user_preferences", charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "auto_update_exercises", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "theme"
     t.index ["user_id"], name: "index_user_preferences_on_user_id", unique: true
   end
 
@@ -1502,7 +1507,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_005532) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "summary_key"
     t.text "summary_data"
-    t.datetime "last_touched_at", precision: nil, null: false
+    t.datetime "last_touched_at", null: false
     t.boolean "practice_mode", default: false, null: false
     t.text "objectives"
     t.index ["track_id", "user_id"], name: "index_user_tracks_on_track_id_and_user_id", unique: true

--- a/test/controllers/api/community_solution_comments_controller_test.rb
+++ b/test/controllers/api/community_solution_comments_controller_test.rb
@@ -9,7 +9,7 @@ class API::CommunitySolutionCommentsControllerTest < API::BaseTestCase
   ###
   test "index returns comments for request and solution" do
     setup_user
-    solution = create :concept_solution, :published
+    solution = create :concept_solution, :published, allow_comments: true
     comment = create(:solution_comment, solution:, content_markdown: "Hello", updated_at: Time.utc(2016, 12, 25))
 
     get api_track_exercise_community_solution_comments_path(
@@ -94,7 +94,7 @@ class API::CommunitySolutionCommentsControllerTest < API::BaseTestCase
 
   test "create should create correctly for user" do
     user = create :user
-    solution = create :practice_solution, :published
+    solution = create :practice_solution, :published, allow_comments: true
     content_markdown = "foo to the baaar"
     comment = create(:solution_comment, author: user, solution:, content_markdown:)
 

--- a/test/models/blog_post_test.rb
+++ b/test/models/blog_post_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class BlogPostTest < ActiveSupport::TestCase
   test "published and scheduled scopes" do
     freeze_time do
-      post_1 = create :blog_post, published_at: Time.current - 1.second
-      post_2 = create :blog_post, published_at: Time.current + 1.second
-      post_3 = create :blog_post, published_at: Time.current
+      post_1 = create :blog_post, :random_slug, published_at: Time.current - 1.second
+      post_2 = create :blog_post, :random_slug, published_at: Time.current + 1.second
+      post_3 = create :blog_post, :random_slug, published_at: Time.current
 
       assert_equal [post_1, post_3], BlogPost.published
       assert_equal [post_2], BlogPost.scheduled


### PR DESCRIPTION
@dem4ron @ErikSchierboom This is the real production `schema.rb`. It's effectively a noop, but means we should all get a clean database (which will make Erik happy as my shitty setup annoys him!)

https://github.com/exercism/website/pull/3732 removes the old unused tables.