### PR TITLE
Reset to light mode after losing insiders

### DIFF
--- a/app/commands/user/insiders_status/update.rb
+++ b/app/commands/user/insiders_status/update.rb
@@ -78,5 +78,6 @@ class User::InsidersStatus::Update
 
   def update_to_ineligible
     user.update!(insiders_status: :ineligible)
+    user.preferences.update(theme: "light") if user.preferences.theme == "dark"
   end
 end

--- a/app/commands/user/insiders_status/update.rb
+++ b/app/commands/user/insiders_status/update.rb
@@ -78,9 +78,12 @@ class User::InsidersStatus::Update
 
   def update_to_ineligible
     user.update!(insiders_status: :ineligible)
-
-    return unless %w[dark system].include?(user.preferences.theme)
-
-    user.preferences.update(theme: "light")
+    user.preferences.update(theme: DEFAULT_THEME) if uses_insiders_only_theme?
   end
+
+  def uses_insiders_only_theme? = INSIDERS_ONLY_THEMES.include?(user.preferences.theme)
+
+  DEFAULT_THEME = "light".freeze
+  INSIDERS_ONLY_THEMES = %w[dark system].freeze
+  private_constant :DEFAULT_THEME, :INSIDERS_ONLY_THEMES
 end

--- a/app/commands/user/insiders_status/update.rb
+++ b/app/commands/user/insiders_status/update.rb
@@ -78,6 +78,9 @@ class User::InsidersStatus::Update
 
   def update_to_ineligible
     user.update!(insiders_status: :ineligible)
-    user.preferences.update(theme: "light") if user.preferences.theme == "dark"
+
+    return unless %w[dark system].include?(user.preferences.theme)
+
+    user.preferences.update(theme: "light")
   end
 end

--- a/test/commands/user/insiders_status/update_test.rb
+++ b/test/commands/user/insiders_status/update_test.rb
@@ -37,20 +37,40 @@ class User::InsidersStatus::UpdateTest < ActiveSupport::TestCase
     assert_equal :ineligible, user.reload.insiders_status
   end
 
-  test "active -> ineligible: reset theme to light" do
-    user = create :user, insiders_status: :active
-    User::InsidersStatus::DetermineEligibilityStatus.expects(:call).returns(:ineligible)
+  %w[dark system].each do |theme|
+    test "active -> ineligible: reset insider-only #{theme} theme to light theme" do
+      user = create :user, insiders_status: :active
+      User::InsidersStatus::DetermineEligibilityStatus.expects(:call).returns(:ineligible)
 
-    User::SetDiscordRoles.expects(:defer).with(user)
-    User::SetDiscourseGroups.expects(:defer).with(user)
-    User::Notification::Create.expects(:defer).never
-    User::UpdateFlair.expects(:defer).with(user)
+      User::SetDiscordRoles.expects(:defer).with(user)
+      User::SetDiscourseGroups.expects(:defer).with(user)
+      User::Notification::Create.expects(:defer).never
+      User::UpdateFlair.expects(:defer).with(user)
 
-    user.preferences.update(theme: "dark")
+      user.preferences.update(theme:)
 
-    User::InsidersStatus::Update.(user)
+      User::InsidersStatus::Update.(user)
 
-    assert_equal "light", user.preferences.reload.theme
+      assert_equal "light", user.preferences.reload.theme
+    end
+  end
+
+  %w[accessibility-dark sepia light].each do |theme|
+    test "active -> ineligible: don't reset #{theme}" do
+      user = create :user, insiders_status: :active
+      User::InsidersStatus::DetermineEligibilityStatus.expects(:call).returns(:ineligible)
+
+      User::SetDiscordRoles.expects(:defer).with(user)
+      User::SetDiscourseGroups.expects(:defer).with(user)
+      User::Notification::Create.expects(:defer).never
+      User::UpdateFlair.expects(:defer).with(user)
+
+      user.preferences.update(theme:)
+
+      User::InsidersStatus::Update.(user)
+
+      assert_equal theme, user.preferences.reload.theme
+    end
   end
 
   %i[ineligible eligible eligible_lifetime].each do |status|


### PR DESCRIPTION
- Reset theme to light when losing insiders status
- Reset insider-only theme to light theme
- Reset insider-only theme to light theme
