### PR TITLE
Fix z-index of docs' sidenav

### DIFF
--- a/app/css/components/docs-side-nav.css
+++ b/app/css/components/docs-side-nav.css
@@ -2,7 +2,7 @@
 
 .c-docs-side-nav {
     @apply xl:static fixed top-0 left-0 bottom-0;
-    @apply bg-backgroundColorA xl:bg-backgroundColorB z-[100];
+    @apply bg-backgroundColorA xl:bg-backgroundColorB xl:z-1 z-[100];
     @apply xl:border-r-1 border-borderColor6;
     @apply xl:pt-32 xl:pr-32 xl:pl-0 p-16 pb-0;
     @apply overflow-auto;


### PR DESCRIPTION
https://forum.exercism.org/t/on-hover-menus-appear-under-side-nav/6402

<img width="1512" alt="Screenshot 2023-07-07 at 16 55 49" src="https://github.com/exercism/website/assets/66035744/891cd64f-39fd-418a-acf8-f45e7b761328">
