### PR TITLE
Move verify into bootstrapping

### DIFF
--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -7,5 +7,6 @@ class User::Bootstrap
     user.auth_tokens.create!
     AwardBadgeJob.perform_later(user, :member)
     Metric::Queue.(:sign_up, user.created_at, user:)
+    User::VerifyEmail.defer(user)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,11 +154,10 @@ class User < ApplicationRecord
     create_communication_preferences
 
     after_confirmation if confirmed?
-    verify_email! if email_status_unverified?
   end
 
   after_update_commit do
-    verify_email! if previous_changes.key?('email')
+    reverify_email! if previous_changes.key?('email')
   end
 
   # If we don't know about this record, maybe the
@@ -333,7 +332,7 @@ class User < ApplicationRecord
     devise_mailer.send(notification, self, *args).deliver_later
   end
 
-  def verify_email!
+  def reverify_email!
     email_status_unverified!
     User::VerifyEmail.defer(self)
   end

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -30,4 +30,11 @@ class User::BootstrapTest < ActiveSupport::TestCase
     assert_equal user.created_at, metric.occurred_at
     assert_equal user, metric.user
   end
+
+  test "email verified for new user" do
+    user = create :user
+
+    User::VerifyEmail.expects(:defer).with(user).once
+    User::Bootstrap.(user)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -429,17 +429,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal :insider, user.flair
   end
 
-  test "email verified for new user" do
-    User::VerifyEmail.expects(:defer).once
-
-    # We need this little build/update dance as the factory for users
-    # sets the email status to :verified by default, which is different
-    # from the normal default, which is :unverified
-    user = build :user
-    user.email_status = :unverified
-    user.save
-  end
-
   test "email verified when email changes" do
     user = create :user
 


### PR DESCRIPTION
The purpose of the Bootstrap call is to move business logic away from the model creation largely to avoid having issues with tests etc (also for things like bulk creation/migration too, but that's less relevant here).