### PR TITLE
Destroy account fix

### DIFF
--- a/app/commands/user/destroy_account.rb
+++ b/app/commands/user/destroy_account.rb
@@ -7,8 +7,8 @@ class User::DestroyAccount
     User::ResetAccount.(user)
     user.student_relationships.destroy_all
     user.mentor_relationships.destroy_all
-    user.subscriptions.update_all(user_id: User::GHOST_USER_ID)
-    user.payments.update_all(user_id: User::GHOST_USER_ID)
+    user.subscriptions.destroy_all
+    user.payments.destroy_all
     user.destroy
   end
 end

--- a/app/commands/user/destroy_account.rb
+++ b/app/commands/user/destroy_account.rb
@@ -7,6 +7,8 @@ class User::DestroyAccount
     User::ResetAccount.(user)
     user.student_relationships.destroy_all
     user.mentor_relationships.destroy_all
+    user.subscriptions.update_all(user_id: User::GHOST_USER_ID)
+    user.payments.update_all(user_id: User::GHOST_USER_ID)
     user.destroy
   end
 end

--- a/test/commands/user/destroy_account_test.rb
+++ b/test/commands/user/destroy_account_test.rb
@@ -8,6 +8,9 @@ class User::DestroyAccountTest < ActiveSupport::TestCase
     rel_1 = create :mentor_student_relationship, mentor: user
     rel_2 = create :mentor_student_relationship, student: user
     rel_3 = create :mentor_student_relationship
+    subscription = create(:payments_subscription, user:)
+    payment_1 = create(:payments_payment, user:, subscription:)
+    payment_2 = create(:payments_payment, user:)
 
     User::ResetAccount.expects(:call).with(user)
 
@@ -16,6 +19,9 @@ class User::DestroyAccountTest < ActiveSupport::TestCase
     assert_raises ActiveRecord::RecordNotFound, &proc { user.reload }
     assert_raises ActiveRecord::RecordNotFound, &proc { rel_1.reload }
     assert_raises ActiveRecord::RecordNotFound, &proc { rel_2.reload }
+    assert_raises ActiveRecord::RecordNotFound, &proc { subscription.reload }
+    assert_raises ActiveRecord::RecordNotFound, &proc { payment_1.reload }
+    assert_raises ActiveRecord::RecordNotFound, &proc { payment_2.reload }
     assert_nothing_raised { rel_3.reload }
   end
 
@@ -57,24 +63,5 @@ class User::DestroyAccountTest < ActiveSupport::TestCase
 
     perform_enqueued_jobs
     assert_empty Solution::SearchCommunitySolutions.(solution.exercise)
-  end
-
-  test "resets payments and subscriptions" do
-    create :user, :ghost
-    user = create :user
-
-    # Create all the things the person might have
-    subscription = create(:payments_subscription, user:)
-    payment_1 = create(:payments_payment, user:, subscription:)
-    payment_2 = create(:payments_payment, user:)
-
-    User::ResetAccount.expects(:call).with(user)
-
-    User::DestroyAccount.(user)
-
-    assert_raises ActiveRecord::RecordNotFound, &proc { user.reload }
-    assert_equal User::GHOST_USER_ID, subscription.reload.user_id
-    assert_equal User::GHOST_USER_ID, payment_1.reload.user_id
-    assert_equal User::GHOST_USER_ID, payment_2.reload.user_id
   end
 end

--- a/test/commands/user/reset_account_test.rb
+++ b/test/commands/user/reset_account_test.rb
@@ -198,4 +198,15 @@ class User::ResetAccountTest < ActiveSupport::TestCase
       challenge.reload
     end
   end
+
+  test "cleans up viewed community solutions" do
+    create :user, :ghost
+    user = create :user
+    viewed_solution = create(:user_track_viewed_community_solution, user:)
+
+    User::ResetAccount.(user)
+    assert_raises ActiveRecord::RecordNotFound do
+      viewed_solution.reload
+    end
+  end
 end


### PR DESCRIPTION
- Add test for cleaning up viewed community solutions
- Assign payments and subscriptions to ghost user when destroying account
