### PR TITLE
Fix footer taking an extra 150ms

### DIFF
--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -668,11 +668,13 @@ import { handleNavbarFocus, scrollIntoView, showSiteFooter } from '@/utils'
 import { lazyHighlightAll } from '@/utils/lazy-highlight-all'
 
 document.addEventListener('turbo:load', () => {
-  lazyHighlightAll()
   showSiteFooter()
   handleNavbarFocus()
   scrollIntoView()
   document.querySelector('meta[name="turbo-visit-control"]')?.remove()
+
+  // Do this last
+  lazyHighlightAll()
 })
 
 // object.entries polyfill

--- a/app/javascript/utils/show-site-footer.ts
+++ b/app/javascript/utils/show-site-footer.ts
@@ -11,22 +11,23 @@ export function showSiteFooter(): void {
   const elems = document.body.getElementsByClassName('c-react-component')
   for (const elem of elems) {
     // If this elem is hydrated, move onto the next one...
-    if (elem.childElementCount > 0) {
+    if (
+      elem.childElementCount > 0 &&
+      elem.children[0].classList != 'c-loading-suspense'
+    ) {
       continue
     }
 
-    // ...otherwise wait another 50ms and try again
+    // ...otherwise wait another 10ms and try again
     retryCount++
-    setTimeout(showSiteFooter, 50)
+    setTimeout(showSiteFooter, 10)
     return
   }
 
   /*
-   * Now everything is rendered, it might take the browser
-   * a few ms to actually paint everything. In my testing, it's
-   * always between 50-100ms, so I've added a little extra to be safe.
+   * Now everything is rendered, display the footer!
    */
-  setTimeout(displayFooter, 150)
+  displayFooter()
   retryCount = 0
 }
 


### PR DESCRIPTION
This should knock off the 150ms from loading the footer. It didn't sit right with me that we needed this, so I debugged it and discovered the issue was actually that the footer was being ok'd when the suspense icon loaded, not when the actual content loaded. This now guards against that.

I also moved the highlightjs to the very end as well, so that we put that network request after the ones that come from loading the footer etc.