### PR TITLE
Update tags when head tests status changes

### DIFF
--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -59,7 +59,7 @@ class Solution::QueueHeadTestRun
     return unless latest_published_submission
 
     # If we don't have a test runner then we shouldn't run anything so get out of here
-    return solution.update_published_iteration_head_tests_status!(:not_queued) unless exercise.has_test_runner?
+    return Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :not_queued) unless exercise.has_test_runner?
 
     return unless should_run_published?
 
@@ -71,7 +71,7 @@ class Solution::QueueHeadTestRun
     begin
       process_submission!(latest_published_submission)
     rescue Rugged::TreeError
-      solution.update_published_iteration_head_tests_status!(:exceptioned)
+      Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :exceptioned)
     end
   end
 
@@ -85,7 +85,7 @@ class Solution::QueueHeadTestRun
     if latest_published_submission.tests_queued? &&
        latest_published_submission.git_important_files_hash == exercise.git_important_files_hash
 
-      solution.update_published_iteration_head_tests_status!(:queued)
+      Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :queued)
       return false
     end
 

--- a/app/commands/solution/queue_head_test_run.rb
+++ b/app/commands/solution/queue_head_test_run.rb
@@ -20,14 +20,14 @@ class Solution::QueueHeadTestRun
     return unless latest_submission
 
     # If we don't have a test runner then we shouldn't run anything so get out of here
-    return solution.update_latest_iteration_head_tests_status!(:not_queued) unless exercise.has_test_runner?
+    return Solution::UpdateLatestIterationHeadTestsStatus.(solution, :not_queued) unless exercise.has_test_runner?
 
     return unless should_run_latest?
 
     begin
       process_submission!(latest_submission)
     rescue Rugged::TreeError
-      solution.update_latest_iteration_head_tests_status!(:exceptioned)
+      Solution::UpdateLatestIterationHeadTestsStatus.(solution, :exceptioned)
     end
   end
 
@@ -41,7 +41,7 @@ class Solution::QueueHeadTestRun
     if latest_submission.tests_queued? &&
        latest_submission.git_important_files_hash == exercise.git_important_files_hash
 
-      solution.update_latest_iteration_head_tests_status!(:queued)
+      Solution::UpdateLatestIterationHeadTestsStatus.(solution, :queued)
       return false
     end
 

--- a/app/commands/solution/sync_latest_iteration_head_tests_status.rb
+++ b/app/commands/solution/sync_latest_iteration_head_tests_status.rb
@@ -20,7 +20,7 @@ class Solution::SyncLatestIterationHeadTestsStatus
 
     # Always call this as it also updates the git_sha
     # and git_important_files_hash
-    solution.update_latest_iteration_head_tests_status!(status)
+    Solution::UpdateLatestIterationHeadTestsStatus.(solution, status)
 
     Solution::AutoUpdateToLatestExerciseVersion.(solution)
 

--- a/app/commands/solution/sync_published_iteration_head_tests_status.rb
+++ b/app/commands/solution/sync_published_iteration_head_tests_status.rb
@@ -20,7 +20,7 @@ class Solution::SyncPublishedIterationHeadTestsStatus
 
     return true if solution.published_iteration_head_tests_status == status
 
-    solution.update_published_iteration_head_tests_status!(status)
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, status)
 
     true
   end

--- a/app/commands/solution/sync_to_search_index.rb
+++ b/app/commands/solution/sync_to_search_index.rb
@@ -6,6 +6,8 @@ class Solution::SyncToSearchIndex
   initialize_with :solution
 
   def call
+    Solution::CreateSearchIndexDocument.(solution)
+
     if solution.user.ghost?
       delete_document!
     else

--- a/app/commands/solution/update_latest_iteration_head_tests_status.rb
+++ b/app/commands/solution/update_latest_iteration_head_tests_status.rb
@@ -1,0 +1,12 @@
+class Solution::UpdateLatestIterationHeadTestsStatus
+  include Mandate
+
+  initialize_with :solution, :status
+
+  def call
+    return if solution.latest_iteration_head_tests_status == status.to_sym
+
+    solution.update_column(:latest_iteration_head_tests_status, status)
+    Solution::SyncToSearchIndex.defer(solution)
+  end
+end

--- a/app/commands/solution/update_published_iteration_head_tests_status.rb
+++ b/app/commands/solution/update_published_iteration_head_tests_status.rb
@@ -7,6 +7,8 @@ class Solution::UpdatePublishedIterationHeadTestsStatus
     return if solution.published_iteration_head_tests_status == status.to_sym
 
     solution.update_column(:published_iteration_head_tests_status, status)
+
     Solution::SyncToSearchIndex.defer(solution)
+    Solution::UpdateTags.defer(solution)
   end
 end

--- a/app/commands/solution/update_published_iteration_head_tests_status.rb
+++ b/app/commands/solution/update_published_iteration_head_tests_status.rb
@@ -1,0 +1,12 @@
+class Solution::UpdatePublishedIterationHeadTestsStatus
+  include Mandate
+
+  initialize_with :solution, :status
+
+  def call
+    return if solution.published_iteration_head_tests_status == status.to_sym
+
+    solution.update_column(:published_iteration_head_tests_status, status)
+    Solution::SyncToSearchIndex.defer(solution)
+  end
+end

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -30,7 +30,7 @@ class Submission::TestRun::Init
     submission.tests_queued!
 
     if submission == solution.latest_iteration_submission
-      solution.update_latest_iteration_head_tests_status!(:queued)
+      Solution::UpdateLatestIterationHeadTestsStatus.(solution, :queued)
     end
 
     if submission == solution.latest_published_iteration_submission

--- a/app/commands/submission/test_run/init.rb
+++ b/app/commands/submission/test_run/init.rb
@@ -34,7 +34,7 @@ class Submission::TestRun::Init
     end
 
     if submission == solution.latest_published_iteration_submission
-      solution.update_published_iteration_head_tests_status!(:queued)
+      Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :queued)
     end
   end
   # rubocop:enable Style/GuardClause

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -102,13 +102,6 @@ class Solution < ApplicationRecord
 
   delegate :instructions, :introduction, :hints, :test_files, :source, :source_url, to: :git_exercise
 
-  def update_published_iteration_head_tests_status!(status)
-    return if published_iteration_head_tests_status == status.to_sym
-
-    update_column(:published_iteration_head_tests_status, status)
-    Solution::SyncToSearchIndex.defer(self)
-  end
-
   def update_latest_iteration_head_tests_status!(status)
     return if latest_iteration_head_tests_status == status.to_sym
 

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -102,13 +102,6 @@ class Solution < ApplicationRecord
 
   delegate :instructions, :introduction, :hints, :test_files, :source, :source_url, to: :git_exercise
 
-  def update_latest_iteration_head_tests_status!(status)
-    return if latest_iteration_head_tests_status == status.to_sym
-
-    update_column(:latest_iteration_head_tests_status, status)
-    Solution::SyncToSearchIndex.defer(self)
-  end
-
   memoize
   def latest_published_iteration = published_iterations.last
 

--- a/test/commands/solution/update_latest_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/update_latest_iteration_head_tests_status_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Solution::UpdateLatestIterationHeadTestsStatusTest < ActiveSupport::TestCase
+  test "updates latest iteration head tests status when status is different" do
+    new_status = :passed
+    solution = create(:practice_solution, latest_iteration_head_tests_status: :queued)
+
+    Solution::UpdateLatestIterationHeadTestsStatus.(solution, new_status)
+
+    assert_equal new_status, solution.latest_iteration_head_tests_status
+  end
+
+  test "sync to search index when status is different" do
+    solution = create :practice_solution, latest_iteration_head_tests_status: :queued
+
+    Solution::SyncToSearchIndex.expects(:defer).with(solution).once
+
+    Solution::UpdateLatestIterationHeadTestsStatus.(solution, :passed)
+  end
+
+  test "does not update solution when status is the same" do
+    updated_at = Time.current - 1.week
+    solution = create(:practice_solution, updated_at:)
+
+    Solution::UpdateLatestIterationHeadTestsStatus.(solution, solution.latest_iteration_head_tests_status)
+
+    assert_equal updated_at, solution.updated_at
+  end
+
+  test "does not sync to search index when status is the same" do
+    solution = create :practice_solution
+
+    Solution::SyncToSearchIndex.expects(:defer).never
+
+    Solution::UpdateLatestIterationHeadTestsStatus.(solution, solution.latest_iteration_head_tests_status)
+  end
+end

--- a/test/commands/solution/update_published_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/update_published_iteration_head_tests_status_test.rb
@@ -18,6 +18,14 @@ class Solution::UpdatePublishedIterationHeadTestsStatusTest < ActiveSupport::Tes
     Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :passed)
   end
 
+  test "updates solution tags when status is different" do
+    solution = create :practice_solution, published_iteration_head_tests_status: :queued
+
+    Solution::UpdateTags.expects(:defer).with(solution).once
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :passed)
+  end
+
   test "does not update solution when status is the same" do
     updated_at = Time.current - 1.week
     solution = create(:practice_solution, updated_at:)
@@ -31,6 +39,14 @@ class Solution::UpdatePublishedIterationHeadTestsStatusTest < ActiveSupport::Tes
     solution = create :practice_solution
 
     Solution::SyncToSearchIndex.expects(:defer).never
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, solution.published_iteration_head_tests_status)
+  end
+
+  test "does not update solution tags when status is the same" do
+    solution = create :practice_solution
+
+    Solution::UpdateTags.expects(:defer).never
 
     Solution::UpdatePublishedIterationHeadTestsStatus.(solution, solution.published_iteration_head_tests_status)
   end

--- a/test/commands/solution/update_published_iteration_head_tests_status_test.rb
+++ b/test/commands/solution/update_published_iteration_head_tests_status_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Solution::UpdatePublishedIterationHeadTestsStatusTest < ActiveSupport::TestCase
+  test "updates published iteration head tests status when status is different" do
+    new_status = :passed
+    solution = create(:practice_solution, published_iteration_head_tests_status: :queued)
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, new_status)
+
+    assert_equal new_status, solution.published_iteration_head_tests_status
+  end
+
+  test "sync to search index when status is different" do
+    solution = create :practice_solution, published_iteration_head_tests_status: :queued
+
+    Solution::SyncToSearchIndex.expects(:defer).with(solution).once
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, :passed)
+  end
+
+  test "does not update solution when status is the same" do
+    updated_at = Time.current - 1.week
+    solution = create(:practice_solution, updated_at:)
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, solution.published_iteration_head_tests_status)
+
+    assert_equal updated_at, solution.updated_at
+  end
+
+  test "does not sync to search index when status is the same" do
+    solution = create :practice_solution
+
+    Solution::SyncToSearchIndex.expects(:defer).never
+
+    Solution::UpdatePublishedIterationHeadTestsStatus.(solution, solution.published_iteration_head_tests_status)
+  end
+end

--- a/test/system/components/journey/solutions_test.rb
+++ b/test/system/components/journey/solutions_test.rb
@@ -222,10 +222,12 @@ module Components
         solution_1.update!(published_iteration: create(:iteration, solution: solution_1, submission: submission_1))
         solution_2.update!(published_iteration: create(:iteration, solution: solution_2, submission: submission_2))
 
-        perform_enqueued_jobs
+        perform_enqueued_jobs_until_empty
         submission_1.reload.update_column(:tests_status, :failed)
         submission_2.reload.update_column(:tests_status, :passed)
-        perform_enqueued_jobs
+
+        Solution::SyncToSearchIndex.(solution_1)
+        Solution::SyncToSearchIndex.(solution_2)
         wait_for_opensearch_to_be_synced
 
         use_capybara_host do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -317,6 +317,15 @@ class ActiveSupport::TestCase
     end
   end
 
+  def perform_enqueued_jobs_until_empty
+    loop do
+      perform_enqueued_jobs
+      break if queue_adapter.enqueued_jobs.size.zero?
+    end
+
+    assert_no_enqueued_jobs
+  end
+
   def stub_latest_track_forum_threads(track)
     stub_request(:get, "https://forum.exercism.org/c/programming/#{track.slug}/l/latest.json")
   end


### PR DESCRIPTION
- Extract update_published_iteration_head_tests_status! from Solution to command
- Extract update_latest_iteration_head_tests_status! from Solution to command
- Use Solution::UpdatePublishedIterationHeadTestsStatus command instead of method
- Use Solution::UpdateLatestIterationHeadTestsStatus command instead of method
- Update tags when updating published_iteration_head_tests_status
