### PR TITLE
Attempt to award reputation token even when authorship/contributorship exists

### DIFF
--- a/app/commands/concept/authorship/create.rb
+++ b/app/commands/concept/authorship/create.rb
@@ -4,16 +4,12 @@ class Concept::Authorship::Create
   initialize_with :concept, :author
 
   def call
-    begin
-      authorship = concept.authorships.create!(author:)
-    rescue ActiveRecord::RecordNotUnique
-      return nil
+    concept.authorships.find_or_create_by(author:).tap do |authorship|
+      User::ReputationToken::Create.defer(
+        author,
+        :concept_author,
+        authorship:
+      )
     end
-
-    User::ReputationToken::Create.defer(
-      author,
-      :concept_author,
-      authorship:
-    )
   end
 end

--- a/app/commands/concept/contributorship/create.rb
+++ b/app/commands/concept/contributorship/create.rb
@@ -4,16 +4,12 @@ class Concept::Contributorship::Create
   initialize_with :concept, :contributor
 
   def call
-    begin
-      contributorship = concept.contributorships.create!(contributor:)
-    rescue ActiveRecord::RecordNotUnique
-      return nil
+    concept.contributorships.find_or_create_by(contributor:).tap do |contributorship|
+      User::ReputationToken::Create.defer(
+        contributor,
+        :concept_contribution,
+        contributorship:
+      )
     end
-
-    User::ReputationToken::Create.defer(
-      contributor,
-      :concept_contribution,
-      contributorship:
-    )
   end
 end

--- a/app/commands/exercise/authorship/create.rb
+++ b/app/commands/exercise/authorship/create.rb
@@ -4,16 +4,12 @@ class Exercise::Authorship::Create
   initialize_with :exercise, :author
 
   def call
-    begin
-      authorship = exercise.authorships.create!(author:)
-    rescue ActiveRecord::RecordNotUnique
-      return nil
+    exercise.authorships.find_or_create_by(author:).tap do |authorship|
+      User::ReputationToken::Create.defer(
+        author,
+        :exercise_author,
+        authorship:
+      )
     end
-
-    User::ReputationToken::Create.defer(
-      author,
-      :exercise_author,
-      authorship:
-    )
   end
 end

--- a/app/commands/exercise/contributorship/create.rb
+++ b/app/commands/exercise/contributorship/create.rb
@@ -4,16 +4,12 @@ class Exercise::Contributorship::Create
   initialize_with :exercise, :contributor
 
   def call
-    begin
-      contributorship = exercise.contributorships.create!(contributor:)
-    rescue ActiveRecord::RecordNotUnique
-      return nil
+    exercise.contributorships.find_or_create_by(contributor:).tap do |contributorship|
+      User::ReputationToken::Create.defer(
+        contributor,
+        :exercise_contribution,
+        contributorship:
+      )
     end
-
-    User::ReputationToken::Create.defer(
-      contributor,
-      :exercise_contribution,
-      contributorship:
-    )
   end
 end


### PR DESCRIPTION
I'm not yet sure why this happens, but it looks like sometimes the author is added to the concept/exercise but the reputation token isn't. This PR wil "solve" this by just trying to add the reputation token regardless if the authorship/contributorship already exists.

We can run this code to fix this:

```ruby
Concept::Contributorship.find_each do |contributorship|
  User::ReputationToken::Create.defer(
    contributorship.contributor,
    :concept_contribution,
    contributorship:
  )
end

Concept::Authorship.find_each do |authorship|
  User::ReputationToken::Create.defer(
    authorship.author,
    :concept_author,
    authorship:
  )
end

Exercise::Contributorship.find_each do |contributorship|
  User::ReputationToken::Create.defer(
    contributorship.contributor,
    :exercise_contribution,
    contributorship:
  )
end

Exercise::Authorship.find_each do |authorship|
  User::ReputationToken::Create.defer(
    authorship.author,
    :exercise_author,
    authorship:
  )
end
```