### PR TITLE
Hide explore concept button on page-exercise-show

### DIFF
--- a/app/css/pages/exercise-show.css
+++ b/app/css/pages/exercise-show.css
@@ -24,6 +24,12 @@ body.namespace-.controller-tracks {
     }
 }
 
+body.namespace-tracks.controller-exercises.action-show {
+    .explore-concept-button {
+        display: none;
+    }
+}
+
 #page-exercise-show {
     & section.completed-heading {
         @apply flex items-center py-12 px-32 shadow-lg rounded-8 mb-24;

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -40,5 +40,5 @@
       #{@concept.name} is available for you to learn.
 
 
-= link_to Exercism::Routes.track_concept_path(@track, @concept), class: 'btn-xs btn-secondary mt-16' do
+= link_to Exercism::Routes.track_concept_path(@track, @concept), class: 'explore-concept-button btn-xs btn-secondary mt-16' do
   Explore concept


### PR DESCRIPTION
To make navigation easier between multiple buttons with tooltips, I decided against making tooltips interactive and instead hid the 'Explore concept' button.

<img width="660" alt="Screenshot 2023-10-31 at 14 37 36" src="https://github.com/exercism/website/assets/66035744/3f6b9108-d7a3-46b5-b861-e9ba7ebf1135">
<img width="579" alt="Screenshot 2023-10-31 at 14 37 14" src="https://github.com/exercism/website/assets/66035744/3ddb3e48-3d0e-42b4-a9ec-bf2560b3cf84">
