### PR TITLE
Fix PayPal payments not being created

### DIFF
--- a/app/commands/payments/paypal/customer/find_or_update.rb
+++ b/app/commands/payments/paypal/customer/find_or_update.rb
@@ -1,7 +1,7 @@
 class Payments::Paypal::Customer::FindOrUpdate
   include Mandate
 
-  initialize_with :paypal_payer_id, :paypal_payer_email, user_id: nil
+  initialize_with :paypal_payer_id, :paypal_payer_email, user_id: nil, paypal_subscription_id: nil
 
   def call
     return user_by_paypal_id if user_by_paypal_id
@@ -13,7 +13,13 @@ class Payments::Paypal::Customer::FindOrUpdate
   memoize
   def user_by_paypal_id = User.with_data.find_by(data: { paypal_payer_id: })
 
-  def user = user_by_id || user_by_email
+  def user = user_by_id || user_by_paypal_subscription_id || user_by_email
   def user_by_id = User.find_by(id: user_id)
   def user_by_email = User.find_by(email: paypal_payer_email)
+
+  def user_by_paypal_subscription_id
+    return nil unless paypal_subscription_id
+
+    User.find_by(id: Payments::Subscription.paypal.where(external_id: paypal_subscription_id).pick(:user_id))
+  end
 end

--- a/app/commands/payments/paypal/customer/find_or_update.rb
+++ b/app/commands/payments/paypal/customer/find_or_update.rb
@@ -20,6 +20,6 @@ class Payments::Paypal::Customer::FindOrUpdate
   def user_by_paypal_subscription_id
     return nil unless paypal_subscription_id
 
-    User.find_by(id: Payments::Subscription.paypal.where(external_id: paypal_subscription_id).pick(:user_id))
+    Payments::Subscription.paypal.find_by(external_id: paypal_subscription_id)&.user
   end
 end

--- a/app/commands/payments/paypal/debug.rb
+++ b/app/commands/payments/paypal/debug.rb
@@ -6,7 +6,7 @@ class Payments::Paypal::Debug
   def call
     return unless Rails.env.production?
 
-    IO.write("/mnt/efs/repos/debug/paypal.txt", "#{timestamp} #{message}\n", mode: 'a')
+    IO.write("/mnt/efs/repos/debug/paypal.txt", "#{timestamp} #{message}\n\n", mode: 'a')
   rescue StandardError
     # We don't want debug logging errors to crash anything
   end

--- a/app/commands/payments/paypal/debug.rb
+++ b/app/commands/payments/paypal/debug.rb
@@ -6,8 +6,11 @@ class Payments::Paypal::Debug
   def call
     return unless Rails.env.production?
 
-    IO.write("/mnt/efs/repos/debug/paypal.txt", "#{message}\n", mode: 'a')
+    IO.write("/mnt/efs/repos/debug/paypal.txt", "#{timestamp} #{message}\n", mode: 'a')
   rescue StandardError
     # We don't want debug logging errors to crash anything
   end
+
+  private
+  def timestamp = Time.current.strftime('%Y-%m-%d %H:%M:%S')
 end

--- a/app/commands/payments/paypal/subscription/ipn/handle_recurring_payment.rb
+++ b/app/commands/payments/paypal/subscription/ipn/handle_recurring_payment.rb
@@ -5,7 +5,7 @@ class Payments::Paypal::Subscription::IPN::HandleRecurringPayment
   initialize_with :payload
 
   def call
-    user = Payments::Paypal::Customer::FindOrUpdate.(payer_id, payer_email)
+    user = Payments::Paypal::Customer::FindOrUpdate.(payer_id, payer_email, paypal_subscription_id: subscription_external_id)
     return unless user
 
     subscription = Payments::Paypal::Subscription::Create.(user, subscription_external_id, amount, product, interval)

--- a/app/commands/payments/paypal/subscription/ipn/handle_recurring_payment_profile_created.rb
+++ b/app/commands/payments/paypal/subscription/ipn/handle_recurring_payment_profile_created.rb
@@ -5,14 +5,14 @@ class Payments::Paypal::Subscription::IPN::HandleRecurringPaymentProfileCreated
   initialize_with :payload
 
   def call
-    user = Payments::Paypal::Customer::FindOrUpdate.(payer_id, payer_email)
+    user = Payments::Paypal::Customer::FindOrUpdate.(payer_id, payer_email, paypal_subscription_id: subscription_external_id)
     return unless user
 
-    Payments::Paypal::Subscription::Create.(user, external_id, amount, product, interval)
+    Payments::Paypal::Subscription::Create.(user, subscription_external_id, amount, product, interval)
   end
 
   def amount = payload["amount"].to_f
-  def external_id = payload["recurring_payment_id"]
+  def subscription_external_id = payload["recurring_payment_id"]
   def payer_id = payload["payer_id"]
   def payer_email = payload["payer_email"]
   def product = Payments::Paypal.product_from_name(payload["product_name"])

--- a/app/commands/webhooks/process_paypal_api_event.rb
+++ b/app/commands/webhooks/process_paypal_api_event.rb
@@ -4,7 +4,8 @@ class Webhooks::ProcessPaypalAPIEvent
   initialize_with :payload, :headers
 
   def call
-    Payments::Paypal::Debug.("\n[Webhook] Headers:\n#{headers}")
+    Payments::Paypal::Debug.("")
+    Payments::Paypal::Debug.("[Webhook] Headers:\n#{headers}")
     Payments::Paypal::Debug.("[Webhook] Payload:\n#{payload}")
     Payments::Paypal::VerifyAPIEvent.(event, headers)
 

--- a/app/commands/webhooks/process_paypal_ipn.rb
+++ b/app/commands/webhooks/process_paypal_ipn.rb
@@ -4,7 +4,8 @@ class Webhooks::ProcessPaypalIPN
   initialize_with :payload
 
   def call
-    Payments::Paypal::Debug.("\n[IPN] Payload:\n#{payload}")
+    Payments::Paypal::Debug.("")
+    Payments::Paypal::Debug.("[IPN] Payload:\n#{payload}")
     Payments::Paypal::VerifyIPN.(payload)
 
     handle!

--- a/test/commands/payments/paypal/customer/find_or_update_test.rb
+++ b/test/commands/payments/paypal/customer/find_or_update_test.rb
@@ -11,12 +11,24 @@ class Payments::Paypal::Customer::FindOrUpdateTest < Payments::TestBase
     assert_equal user, found_user
   end
 
-  test "updates existing user with matching user email" do
+  test "updates existing user with matching user id" do
     paypal_payer_id = SecureRandom.uuid
 
     user = create(:user)
 
     found_user = Payments::Paypal::Customer::FindOrUpdate.(paypal_payer_id, nil, user_id: user.id)
+
+    assert_equal user, found_user
+    assert_equal paypal_payer_id, found_user.paypal_payer_id
+  end
+
+  test "updates existing user with matching paypal subscription id" do
+    paypal_payer_id = SecureRandom.uuid
+
+    user = create :user
+    subscription = create(:payments_subscription, :paypal, user:)
+
+    found_user = Payments::Paypal::Customer::FindOrUpdate.(paypal_payer_id, nil, paypal_subscription_id: subscription.external_id)
 
     assert_equal user, found_user
     assert_equal paypal_payer_id, found_user.paypal_payer_id

--- a/test/commands/payments/paypal/subscription/ipn/handle_recurring_payment_profile_created_test.rb
+++ b/test/commands/payments/paypal/subscription/ipn/handle_recurring_payment_profile_created_test.rb
@@ -102,6 +102,44 @@ class Payments::Paypal::Subscription::IPN::HandleRecurringPaymentProfileCreatedT
     end
   end
 
+  test "creates subscription for unknown paypal payer id and email but known paypal subscription id" do
+    freeze_time do
+      recurring_payment_id = SecureRandom.uuid
+      paypal_payer_id = SecureRandom.uuid
+      user = create :user
+      amount_in_dollars = 15
+      amount_in_cents = amount_in_dollars * 100
+      payload = {
+        "recurring_payment_id" => recurring_payment_id,
+        "txn_type" => "recurring_payment_profile_created",
+        "payment_status" => "Completed",
+        "payer_email" => "unknown@test.org",
+        "payer_id" => paypal_payer_id,
+        "amount" => "#{amount_in_dollars}.0",
+        "product_name" => Exercism.secrets.paypal_donation_product_name,
+        "payment_cycle" => "Yearly"
+      }
+
+      create(:payments_subscription, :paypal, :active, interval: :year, user:, external_id: recurring_payment_id,
+        amount_in_cents:)
+      user.update(active_donation_subscription: true)
+
+      Payments::Paypal::Subscription::IPN::HandleRecurringPaymentProfileCreated.(payload)
+
+      refute Payments::Payment.exists?
+      assert_equal 1, Payments::Subscription.count
+      subscription = Payments::Subscription.last
+      assert_equal recurring_payment_id, subscription.external_id
+      assert_equal amount_in_cents, subscription.amount_in_cents
+      assert_equal user, subscription.user
+      assert_equal paypal_payer_id, subscription.user.paypal_payer_id
+      assert_equal :active, subscription.status
+      assert_equal :paypal, subscription.provider
+      assert_equal :year, subscription.interval
+      assert user.reload.active_donation_subscription?
+    end
+  end
+
   test "ignore when paypal payer id and email are unknown" do
     payload = {
       "recurring_payment_id" => SecureRandom.uuid,


### PR DESCRIPTION
- Add timestamp to paypal logging
- Update paypal payer ID from paypal subscription
