### PR TITLE
Fix race condition in creating reputation tokens

### DIFF
--- a/app/commands/concept/authorship/create.rb
+++ b/app/commands/concept/authorship/create.rb
@@ -8,7 +8,10 @@ class Concept::Authorship::Create
       User::ReputationToken::Create.defer(
         author,
         :concept_author,
-        authorship:
+        authorship:,
+        # This is called in a big transaction, so give it time
+        # to materialise to the database before calling things.
+        wait: 30.seconds
       )
     end
   end

--- a/app/commands/concept/contributorship/create.rb
+++ b/app/commands/concept/contributorship/create.rb
@@ -8,7 +8,10 @@ class Concept::Contributorship::Create
       User::ReputationToken::Create.defer(
         contributor,
         :concept_contribution,
-        contributorship:
+        contributorship:,
+        # This is called in a big transaction, so give it time
+        # to materialise to the database before calling things.
+        wait: 30.seconds
       )
     end
   end

--- a/app/commands/exercise/authorship/create.rb
+++ b/app/commands/exercise/authorship/create.rb
@@ -8,7 +8,10 @@ class Exercise::Authorship::Create
       User::ReputationToken::Create.defer(
         author,
         :exercise_author,
-        authorship:
+        authorship:,
+        # This is called in a big transaction, so give it time
+        # to materialise to the database before calling things.
+        wait: 30.seconds
       )
     end
   end

--- a/app/commands/exercise/contributorship/create.rb
+++ b/app/commands/exercise/contributorship/create.rb
@@ -8,7 +8,10 @@ class Exercise::Contributorship::Create
       User::ReputationToken::Create.defer(
         contributor,
         :exercise_contribution,
-        contributorship:
+        contributorship:,
+        # This is called in a big transaction, so give it time
+        # to materialise to the database before calling things.
+        wait: 30.seconds
       )
     end
   end

--- a/app/controllers/discourse_controller.rb
+++ b/app/controllers/discourse_controller.rb
@@ -11,7 +11,7 @@ class DiscourseController < ApplicationController
     sso.bio = current_user.bio
     sso.sso_secret = secret
 
-    User::SetDiscourseGroups.defer(current_user, wait: 30)
+    User::SetDiscourseGroups.defer(current_user, wait: 30.seconds)
     AwardBadgeJob.perform_later(current_user, :discourser)
 
     redirect_to sso.to_url("https://forum.exercism.org/session/sso_login"), allow_other_host: true

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -22,7 +22,7 @@ class ApplicationJob < ActiveJob::Base
     # Sleep for a total of 5 seconds (20*0.25). This is rare enough
     # that we don't mind locking the jobs for this duration.
     # It's worse to drop jobs by accident.
-    20.times do |_offset|
+    20.times do
       sleep(0.25)
 
       begin

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,24 +9,33 @@ class ApplicationJob < ActiveJob::Base
 
   rescue_from ActiveRecord::Deadlocked, &skip_bugnag_and_raise
   rescue_from ActiveJob::DeserializationError do |exception|
-    # We except this to be a record not found. If it's not
-    # then get out of here
-    skip_bugnag_and_raise.(exception) unless exception.cause.is_a?(ActiveRecord::RecordNotFound)
+    # We expect this to be a record not found. If it's not
+    # then get out of here and go via Bugsnag!
+    raise exception unless exception.cause.is_a?(ActiveRecord::RecordNotFound)
 
     # Let any transactions finish then look up again
     # If the thing is now found, requeue the job.
     # Or if it's still missing, just kill the job. This happens if
     # the record is deleted in the time it takes to execute the job
     # (e.g. a User's records being deleted)
-    sleep(0.5)
-    begin
-      exception.cause.model.constantize.find(exception.cause.id)
-      retry_job
-    rescue NoMethodError
-      # The model has gone. Kill the job.
-    rescue ActiveRecord::RecordNotFound
-      # The record is gone. Kill the job.
+
+    # Sleep for a total of 5 seconds (20*0.25). This is rare enough
+    # that we don't mind locking the jobs for this duration.
+    # It's worse to drop jobs by accident.
+    20.times do |_offset|
+      sleep(0.25)
+
+      begin
+        exception.cause.model.constantize.find(exception.cause.id)
+        retry_job
+        break
+      rescue NoMethodError, ActiveRecord::RecordNotFound
+        # Continue to loop
+      end
     end
+
+    # If we get to this point, the model has gone
+    # so just exit the job which removes it from sidekiq
   end
 
   include Bullet::ActiveJob if Rails.env.development?

--- a/test/controllers/discourse_controller_test.rb
+++ b/test/controllers/discourse_controller_test.rb
@@ -16,7 +16,7 @@ class DiscourseControllerTest < ActionDispatch::IntegrationTest
 
     sso.expects(:to_url).returns(resulting_url)
     DiscourseApi::SingleSignOn.expects(:parse).with("who=why", Exercism.secrets.discourse_oauth_secret).returns(sso)
-    User::SetDiscourseGroups.expects(:defer).with(user, wait: 30)
+    User::SetDiscourseGroups.expects(:defer).with(user, wait: 30.seconds)
 
     sign_in!(user)
 


### PR DESCRIPTION
@ErikSchierboom This issue with this is that exercise and concept authors are called in a single transaction (`git grep transaction app/commands/git`). That's creating a race condition where Sidekiq gets the records before they're materialised to the database.

The reason this is hurting us now is due to the ignoring of ActiveRecord::NotFound exceptions in the ApplicationJob, to avoid us having tons of dead (but forever-retrying) jobs from deleted users (and their records).

Two fixes:
1. Wait 30s before doing these specific jobs
2. Give us a bit more breathing room in the application job code.