### PR TITLE
Refine styling for c-completed-exercise-progress widgets

### DIFF
--- a/app/css/components/completed-exercise-progress.css
+++ b/app/css/components/completed-exercise-progress.css
@@ -49,6 +49,10 @@
                 .c-unlocked-concept {
                     @apply m-0;
                 }
+
+                .c-exercise-widget {
+                    @apply w-auto;
+                }
             }
         }
     }

--- a/app/css/components/completed-exercise-progress.css
+++ b/app/css/components/completed-exercise-progress.css
@@ -45,10 +45,10 @@
                 }
             }
             & .list {
-                @apply flex flex-wrap;
-            }
-            & .c-exercise-widget {
-                @apply mr-12 mb-12;
+                @apply flex flex-wrap gap-12;
+                .c-unlocked-concept {
+                    @apply m-0;
+                }
             }
         }
     }


### PR DESCRIPTION
### Use gaps instead of margins
<img width="916" alt="Screenshot 2023-10-04 at 11 39 17" src="https://github.com/exercism/website/assets/66035744/8e1a9e2c-e950-485c-8cfc-120324192264">

### Change width of ExerciseWidget on modal:

#### Before:
<img width="582" alt="Screenshot 2023-10-04 at 12 01 50" src="https://github.com/exercism/website/assets/66035744/337c5042-f981-4dc2-868a-a9ff8d827243">

#### After:
<img width="553" alt="Screenshot 2023-10-04 at 12 01 54" src="https://github.com/exercism/website/assets/66035744/7652ed16-f2e9-462a-9b6f-79822e7c4f87">
<img width="922" alt="Screenshot 2023-10-04 at 12 11 41" src="https://github.com/exercism/website/assets/66035744/db14ffb0-8964-451d-ae78-6b8649b93250">

