### PR TITLE
Reset removes user solutions from search index

### DIFF
--- a/app/commands/solution/remove_user_solutions_for_track_from_search_index.rb
+++ b/app/commands/solution/remove_user_solutions_for_track_from_search_index.rb
@@ -1,0 +1,20 @@
+class Solution::RemoveUserSolutionsForTrackFromSearchIndex
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :user_track
+
+  def call
+    Exercism.opensearch_client.delete_by_query(index: Solution::OPENSEARCH_INDEX, body: {
+      query: {
+        bool: {
+          must: [
+            { term: { 'user.id': user_track.user_id } },
+            { term: { 'track.id': user_track.track_id } }
+          ]
+        }
+      }
+    })
+  end
+end

--- a/app/commands/user_track/reset.rb
+++ b/app/commands/user_track/reset.rb
@@ -13,5 +13,6 @@ class UserTrack::Reset
     )
     user_track.reset_summary!
     User::ReputationTokens::PublishedSolutionToken.where(user:, track:).destroy_all
+    Solution::RemoveUserSolutionsForTrackFromSearchIndex.defer(user_track)
   end
 end

--- a/test/commands/solution/remove_user_solutions_for_track_from_search_index_test.rb
+++ b/test/commands/solution/remove_user_solutions_for_track_from_search_index_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Solution::RemoveUserSolutionsForTrackFromSearchIndexTest < ActiveSupport::TestCase
+  test "remove solutions from search index" do
+    user = create :user
+    other_user = create :user
+    track = create :track, :random_slug
+    other_track = create :track, :random_slug
+
+    user_track_1 = create(:user_track, user:, track:)
+    create :user_track, user:, track: other_track
+    create(:user_track, user: other_user, track:)
+
+    ce_track = create(:concept_exercise, track:)
+    pe_track = create(:practice_exercise, track:)
+    pe_other_track = create :practice_exercise, track: other_track
+
+    solution_1 = create(:concept_solution, exercise: ce_track, user:)
+    solution_2 = create(:practice_solution, exercise: pe_track, user:)
+    solution_3 = create(:practice_solution, exercise: pe_other_track, user:)
+    solution_4 = create(:practice_solution, exercise: ce_track, user: other_user)
+
+    Solution::SyncToSearchIndex.(solution_1)
+    Solution::SyncToSearchIndex.(solution_2)
+    Solution::SyncToSearchIndex.(solution_3)
+    Solution::SyncToSearchIndex.(solution_4)
+
+    wait_for_opensearch_to_be_synced
+
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_1.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_2.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_3.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_4.id)
+
+    Solution::RemoveUserSolutionsForTrackFromSearchIndex.(user_track_1)
+
+    wait_for_opensearch_to_be_synced
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_1.id)
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_2.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_3.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_4.id)
+  end
+end

--- a/test/commands/user_track/reset_test.rb
+++ b/test/commands/user_track/reset_test.rb
@@ -40,6 +40,17 @@ class UserTrack::ResetTest < ActiveSupport::TestCase
     end
   end
 
+  test "remove solutions from search index" do
+    create :user, :ghost
+    user = create :user
+    track = create :track
+    user_track = create(:user_track, user:, track:)
+
+    Solution::RemoveUserSolutionsForTrackFromSearchIndex.expects(:defer).with(user_track)
+
+    UserTrack::Reset.(user_track)
+  end
+
   test "removes track-specification reputation" do
     freeze_time do
       create :user, :ghost

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -309,6 +309,8 @@ class ActiveSupport::TestCase
 
   def get_opensearch_doc(index, id)
     Exercism.opensearch_client.get(index:, id:)
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    nil
   end
 
   def wait_for_opensearch_to_be_synced


### PR DESCRIPTION
We should also cleanup any existing records:

```ruby
Solution.where(user: User::GHOST_USER_ID).find_in_batches(batch_size: 1000) do |batch|
  body = batch.map do |solution|
    {
      delete: {
        _index: Solution::OPENSEARCH_INDEX,
        _id: solution.id
      }
    }
  end

  Exercism.opensearch_client.bulk(body:)
end
```