### PR TITLE
Fix line height of HandleWithFlair

### DIFF
--- a/app/helpers/view_components/handle_with_flair.rb
+++ b/app/helpers/view_components/handle_with_flair.rb
@@ -5,14 +5,8 @@ module ViewComponents
     initialize_with :handle, :flair, size: :base
 
     def to_s
-      tag.span(class: 'inline-flex items-center') do
-        safe_join(
-          [
-            tag.span(handle),
-            icon_part
-          ].compact
-        )
-      end
+      content = safe_join([handle, icon_part].compact)
+      tag.span(content, class: 'inline-flex items-center leading-150')
     end
 
     private

--- a/test/helpers/view_components/handle_with_flair_test.rb
+++ b/test/helpers/view_components/handle_with_flair_test.rb
@@ -7,7 +7,7 @@ class ViewComponents::HandleWithFlairTest < ActionView::TestCase
   test "nothing with no flair" do
     handle = "iHiD"
 
-    expected = %(<span class="inline-flex items-center"><span>#{handle}</span></span>)
+    expected = %(<span class="inline-flex items-center leading-150">#{handle}</span>)
     actual = render(ViewComponents::HandleWithFlair.new(handle, nil))
     assert_equal expected, actual
   end
@@ -18,9 +18,11 @@ class ViewComponents::HandleWithFlairTest < ActionView::TestCase
     title = 'An Exercism Insider'
     alt = "#{title}'s flair"
 
-    expected = tag.span(class: 'inline-flex items-center') do
-      tag.span(handle) +
-        icon(:insiders, alt, style: "all:unset; height: 13px; width: 13px; margin-left: 4px; margin-bottom: 1px", title:).to_s
+    expected = tag.span(class: 'inline-flex items-center leading-150') do
+      safe_join([
+        handle,
+        icon(:insiders, alt, style: "all:unset; height: 13px; width: 13px; margin-left: 4px; margin-bottom: 1px", title:)
+      ].compact)
     end
 
     actual = render(ViewComponents::HandleWithFlair.new(handle, flair))


### PR DESCRIPTION
This PR removes an extra layer of span, and adds correct line height:

#### Before
![Screenshot 2023-08-23 at 13 30 55](https://github.com/exercism/website/assets/66035744/409410e5-1398-4c90-b3dc-a49dc1017866)


#### After
![Screenshot 2023-08-23 at 13 29 28](https://github.com/exercism/website/assets/66035744/7b918cce-0414-4c68-84a4-66e757ef908c)
