### PR TITLE
Remove reload meta tag

### DIFF
--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useLayoutEffect } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
 import { TagsFilter } from './tracks-list/TagsFilter'
 import { List } from './tracks-list/List'
@@ -70,10 +70,6 @@ export default ({
       clearTimeout(handler)
     }
   }, [setRequestCriteria, criteria])
-
-  useLayoutEffect(() => {
-    document.querySelector('meta[name="turbo-visit-control"]')?.remove()
-  }, [])
 
   return (
     <div className="c-tracks-list">

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect, useLayoutEffect } from 'react'
 import { Request, usePaginatedRequestQuery } from '../../hooks/request-query'
 import { TagsFilter } from './tracks-list/TagsFilter'
 import { List } from './tracks-list/List'
@@ -29,14 +29,15 @@ export default ({
   tagOptions: readonly TagOption[]
   request: Request
 }): JSX.Element => {
-  const { request, setCriteria: setRequestCriteria, setQuery } = useList(
-    initialRequest
-  )
+  const {
+    request,
+    setCriteria: setRequestCriteria,
+    setQuery,
+  } = useList(initialRequest)
   const [criteria, setCriteria] = useState(request.query?.criteria || '')
   const CACHE_KEY = ['track-list', request.endpoint, request.query]
-  const { resolvedData, isError, isFetching } = usePaginatedRequestQuery<
-    APIResponse
-  >(CACHE_KEY, request)
+  const { resolvedData, isError, isFetching } =
+    usePaginatedRequestQuery<APIResponse>(CACHE_KEY, request)
 
   const setTags = useCallback(
     (tags) => {
@@ -69,6 +70,10 @@ export default ({
       clearTimeout(handler)
     }
   }, [setRequestCriteria, criteria])
+
+  useLayoutEffect(() => {
+    document.querySelector('meta[name="turbo-visit-control"]')?.remove()
+  }, [])
 
   return (
     <div className="c-tracks-list">

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -518,6 +518,7 @@ import { TrophiesProps, Trophy } from '@/components/track/Trophies.js'
 
 document.addEventListener('turbo:load', () => {
   highlightAll()
+  document.querySelector('meta[name="turbo-visit-control"]')?.remove()
 })
 
 showSiteFooterOnTurboLoad()


### PR DESCRIPTION
This PR gets rid of the double render of track show elements, while maintains this functionality:
https://github.com/exercism/website/pull/2676

https://github.com/exercism/website/assets/66035744/0f452b36-db79-4b30-b10a-e767cf216e06

