### PR TITLE
Re-sync exercise representation after num_loc changes

### DIFF
--- a/app/commands/solution/publish_iteration.rb
+++ b/app/commands/solution/publish_iteration.rb
@@ -10,12 +10,6 @@ class Solution::PublishIteration
     Solution::UpdatePublishedExerciseRepresentation.(solution)
     Solution::UpdateSnippet.(solution)
     Solution::UpdateNumLoc.(solution)
-
-    # Calculate the solution latest published iteration's num_loc
-    # when that has not yet been done
-    return unless latest_published_iteration && latest_published_iteration.num_loc.nil?
-
-    Iteration::CalculateLinesOfCode.defer(latest_published_iteration)
   end
 
   private
@@ -25,7 +19,4 @@ class Solution::PublishIteration
 
     solution.iterations.find_by(idx: iteration_idx)
   end
-
-  memoize
-  def latest_published_iteration = iteration || solution.latest_published_iteration
 end

--- a/app/commands/solution/publish_iteration.rb
+++ b/app/commands/solution/publish_iteration.rb
@@ -27,5 +27,5 @@ class Solution::PublishIteration
   end
 
   memoize
-  def latest_published_iteration = solution.latest_published_iteration
+  def latest_published_iteration = iteration || solution.latest_published_iteration
 end

--- a/app/commands/solution/publish_iteration.rb
+++ b/app/commands/solution/publish_iteration.rb
@@ -10,6 +10,12 @@ class Solution::PublishIteration
     Solution::UpdatePublishedExerciseRepresentation.(solution)
     Solution::UpdateSnippet.(solution)
     Solution::UpdateNumLoc.(solution)
+
+    # Calculate the solution latest published iteration's num_loc
+    # when that has not yet been done
+    return unless latest_published_iteration && latest_published_iteration.num_loc.nil?
+
+    Iteration::CalculateLinesOfCode.defer(latest_published_iteration)
   end
 
   private
@@ -20,7 +26,6 @@ class Solution::PublishIteration
     solution.iterations.find_by(idx: iteration_idx)
   end
 
-  def num_loc
-    iteration ? iteration.num_loc : solution.latest_iteration&.num_loc
-  end
+  memoize
+  def latest_published_iteration = solution.latest_published_iteration
 end

--- a/app/commands/solution/update_num_loc.rb
+++ b/app/commands/solution/update_num_loc.rb
@@ -5,9 +5,10 @@ class Solution::UpdateNumLoc
 
   def call
     if iteration && iteration.num_loc.nil?
-      Solution::UpdateNumLoc.defer(solution, prereq_jobs: [
-                                     Iteration::CalculateLinesOfCode.defer(iteration)
-                                   ])
+      Solution::UpdateNumLoc.defer(solution,
+        prereq_jobs: [
+          Iteration::CalculateLinesOfCode.defer(iteration)
+        ])
       return
     end
 

--- a/app/commands/solution/update_num_loc.rb
+++ b/app/commands/solution/update_num_loc.rb
@@ -3,9 +3,14 @@ class Solution::UpdateNumLoc
 
   initialize_with :solution
 
-  def call = solution.update!(num_loc:)
+  def call
+    return if num_loc == solution.num_loc
+
+    solution.update!(num_loc:)
+  end
 
   private
+  memoize
   def num_loc
     iteration = solution.latest_published_iteration || solution.latest_iteration
     iteration&.num_loc.to_i

--- a/app/commands/solution/update_num_loc.rb
+++ b/app/commands/solution/update_num_loc.rb
@@ -5,8 +5,9 @@ class Solution::UpdateNumLoc
 
   def call
     if iteration && iteration.num_loc.nil?
-      calc_job = Iteration::CalculateLinesOfCode.defer(iteration)
-      Solution::UpdateNumLoc.defer(prereq_jobs: [calc_job])
+      Solution::UpdateNumLoc.defer(solution, prereq_jobs: [
+                                     Iteration::CalculateLinesOfCode.defer(iteration)
+                                   ])
       return
     end
 

--- a/app/commands/solution/update_num_loc.rb
+++ b/app/commands/solution/update_num_loc.rb
@@ -7,6 +7,7 @@ class Solution::UpdateNumLoc
     return if num_loc == solution.num_loc
 
     solution.update!(num_loc:)
+    resync_representation_to_search_index!
   end
 
   private
@@ -14,5 +15,11 @@ class Solution::UpdateNumLoc
   def num_loc
     iteration = solution.latest_published_iteration || solution.latest_iteration
     iteration&.num_loc.to_i
+  end
+
+  def resync_representation_to_search_index!
+    Exercise::Representation.where(oldest_solution: solution).each do |representation|
+      Exercise::Representation::SyncToSearchIndex.defer(representation)
+    end
   end
 end

--- a/app/commands/solution/update_num_loc.rb
+++ b/app/commands/solution/update_num_loc.rb
@@ -4,6 +4,12 @@ class Solution::UpdateNumLoc
   initialize_with :solution
 
   def call
+    if iteration && iteration.num_loc.nil?
+      calc_job = Iteration::CalculateLinesOfCode.defer(iteration)
+      Solution::UpdateNumLoc.defer(prereq_jobs: [calc_job])
+      return
+    end
+
     return if num_loc == solution.num_loc
 
     solution.update!(num_loc:)
@@ -11,10 +17,13 @@ class Solution::UpdateNumLoc
   end
 
   private
-  memoize
   def num_loc
-    iteration = solution.latest_published_iteration || solution.latest_iteration
     iteration&.num_loc.to_i
+  end
+
+  memoize
+  def iteration
+    solution.latest_published_iteration || solution.latest_iteration
   end
 
   def resync_representation_to_search_index!

--- a/config/initializers/mandate.rb
+++ b/config/initializers/mandate.rb
@@ -71,17 +71,17 @@ module Mandate
     def defer(*args, wait: nil, **kwargs)
       # We need to convert the jobs to a hash before we serialize as there's no serialization
       # format for a job. We do this here to avoid cluttering the codebase with this logic.
-      if kwargs[:prereq_jobs]
-        # When we stub certain jobs, we don't want prereq_jobs to fail
-        # with nil exceptions, so in dev we strip any nil preqreqs
-        kwargs[:prereq_jobs].compact! if Rails.env.test?
+      if (prereqs = kwargs.delete(:prereq_jobs))
+        prereqs.map! do |job|
+          next unless job&.provider_job_id
 
-        kwargs[:prereq_jobs] = kwargs[:prereq_jobs].map do |job|
           {
             job_id: job.provider_job_id,
             queue_name: job.queue_name
           }
         end
+        prereqs.compact!
+        kwargs[:prereq_jobs] = prereqs if prereqs.present?
       end
 
       MandateJob.set(

--- a/config/initializers/mandate.rb
+++ b/config/initializers/mandate.rb
@@ -80,7 +80,6 @@ module Mandate
             queue_name: job.queue_name
           }
         end
-        prereqs.compact!
         kwargs[:prereq_jobs] = prereqs if prereqs.present?
       end
 

--- a/config/initializers/mandate.rb
+++ b/config/initializers/mandate.rb
@@ -73,8 +73,6 @@ module Mandate
       # format for a job. We do this here to avoid cluttering the codebase with this logic.
       if (prereqs = kwargs.delete(:prereq_jobs))
         prereqs.map! do |job|
-          next unless job&.provider_job_id
-
           {
             job_id: job.provider_job_id,
             queue_name: job.queue_name

--- a/config/initializers/mandate.rb
+++ b/config/initializers/mandate.rb
@@ -72,6 +72,10 @@ module Mandate
       # We need to convert the jobs to a hash before we serialize as there's no serialization
       # format for a job. We do this here to avoid cluttering the codebase with this logic.
       if kwargs[:prereq_jobs]
+        # When we stub certain jobs, we don't want prereq_jobs to fail
+        # with nil exceptions, so in dev we strip any nil preqreqs
+        kwargs[:prereq_jobs].compact! if Rails.env.test?
+
         kwargs[:prereq_jobs] = kwargs[:prereq_jobs].map do |job|
           {
             job_id: job.provider_job_id,

--- a/test/commands/solution/publish_iteration_test.rb
+++ b/test/commands/solution/publish_iteration_test.rb
@@ -87,4 +87,20 @@ class Solution::PublishIterationTest < ActiveSupport::TestCase
 
     Solution::Publish.(solution, user_track, nil)
   end
+
+  test "calculate lines of code for latest published iteration when not already done" do
+    track = create :track
+    exercise = create(:concept_exercise, track:)
+
+    create(:exercise_representation, exercise:)
+    solution = create(:concept_solution, :published)
+    first_iteration = create(:iteration, submission: create(:submission, solution:), idx: 1)
+    second_iteration = create(:iteration, submission: create(:submission, solution:), idx: 2)
+
+    Iteration::CalculateLinesOfCode.expects(:defer).with(second_iteration)
+    Solution::PublishIteration.(solution, nil)
+
+    Iteration::CalculateLinesOfCode.expects(:defer).with(first_iteration)
+    Solution::PublishIteration.(solution.reload, first_iteration.idx)
+  end
 end

--- a/test/commands/solution/publish_iteration_test.rb
+++ b/test/commands/solution/publish_iteration_test.rb
@@ -89,6 +89,8 @@ class Solution::PublishIterationTest < ActiveSupport::TestCase
   end
 
   test "calculate lines of code for latest published iteration when not already done" do
+    Solution::UpdateNumLoc.expects(:defer).twice
+
     track = create :track
     exercise = create(:concept_exercise, track:)
 

--- a/test/commands/solution/publish_test.rb
+++ b/test/commands/solution/publish_test.rb
@@ -121,6 +121,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards anybody_there badge" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     user = create :user
 
     # 4 hello worlds is not enough
@@ -141,6 +143,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards functional february badge when published five or more exercises in Functional February track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 2, 24)
 
     track = create :track, slug: 'fsharp'
@@ -167,6 +171,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards mechanical march badge when published five or more exercises in Mechanical March track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 3, 12)
 
     track = create :track, slug: 'rust'
@@ -193,6 +199,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards analytical april badge when published five or more exercises in an Analytical April track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 4, 12)
 
     track = create :track, slug: 'python'
@@ -219,6 +227,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards mind-shifting may badge when published five or more exercises in a Mind Shifting May track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 5, 12)
 
     track = create :track, slug: 'unison'
@@ -245,6 +255,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards summer-of-sexps badge when published five or more exercises in a Summer of Sexps track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 6, 12)
 
     track = create :track, slug: 'clojure'
@@ -271,6 +283,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards jurassic-july badge when published five or more exercises in a Jurassic July track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 7, 12)
 
     track = create :track, slug: 'fortran'
@@ -297,6 +311,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards apps august badge when published five or more exercises in an Appy August track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 8, 12)
 
     track = create :track, slug: 'kotlin'
@@ -323,6 +339,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards slimline september badge when published five or more exercises in a Slimline September track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 9, 12)
 
     track = create :track, slug: 'jq'
@@ -349,6 +367,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "awards object-oriented october badge when published five or more exercises in an Object-oriented October track" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     travel_to Time.utc(2022, 10, 12)
 
     track = create :track, slug: 'csharp'
@@ -397,6 +417,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "adds metric" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     track = create :track
     user = create :user
     exercise = create(:concept_exercise, track:)
@@ -417,6 +439,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "updates num_published_solutions" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     track = create :track
     user = create :user
     exercise = create(:concept_exercise, track:)
@@ -432,6 +456,8 @@ class Solution::PublishTest < ActiveSupport::TestCase
   end
 
   test "updates user's num_published_solutions" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     track = create :track
     user = create :user
     exercise = create(:concept_exercise, track:)

--- a/test/commands/solution/unpublish_test.rb
+++ b/test/commands/solution/unpublish_test.rb
@@ -35,6 +35,9 @@ class Solution::UnpublishTest < ActiveSupport::TestCase
   end
 
   test "updates num_published_solutions" do
+    Solution::UpdateNumLoc.any_instance.expects(:call)
+    Solution::UpdateSnippet.any_instance.expects(:call)
+
     exercise = create(:concept_exercise)
     solution = create(:concept_solution, :published, exercise:)
     create(:iteration, solution:)

--- a/test/commands/solution/update_num_loc_test.rb
+++ b/test/commands/solution/update_num_loc_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Solution::UpdateNumLocTest < ActiveSupport::TestCase
+  test "set solution num_loc to latest published iteration's num_loc when present" do
+    solution = create :concept_solution, num_loc: 0
+    published_iteration = create :iteration, solution:, num_loc: 5
+    solution.update(published_iteration:, published_at: Time.current)
+    create :iteration, solution:, num_loc: 7
+
+    Solution::UpdateNumLoc.(solution)
+
+    assert_equal published_iteration.num_loc, solution.num_loc
+  end
+
+  test "set solution num_loc to latest iteration's num_loc when no iterations are published" do
+    solution = create :concept_solution, num_loc: 0
+    create :iteration, solution:, num_loc: 5
+    last_iteration = create :iteration, solution:, num_loc: 8
+    solution.update(published_iteration: nil, published_at: nil)
+
+    Solution::UpdateNumLoc.(solution)
+
+    assert_equal last_iteration.num_loc, solution.num_loc
+  end
+
+  test "set solution num_loc to 0 when there are no active iterations" do
+    solution = create :concept_solution, num_loc: 0
+    create :iteration, :deleted, solution:, num_loc: 5
+    create :iteration, :deleted, solution:, num_loc: 8
+    solution.update(published_iteration: nil, published_at: nil)
+
+    Solution::UpdateNumLoc.(solution)
+
+    assert_equal 0, solution.num_loc
+  end
+end

--- a/test/commands/user/destroy_account_test.rb
+++ b/test/commands/user/destroy_account_test.rb
@@ -38,6 +38,8 @@ class User::DestroyAccountTest < ActiveSupport::TestCase
   end
 
   test "removes their solutions from the index" do
+    Solution::PublishIteration.any_instance.stubs(:call)
+
     create :user, :ghost
 
     user = create :user

--- a/test/commands/user_track/reset_test.rb
+++ b/test/commands/user_track/reset_test.rb
@@ -76,6 +76,8 @@ class UserTrack::ResetTest < ActiveSupport::TestCase
   end
 
   test "removes track-specification reputation" do
+    Solution::PublishIteration.stubs(:call)
+
     freeze_time do
       create :user, :ghost
 

--- a/test/integration/test_runner_flow_test.rb
+++ b/test/integration/test_runner_flow_test.rb
@@ -27,8 +27,9 @@ class TestRunnerFlowTest < ActionDispatch::IntegrationTest
 
   test "runs the tests for an iteration submission" do
     # Stub things we don't care about here
-    Iteration::GenerateSnippet.any_instance.expects(:call)
-    Iteration::CalculateLinesOfCode.any_instance.expects(:call)
+    Iteration::GenerateSnippet.any_instance.stubs(:call)
+    Solution::UpdateNumLoc.any_instance.stubs(:call)
+    Iteration::CalculateLinesOfCode.any_instance.stubs(:call)
 
     solution = create(:concept_solution)
     user_track = create :user_track, user: solution.user, track: solution.track
@@ -73,8 +74,9 @@ class TestRunnerFlowTest < ActionDispatch::IntegrationTest
 
   test "handles a new git sha being pushed: failing" do
     # Stub things we don't care about here
-    Iteration::GenerateSnippet.any_instance.expects(:call)
-    Iteration::CalculateLinesOfCode.any_instance.expects(:call)
+    Iteration::GenerateSnippet.any_instance.stubs(:call)
+    Solution::UpdateNumLoc.any_instance.stubs(:call)
+    Iteration::CalculateLinesOfCode.any_instance.stubs(:call)
 
     exercise = create :practice_exercise, git_sha: '0b04b8976650d993ecf4603cf7413f3c6b898eff'
     solution = create(:practice_solution, exercise:)
@@ -175,8 +177,9 @@ class TestRunnerFlowTest < ActionDispatch::IntegrationTest
 
   test "handles a new git sha being pushed: passing auto updates" do
     # Stub things we don't care about here
-    Iteration::GenerateSnippet.any_instance.expects(:call)
-    Iteration::CalculateLinesOfCode.any_instance.expects(:call)
+    Iteration::GenerateSnippet.any_instance.stubs(:call)
+    Solution::UpdateNumLoc.any_instance.stubs(:call)
+    Iteration::CalculateLinesOfCode.any_instance.stubs(:call)
 
     exercise = create :practice_exercise, git_sha: '0b04b8976650d993ecf4603cf7413f3c6b898eff'
     solution = create(:practice_solution, exercise:)
@@ -267,8 +270,9 @@ class TestRunnerFlowTest < ActionDispatch::IntegrationTest
 
   test "honours [no important files changed] and auto-updates" do
     # Stub things we don't care about here
-    Iteration::GenerateSnippet.any_instance.expects(:call)
-    Iteration::CalculateLinesOfCode.any_instance.expects(:call)
+    Iteration::GenerateSnippet.any_instance.stubs(:call)
+    Solution::UpdateNumLoc.any_instance.stubs(:call)
+    Iteration::CalculateLinesOfCode.any_instance.stubs(:call)
 
     # This exercise contains the right set of things to
     # go with this commit for this test.


### PR DESCRIPTION
- Add tests for updating num_loc
- No-op when num-loc hasn't changed
- Resync representation when solution num_loc changes
