### PR TITLE
Delete exercise site updates on destroy

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -18,6 +18,7 @@ class Exercise < ApplicationRecord
   has_many :submissions, through: :solutions
   has_many :representations, dependent: :destroy
   has_many :community_videos, dependent: :destroy
+  has_many :site_updates, dependent: :destroy
 
   has_many :approaches,
     class_name: "Exercise::Approach",

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -202,4 +202,29 @@ class ExerciseTest < ActiveSupport::TestCase
       exercise.update!(slug: 'test')
     end
   end
+
+  test "deletes associated site updates" do
+    concept_exercise = create :concept_exercise
+    practice_exercise = create :practice_exercise
+
+    ce_site_update = create :new_exercise_site_update, params: { exercise: concept_exercise }
+    assert_equal concept_exercise, ce_site_update.exercise # Sanity
+
+    pe_site_update = create :new_exercise_site_update, params: { exercise: practice_exercise }
+    assert_equal practice_exercise, pe_site_update.exercise # Sanity
+
+    concept_exercise.destroy
+
+    refute ConceptExercise.where(id: concept_exercise.id).exists?
+    refute SiteUpdate.where(id: ce_site_update.id).exists?
+    assert PracticeExercise.where(id: practice_exercise.id).exists?
+    assert SiteUpdate.where(id: pe_site_update.id).exists?
+
+    practice_exercise.destroy
+
+    refute ConceptExercise.where(id: concept_exercise.id).exists?
+    refute SiteUpdate.where(id: ce_site_update.id).exists?
+    refute PracticeExercise.where(id: practice_exercise.id).exists?
+    refute SiteUpdate.where(id: pe_site_update.id).exists?
+  end
 end


### PR DESCRIPTION
Other than new exercise and concept updates, we have arbitrary site updates but those aren't linked AFAICT.