### PR TITLE
Make lifetime subscription a donation

### DIFF
--- a/app/commands/payments/stripe/payment_intent/create.rb
+++ b/app/commands/payments/stripe/payment_intent/create.rb
@@ -21,8 +21,6 @@ class Payments::Stripe::PaymentIntent::Create
       Payments::Stripe::PaymentIntent::CreateForPremiumSubscription.(customer_id, :monthly)
     when :premium_yearly_subscription
       Payments::Stripe::PaymentIntent::CreateForPremiumSubscription.(customer_id, :yearly)
-    when :premium_lifetime_subscription
-      Payments::Stripe::PaymentIntent::CreateForPremiumSubscription.(customer_id, :lifetime)
     when :subscription
       Payments::Stripe::PaymentIntent::CreateForSubscription.(customer_id, amount_in_cents)
     else

--- a/app/commands/payments/stripe/payment_intent/create_for_premium_subscription.rb
+++ b/app/commands/payments/stripe/payment_intent/create_for_premium_subscription.rb
@@ -25,8 +25,6 @@ class Payments::Stripe::PaymentIntent::CreateForPremiumSubscription
       Exercism.secrets.stripe_premium_monthly_price_id
     when :yearly
       Exercism.secrets.stripe_premium_yearly_price_id
-    when :lifetime
-      Exercism.secrets.stripe_premium_lifetime_price_id
     else
       raise Payments::Stripe::PaymentIntentError, "Unknown premium subscription interval"
     end

--- a/app/helpers/react_components/premium/price_option.rb
+++ b/app/helpers/react_components/premium/price_option.rb
@@ -34,8 +34,8 @@ module ReactComponents
       def data_for_lifetime
         {
           period: 'lifetime',
-          display_amount: 500,
-          payment_intent_type: 'premium_lifetime_subscription',
+          display_amount: 499,
+          payment_intent_type: 'payment',
           paypal_link: 'https://www.paypal.com/webapps/billing/plans/subscribe?plan_id=P-79144942EH3169155MRTX2NI'
         }
       end

--- a/app/javascript/components/donations/StripeForm.tsx
+++ b/app/javascript/components/donations/StripeForm.tsx
@@ -274,8 +274,6 @@ function generateStripeButtonText(
       return `Donate ${amount.format()} to Exercism`
     case 'subscription':
       return `Donate ${amount.format()} to Exercism monthly`
-    case 'premium_lifetime_subscription':
-      return `Subscribe for Premium for lifetime for ${amount.format()}`
     case 'premium_monthly_subscription':
       return `Subscribe for Premium for ${amount.format()}/month`
     case 'premium_yearly_subscription':

--- a/app/javascript/components/premium/PriceOption.tsx
+++ b/app/javascript/components/premium/PriceOption.tsx
@@ -18,7 +18,7 @@ export type PriceOptionProps = {
 
 type PriceCardProps = PriceOptionProps & { onStripeClick: () => void }
 
-export function PriceOption({ data }: PriceOptionProps): JSX.Element {
+export function PriceOption({ data }: { data: PriceOptionProps }): JSX.Element {
   const [stripeModalOpen, setStripeModalOpen] = useState(false)
   const [paymentMade, setPaymentMade] = useState(false)
 
@@ -33,7 +33,7 @@ export function PriceOption({ data }: PriceOptionProps): JSX.Element {
     []
   )
 
-  const handleModalOpen = useCallback((data) => {
+  const handleModalOpen = useCallback(() => {
     setStripeModalOpen(true)
   }, [])
 
@@ -42,7 +42,7 @@ export function PriceOption({ data }: PriceOptionProps): JSX.Element {
       <PriceCard
         key={data.paymentIntentType}
         {...data}
-        onStripeClick={() => handleModalOpen(data)}
+        onStripeClick={handleModalOpen}
       />
       {/* TODO: add correct closelink here */}
       <PremiumSubscriptionSuccessModal
@@ -59,7 +59,6 @@ export function PriceOption({ data }: PriceOptionProps): JSX.Element {
         <ExercismStripeElements>
           <StripeForm
             {...data}
-            paymentIntentType={data.paymentIntentType}
             amount={currency(data.displayAmount)}
             onSuccess={handleSuccess}
           />
@@ -69,12 +68,7 @@ export function PriceOption({ data }: PriceOptionProps): JSX.Element {
   )
 }
 
-function PriceCard({
-  onStripeClick,
-  displayAmount,
-  period,
-  paypalLink,
-}: PriceCardProps): JSX.Element {
+function PriceCard({ onStripeClick, paypalLink }: PriceCardProps): JSX.Element {
   return (
     <div className="flex flex-col">
       <button onClick={onStripeClick} className="btn-m btn-primary mb-16">

--- a/test/commands/payments/stripe/payment_intent/create_for_premium_subscription_test.rb
+++ b/test/commands/payments/stripe/payment_intent/create_for_premium_subscription_test.rb
@@ -3,8 +3,7 @@ require_relative '../../test_base'
 class Payments::Stripe::PaymentIntent::CreateForPremiumSubscriptionTest < Payments::TestBase
   [
     [:monthly, Exercism.secrets.stripe_premium_monthly_price_id],
-    [:yearly, Exercism.secrets.stripe_premium_yearly_price_id],
-    [:lifetime, Exercism.secrets.stripe_premium_lifetime_price_id]
+    [:yearly, Exercism.secrets.stripe_premium_yearly_price_id]
   ].each do |(interval, expected_price)|
     test "creates subscription with correct price for #{interval} interval" do
       customer_id = SecureRandom.uuid

--- a/test/commands/payments/stripe/payment_intent/create_test.rb
+++ b/test/commands/payments/stripe/payment_intent/create_test.rb
@@ -93,28 +93,6 @@ class Payments::Stripe::PaymentIntent::CreateTest < Payments::TestBase
     assert_equal payment_intent, actual
   end
 
-  test "creates premium lifetime subscription correctly" do
-    customer_id = SecureRandom.uuid
-    user = create :user, stripe_customer_id: customer_id
-    type = 'premium_lifetime_subscription'
-    amount_in_cents = '1200'
-    payment_intent = mock
-    stripe_subscription = mock_stripe_subscription(nil, nil, payment_intent:)
-
-    Stripe::Customer.expects(:retrieve).with(customer_id).once
-    Stripe::Subscription.expects(:create).with(
-      customer: customer_id,
-      items: [{
-        price: Exercism.secrets.stripe_premium_lifetime_price_id
-      }],
-      payment_behavior: 'default_incomplete',
-      expand: ['latest_invoice.payment_intent']
-    ).returns(stripe_subscription)
-
-    actual = Payments::Stripe::PaymentIntent::Create.(user, type, amount_in_cents)
-    assert_equal payment_intent, actual
-  end
-
   test "don't create Stripe payment intent when user's email uses blocked domain" do
     customer_id = SecureRandom.uuid
     block_domain = create :user_block_domain


### PR DESCRIPTION
- Turn lifetime intent type into a one off `payment`
- Remove premium_lifetime related bits
