### PR TITLE
Fix wrong bg colours on about page

### DIFF
--- a/app/css/pages/about.css
+++ b/app/css/pages/about.css
@@ -1,7 +1,7 @@
 @import "../styles";
 
 #page-about {
-    @apply bg-backgroundColorA;
+    @apply bg-backgroundColorB;
 
     & > header {
         & .md-container {
@@ -23,7 +23,7 @@
 
     & .purpose {
         @apply border-purple;
-        background: var(--backgroundColorTracksListJoined);
+        background: var(--backgroundColorI);
         & h2 {
             & .c-icon {
                 height: 32px;


### PR DESCRIPTION
### Currently in prod:

https://github.com/exercism/website/assets/66035744/c4d7daac-ad87-4a97-8dd7-ba093a8db010

https://github.com/exercism/website/assets/66035744/35da10d4-ac3c-4929-8cbc-1157af4c2efa



### After this PR:

https://github.com/exercism/website/assets/66035744/80f1d539-f801-4def-8527-d5f843d913de

https://github.com/exercism/website/assets/66035744/7edd63a6-5f0d-44fb-8e29-0d7f2638b470



