### PR TITLE
Fix menu's overflow bug

### DIFF
--- a/app/css/components/nav-bar.css
+++ b/app/css/components/nav-bar.css
@@ -168,7 +168,7 @@
                 li {
                     @apply pr-8 w-100;
                     .nav-dropdown-view {
-                        @apply absolute hidden rounded-8;
+                        @apply absolute hidden rounded-8 overflow-auto;
                         background: var(--nav-highlightColor);
                         height: var(--nd-height);
                         top: var(--nd-height);


### PR DESCRIPTION
#### Before:
<img width="954" alt="Screenshot 2023-08-11 at 12 18 22" src="https://github.com/exercism/website/assets/66035744/2cfac438-4db9-4d5f-9754-61b827276af9">

#### After:

<img width="908" alt="Screenshot 2023-08-11 at 12 33 33" src="https://github.com/exercism/website/assets/66035744/9afd0b6f-b06a-4c21-b64e-3b856b98dc27">
