### PR TITLE
Remove solutions from index when resetting/destroying account

### DIFF
--- a/app/commands/solution/remove_user_solutions_from_search_index.rb
+++ b/app/commands/solution/remove_user_solutions_from_search_index.rb
@@ -1,0 +1,19 @@
+class Solution::RemoveUserSolutionsFromSearchIndex
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :user
+
+  def call
+    Exercism.opensearch_client.delete_by_query(index: Solution::OPENSEARCH_INDEX, body: {
+      query: {
+        bool: {
+          must: [
+            { term: { 'user.id': user.id } }
+          ]
+        }
+      }
+    })
+  end
+end

--- a/app/commands/solution/sync_to_search_index.rb
+++ b/app/commands/solution/sync_to_search_index.rb
@@ -29,5 +29,7 @@ class Solution::SyncToSearchIndex
       type: 'solution',
       id: solution.id
     )
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    nil
   end
 end

--- a/app/commands/user/reset_account.rb
+++ b/app/commands/user/reset_account.rb
@@ -37,6 +37,8 @@ class User::ResetAccount
     user.user_tracks.each do |user_track|
       UserTrack::Destroy.(user_track)
     end
+
+    Solution::RemoveUserSolutionsFromSearchIndex.defer(user)
   end
 
   def reset_mentoring!

--- a/test/commands/solution/remove_user_solutions_from_search_index_test.rb
+++ b/test/commands/solution/remove_user_solutions_from_search_index_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Solution::RemoveUserSolutionsFromSearchIndexTest < ActiveSupport::TestCase
+  test "remove solutions from search index" do
+    user = create :user
+    other_user = create :user
+    track = create :track, :random_slug
+    other_track = create :track, :random_slug
+
+    create(:user_track, user:, track:)
+    create :user_track, user:, track: other_track
+    create(:user_track, user: other_user, track:)
+
+    ce_track = create(:concept_exercise, track:)
+    pe_track = create(:practice_exercise, track:)
+    pe_other_track = create :practice_exercise, track: other_track
+
+    solution_1 = create(:concept_solution, exercise: ce_track, user:)
+    solution_2 = create(:practice_solution, exercise: pe_track, user:)
+    solution_3 = create(:practice_solution, exercise: pe_other_track, user:)
+    solution_4 = create(:practice_solution, exercise: ce_track, user: other_user)
+
+    Solution::SyncToSearchIndex.(solution_1)
+    Solution::SyncToSearchIndex.(solution_2)
+    Solution::SyncToSearchIndex.(solution_3)
+    Solution::SyncToSearchIndex.(solution_4)
+
+    wait_for_opensearch_to_be_synced
+
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_1.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_2.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_3.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_4.id)
+
+    Solution::RemoveUserSolutionsFromSearchIndex.(user)
+
+    wait_for_opensearch_to_be_synced
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_1.id)
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_2.id)
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_3.id)
+    refute_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution_4.id)
+  end
+end

--- a/test/commands/solution/sync_to_search_index_test.rb
+++ b/test/commands/solution/sync_to_search_index_test.rb
@@ -419,4 +419,15 @@ class Solution::SyncToSearchIndexTest < ActiveSupport::TestCase
 
     assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution.id)
   end
+
+  test "remove solution from index gracefully handles missing document" do
+    user = create :user
+    ghost_user = create :user, :ghost
+    solution = create(:practice_solution, user:)
+
+    solution.update(user: ghost_user)
+    Solution::SyncToSearchIndex.(solution)
+
+    assert_nil get_opensearch_doc(Solution::OPENSEARCH_INDEX, solution.id)
+  end
 end

--- a/test/commands/user/reset_account_test.rb
+++ b/test/commands/user/reset_account_test.rb
@@ -43,6 +43,8 @@ class User::ResetAccountTest < ActiveSupport::TestCase
         ut.track == orphaned_solution.track && ut.user == user
       end
 
+      Solution::RemoveUserSolutionsFromSearchIndex.expects(:defer).with(user)
+
       User::ResetAccount.(user)
 
       assert_raises ActiveRecord::RecordNotFound do


### PR DESCRIPTION
- Remove solutions from index when resetting account
- Remove solutions from index when resetting account
- Gracefully handle deleting opensearch document that isn't there
