### PR TITLE
Fix ugly table in article snippet

### DIFF
--- a/app/css/pages/approach.css
+++ b/app/css/pages/approach.css
@@ -53,8 +53,7 @@
         .c-responsive-table-wrapper {
             all: unset;
             table {
-                @apply w-100;
-                @apply text-left;
+                @apply w-100 text-left;
             }
         }
     }

--- a/app/css/pages/approach.css
+++ b/app/css/pages/approach.css
@@ -47,3 +47,15 @@
         }
     }
 }
+
+#page-approaches-index {
+    .dig-deeper-snippet {
+        .c-responsive-table-wrapper {
+            all: unset;
+            table {
+                @apply w-100;
+                @apply text-left;
+            }
+        }
+    }
+}

--- a/app/javascript/components/track/approaches-elements/ApproachSnippet.tsx
+++ b/app/javascript/components/track/approaches-elements/ApproachSnippet.tsx
@@ -15,7 +15,7 @@ export function ApproachSnippet({
   return (
     <a
       href={approach.links.self}
-      className="bg-backgroundColorA shadow-base rounded-8 px-20 py-16 mb-16"
+      className="dig-deeper-snippet bg-backgroundColorA shadow-base rounded-8 px-20 py-16 mb-16"
     >
       <pre
         className="border-1 border-borderColor7 rounded-8 p-16 mb-16"

--- a/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
+++ b/app/javascript/components/track/approaches-elements/ArticleSnippet.tsx
@@ -9,7 +9,7 @@ export function ArticleSnippet({ article }: { article: Article }): JSX.Element {
   return (
     <a
       href={article.links.self}
-      className="bg-backgroundColorA shadow-base rounded-8 px-20 py-16 mb-16"
+      className="dig-deeper-snippet bg-backgroundColorA shadow-base rounded-8 px-20 py-16 mb-16"
     >
       <pre
         className="border-1 border-borderColor7 rounded-8 p-16 mb-16"


### PR DESCRIPTION
### Before:
<img width="633" alt="Screenshot 2023-10-05 at 14 24 58" src="https://github.com/exercism/website/assets/66035744/6406d91d-01b4-4a6e-b158-ba22cadf25e0">


### After:
<img width="378" alt="Screenshot 2023-10-05 at 14 30 26" src="https://github.com/exercism/website/assets/66035744/d29985ee-e083-4d23-a2df-c674531113d8">
