### PR TITLE
Fix potential race in representation status

### DIFF
--- a/app/commands/solution/update_to_latest_exercise_version.rb
+++ b/app/commands/solution/update_to_latest_exercise_version.rb
@@ -45,7 +45,7 @@ class Solution::UpdateToLatestExerciseVersion
   def rerun_tests!
     # We might have already run this when running the head test run
     # If we do, then sync the status to it
-    # (reload as submission's test run will be cached)
+    # (reload as submission's test run will be cached to nil)
     if submission.reload_test_run
       Submission::SyncTestsStatus.(submission)
     else
@@ -58,7 +58,7 @@ class Solution::UpdateToLatestExerciseVersion
 
     # We might have already run this when running the head test run
     # If we do, then sync the status to it
-    # (reload as submission's test run will be cached)
+    # (reload as submission's test run will be cached to nil)
     if submission.reload_submission_representation
       Submission::SyncRepresentationStatus.(submission)
     else

--- a/app/commands/submission/representation/process.rb
+++ b/app/commands/submission/representation/process.rb
@@ -85,11 +85,6 @@ class Submission::Representation::Process
     tooling_job.execution_status.to_i
   end
 
-  memoize
-  def ops_success?
-    ops_status == 200
-  end
-
   def representer_version = metadata[:version] || 1
 
   def exercise_version

--- a/app/commands/submission/sync_representation_status.rb
+++ b/app/commands/submission/sync_representation_status.rb
@@ -1,13 +1,13 @@
-# This syncs submission's test status to the results of its latest test_run
+# This syncs submission's representation status to the results of its latest test_run
 class Submission::SyncRepresentationStatus
   include Mandate
 
   initialize_with :submission
 
   def call
-    return false unless submission_representation
+    return false unless representation
 
-    if submission_representation.ops_errored?
+    if representation.ops_errored?
       status = :exceptioned
     else
       status = :generated
@@ -18,5 +18,7 @@ class Submission::SyncRepresentationStatus
     true
   end
 
-  delegate :submission_representation, to: :submission
+  # Get this afresh from the database - don't use reload etc
+  memoize
+  def representation = Submission::Representation.for!(submission)
 end

--- a/app/commands/submission/sync_tests_status.rb
+++ b/app/commands/submission/sync_tests_status.rb
@@ -22,5 +22,7 @@ class Submission::SyncTestsStatus
     true
   end
 
-  delegate :test_run, to: :submission
+  # Get this afresh from the database - don't use reload etc
+  memoize
+  def test_run = Submission::TestRun.for!(submission)
 end

--- a/app/models/submission/representation.rb
+++ b/app/models/submission/representation.rb
@@ -36,6 +36,10 @@ class Submission::Representation < ApplicationRecord
 
   delegate :has_feedback?, to: :exercise_representation
 
+  def self.for!(submission)
+    where(submission:).last
+  end
+
   def ops_success? = ops_status == OPS_STATUS_SUCCESS
   def ops_errored? = !ops_success?
 

--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -36,6 +36,10 @@ class Submission::TestRun < ApplicationRecord
     self.track = submission.track unless track
   end
 
+  def self.for!(submission)
+    where(submission:).last
+  end
+
   def status = super.try(&:to_sym)
   def ops_success? = ops_status == 200
   def timed_out? = ops_status == 408

--- a/test/commands/submission/sync_representation_status_test.rb
+++ b/test/commands/submission/sync_representation_status_test.rb
@@ -27,4 +27,21 @@ class Submission::SyncRepresentationStatusTest < ActiveSupport::TestCase
     assert Submission::SyncRepresentationStatus.(submission)
     assert_equal 'generated', submission.representation_status
   end
+
+  test "uses latest representation, even if a previous one is cached" do
+    submission = create :submission, representation_status: :queued
+    rep_1 = create :submission_representation, submission:, ops_status: 500
+    assert_equal rep_1, submission.submission_representation # Sanity
+
+    Submission::SyncRepresentationStatus.(submission)
+    assert_equal 'exceptioned', submission.representation_status
+
+    create :submission_representation, submission:, ops_status: 200
+    # Sanity - Check that Rails has this cached to rep_1, so that
+    # we're actually testing the correct behaviour
+    assert_equal rep_1, submission.submission_representation
+
+    Submission::SyncRepresentationStatus.(submission)
+    assert_equal 'generated', submission.representation_status
+  end
 end


### PR DESCRIPTION
This should always retrieve the latest version of a test run or representation.

I considered adding locking or SQL updates, but I think that's probably not necessary.

One issue here is that I was previously relying on `submission.reload_test_run`. However, I've discovered that doesn't actually do what I thought. For a `belongs_to` it will only reload the **data** of the test run, or change it from `nil` to a record. It won't change it from one record to another (as `belongs_to` generally presumes it will never change).