### PR TITLE
Cache individual columns, not all the data

### DIFF
--- a/app/commands/mentor/testimonial/create.rb
+++ b/app/commands/mentor/testimonial/create.rb
@@ -10,6 +10,6 @@ class Mentor::Testimonial::Create
       discussion:,
       content: testimonial
     )
-    User::ResetCache.defer(discussion.mentor)
+    User::ResetCache.defer(discussion.mentor, :has_unrevealed_testimonials?)
   end
 end

--- a/app/commands/mentor/testimonial/reveal.rb
+++ b/app/commands/mentor/testimonial/reveal.rb
@@ -7,6 +7,6 @@ class Mentor::Testimonial::Reveal
     return if testimonial.revealed?
 
     testimonial.update!(revealed: true)
-    User::ResetCache.defer(testimonial.mentor)
+    User::ResetCache.defer(testimonial.mentor, :has_unrevealed_testimonials?)
   end
 end

--- a/app/commands/user/acquired_badge/create.rb
+++ b/app/commands/user/acquired_badge/create.rb
@@ -25,7 +25,7 @@ class User::AcquiredBadge::Create
         end
 
         User::Notification::Create.(user, badge.notification_key) if badge.notification_key.present?
-        User::ResetCache.defer(user)
+        User::ResetCache.defer(user, :has_unrevealed_badges?)
       end
 
     # Guard against the race condition

--- a/app/commands/user/acquired_badge/reveal.rb
+++ b/app/commands/user/acquired_badge/reveal.rb
@@ -7,6 +7,6 @@ class User::AcquiredBadge::Reveal
     return if badge.revealed?
 
     badge.update!(revealed: true)
-    User::ResetCache.defer(badge.user)
+    User::ResetCache.defer(badge.user, :has_unrevealed_badges?)
   end
 end

--- a/app/commands/user/add_roles.rb
+++ b/app/commands/user/add_roles.rb
@@ -4,7 +4,9 @@ class User::AddRoles
   initialize_with :user, :roles
 
   def call
-    user.update(roles: user.roles + roles)
+    user.data.with_lock do
+      user.update(roles: user.roles + roles)
+    end
     User::SetDiscordRoles.(user)
     User::InsidersStatus::TriggerUpdate.(user)
   end

--- a/app/commands/user/add_roles.rb
+++ b/app/commands/user/add_roles.rb
@@ -4,9 +4,8 @@ class User::AddRoles
   initialize_with :user, :roles
 
   def call
-    user.data.with_lock do
-      user.update(roles: user.roles + roles)
-    end
+    user.update(roles: user.roles + roles)
+
     User::SetDiscordRoles.(user)
     User::InsidersStatus::TriggerUpdate.(user)
   end

--- a/app/commands/user/remove_roles.rb
+++ b/app/commands/user/remove_roles.rb
@@ -4,7 +4,9 @@ class User::RemoveRoles
   initialize_with :user, :roles
 
   def call
-    user.update(roles: user.roles - roles)
+    user.data.with_lock do
+      user.update(roles: user.roles - roles)
+    end
     User::SetDiscordRoles.(user)
     User::InsidersStatus::TriggerUpdate.(user)
   end

--- a/app/commands/user/remove_roles.rb
+++ b/app/commands/user/remove_roles.rb
@@ -4,9 +4,8 @@ class User::RemoveRoles
   initialize_with :user, :roles
 
   def call
-    user.data.with_lock do
-      user.update(roles: user.roles - roles)
-    end
+    user.update(roles: user.roles - roles)
+
     User::SetDiscordRoles.(user)
     User::InsidersStatus::TriggerUpdate.(user)
   end

--- a/app/commands/user/reputation_token/create.rb
+++ b/app/commands/user/reputation_token/create.rb
@@ -18,7 +18,7 @@ class User::ReputationToken::Create
 
       AwardBadgeJob.perform_later(user, :contributor, context: token)
       User::ReputationPeriod::MarkForToken.(token)
-      User::ResetCache.defer(user)
+      User::ResetCache.defer(user, :has_unseen_reputation_tokens?)
     rescue ActiveRecord::RecordNotUnique
       return klass.find_by!(user:, uniqueness_key: token.uniqueness_key)
     end

--- a/app/commands/user/reputation_token/mark_all_as_seen.rb
+++ b/app/commands/user/reputation_token/mark_all_as_seen.rb
@@ -9,7 +9,7 @@ class User::ReputationToken::MarkAllAsSeen
         update_all(seen: true)
 
       ReputationChannel.broadcast_changed!(user) if num_changed.positive?
-      User::ResetCache.defer(user) if num_changed.positive?
+      User::ResetCache.defer(user, :has_unseen_reputation_tokens?) if num_changed.positive?
     end
   end
 end

--- a/app/commands/user/reputation_token/mark_as_seen.rb
+++ b/app/commands/user/reputation_token/mark_as_seen.rb
@@ -7,6 +7,6 @@ class User::ReputationToken::MarkAsSeen
     return if token.seen?
 
     token.seen!
-    User::ResetCache.defer(token.user)
+    User::ResetCache.defer(token.user, :has_unseen_reputation_tokens?)
   end
 end

--- a/app/commands/user/reset_cache.rb
+++ b/app/commands/user/reset_cache.rb
@@ -1,9 +1,13 @@
 class User::ResetCache
   include Mandate
 
-  initialize_with :user
+  initialize_with :user, :key
 
   def call
+    # Some of these queries are really slow
+    # so we don't want to wrap them in a pesimistic lock.
+    # As user-data has an optimistic lock, it's not necessary either
+
     # Don't call user.update! here
     user.data.update!(cache:)
     cache
@@ -12,10 +16,12 @@ class User::ResetCache
   private
   memoize
   def cache
-    {
-      has_unrevealed_testimonials?: user.mentor_testimonials.unrevealed.exists?,
-      has_unrevealed_badges?: user.acquired_badges.unrevealed.exists?,
-      has_unseen_reputation_tokens?: user.reputation_tokens.unseen.exists?
-    }
+    user.cache.tap do |c|
+      c[key.to_s] = send("value_for_#{key}")
+    end
   end
+
+  def value_for_has_unrevealed_testimonials? = user.mentor_testimonials.unrevealed.exists?
+  def value_for_has_unrevealed_badges? = user.acquired_badges.unrevealed.exists?
+  def value_for_has_unseen_reputation_tokens? = user.reputation_tokens.unseen.exists?
 end

--- a/app/commands/user/set_github_username.rb
+++ b/app/commands/user/set_github_username.rb
@@ -7,7 +7,10 @@ class User::SetGithubUsername
     return if user.github_username == username
 
     begin
-      user.update!(github_username: username)
+      user.data.with_lock do
+        user.data.update!(github_username: username)
+      end
+
       User::ReputationToken::AwardForPullRequestsForUser.defer(user)
     rescue ActiveRecord::RecordNotUnique
       # Sometimes users change github usernames which can cause this to violate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -175,7 +175,9 @@ class ApplicationController < ActionController::Base
     return unless request.format == :html
     return if current_user.last_visited_on == Time.zone.today
 
-    current_user.update(last_visited_on: Time.zone.today)
+    current_user.data.with_lock do
+      current_user.update(last_visited_on: Time.zone.today)
+    end
   end
 
   def render_template_as_json

--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -51,7 +51,7 @@ class User::Data < ApplicationRecord
   ].each do |meth|
     define_method meth do
       self.cache.key?(meth) || User::ResetCache.(user, meth)
-      self.cache[meth]
+      self.reload.cache[meth]
     end
   end
   def cache = super || (self.cache = {})

--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -50,10 +50,11 @@ class User::Data < ApplicationRecord
     has_unseen_reputation_tokens?
   ].each do |meth|
     define_method meth do
-      self.cache.presence || User::ResetCache.(user)
+      self.cache.key?(meth) || User::ResetCache.(user, meth)
       self.cache[meth]
     end
   end
+  def cache = super || (self.cache = {})
 
   FIELDS = %w[
     bio roles usages insiders_status cache

--- a/app/views/community/show.html.haml
+++ b/app/views/community/show.html.haml
@@ -21,7 +21,6 @@
             %span Explore our forum
             = graphical_icon "arrow-right"
 
-
         .text-warning.font-semibold.leading-150.flex.items-center.mb-8.py-6.px-12
           = graphical_icon 'sparkle', css_class: 'filter-warning w-[16px] h-[16px] mr-8'
           Recent forum topics

--- a/db/migrate/20230511221617_add_optimistic_locking_to_user_data.rb
+++ b/db/migrate/20230511221617_add_optimistic_locking_to_user_data.rb
@@ -1,0 +1,5 @@
+class AddOptimisticLockingToUserData < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_data, :lock_version, :integer, default: 1
+  end
+end

--- a/db/migrate/20230511221617_add_optimistic_locking_to_user_data.rb
+++ b/db/migrate/20230511221617_add_optimistic_locking_to_user_data.rb
@@ -1,5 +1,0 @@
-class AddOptimisticLockingToUserData < ActiveRecord::Migration[7.0]
-  def change
-    add_column :user_data, :lock_version, :integer, default: 1
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1036,12 +1036,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.bigint "user_id", null: false
     t.text "bio"
     t.json "roles"
-    t.json "usages"
     t.integer "insiders_status", limit: 1, default: 0, null: false
-    t.string "github_username"
     t.string "stripe_customer_id"
-    t.string "paypal_payer_id"
     t.string "discord_uid"
+    t.string "github_username"
     t.datetime "accepted_privacy_policy_at"
     t.datetime "accepted_terms_at"
     t.datetime "became_mentor_at"
@@ -1055,21 +1053,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.boolean "show_on_supporters_page", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "usages"
     t.json "cache"
     t.datetime "premium_until"
     t.integer "email_status", limit: 1, default: 0, null: false
+    t.integer "lock_version", default: 1
     t.index ["discord_uid"], name: "index_user_data_on_discord_uid", unique: true
-    t.index ["first_donated_at", "show_on_supporters_page"], name: "index_user_data_show_on_supporters_page", order: { first_donated_at: :desc }
-    t.index ["insiders_status"], name: "index_user_data_on_insiders_status"
-    t.index ["last_visited_on"], name: "index_user_data_last_visited_on"
-    t.index ["stripe_customer_id"], name: "index_user_data_stripe_customer_id", unique: true
-    t.index ["paypal_payer_id"], name: "index_user_data_on_paypal_payer_id", unique: true
+    t.index ["first_donated_at", "show_on_supporters_page"], name: "user-data-supporters-page", order: { first_donated_at: :desc }
     t.index ["github_username"], name: "index_user_data_on_github_username", unique: true
-    t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
-    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page", order: { first_donated_at: :desc }
-    t.index ["insiders_status"], name: "index_users_on_insiders_status"
-    t.index ["last_visited_on"], name: "index_users_on_last_visited_on"
-    t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
+    t.index ["insiders_status"], name: "index_user_data_on_insiders_status"
+    t.index ["last_visited_on"], name: "index_user_data_on_last_visited_on"
+    t.index ["stripe_customer_id"], name: "index_user_data_on_stripe_customer_id", unique: true
     t.index ["user_id"], name: "index_user_data_on_user_id", unique: true
   end
 
@@ -1231,52 +1225,25 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.datetime "accepted_privacy_policy_at"
-    t.datetime "accepted_terms_at"
-    t.datetime "became_mentor_at"
     t.datetime "deleted_at"
-    t.datetime "joined_research_at"
-    t.string "github_username"
     t.integer "reputation", default: 0, null: false
-    t.json "roles"
-    t.text "bio"
     t.string "avatar_url"
     t.string "location"
     t.string "pronouns"
-    t.integer "num_solutions_mentored", limit: 3, default: 0, null: false
-    t.integer "mentor_satisfaction_percentage", limit: 1
-    t.string "stripe_customer_id"
-    t.integer "total_donated_in_cents", default: 0
-    t.boolean "active_donation_subscription", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "show_on_supporters_page", default: true, null: false
     t.datetime "disabled_at"
-    t.date "last_visited_on"
-    t.datetime "first_donated_at"
-    t.string "discord_uid"
-    t.integer "insiders_status", limit: 1, default: 0, null: false
     t.integer "flair", limit: 1
-    t.string "paypal_payer_id"
-    t.json "usages"
     t.json "cache"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page", order: { first_donated_at: :desc }
-    t.index ["github_username"], name: "index_users_on_github_username", unique: true
     t.index ["handle"], name: "index_users_on_handle", unique: true
-    t.index ["insiders_status"], name: "index_users_on_insiders_status"
-    t.index ["last_visited_on"], name: "index_users_on_last_visited_on"
-    t.index ["paypal_payer_id"], name: "index_users_on_paypal_payer_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
   add_foreign_key "cohort_memberships", "cohorts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1036,10 +1036,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.bigint "user_id", null: false
     t.text "bio"
     t.json "roles"
+    t.json "usages"
     t.integer "insiders_status", limit: 1, default: 0, null: false
-    t.string "stripe_customer_id"
-    t.string "discord_uid"
     t.string "github_username"
+    t.string "stripe_customer_id"
+    t.string "paypal_payer_id"
+    t.string "discord_uid"
     t.datetime "accepted_privacy_policy_at"
     t.datetime "accepted_terms_at"
     t.datetime "became_mentor_at"
@@ -1053,17 +1055,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.boolean "show_on_supporters_page", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "usages"
     t.json "cache"
     t.datetime "premium_until"
     t.integer "email_status", limit: 1, default: 0, null: false
     t.integer "lock_version", default: 1
     t.index ["discord_uid"], name: "index_user_data_on_discord_uid", unique: true
-    t.index ["first_donated_at", "show_on_supporters_page"], name: "user-data-supporters-page", order: { first_donated_at: :desc }
-    t.index ["github_username"], name: "index_user_data_on_github_username", unique: true
+    t.index ["first_donated_at", "show_on_supporters_page"], name: "index_user_data_show_on_supporters_page", order: { first_donated_at: :desc }
     t.index ["insiders_status"], name: "index_user_data_on_insiders_status"
-    t.index ["last_visited_on"], name: "index_user_data_on_last_visited_on"
-    t.index ["stripe_customer_id"], name: "index_user_data_on_stripe_customer_id", unique: true
+    t.index ["last_visited_on"], name: "index_user_data_last_visited_on"
+    t.index ["stripe_customer_id"], name: "index_user_data_stripe_customer_id", unique: true
+    t.index ["paypal_payer_id"], name: "index_user_data_on_paypal_payer_id", unique: true
+    t.index ["github_username"], name: "index_user_data_on_github_username", unique: true
+    t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
+    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page", order: { first_donated_at: :desc }
+    t.index ["insiders_status"], name: "index_users_on_insiders_status"
+    t.index ["last_visited_on"], name: "index_users_on_last_visited_on"
+    t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
     t.index ["user_id"], name: "index_user_data_on_user_id", unique: true
   end
 
@@ -1225,25 +1232,52 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.datetime "accepted_privacy_policy_at"
+    t.datetime "accepted_terms_at"
+    t.datetime "became_mentor_at"
     t.datetime "deleted_at"
+    t.datetime "joined_research_at"
+    t.string "github_username"
     t.integer "reputation", default: 0, null: false
+    t.json "roles"
+    t.text "bio"
     t.string "avatar_url"
     t.string "location"
     t.string "pronouns"
+    t.integer "num_solutions_mentored", limit: 3, default: 0, null: false
+    t.integer "mentor_satisfaction_percentage", limit: 1
+    t.string "stripe_customer_id"
+    t.integer "total_donated_in_cents", default: 0
+    t.boolean "active_donation_subscription", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "show_on_supporters_page", default: true, null: false
     t.datetime "disabled_at"
+    t.date "last_visited_on"
+    t.datetime "first_donated_at"
+    t.string "discord_uid"
+    t.integer "insiders_status", limit: 1, default: 0, null: false
     t.integer "flair", limit: 1
+    t.string "paypal_payer_id"
+    t.json "usages"
     t.json "cache"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["discord_uid"], name: "index_users_on_discord_uid", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["first_donated_at", "show_on_supporters_page"], name: "users-supporters-page", order: { first_donated_at: :desc }
+    t.index ["github_username"], name: "index_users_on_github_username", unique: true
     t.index ["handle"], name: "index_users_on_handle", unique: true
+    t.index ["insiders_status"], name: "index_users_on_insiders_status"
+    t.index ["last_visited_on"], name: "index_users_on_last_visited_on"
+    t.index ["paypal_payer_id"], name: "index_users_on_paypal_payer_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
   add_foreign_key "cohort_memberships", "cohorts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1058,7 +1058,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_120146) do
     t.json "cache"
     t.datetime "premium_until"
     t.integer "email_status", limit: 1, default: 0, null: false
-    t.integer "lock_version", default: 1
     t.index ["discord_uid"], name: "index_user_data_on_discord_uid", unique: true
     t.index ["first_donated_at", "show_on_supporters_page"], name: "index_user_data_show_on_supporters_page", order: { first_donated_at: :desc }
     t.index ["insiders_status"], name: "index_user_data_on_insiders_status"

--- a/test/commands/mentor/testimonial/create_test.rb
+++ b/test/commands/mentor/testimonial/create_test.rb
@@ -17,11 +17,12 @@ class Mentor::Testimonial::CreateTest < ActiveSupport::TestCase
   end
 
   test "resets cache" do
-    discussion = create :mentor_discussion
+    mentor = create :user
+    discussion = create(:mentor_discussion, mentor:)
     content = "Such a lovely chat"
 
-    User::ResetCache.expects(:defer).with(discussion.mentor)
-
-    Mentor::Testimonial::Create.(discussion, content)
+    assert_user_data_cache_reset(mentor, :has_unrevealed_testimonials?, true) do
+      Mentor::Testimonial::Create.(discussion, content)
+    end
   end
 end

--- a/test/commands/mentor/testimonial/reveal_test.rb
+++ b/test/commands/mentor/testimonial/reveal_test.rb
@@ -13,11 +13,12 @@ class Mentor::Testimonial::RevealTest < ActiveSupport::TestCase
   end
 
   test "resets user cache" do
-    testimonial = create :mentor_testimonial, :unrevealed
+    mentor = create :user
+    testimonial = create(:mentor_testimonial, :unrevealed, mentor:)
 
-    User::ResetCache.expects(:defer).with(testimonial.mentor)
-
-    Mentor::Testimonial::Reveal.(testimonial)
+    assert_user_data_cache_reset(mentor, :has_unrevealed_testimonials?, false) do
+      Mentor::Testimonial::Reveal.(testimonial)
+    end
   end
 
   test "does not reset user cache if already revealed" do

--- a/test/commands/user/acquired_badge/create_test.rb
+++ b/test/commands/user/acquired_badge/create_test.rb
@@ -97,9 +97,9 @@ class User::AcquiredBadge::CreateTest < ActiveSupport::TestCase
     create :contributor_badge
     Badges::ContributorBadge.any_instance.expects(:award_to?).with(user).returns(true)
 
-    User::ResetCache.expects(:defer).with(user)
-
-    User::AcquiredBadge::Create.(user, :contributor)
+    assert_user_data_cache_reset(user, :has_unrevealed_badges?, true) do
+      User::AcquiredBadge::Create.(user, :contributor)
+    end
   end
 
   def force_award!(user)

--- a/test/commands/user/acquired_badge/reveal_test.rb
+++ b/test/commands/user/acquired_badge/reveal_test.rb
@@ -22,9 +22,9 @@ class User::AcquiredBadge::RevealTest < ActiveSupport::TestCase
     # Sanity check
     refute acquired_badge.revealed?
 
-    User::ResetCache.expects(:defer).with(user)
-
-    User::AcquiredBadge::Reveal.(acquired_badge)
+    assert_user_data_cache_reset(user, :has_unrevealed_badges?, false) do
+      User::AcquiredBadge::Reveal.(acquired_badge)
+    end
   end
 
   test "does not reset user cache if already revealed" do

--- a/test/commands/user/reputation_token/create_test.rb
+++ b/test/commands/user/reputation_token/create_test.rb
@@ -156,12 +156,12 @@ class User::ReputationToken::CreateTest < ActiveSupport::TestCase
     user = create :user, handle: "User22", github_username: "user22"
     contributorship = create :exercise_contributorship, contributor: user
 
-    User::ResetCache.expects(:defer).with(user)
-
-    User::ReputationToken::Create.(
-      user,
-      :exercise_contribution,
-      contributorship:
-    )
+    assert_user_data_cache_reset(user, :has_unseen_reputation_tokens?, true) do
+      User::ReputationToken::Create.(
+        user,
+        :exercise_contribution,
+        contributorship:
+      )
+    end
   end
 end

--- a/test/commands/user/reputation_token/mark_all_as_seen_test.rb
+++ b/test/commands/user/reputation_token/mark_all_as_seen_test.rb
@@ -32,9 +32,9 @@ class User::ReputationTokens::MarkAllAsSeenTest < ActiveSupport::TestCase
     user = create :user
     create(:user_reputation_token, user:)
 
-    User::ResetCache.expects(:defer).with(user)
-
-    User::ReputationToken::MarkAllAsSeen.(user)
+    assert_user_data_cache_reset(user, :has_unseen_reputation_tokens?, false) do
+      User::ReputationToken::MarkAllAsSeen.(user)
+    end
   end
 
   test "does not reset cache if none were changed" do

--- a/test/commands/user/reputation_token/mark_as_seen_test.rb
+++ b/test/commands/user/reputation_token/mark_as_seen_test.rb
@@ -13,11 +13,11 @@ class User::ReputationTokens::MarkAsSeenTest < ActiveSupport::TestCase
   end
 
   test "reset cache" do
-    reputation_token = create :user_reputation_token
-
-    User::ResetCache.expects(:defer).with(reputation_token.user)
-
-    User::ReputationToken::MarkAsSeen.(reputation_token)
+    user = create :user
+    reputation_token = create(:user_reputation_token, user:)
+    assert_user_data_cache_reset(user, :has_unseen_reputation_tokens?, false) do
+      User::ReputationToken::MarkAsSeen.(reputation_token)
+    end
   end
 
   test "does not reset cache if token was already seen" do

--- a/test/commands/user/reset_cache_test.rb
+++ b/test/commands/user/reset_cache_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class User::ResetCacheTest < ActiveSupport::TestCase
+  test "sets has_unrevealed_badges correctly" do
+    user = create :user
+    assert_cache(user, :has_unrevealed_badges?, false)
+
+    user = create :user
+    create(:user_acquired_badge, user:)
+    assert_cache(user, :has_unrevealed_badges?, true)
+  end
+
+  private
+  def assert_cache(user, key, expected)
+    assert_nil user.data.reload.cache[key.to_s] # Sanity
+
+    User::ResetCache.(user, key)
+
+    assert_equal expected, user.data.reload.cache[key.to_s]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -355,6 +355,14 @@ class ActiveSupport::TestCase
       end
     end
   end
+
+  def assert_user_data_cache_reset(user, key, expected, &block)
+    assert_nil user.data.reload.cache[key.to_s]
+
+    perform_enqueued_jobs(&block)
+
+    assert_equal expected, user.data.reload.cache[key.to_s]
+  end
 end
 
 class ActionView::TestCase


### PR DESCRIPTION
@ErikSchierboom This builds on your work to just cache individual columns, not everything. I think this would be best refactored into different commands rather than using the `key` but I want to do this so I can add an extra bit into the cache and it's much quicker for me to do this.

I've also refactored the tests to check the thing is actually cached (which I think you'll approve of).

This also adds Optimistic merging to user data, which I think is wise to have. It does make it a little risky to add at first though, as we might need to add some Pessimistic locks in place in places where we update things. However, the combination is really solid. https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html

I'll build on this with another branch adding the extra key.