### PR TITLE
Announcement-bar tweaks

### DIFF
--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -38,7 +38,7 @@ body.keyboard-navigation .nav-element:hover .arrow {
         }
 
         .lg-container {
-            @apply flex justify-center items-center;
+            @apply flex md:flex-row flex-col justify-center items-center;
             .text-container {
                 @apply sm:flex flex-row;
             }

--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -28,7 +28,6 @@ body.keyboard-navigation .nav-element:hover .arrow {
     @apply z-menu;
 
     & .announcement-bar {
-        @apply block;
         @apply py-8;
         @apply text-aliceBlue font-semibold text-16 leading-160 text-center;
         background: var(--backgroundColorAnnouncementBar);

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -23,8 +23,8 @@ module ViewComponents
         tag.div(class: "lg-container") do
           graphical_icon(:premium, css_class: 'h-[16px] w-[16px] mr-12') +
             tag.span("Exercism Premium has launched.") +
-            tag.strong("Supercharge your experience!") +
-            tag.div("Check it out", class: 'btn-primary btn-xs ml-4')
+            tag.strong("Click here to learn more.") +
+            tag.div("Check it out", class: 'btn-primary btn-xs ml-4 hidden md:block')
         end
       end
     end

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -19,12 +19,12 @@ module ViewComponents
     def announcement_bar
       return tag.span("") if current_user&.premium? || !user_signed_in?
 
-      link_to(Exercism::Routes.premium_path, class: "announcement-bar") do
+      link_to(Exercism::Routes.premium_path, class: "announcement-bar md:block hidden") do
         tag.div(class: "lg-container") do
           graphical_icon(:premium, css_class: 'h-[16px] w-[16px] mr-12') +
             tag.span("Exercism Premium has launched.") +
-            tag.strong("Click here to learn more.") +
-            tag.div("Check it out", class: 'btn-primary btn-xs ml-4 hidden md:block')
+            tag.strong("Supercharge your experience!") +
+            tag.div("Check it out", class: 'btn-primary btn-xs ml-4')
         end
       end
     end

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -17,7 +17,7 @@ module ViewComponents
     end
 
     def announcement_bar
-      return tag.span("") if current_user&.premium?
+      return tag.span("") if current_user&.premium? || !user_signed_in?
 
       link_to(Exercism::Routes.premium_path, class: "announcement-bar") do
         tag.div(class: "lg-container") do

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -17,7 +17,7 @@ module ViewComponents
     end
 
     def announcement_bar
-      return tag.span("") if current_user&.premium? || !user_signed_in?
+      return tag.span("") unless user_signed_in? && !current_user.premium?
 
       link_to(Exercism::Routes.premium_path, class: "announcement-bar md:block hidden") do
         tag.div(class: "lg-container") do


### PR DESCRIPTION
#### Hidden for logged out users:
<img width="1512" alt="Screenshot 2023-06-19 at 12 29 45" src="https://github.com/exercism/website/assets/66035744/2ae90f62-a08e-48ab-8786-262b44d4d02e">

#### Hidden under `md`:
<img width="611" alt="Screenshot 2023-06-19 at 12 45 29" src="https://github.com/exercism/website/assets/66035744/4dbfe8be-e623-446f-83bf-8ff0fe9c3aea">
<img width="1263" alt="Screenshot 2023-06-19 at 12 45 17" src="https://github.com/exercism/website/assets/66035744/908a528c-3a06-4bfd-bd5d-abf314d67ecd">
