### PR TITLE
Dark-only premium/insiders site-header

### DIFF
--- a/app/css/components/site-footer.css
+++ b/app/css/components/site-footer.css
@@ -1,6 +1,7 @@
 @import "../styles";
 
 body.namespace-.controller-journey,
+body.namespace-.controller-premium,
 body.namespace-.controller-insiders {
     & #site-footer {
         margin-top: 0px;

--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -27,6 +27,16 @@ body.namespace-.controller-insiders,
 body.namespace-.controller-premium {
     #site-header {
         /* russianViolet is site-header background */
+
+        --nav-backgroundColor: theme(colors.russianViolet);
+        --nav-highlightColor: theme(colors.eerieBlack);
+        nav {
+            background: var(--nav-backgroundColor);
+            nav-element-label {
+                @apply text-aliceBlue;
+            }
+        }
+
         @apply bg-russianViolet border-[#433F56];
         .c-icon:not(button .c-icon),
         .user-menu .c-icon {

--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -27,7 +27,6 @@ body.namespace-.controller-insiders,
 body.namespace-.controller-premium {
     #site-header {
         /* russianViolet is site-header background */
-
         @apply bg-russianViolet border-[#433F56];
         .c-icon:not(button .c-icon),
         .user-menu .c-icon {

--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -28,15 +28,6 @@ body.namespace-.controller-premium {
     #site-header {
         /* russianViolet is site-header background */
 
-        --nav-backgroundColor: theme(colors.russianViolet);
-        --nav-highlightColor: theme(colors.eerieBlack);
-        nav {
-            background: var(--nav-backgroundColor);
-            nav-element-label {
-                @apply text-aliceBlue;
-            }
-        }
-
         @apply bg-russianViolet border-[#433F56];
         .c-icon:not(button .c-icon),
         .user-menu .c-icon {

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -19,11 +19,7 @@ module ViewComponents
     end
 
     def site_header_class
-      if ['/insiders', '/premium'].include?(request_path)
-        'theme-dark'
-      else
-        ''
-      end
+      ['/insiders', '/premium'].include?(request_path) ? 'theme-dark' : ''
     end
 
     def announcement_bar

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -4,15 +4,25 @@ module ViewComponents
     include ViewComponents::NavHelpers::All
     include ViewComponents::ThemeToggleButton
 
+    initialize_with request_path: nil
+
     delegate :namespace_name, :controller_name,
       to: :view_context
 
     def to_s
-      tag.header(id: "site-header") do
+      tag.header(id: "site-header", class: site_header_class) do
         announcement_bar +
           tag.div(class: "lg-container container") do
             logo + docs_nav + contextual_section
           end
+      end
+    end
+
+    def site_header_class
+      if ['/insiders', '/premium'].include?(request_path)
+        'theme-dark'
+      else
+        ''
       end
     end
 
@@ -62,7 +72,7 @@ module ViewComponents
               generic_nav("Contribute", submenu: CONTRIBUTE_SUBMENU, path: Exercism::Routes.contributing_root_path, offset: 20),
               generic_nav("Community", submenu: COMMUNITY_SUBMENU, path: Exercism::Routes.community_path, offset: 0),
               # generic_nav("Resources", submenu: LEARN_SUBMENU, offset: 100),
-              generic_nav("Premium", path: Exercism::Routes.donate_path, offset: 150, view: :mentoring),
+              generic_nav("Premium", path: Exercism::Routes.premium_index_path, offset: 150, view: :mentoring),
               ReactComponents::Common::ThemeToggleButton.new(disabled_theme_toggle_button)
             ]
           )

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -483,6 +483,11 @@ import { PriceOption, PriceOptionProps } from '@/components/premium/PriceOption'
 
 document.addEventListener('turbo:load', () => {
   highlightAll()
+
+  if (window.location.pathname === '/dashboard') {
+    const siteHeader = document.querySelector('#site-header')
+    siteHeader?.classList.remove('theme-dark')
+  }
 })
 
 handleNavbarFocus()

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
     = render "layouts/meta_tags"
 
   %body{ class: body_class }
-    = render ViewComponents::SiteHeader.new
+    = render ViewComponents::SiteHeader.new(request_path: request.path)
 
     = render template: "layouts/turbo_frame"
 


### PR DESCRIPTION

##### Everything inside a `view` is rendered with its theme-dark variant
<img width="1470" alt="Screenshot 2023-05-25 at 22 29 02" src="https://github.com/exercism/website/assets/66035744/3007d990-2338-4137-a810-69bd9a636ffb">


