### PR TITLE
Move overlapping advert

### DIFF
--- a/app/views/tracks/_exercise_header.html.haml
+++ b/app/views/tracks/_exercise_header.html.haml
@@ -12,45 +12,43 @@
     .seperator /
     .exercise-title= exercise.title
 
-.lg-container.relative
-  .absolute{ style: 'right: var(--container-padding-x)', class: 'z-[10] top-[-55px]' }
-    = render ViewComponents::Partner::Advert.new(track:)
-
 - if solution&.out_of_date?
   .lg-container
     = render ReactComponents::Student::UpdateExerciseNotice.new(solution)
 
-.content.lg-container.container.flex.items-center.relative
-  = exercise_icon exercise, css_class: "self-start md:self-center"
-  .flex-grow.flex.flex-col.md:flex-row
-    .info
-      %h1
-        = exercise.title
-        - if solution&.completed?
-          = icon 'completed-check-circle', "Exercise is completed"
+.flex
+  .content.lg-container.container.flex.items-center.relative
+    = exercise_icon exercise, css_class: "self-start md:self-center"
+    .flex-grow.flex.flex-col.md:flex-row
+      .info
+        %h1
+          = exercise.title
+          - if solution&.completed?
+            = icon 'completed-check-circle', "Exercise is completed"
 
-      .tags.mb-16.lg:mb-0
-        = render ViewComponents::Track::ExerciseStatusTag.new(exercise, user_track)
+        .tags.mb-16.lg:mb-0
+          = render ViewComponents::Track::ExerciseStatusTag.new(exercise, user_track)
 
-        - if exercise.tutorial?
-          .c-exercise-type-tag.--tutorial Tutorial Exercise
-        - elsif exercise.concept_exercise?
-          .c-exercise-type-tag.--concept
-            = graphical_icon 'concept-exercise'
-            Learning Exercise
-        - elsif exercise.difficulty_category == :easy
-          -# TODO: Use the React component for these
-          .c-difficulty-tag.--easy
-            .icon
-            Easy
-        - elsif exercise.difficulty_category == :medium
-          .c-difficulty-tag.--medium
-            .icon
-            Medium
-        - elsif exercise.difficulty_category == :hard
-          .c-difficulty-tag.--hard
-            .icon
-            Hard
+          - if exercise.tutorial?
+            .c-exercise-type-tag.--tutorial Tutorial Exercise
+          - elsif exercise.concept_exercise?
+            .c-exercise-type-tag.--concept
+              = graphical_icon 'concept-exercise'
+              Learning Exercise
+          - elsif exercise.difficulty_category == :easy
+            -# TODO: Use the React component for these
+            .c-difficulty-tag.--easy
+              .icon
+              Easy
+          - elsif exercise.difficulty_category == :medium
+            .c-difficulty-tag.--medium
+              .icon
+              Medium
+          - elsif exercise.difficulty_category == :hard
+            .c-difficulty-tag.--hard
+              .icon
+              Hard
+    = render ViewComponents::Partner::Advert.new(track:)
 
     -#
       TODO: Cache this


### PR DESCRIPTION
https://forum.exercism.org/t/ui-advertise-hides-outdated-exercise-banner/7896

<img width="1004" alt="Screenshot 2023-10-27 at 12 39 57" src="https://github.com/exercism/website/assets/66035744/70315169-936c-4c24-8e13-75fceb4a3e75">
<img width="1004" alt="Screenshot 2023-10-27 at 12 39 42" src="https://github.com/exercism/website/assets/66035744/155c30fd-1fe8-4371-8148-c63ec7d025c9">
<img width="1121" alt="Screenshot 2023-10-27 at 12 38 25" src="https://github.com/exercism/website/assets/66035744/a6deb5a4-9a96-4210-8fdf-ea46f6d82713">
<img width="1124" alt="Screenshot 2023-10-27 at 12 38 07" src="https://github.com/exercism/website/assets/66035744/23a3be0a-0cbb-4200-b461-e7f57dde2fcf">
