### PR TITLE
Clean out built assets on every ./bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+rm -rf .build-assets
+
 docker run -dp 3042:8080 -p 3040:4566 -p 3041:4566 $(jq -r '.localstack' .dockerimages.json)
 docker run -dp 9200:9200 -e "discovery.type=single-node" $(jq -r '.opensearch' .dockerimages.json)
 hivemind Procfile.dev


### PR DESCRIPTION
This will add a small extra time to startup time (both the `rm` and the recompile of everything) but it will keep `rails s` much faster, and avoid weird errors that occur every few days for both me and Aron.