### PR TITLE
Save 20ms by preloading assets using headers

### DIFF
--- a/app/controllers/spi/base_controller.rb
+++ b/app/controllers/spi/base_controller.rb
@@ -10,6 +10,7 @@ module SPI
     skip_before_action :authenticate_user!
     skip_after_action :set_body_class_header
     skip_after_action :set_csp_header
+    skip_after_action :set_link_header
 
     layout false
   end


### PR DESCRIPTION
This uses the `Link` header to preload assets before the parsing/rendering of the HTML happens. This saves us 20ms.

The next step is to use HTTP2 103 early hints to send this header BEFORE the request is actually parsed, but I have no idea whether this is in any way possible with cloudfront - my initial reading suggests not.