### PR TITLE
Make solution group info-box appear more centered

### DIFF
--- a/app/views/tracks/community_solutions/show.html.haml
+++ b/app/views/tracks/community_solutions/show.html.haml
@@ -95,16 +95,16 @@
             = graphical_icon "stats", css_class: 'mr-16 h-[24px] w-[24px] filter-textColor2'
             About this solution
           %p.text-p-base.mb-12 We automatically group similar solutions and generate statistics about how popular they are.
-          .py-16.shadow-base.rounded-8.bg-backgroundColorA.text-center.grid.grid-cols-3.leading-150
-            .flex.flex-col
+          .py-16.px-8.shadow-base.rounded-8.bg-backgroundColorA.text-center.grid.grid-cols-3.leading-150
+            .flex.flex-col{ style: "width: 122px" }
               .text-18.font-medium.mb-8.text-textColor2= number_with_delimiter(@exercise_representation.num_published_solutions)
               .text-15= "Submission".pluralize(@exercise_representation.num_published_solutions)
 
-            .flex.flex-col
+            .flex.flex-col{ style: "width: 122px" }
               .text-18.font-medium.mb-8.text-textColor2 #{time_ago_in_words(@exercise_representation.first_submitted_at, short: true)} ago
               .text-15 First submitted
 
-            .flex.flex-col
+            .flex.flex-col{ style: "width: 122px" }
               .text-18.font-medium.text-textColor2.mb-8.flex.items-center.justify-center
                 = icon "reputation", "Reputation", css_class: "w-[16px] h-[16px] mr-6 filter-textColor2"
                 = number_with_delimiter(@exercise_representation.max_reputation)


### PR DESCRIPTION
##### Before:
<img width="500" alt="Screenshot 2023-10-26 at 10 45 38" src="https://github.com/exercism/website/assets/66035744/1a3fad0d-8aa5-49d8-b17a-053fc635b0b4">

##### After:

<img width="487" alt="Screenshot 2023-10-26 at 10 42 55" src="https://github.com/exercism/website/assets/66035744/1d3f4ef9-64e5-4b83-a8ac-6756b8d8bf1d">
