### PR TITLE
Add fallback TrackIcon

### DIFF
--- a/app/javascript/components/common/TrackIcon.tsx
+++ b/app/javascript/components/common/TrackIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { missingTrackIconErrorHandler } from './imageErrorHandler'
+import { assetUrl } from '@/utils/assets'
 
 type TrackIconProps = {
   iconUrl: string
@@ -20,7 +21,7 @@ export function TrackIcon({
   return (
     <img
       className={classNames.join(' ')}
-      src={iconUrl}
+      src={iconUrl || assetUrl('icons/all-tracks.svg')}
       alt={`icon for ${title} track`}
       onError={missingTrackIconErrorHandler}
     />

--- a/app/serializers/serialize_track_for_select.rb
+++ b/app/serializers/serialize_track_for_select.rb
@@ -4,7 +4,7 @@ class SerializeTrackForSelect
   ALL_TRACK = {
     slug: nil,
     title: "All Tracks",
-    icon_url: "ICON"
+    icon_url: nil
   }.freeze
 
   initialize_with :track

--- a/test/assemblers/assemble_contributions_summary_test.rb
+++ b/test/assemblers/assemble_contributions_summary_test.rb
@@ -56,7 +56,7 @@ class AssembleContributionsSummaryTest < ActiveSupport::TestCase
         {
           slug: nil,
           title: "All Tracks",
-          icon_url: "ICON",
+          icon_url: nil,
           categories: [
             { id: :publishing, reputation: 10, metric_full: "5 solutions published", metric_short: "5 solutions" },
             { id: :mentoring, reputation: 45, metric_full: "9 students mentored", metric_short: "9 students" },
@@ -105,7 +105,7 @@ class AssembleContributionsSummaryTest < ActiveSupport::TestCase
         {
           slug: nil,
           title: "All Tracks",
-          icon_url: "ICON",
+          icon_url: nil,
           categories: [
             { id: :publishing, reputation: 0, metric_full: "No solutions published", metric_short: "No solutions" },
             { id: :mentoring, reputation: 0, metric_full: "No students mentored", metric_short: "No students" },

--- a/test/controllers/api/mentoring/discussions_controller_test.rb
+++ b/test/controllers/api/mentoring/discussions_controller_test.rb
@@ -105,7 +105,7 @@ class API::Mentoring::DiscussionsControllerTest < API::BaseTestCase
     assert_response :ok
 
     expected = [
-      { slug: nil, title: 'All Tracks', icon_url: "ICON", count: 3 },
+      { slug: nil, title: 'All Tracks', icon_url: nil, count: 3 },
       { slug: go.slug, title: go.title, icon_url: go.icon_url, count: 2 },
       { slug: ruby.slug, title: ruby.title, icon_url: ruby.icon_url, count: 1 }
     ]

--- a/test/javascript/components/Editor/GetHelp/__snapshots__/GetHelpPanel.test.tsx.snap
+++ b/test/javascript/components/Editor/GetHelp/__snapshots__/GetHelpPanel.test.tsx.snap
@@ -529,7 +529,7 @@ to add values.
           <img
             alt="icon for Ruby track"
             class="c-icon c-track-icon w-[24px] h-[24px] mr-16"
-            src=""
+            src="undefined/assets/undefined"
           />
           <div
             class="flex items-center justify-between w-100"

--- a/test/serializers/serialize_track_for_select_test.rb
+++ b/test/serializers/serialize_track_for_select_test.rb
@@ -15,7 +15,7 @@ class SerializeTrackForSelectTest < ActiveSupport::TestCase
     expected = {
       slug: nil,
       title: "All Tracks",
-      icon_url: "ICON"
+      icon_url: nil
     }
     assert_equal expected, SerializeTrackForSelect::ALL_TRACK
   end


### PR DESCRIPTION
##### This will remove the 404 "ICON" not found error (probably present only in dev env) on pages where the TrackSelector is present, e.g., the Community page.
<img width="285" alt="Screenshot 2023-10-04 at 15 26 04" src="https://github.com/exercism/website/assets/66035744/ea84ee01-8e64-4e35-916c-34e20c642cc5">
