### PR TITLE
:lipstick: Fix code snippet overflow in tracks about section

### DIFF
--- a/app/css/pages/track-about.css
+++ b/app/css/pages/track-about.css
@@ -144,6 +144,11 @@
                 @screen md {
                     max-width: 450px;
                 }
+
+                & > code {
+                    display: block;
+                    overflow-x: auto;
+                }
             }
         }
     }


### PR DESCRIPTION
On Ballerina track (https://exercism.org/tracks/ballerina) the code snippet is not readable because it overflows to the right.

I am not sure about the selector but it looks like this component css is designed like this.

Before:
![image](https://user-images.githubusercontent.com/16977446/235789340-d6d1ed67-15dd-45b6-a496-e10cc6128e3a.png)

After:
![image](https://user-images.githubusercontent.com/16977446/235789573-18021bf7-4df9-4194-b7aa-577ae9fdf706.png)
![image](https://user-images.githubusercontent.com/16977446/235789664-27dbb4a7-2841-4ee7-89f5-62401654e7a0.png)
