### PR TITLE
Move makers button on exercise show page

### DIFF
--- a/app/css/components/makers-button.css
+++ b/app/css/components/makers-button.css
@@ -6,12 +6,12 @@
 
     & .stats {
         @apply ml-16;
-        @apply flex flex-col items-start;
+        @apply flex flex-col items-start gap-8;
         & .authors {
             @apply font-semibold;
         }
         & .contributors {
-            @apply font-medium mt-8;
+            @apply font-medium;
         }
     }
 }

--- a/app/javascript/components/modals/ExerciseMakersModal.tsx
+++ b/app/javascript/components/modals/ExerciseMakersModal.tsx
@@ -35,9 +35,9 @@ const MakerInner = ({
       <div className="handle">
         <HandleWithFlair handle={maker.handle} flair={maker.flair} />
       </div>
-      <Reputation value={maker.reputation!} type="primary" size="small" />
+      <Reputation value={maker.reputation || '0'} type="primary" size="small" />
       {showIcon ? (
-        <GraphicalIcon icon="chevron-right" />
+        <GraphicalIcon icon="chevron-right" className="filter-textColor6" />
       ) : (
         <div className="faux-icon" />
       )}

--- a/app/javascript/components/types.ts
+++ b/app/javascript/components/types.ts
@@ -1,5 +1,6 @@
 import { Props as ConceptWidgetProps } from './common/ConceptWidget'
 import { Props as ExerciseWidgetProps } from './common/ExerciseWidget'
+import { Flair } from './common/HandleWithFlair'
 import { DiscussionPostProps } from './mentoring/discussion/DiscussionPost'
 import { Scratchpad } from './mentoring/Session'
 
@@ -91,7 +92,7 @@ type UserLinks = {
 }
 export type User = {
   avatarUrl: string
-  flair: string
+  flair: Flair
   name?: string
   handle: string
   hasAvatar?: boolean

--- a/app/views/tracks/_exercise_header.html.haml
+++ b/app/views/tracks/_exercise_header.html.haml
@@ -49,6 +49,3 @@
             Hard
 
     .decorations.hidden.lg:block
-
-    / TODO: Cache this
-    = render ReactComponents::Track::ExerciseMakersButton.new(exercise)

--- a/app/views/tracks/exercises/show.html.haml
+++ b/app/views/tracks/exercises/show.html.haml
@@ -47,7 +47,7 @@
             - else
               Explore the #{external_link_to 'source of this exercise', source_url}.
       %section.extra-info
-        .updated-at Last updated #{@exercise.updated_at.strftime('%e %B %Y')}
+        = render ReactComponents::Track::ExerciseMakersButton.new(@exercise)
 
         = link_to "https://github.com/exercism/#{@track.slug}/tree/main/exercises/#{@exercise.git_type}/#{@exercise.slug}", target: "_blank", rel: 'noreferrer' do
           = graphical_icon "external-site-github", css_class: "github-icon"


### PR DESCRIPTION
![Screenshot 2023-06-19 at 11 26 00](https://github.com/exercism/website/assets/66035744/89b730af-2e5b-4d8d-8510-75dc16f25d45)
![Screenshot 2023-06-19 at 11 26 04](https://github.com/exercism/website/assets/66035744/0dfec302-2c6c-4857-bf4b-08396dd7e82c)
![Screenshot 2023-06-19 at 11 30 05](https://github.com/exercism/website/assets/66035744/6f754e60-37af-491a-be33-b90899561008)

### improved styling
this is why I prefer `gap` over margins: (the ones above have margin-top, but looks off when `authors` is missing)

![Screenshot 2023-06-19 at 11 38 22](https://github.com/exercism/website/assets/66035744/7d899a1c-7c16-455c-aa91-8270a4195a23)
![Screenshot 2023-06-19 at 11 38 10](https://github.com/exercism/website/assets/66035744/cf8e4341-5b99-4f43-a8e8-9e5e4ce0e7db)


