### PR TITLE
Add rep guard UI to external mentoring requests

### DIFF
--- a/app/views/mentoring/external_requests/show_not_mentor.html.haml
+++ b/app/views/mentoring/external_requests/show_not_mentor.html.haml
@@ -4,7 +4,9 @@
     %h1.text-h1.mb-16 Want to mentor #{@solution.user.handle}?
     %p.text-p-2xlarge.mb-32 You&apos;ll need to register as a mentor first to get started.
     = render 'exercise_tag', solution: @solution
-    .buttons.grid.grid-cols-2-auto.gap-20
-      = ReactComponents::Mentoring::TryMentoringButton.new(text: "Register as mentor", size: "l", redirect_link: @solution.external_mentoring_request_url)
-      = link_to "Learn more", mentoring_path, class: 'btn-enhanced btn-l'
-
+    - if current_user.reputation >= User::MIN_REP_TO_MENTOR
+      .buttons.grid.grid-cols-2-auto.gap-20
+        = ReactComponents::Mentoring::TryMentoringButton.new(text: "Register as mentor", size: "l", redirect_link: @solution.external_mentoring_request_url)
+        = link_to "Learn more", mentoring_path, class: 'btn-enhanced btn-l'
+    - else
+      = render "mentoring/external/locked", profile_min_reputation: User::MIN_REP_TO_MENTOR

--- a/test/system/flows/external_mentoring_test.rb
+++ b/test/system/flows/external_mentoring_test.rb
@@ -20,9 +20,23 @@ module Flows
       end
     end
 
-    test "not a mentor" do
+    test "not a mentor with not enough rep" do
       solution = create :concept_solution
-      user = create :user, :not_mentor
+      user = create :user, :not_mentor, reputation: 19
+
+      use_capybara_host do
+        sign_in!(user)
+        visit solution.external_mentoring_request_url
+
+        assert_text "Want to mentor #{solution.user.handle}?"
+        refute_button "Register as mentor"
+        assert_text "Ability to mentor unlocks at"
+      end
+    end
+
+    test "not a mentor with enough reps" do
+      solution = create :concept_solution
+      user = create :user, :not_mentor, reputation: 20
 
       use_capybara_host do
         sign_in!(user)
@@ -30,6 +44,9 @@ module Flows
 
         assert_text "Want to mentor #{solution.user.handle}?"
         assert_button "Register as mentor"
+        assert_link "Learn more"
+        click_on "Register as mentor"
+        assert_text "Select the tracks you want to mentor"
       end
     end
 


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2023-10-04 at 13 11 25" src="https://github.com/exercism/website/assets/66035744/f74aa2d2-971a-4cc4-8857-c9e1b3b6f399">
<img width="1512" alt="Screenshot 2023-10-04 at 13 04 59" src="https://github.com/exercism/website/assets/66035744/4d39eccd-3157-457d-9225-c0bc78e4c035">
