### PR TITLE
Update highlight.js 11.5.1 -> 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "focus-visible": "^5.2.0",
     "fontfaceobserver": "^2.1.0",
     "global": "^4.4.0",
-    "highlight.js": "^11.5.1",
+    "highlight.js": "11.9.0",
     "highlightjs-bqn": "^0.0.1",
     "highlightjs-cobol": "^0.3.1",
     "highlightjs-sap-abap": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5203,9 +5203,9 @@ highlight.js@11.2.0:
   integrity sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==
 
 highlight.js@^11.5.1:
-  version "11.5.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.5.1.tgz#027c24e4509e2f4dcd00b4a6dda542ce0a1f7aea"
-  integrity sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.9.0.tgz#04ab9ee43b52a41a047432c8103e2158a1b8b5b0"
+  integrity sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==
 
 highlightjs-bqn@^0.0.1:
   version "0.0.1"


### PR DESCRIPTION
https://forum.exercism.org/t/syntax-highlighting-for-match-case-in-python/7801

<img width="928" alt="Screenshot 2023-10-19 at 15 06 31" src="https://github.com/exercism/website/assets/66035744/45f3b10d-9852-49ca-be21-76d7fd97551e">
