### PR TITLE
Add padding-top to CLI walkthrough page

### DIFF
--- a/app/views/pages/cli_walkthrough.html.haml
+++ b/app/views/pages/cli_walkthrough.html.haml
@@ -1,4 +1,4 @@
-#page-cli-walkthrough
+#page-cli-walkthrough.pt-32
   .lg-container
     = render ReactComponents::Common::CLIWalkthrough.new(current_user)
 


### PR DESCRIPTION
##### This is unaffected:
<img width="1175" alt="Screenshot 2023-10-31 at 16 02 34" src="https://github.com/exercism/website/assets/66035744/da46de7e-7b39-4847-a00f-040df18b6d61">

---

<img width="1506" alt="Screenshot 2023-10-31 at 15 58 42" src="https://github.com/exercism/website/assets/66035744/7f30c5fd-1b5d-47b2-bbf1-d26c6bf480d8">
