### PR TITLE
Verify that we don't change tables in production

### DIFF
--- a/test/misc/migrations_test.rb
+++ b/test/misc/migrations_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class MigrationsTest < ActiveSupport::TestCase
+  test "don't modify tables in production" do
+    ApplicationRecord.connection.migration_context.migrations.each do |migration_proxy|
+      # We only started running migrations manually after the below time
+      next if migration_proxy.version <= 20231017101049 # rubocop:disable Style/NumericLiterals
+
+      migration = File.read(migration_proxy.filename)
+      assert_includes migration, "return if Rails.env.production?"
+    end
+  end
+end


### PR DESCRIPTION
This is completely rudimentary, but gives us _some_ protection