### PR TITLE
Cancel pending subscriptions

### DIFF
--- a/app/commands/payments/subscription/cancel_pending.rb
+++ b/app/commands/payments/subscription/cancel_pending.rb
@@ -1,0 +1,12 @@
+# Cancel any long-standing pending subscriptions, which will be due to
+# the user clicking on the subscribe button but not actually finishing
+# the payment
+class Payments::Subscription::CancelPending
+  include Mandate
+
+  def call
+    Payments::Subscription.pending.where('created_at < ?', Time.current - 2.days).find_each do |subscription|
+      Payments::Subscription::Cancel.(subscription)
+    end
+  end
+end

--- a/app/commands/payments/subscription/cancel_pending.rb
+++ b/app/commands/payments/subscription/cancel_pending.rb
@@ -7,6 +7,8 @@ class Payments::Subscription::CancelPending
   def call
     Payments::Subscription.pending.where('created_at < ?', Time.current - 2.days).find_each do |subscription|
       Payments::Subscription::Cancel.(subscription)
+    rescue StandardError => e
+      Bugsnag.notify(e)
     end
   end
 end

--- a/app/jobs/sync_payments_job.rb
+++ b/app/jobs/sync_payments_job.rb
@@ -1,6 +1,6 @@
 # The goal of this job is to re-sync sponsors to ensure
 # that our payment and subscription data are correct
-class SyncSponsorsJob < ApplicationJob
+class SyncPaymentsJob < ApplicationJob
   queue_as :dribble
 
   def perform

--- a/app/jobs/sync_payments_job.rb
+++ b/app/jobs/sync_payments_job.rb
@@ -7,5 +7,6 @@ class SyncPaymentsJob < ApplicationJob
     Payments::Github::Sponsorship::SyncAll.()
     Payments::Stripe::Subscription::SyncAll.()
     Payments::Stripe::Payment::SyncAll.()
+    Payments::Subscription::CancelPending.()
   end
 end

--- a/config/sidekiq-schedule.yml
+++ b/config/sidekiq-schedule.yml
@@ -41,6 +41,11 @@ mark_outdated_reputation_year_periods:
   queue: reputation
   args: ["year"]
 
+sync_payments:
+  cron: "0 5 * * *"
+  class: "SyncPaymentsJob"
+  queue: dribble
+
 # 1am Monday
 fetch_and_sync_all_pull_requests_reputation:
   cron: "0 1 * * 1"
@@ -62,11 +67,6 @@ sync_tracks:
 sync_team_members:
   cron: "0 1 * * 3"
   class: "SyncTeamMembersJob"
-  queue: dribble
-
-sync_payments:
-  cron: "0 1 * * 3"
-  class: "SyncPaymentsJob"
   queue: dribble
 
 # 1am Thursday

--- a/config/sidekiq-schedule.yml
+++ b/config/sidekiq-schedule.yml
@@ -64,9 +64,9 @@ sync_team_members:
   class: "SyncTeamMembersJob"
   queue: dribble
 
-sync_sponsors:
+sync_payments:
   cron: "0 1 * * 3"
-  class: "SyncSponsorsJob"
+  class: "SyncPaymentsJob"
   queue: dribble
 
 # 1am Thursday

--- a/test/commands/payments/subscription/cancel_pending_test.rb
+++ b/test/commands/payments/subscription/cancel_pending_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_base'
+
+class Payments::Subscription::CancelPendingTest < Payments::TestBase
+  test "cancels pending subscriptions that have been open for 2 days" do
+    old_pending_sub_1 = create :payments_subscription, :pending, created_at: Time.current - 7.days
+    old_pending_sub_2 = create :payments_subscription, :pending, created_at: Time.current - 2.days
+    new_pending_sub = create :payments_subscription, :pending, created_at: Time.current
+    active_sub = create :payments_subscription, :active
+    overdue_sub = create :payments_subscription, :overdue
+    canceled_sub = create :payments_subscription, :canceled
+
+    Payments::Subscription::CancelPending.()
+
+    assert old_pending_sub_1.reload.canceled?
+    assert old_pending_sub_2.reload.canceled?
+    assert new_pending_sub.reload.pending?
+    assert active_sub.reload.active?
+    assert overdue_sub.reload.overdue?
+    assert canceled_sub.reload.canceled?
+  end
+end


### PR DESCRIPTION
- Rename SyncSponsorsJob to SyncPaymentsJob
- Change payment sync job schedule to daily
- Cancel pending subscriptions in job
- Cancel pending subscriptions
