### PR TITLE
Don't include CSS-only tailwind

### DIFF
--- a/app/css/defaults.css
+++ b/app/css/defaults.css
@@ -1,3 +1,7 @@
+/* @tailwind base; */
+/* @tailwind components; */
+/* @tailwind utilities; */
+
 body {
     @apply font-body antialiased;
     line-height: 1;

--- a/app/css/defaults.css
+++ b/app/css/defaults.css
@@ -1,7 +1,3 @@
-/* @tailwind base; */
-/* @tailwind components; */
-/* @tailwind utilities; */
-
 body {
     @apply font-body antialiased;
     line-height: 1;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,8 +14,6 @@ module.exports = {
   content: [
     './app/views/**/*.haml',
     './app/helpers/**/*.rb',
-    './app/css/*.css',
-    './app/css/**/*.css',
     './app/javascript/**/*',
   ],
   theme: {


### PR DESCRIPTION
If tailwind classes are only used in CSS, then they're inlined, so we don't need to keep them in the main file. This knocks off 16kb from our CSS file.