### PR TITLE
Disable selected theme selector

### DIFF
--- a/app/javascript/components/common/ThemeToggleButton.tsx
+++ b/app/javascript/components/common/ThemeToggleButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { GraphicalIcon } from './GraphicalIcon'
-import { setThemeClassName } from '../settings/ThemePreferenceForm'
+import { setThemeClassName } from '../settings/theme-preference-form/utils'
 
 export function ThemeToggleButton(): JSX.Element {
   const { currentColorScheme, switchToColorMode } = useSwitchTheme()

--- a/app/javascript/components/settings/ThemePreferenceForm.tsx
+++ b/app/javascript/components/settings/ThemePreferenceForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { FormMessage } from './FormMessage'
 import {
   InfoMessage,
   THEMES,
@@ -7,7 +6,6 @@ import {
   isDisabled,
   useTheme,
 } from './theme-preference-form'
-import { Icon } from '../common'
 
 export type ThemePreferenceLinks = {
   update: string
@@ -21,8 +19,6 @@ export type Theme = {
   value: string
 }
 
-const DEFAULT_ERROR = new Error('Unable to update theme preference')
-
 export const ThemePreferenceForm = ({
   defaultThemePreference,
   insidersStatus,
@@ -32,10 +28,7 @@ export const ThemePreferenceForm = ({
   insidersStatus: string
   links: ThemePreferenceLinks
 }): JSX.Element => {
-  const { theme, handleThemeUpdate, status, error } = useTheme(
-    defaultThemePreference,
-    links
-  )
+  const { theme, handleThemeUpdate } = useTheme(defaultThemePreference, links)
 
   return (
     <form data-turbo="false">
@@ -55,23 +48,6 @@ export const ThemePreferenceForm = ({
           />
         ))}
       </div>
-      <div className="form-footer min-h-[80px]">
-        <FormMessage
-          status={status}
-          error={error}
-          defaultError={DEFAULT_ERROR}
-          SuccessMessage={() => <SuccessMessage />}
-        />
-      </div>
     </form>
-  )
-}
-
-const SuccessMessage = () => {
-  return (
-    <div className="status success">
-      <Icon icon="completed-check-circle" alt="Success" />
-      Your theme has been updated!
-    </div>
   )
 }

--- a/app/javascript/components/settings/ThemePreferenceForm.tsx
+++ b/app/javascript/components/settings/ThemePreferenceForm.tsx
@@ -1,74 +1,27 @@
-import React, { useState, useCallback } from 'react'
-import { FormButton, GraphicalIcon, Icon } from '../common'
-import { useSettingsMutation } from './useSettingsMutation'
+import React from 'react'
 import { FormMessage } from './FormMessage'
-import { ExercismTippy } from '../misc/ExercismTippy'
+import {
+  InfoMessage,
+  THEMES,
+  ThemeButton,
+  isDisabled,
+  useTheme,
+} from './theme-preference-form'
+import { Icon } from '../common'
 
 export type ThemePreferenceLinks = {
   update: string
   insidersPath: string
 }
 
-type RequestBody = {
-  user_preferences: {
-    theme: string
-  }
-}
-
-type Theme = {
+export type Theme = {
   label: string
   background: string
   iconFilter: string
   value: string
 }
 
-export function setThemeClassName(theme: string): void {
-  const body = document.querySelector('body')
-  if (!body) return
-
-  const currentTheme = body.classList.value.match(/theme-\S+/)?.[0]
-  const newTheme = `theme-${theme}`
-
-  if (newTheme === currentTheme) {
-    return
-  }
-
-  if (!currentTheme) {
-    body.classList.add(newTheme)
-  } else {
-    body.classList.replace(currentTheme, newTheme)
-  }
-}
-
 const DEFAULT_ERROR = new Error('Unable to update theme preference')
-const THEME_BUTTON_SIZE = 130
-const THEMES: Theme[] = [
-  {
-    label: 'Light',
-    value: 'light',
-    background: 'white',
-    iconFilter: 'textColor1NoDark',
-  },
-  {
-    label: 'System',
-    value: 'system',
-    background:
-      'linear-gradient(135deg, rgba(255,255,255,1) 50%, rgba(48,43,66,1) 50%)',
-    iconFilter: 'gray',
-  },
-  {
-    label: 'Dark',
-    value: 'dark',
-    background: '#302b42', //russianViolet
-    iconFilter: 'aliceBlue',
-  },
-  {
-    label: 'Accessibility Dark',
-    value: 'accessibility-dark',
-    background: 'black',
-    iconFilter: 'white-no-dark',
-  },
-]
 
 export const ThemePreferenceForm = ({
   defaultThemePreference,
@@ -79,30 +32,13 @@ export const ThemePreferenceForm = ({
   insidersStatus: string
   links: ThemePreferenceLinks
 }): JSX.Element => {
-  const [theme, setTheme] = useState<string>(defaultThemePreference || '')
-
-  const { mutation, status, error } = useSettingsMutation<RequestBody>({
-    endpoint: links.update,
-    method: 'PATCH',
-    body: { user_preferences: { theme: theme } },
-  })
-
-  const handleSubmit = useCallback(
-    (e) => {
-      e.preventDefault()
-
-      mutation()
-    },
-    [mutation]
+  const { theme, handleThemeUpdate, status, error } = useTheme(
+    defaultThemePreference,
+    links
   )
 
-  const handleThemeUpdate = useCallback((t) => {
-    setTheme(t.value)
-    setThemeClassName(t.value)
-  }, [])
-
   return (
-    <form data-turbo="false" onSubmit={handleSubmit}>
+    <form data-turbo="false">
       <h2 className="!mb-4">Theme</h2>
       <InfoMessage
         insidersStatus={insidersStatus}
@@ -114,15 +50,12 @@ export const ThemePreferenceForm = ({
             key={t.label}
             theme={t}
             currentTheme={theme}
-            disabled={isDisabled(insidersStatus, t.value)}
+            disabledInfo={isDisabled(insidersStatus, t.value)}
             onClick={() => handleThemeUpdate(t)}
           />
         ))}
       </div>
-      <div className="form-footer">
-        <FormButton status={status} type="submit" className="btn-primary btn-m">
-          Update theme preference
-        </FormButton>
+      <div className="form-footer min-h-[80px]">
         <FormMessage
           status={status}
           error={error}
@@ -141,115 +74,4 @@ const SuccessMessage = () => {
       Your theme has been updated!
     </div>
   )
-}
-
-function InfoMessage({
-  insidersStatus,
-  insidersPath,
-}: {
-  insidersStatus: string
-  insidersPath: string
-}): JSX.Element {
-  switch (insidersStatus) {
-    case 'active':
-    case 'active_lifetime':
-      return (
-        <p className="text-p-base mb-16">
-          We hope you enjoy it. Thanks for all your support.
-        </p>
-      )
-    case 'eligible':
-    case 'eligible_lifetime':
-      return (
-        <p className="text-p-base mb-16">
-          You&apos;re eligible to join Insiders.{' '}
-          <a href={insidersPath}>Get started here.</a>
-        </p>
-      )
-    case 'ineligible':
-      return (
-        <p className="text-p-base mb-16">
-          Dark theme is only available to Exercism Insiders.
-        </p>
-      )
-    default:
-      return (
-        <p className="text-p-base mb-16">
-          [Learn more about Exercism Insiders](...).
-        </p>
-      )
-  }
-}
-
-function ThemeButton({
-  theme,
-  currentTheme,
-  onClick,
-  disabled = false,
-}: {
-  theme: Theme
-  onClick: React.MouseEventHandler<HTMLButtonElement>
-  currentTheme: string
-  disabled?: boolean
-}) {
-  const selected = theme.value === currentTheme
-
-  return (
-    <ExercismTippy content={disabled && <DisabledTooltip />}>
-      <div className="flex flex-col gap-16 items-center">
-        <button
-          type="button"
-          disabled={disabled}
-          value={theme.value}
-          id={`${theme.value}-theme`}
-          style={{
-            height: `${THEME_BUTTON_SIZE}px`,
-            width: `${THEME_BUTTON_SIZE}px`,
-            background: `${theme.background}`,
-            filter: disabled ? 'grayscale(0.9)' : '',
-            opacity: disabled ? '60%' : '100%',
-          }}
-          className={`flex items-center justify-center border-1 border-borderColor6 rounded-8 ${
-            selected && '--selected-theme'
-          }`}
-          onClick={onClick}
-        >
-          <GraphicalIcon
-            icon={disabled ? 'lock-circle' : 'logo'}
-            height={32}
-            width={32}
-            className={!disabled ? `filter-${theme.iconFilter}` : ''}
-          />
-        </button>
-        <label className="text-p text-15" htmlFor={`${theme.value}-theme`}>
-          {theme.label}
-        </label>
-      </div>
-    </ExercismTippy>
-  )
-}
-
-function DisabledTooltip(): JSX.Element {
-  return (
-    <div className="flex items-center bg-russianViolet rounded-16 py-8 px-12 text-p-base text-aliceBlue">
-      You must be an&nbsp;
-      <strong style={{ color: 'inherit' }} className="flex items-center">
-        Exercism Insider&nbsp;
-        <GraphicalIcon icon="insiders" height={24} width={24} />
-      </strong>
-      &nbsp;to unlock this theme.
-    </div>
-  )
-}
-
-function isDisabled(insidersStatus: string, theme: string): boolean {
-  const active = [
-    'active',
-    'active_lifetime',
-    'eligible',
-    'eligible_lifetime',
-  ].includes(insidersStatus)
-  const disabledTheme = ['dark', 'system'].includes(theme)
-
-  return !active && disabledTheme
 }

--- a/app/javascript/components/settings/theme-preference-form/DisabledTooltip.tsx
+++ b/app/javascript/components/settings/theme-preference-form/DisabledTooltip.tsx
@@ -1,0 +1,14 @@
+import { GraphicalIcon } from '@/components/common'
+import React from 'react'
+export function DisabledTooltip(): JSX.Element {
+  return (
+    <div className="flex items-center bg-russianViolet rounded-16 py-8 px-12 text-p-base text-aliceBlue">
+      You must be an&nbsp;
+      <strong style={{ color: 'inherit' }} className="flex items-center">
+        Exercism Insider&nbsp;
+        <GraphicalIcon icon="insiders" height={24} width={24} />
+      </strong>
+      &nbsp;to unlock this theme.
+    </div>
+  )
+}

--- a/app/javascript/components/settings/theme-preference-form/InfoMessage.tsx
+++ b/app/javascript/components/settings/theme-preference-form/InfoMessage.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+export function InfoMessage({
+  insidersStatus,
+  insidersPath,
+}: {
+  insidersStatus: string
+  insidersPath: string
+}): JSX.Element {
+  switch (insidersStatus) {
+    case 'active':
+    case 'active_lifetime':
+      return (
+        <p className="text-p-base mb-16">
+          We hope you enjoy it. Thanks for all your support.
+        </p>
+      )
+    case 'eligible':
+    case 'eligible_lifetime':
+      return (
+        <p className="text-p-base mb-16">
+          You&apos;re eligible to join Insiders.{' '}
+          <a href={insidersPath}>Get started here.</a>
+        </p>
+      )
+    case 'ineligible':
+      return (
+        <p className="text-p-base mb-16">
+          Dark theme is only available to Exercism Insiders.
+        </p>
+      )
+    default:
+      return (
+        <p className="text-p-base mb-16">
+          [Learn more about Exercism Insiders](...).
+        </p>
+      )
+  }
+}

--- a/app/javascript/components/settings/theme-preference-form/ThemeButton.tsx
+++ b/app/javascript/components/settings/theme-preference-form/ThemeButton.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { GraphicalIcon } from '@/components/common'
+import { ExercismTippy } from '@/components/misc/ExercismTippy'
+import { DisabledTooltip } from './DisabledTooltip'
+import type { Theme } from '../ThemePreferenceForm'
+import { isButtonDisabled } from './utils'
+
+const THEME_BUTTON_SIZE = 130
+export function ThemeButton({
+  theme,
+  currentTheme,
+  onClick,
+  disabledInfo,
+}: {
+  theme: Theme
+  onClick: React.MouseEventHandler<HTMLButtonElement>
+  currentTheme: string
+  disabledInfo: isButtonDisabled
+}): JSX.Element {
+  const selected = theme.value === currentTheme
+
+  const nonInsider = disabledInfo.level === 'non-insider'
+  const { disabled } = disabledInfo
+
+  return (
+    <ExercismTippy content={nonInsider && <DisabledTooltip />}>
+      <div className="flex flex-col gap-16 items-center">
+        <button
+          type="submit"
+          disabled={disabled}
+          value={theme.value}
+          id={`${theme.value}-theme`}
+          style={{
+            height: `${THEME_BUTTON_SIZE}px`,
+            width: `${THEME_BUTTON_SIZE}px`,
+            background: `${theme.background}`,
+            filter: nonInsider ? 'grayscale(0.9)' : '',
+            opacity: nonInsider ? '60%' : '100%',
+          }}
+          className={`flex items-center justify-center border-1 border-borderColor6 rounded-8 ${
+            selected && '--selected-theme'
+          }`}
+          onClick={onClick}
+        >
+          <GraphicalIcon
+            icon={nonInsider ? 'lock-circle' : 'logo'}
+            height={32}
+            width={32}
+            className={!nonInsider ? `filter-${theme.iconFilter}` : ''}
+          />
+        </button>
+        <label
+          className={`text-p text-15`}
+          style={{ filter: nonInsider ? 'grayscale(0.9)' : '' }}
+          htmlFor={`${theme.value}-theme`}
+        >
+          {theme.label}
+        </label>
+      </div>
+    </ExercismTippy>
+  )
+}

--- a/app/javascript/components/settings/theme-preference-form/ThemeButtonContent.ts
+++ b/app/javascript/components/settings/theme-preference-form/ThemeButtonContent.ts
@@ -1,0 +1,29 @@
+import { Theme } from '../ThemePreferenceForm'
+
+export const THEMES: Theme[] = [
+  {
+    label: 'Light',
+    value: 'light',
+    background: 'white',
+    iconFilter: 'textColor1NoDark',
+  },
+  {
+    label: 'System',
+    value: 'system',
+    background:
+      'linear-gradient(135deg, rgba(255,255,255,1) 50%, rgba(48,43,66,1) 50%)',
+    iconFilter: 'gray',
+  },
+  {
+    label: 'Dark',
+    value: 'dark',
+    background: '#302b42', //russianViolet
+    iconFilter: 'aliceBlue',
+  },
+  {
+    label: 'Accessibility Dark',
+    value: 'accessibility-dark',
+    background: 'black',
+    iconFilter: 'white-no-dark',
+  },
+]

--- a/app/javascript/components/settings/theme-preference-form/index.ts
+++ b/app/javascript/components/settings/theme-preference-form/index.ts
@@ -1,0 +1,6 @@
+export { DisabledTooltip } from './DisabledTooltip'
+export { InfoMessage } from './InfoMessage'
+export { ThemeButton } from './ThemeButton'
+export { THEMES } from './ThemeButtonContent'
+export { useTheme } from './useTheme'
+export { isDisabled, setThemeClassName } from './utils'

--- a/app/javascript/components/settings/theme-preference-form/useTheme.tsx
+++ b/app/javascript/components/settings/theme-preference-form/useTheme.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+import { useSettingsMutation } from '../useSettingsMutation'
+import { setThemeClassName } from './utils'
+import { Theme, ThemePreferenceLinks } from '../ThemePreferenceForm'
+import { QueryStatus } from 'react-query'
+
+type RequestBody = {
+  user_preferences: {
+    theme: string
+  }
+}
+
+type useThemeReturns = {
+  handleThemeUpdate: (t: Theme) => void
+  status: QueryStatus
+  error: unknown
+  theme: string
+}
+export function useTheme(
+  defaultThemePreference: string,
+  links: ThemePreferenceLinks
+): useThemeReturns {
+  const [theme, setTheme] = useState<string>(defaultThemePreference || '')
+
+  const { mutation, status, error } = useSettingsMutation<RequestBody>({
+    endpoint: links.update,
+    method: 'PATCH',
+    body: { user_preferences: { theme } },
+  })
+
+  const handleThemeUpdate = useCallback(
+    (t) => {
+      mutation()
+      setTheme(t.value)
+      setThemeClassName(t.value)
+    },
+    [mutation]
+  )
+
+  return { handleThemeUpdate, status, error, theme }
+}

--- a/app/javascript/components/settings/theme-preference-form/utils.ts
+++ b/app/javascript/components/settings/theme-preference-form/utils.ts
@@ -1,0 +1,51 @@
+export function setThemeClassName(theme: string): void {
+  const themeData = grabCurrentTheme()
+  if (!themeData) return
+
+  const { body, currentTheme } = themeData
+  const newTheme = `theme-${theme}`
+
+  if (newTheme === currentTheme) {
+    return
+  }
+
+  if (!currentTheme) {
+    body.classList.add(newTheme)
+  } else {
+    body.classList.replace(currentTheme, newTheme)
+  }
+}
+
+function grabCurrentTheme():
+  | {
+      body: HTMLBodyElement
+      currentTheme: string | undefined
+    }
+  | undefined {
+  const body = document.querySelector('body')
+  if (!body) return
+  return { body, currentTheme: body.classList.value.match(/theme-\S+/)?.[0] }
+}
+
+export type isButtonDisabled = { level: string; disabled: boolean }
+export function isDisabled(
+  insidersStatus: string,
+  theme: string
+): isButtonDisabled {
+  const active = ['active', 'active_lifetime'].includes(insidersStatus)
+  const disabledTheme = ['dark', 'system'].includes(theme)
+  const themeData = grabCurrentTheme()
+  const currentTheme = themeData ? themeData.currentTheme : ''
+  const selectedTheme = currentTheme === `theme-${theme}`
+
+  const disabled = (!active && disabledTheme) || selectedTheme
+
+  const disabledIndex =
+    Math.max(Number(selectedTheme) * 1, Number(!active && disabledTheme) * 2) -
+    1
+
+  return {
+    level: ['selected', 'non-insider'][disabledIndex] || 'enabled',
+    disabled,
+  }
+}

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -28,7 +28,7 @@ api_non_get_limit_proc = proc do |req|
   next 30 if req.post? && req.routed_to == 'api/markdown#parse'
   next 30 if req.patch? && req.routed_to == 'api/mentoring/testimonials#reveal'
   next 20 if req.patch? && req.routed_to == 'api/reputation#mark_as_seen'
-  next 8 if req.patch? && req.routed_to == 'api/settings/user_preferences#update'
+  next 20 if req.patch? && req.routed_to == 'api/settings/user_preferences#update'
   next 8 if req.patch? && req.routed_to == 'api/settings/communication_preferences#update'
   next 8 if req.patch? && req.routed_to == 'api/settings#sudo_update'
   next 10 if req.patch? && req.routed_to == 'api/mentoring/representations#update'

--- a/test/controllers/api/settings/user_preferences_controller_test.rb
+++ b/test/controllers/api/settings/user_preferences_controller_test.rb
@@ -12,7 +12,7 @@ class API::Settings::UserPreferencesControllerTest < API::BaseTestCase
 
     user_preferences = { auto_update_exercises: false }
 
-    8.times do
+    20.times do
       patch api_settings_user_preferences_path(user_preferences:), headers: @headers, as: :json
       assert_response :ok
     end


### PR DESCRIPTION
This PR disables functionally the currently selected theme-selector button, but keeps a locked state visually for `non-insiders` disabled level. 
