### PR TITLE
Remove gap between diff linenumbers and codeline

### DIFF
--- a/app/css/components/diff.css
+++ b/app/css/components/diff.css
@@ -23,6 +23,22 @@
         width: 100%;
     }
 
+    .d2h-diff-tbody {
+        tr {
+            @apply flex items-center;
+
+            td.d2h-del:not(.d2h-code-linenumber),
+            td.d2h-ins:not(.d2h-code-linenumber) {
+                @apply grow;
+            }
+
+            td.d2h-del,
+            td.d2h-ins {
+                @apply p-0;
+            }
+        }
+    }
+
     & .d2h-code-linenumber {
         @apply text-textColor6;
         text-align: right;


### PR DESCRIPTION
Before:
<img width="1495" alt="Screenshot 2023-05-10 at 16 04 24" src="https://github.com/exercism/website/assets/66035744/126dc7bd-cc58-468c-8ee9-ee912c942765">


After:
<img width="1495" alt="Screenshot 2023-05-10 at 16 13 21" src="https://github.com/exercism/website/assets/66035744/a98d6d97-1297-47ed-9a2b-bddad278db06">

