### PR TITLE
:lipstick: Fix community solution summary background in dark mode

### DIFF
--- a/app/css/pages/community-solution-show.css
+++ b/app/css/pages/community-solution-show.css
@@ -115,6 +115,7 @@
                     & .c-iteration-summary {
                         @apply py-8 px-24;
                         @apply border-b-1 border-borderColor7;
+                        @apply bg-backgroundColorA;
                     }
                 }
             }


### PR DESCRIPTION
I am not sure that this is the correct `@apply` as I do not have the project setup.

Before:
![image](https://user-images.githubusercontent.com/16977446/236448239-4ba34d01-0b77-43e7-8618-7514bdb56d20.png)

After:
![image](https://user-images.githubusercontent.com/16977446/236448262-7576eb0a-7cb0-426c-8afe-19f9848a90ff.png)