### PR TITLE
Preload a single instance of the font to stop dramatic CLS

### DIFF
--- a/app/css/components/site-header.css
+++ b/app/css/components/site-header.css
@@ -263,6 +263,9 @@ body.keyboard-navigation .nav-element:hover .arrow {
             @apply ml-8;
         }
     }
+    .auth-buttons + .c-react-wrapper-dropdowns-dropdown {
+        @apply min-w-[135px] lg:min-w-[0];
+    }
     & .auth-buttons a,
     & .explore-menu {
         height: 40px;

--- a/app/css/fonts.css
+++ b/app/css/fonts.css
@@ -64,14 +64,6 @@
     font-weight: 500;
     src: url("source-code-pro-v22-latin_latin-ext-500.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
-/* source-code-pro-600 - latin_latin-ext */
-@font-face {
-    font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-    font-family: "Source Code Pro";
-    font-style: normal;
-    font-weight: 600;
-    src: url("source-code-pro-v22-latin_latin-ext-600.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
 /* source-code-pro-700 - latin_latin-ext */
 @font-face {
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */

--- a/app/views/layouts/_font_loading.html.haml
+++ b/app/views/layouts/_font_loading.html.haml
@@ -1,0 +1,16 @@
+/ We want to get the holding font rendered straight away
+%link{ rel: "preload", href: asset_path('poppins-v20-latin-regular.woff2'), as: "font", type: "font/woff2", crossorigin: :anonymous }
+:css
+  @font-face {
+    font-display: fallback;
+    font-family: PoppinsInitial;
+    src: url(#{asset_path('poppins-v20-latin-regular.woff2')}) format('woff2');
+  }
+  body {
+    --body-font: Poppins, PoppinsInitial, serif;
+    font-family: var(--body-font);
+    -webkit-font-smoothing: antialiased;
+  }
+  body.fonts-loaded {
+    --body-font: Poppins, serif;
+  }

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,3 +1,5 @@
+= render "layouts/font_loading"
+
 -# %meta{ "http-equiv": "Content-Security-Policy", content: csp_policy}
 
 / We always want this rendered at the start.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -288,7 +288,7 @@ module.exports = {
       backgroundColorNavDropdown: 'var(--backgroundColorNavDropdown)',
     },
     fontFamily: {
-      body: ['Poppins', 'sans-serif'],
+      body: 'var(--body-font)',
       mono: ['Source Code Pro', 'monospace'],
     },
     fontSize: {


### PR DESCRIPTION
This preloads a single version of Poppins and sets it on body, which results in us making the initial render with Poppins, not the fallback font. The browser makes "guesstimate" versions of the other weights etc. This means that when Poppins loads, we don't get as dramatic layout shifts.

There's details here, although my version is a bit different: https://css-tricks.com/the-best-font-loading-strategies-and-how-to-execute-them/

---

https://www.loom.com/share/f92f54f56a31437ebe605a111271591a