### PR TITLE
Reshape the track page slightly

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -39,6 +39,7 @@ class TracksController < ApplicationController
     @recent_solutions = UserTrack::RetrieveRecentlyActiveSolutions.(@user_track)
     @updates = SiteUpdate.published.for_track(@track).sorted.limit(10).includes(:author)
     @forum_threads = Forum::RetrieveThreads.(track: @track, count: 3)
+    @docs = Document.where(track_id: @track.id)
   end
 
   def join

--- a/app/css/pages/track-show.css
+++ b/app/css/pages/track-show.css
@@ -393,9 +393,8 @@
             }
         }
 
-        & section.weekly-count {
+        .weekly-count {
             @apply flex items-center;
-            @apply mb-24;
 
             & .text {
                 @apply flex-grow;
@@ -404,12 +403,12 @@
                     @apply text-32 leading-150 font-medium;
                 }
                 & h3 {
-                    @apply text-16 leading-150 text-textColor2;
+                    @apply text-16 leading-150 text-textColor2 mb-0;
                 }
             }
 
-            & .c-react-wrapper-progress-graph {
-                @apply ml-48 flex-shrink-0;
+            & .c-react-wrapper-common-progress-graph {
+                @apply ml-32 flex-shrink-0 w-[145px];
             }
 
             & .graph,
@@ -428,7 +427,7 @@
 
         & section.learning-pattern,
         & .stats-box {
-            @apply border-1 border-borderColor6 bg-backgroundColorA rounded-8;
+            @apply bg-backgroundColorA rounded-8;
         }
         & section.learning-pattern {
             @apply py-12 px-24 mb-40;

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,41 +2,41 @@ class ApplicationJob < ActiveJob::Base
   # For some errors we want to put the job back on the queue by raising and
   # letting Sidekiq handle things, but don't want to raise the exceptions
   # to bugsnag. This block handles that.
-  # skip_bugnag_and_raise = lambda do |exception|
-  #   exception.define_singleton_method(:skip_bugsnag) { true }
-  #   raise exception
-  # end
+  skip_bugnag_and_raise = lambda do |exception|
+    exception.define_singleton_method(:skip_bugsnag) { true }
+    raise exception
+  end
 
-  # rescue_from ActiveRecord::Deadlocked, &skip_bugnag_and_raise
-  # rescue_from ActiveJob::DeserializationError do |exception|
-  #   # We expect this to be a record not found. If it's not
-  #   # then get out of here and go via Bugsnag!
-  #   raise exception unless exception.cause.is_a?(ActiveRecord::RecordNotFound)
+  rescue_from ActiveRecord::Deadlocked, &skip_bugnag_and_raise
+  rescue_from ActiveJob::DeserializationError do |exception|
+    # We expect this to be a record not found. If it's not
+    # then get out of here and go via Bugsnag!
+    raise exception unless exception.cause.is_a?(ActiveRecord::RecordNotFound)
 
-  #   # Let any transactions finish then look up again
-  #   # If the thing is now found, requeue the job.
-  #   # Or if it's still missing, just kill the job. This happens if
-  #   # the record is deleted in the time it takes to execute the job
-  #   # (e.g. a User's records being deleted)
+    # Let any transactions finish then look up again
+    # If the thing is now found, requeue the job.
+    # Or if it's still missing, just kill the job. This happens if
+    # the record is deleted in the time it takes to execute the job
+    # (e.g. a User's records being deleted)
 
-  #   # Sleep for a total of 5 seconds (20*0.25). This is rare enough
-  #   # that we don't mind locking the jobs for this duration.
-  #   # It's worse to drop jobs by accident.
-  #   20.times do
-  #     sleep(0.25)
+    # Sleep for a total of 5 seconds (20*0.25). This is rare enough
+    # that we don't mind locking the jobs for this duration.
+    # It's worse to drop jobs by accident.
+    20.times do
+      sleep(0.25)
 
-  #     begin
-  #       exception.cause.model.constantize.find(exception.cause.id)
-  #       retry_job
-  #       break
-  #     rescue NoMethodError, ActiveRecord::RecordNotFound
-  #       # Continue to loop
-  #     end
-  #   end
+      begin
+        exception.cause.model.constantize.find(exception.cause.id)
+        retry_job
+        break
+      rescue NoMethodError, ActiveRecord::RecordNotFound
+        # Continue to loop
+      end
+    end
 
-  #   # If we get to this point, the model has gone
-  #   # so just exit the job which removes it from sidekiq
-  # end
+    # If we get to this point, the model has gone
+    # so just exit the job which removes it from sidekiq
+  end
 
   include Bullet::ActiveJob if Rails.env.development?
 end

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -4,6 +4,6 @@
 #page-track-show
   = render ViewComponents::Track::Header.new(@track, :overview)
 
-  = render "tracks/show/summary_article", track: @track, user_track: @user_track, exercise_statuses: @exercise_statuses, recent_solutions: @recent_solutions, sample_learnt_concepts: @sample_learnt_concepts, sample_mastered_concepts: @sample_mastered_concepts, last_8_weeks_counts: @last_8_weeks_counts, forum_threads: @forum_threads
+  = render "tracks/show/summary_article", track: @track, user_track: @user_track, exercise_statuses: @exercise_statuses, recent_solutions: @recent_solutions, sample_learnt_concepts: @sample_learnt_concepts, sample_mastered_concepts: @sample_mastered_concepts, last_8_weeks_counts: @last_8_weeks_counts, forum_threads: @forum_threads, docs: @docs
   = render "tracks/show/mentoring_article", track: @track, user_track: @user_track
   = render "tracks/show/updates_article", track: @track, updates: @updates

--- a/app/views/tracks/show/_summary_article.html.haml
+++ b/app/views/tracks/show/_summary_article.html.haml
@@ -73,6 +73,7 @@
         - if user_track.num_completed_exercises.zero? && user_track.num_locked_exercises.positive?
           - boxes << render("tracks/show/stats_box_locked_exercises", track:, user_track:)
 
+      - boxes = boxes.first(2)
       .grid.gap-24{ class: "grid-cols-#{boxes.size}" }
         - boxes.each do |box|
           = raw box

--- a/app/views/tracks/show/_summary_article.html.haml
+++ b/app/views/tracks/show/_summary_article.html.haml
@@ -73,7 +73,7 @@
         - if user_track.num_completed_exercises.zero? && user_track.num_locked_exercises.positive?
           - boxes << render("tracks/show/stats_box_locked_exercises", track:, user_track:)
 
-      - boxes = boxes.first(2)
+      - boxes = boxes.first(3)
       .grid.gap-24{ class: "grid-cols-#{boxes.size}" }
         - boxes.each do |box|
           = raw box

--- a/app/views/tracks/show/_summary_article.html.haml
+++ b/app/views/tracks/show/_summary_article.html.haml
@@ -48,6 +48,35 @@
             .status Total Exercises
             .count= user_track.num_exercises
 
+
+        - boxes = []
+
+        - if user_track.num_completed_exercises.positive?
+          - boxes << render("tracks/show/stats_box_completed_exercises", track:, user_track:)
+
+        - if track.course? && !user_track.practice_mode?
+          - if user_track.num_concepts_learnt.positive?
+            - boxes << render("tracks/show/stats_box_learnt_concepts", track:, user_track:)
+          - else
+            - boxes << render("tracks/show/stats_box_available_exercises", track:, user_track:)
+
+          - if user_track.num_concepts_mastered.positive?
+            - boxes << render("tracks/show/stats_box_mastered_concepts", track:, user_track:)
+
+        - else
+          - if user_track.num_in_progress_exercises.positive?
+            - boxes << render("tracks/show/stats_box_in_progress_exercises", track:, user_track:)
+
+          - if user_track.num_available_exercises.positive?
+            - boxes << render("tracks/show/stats_box_available_exercises", track:, user_track:)
+
+        - if user_track.num_completed_exercises.zero? && user_track.num_locked_exercises.positive?
+          - boxes << render("tracks/show/stats_box_locked_exercises", track:, user_track:)
+
+      .grid.gap-24{ class: "grid-cols-#{boxes.size}" }
+        - boxes.each do |box|
+          = raw box
+
       %section#trophy-cabinet.trophy-cabinet
         %h2.text-h4.mb-2.text-center
           #{track.title} Trophy Cabinet
@@ -57,59 +86,48 @@
 
         = render ReactComponents::Track::Trophies.new(track, user_track.user)
 
-    .rhs
-      - if last_8_weeks_counts.any?(&:positive?)
-        %section.weekly-count
-          .text
-            .count= (last_8_weeks_counts.sum / 8.0).round(1)
-            %h3 Avg. exercises completed per week (last 8 weeks)
-
-          = ReactComponents::Common::ProgressGraph.new(last_8_weeks_counts, 70, 145)
-
-      - if user_track.num_completed_exercises.positive?
-        = render "tracks/show/stats_box_completed_exercises", track:, user_track:
-
-      - if track.course? && !user_track.practice_mode?
-        - if user_track.num_concepts_learnt.positive?
-          = render "tracks/show/stats_box_learnt_concepts", track:, user_track:
-        - else
-          = render "tracks/show/stats_box_available_exercises", track:, user_track:
-
-        - if user_track.num_concepts_mastered.positive?
-          = render "tracks/show/stats_box_mastered_concepts", track:, user_track:
-
-      - else
-        - if user_track.num_in_progress_exercises.positive?
-          = render "tracks/show/stats_box_in_progress_exercises", track:, user_track:
-
-        - if user_track.num_available_exercises.positive?
-          = render "tracks/show/stats_box_available_exercises", track:, user_track:
-
-      - if user_track.num_completed_exercises.zero? && user_track.num_locked_exercises.positive?
-        = render "tracks/show/stats_box_locked_exercises", track:, user_track:
-
-      - if forum_threads.present?
-        %h3.text-h4.mt-32.mb-12 From the Forum…
-        .flex.flex-col.gap-8.mb-20
-          - forum_threads.each do |thread|
-            = link_to thread.url, class: 'flex items-start bg-backgroundColorA px-16 py-12 shadow-base hover:shadow-smZ1 rounded-5 mb-8' do
-              = image_tag thread.poster_avatar_url, alt: "", class: 'mr-8 h-[32px] w-[32px] rounded-circle'
-              .flex.flex-col.mr-auto
-                %h5.text-h6= thread.title
-                .text-textColor6.leading-150
-                  Latest by #{thread.poster_username}
-
+    .rhs.flex.flex-col.gap-32
       - if track.intro_video_youtube_slug
-        .mt-32.mb-32
+        %section
           %h3.text-h4.mb-4 A Brief Introduction to #{track.title}
-          %p.text-p-base.mb-12 We've put together an introductory video to #{track.title}. We outline the main features of #{track.title} and solve an exercise using it. Enjoy!
+          %p.text-p-base.mb-12 Dig into #{track.title} with Erik as he explores its main features and solves an interesting exercise.
 
           %div{ class: 'w-[100%] max-w-[500px]' }
             .c-youtube-container
               %iframe{ width: "560", height: "315", src: "https://www.youtube-nocookie.com/embed/#{track.intro_video_youtube_slug}", title: "YouTube video player", frameborder: "0", allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture", allowfullscreen: true }
 
-      = render ViewComponents::ProminentLink.new("Explore the #{track.title} Forum", "https://forum.exercism.org/c/programming/#{track.slug}", with_bg: true, external: true, css_class: 'mb-12')
-      = render ViewComponents::ProminentLink.new("View #{track.title} Documentation", track_docs_path(track), with_bg: true, external: true)
+      - if forum_threads.present?
+        %section
+          %h3.text-h4.mb-12 From the Forum…
+          .flex.flex-col.gap-8.mb-20
+            - forum_threads.each do |thread|
+              = link_to thread.url, class: 'flex items-start bg-backgroundColorA px-16 py-12 shadow-base hover:shadow-smZ1 rounded-5 mb-8' do
+                = image_tag thread.poster_avatar_url, alt: "", class: 'mr-8 h-[32px] w-[32px] rounded-circle'
+                .flex.flex-col.mr-auto
+                  %h5.text-h6= thread.title
+                  .text-textColor6.leading-150
+                    Latest by #{thread.poster_username}
+          = render ViewComponents::ProminentLink.new("Explore the #{track.title} Forum", "https://forum.exercism.org/c/programming/#{track.slug}", with_bg: true, external: true, css_class: 'mb-12')
+
+      - if docs.present?
+        %section
+          %h3.text-h4.mb-6 Stuck? Explore our docs…
+          %ul.text-p-base.list-disc.ml-20
+            - docs.each do |doc|
+              %li.mb-2= link_to doc.nav_title, track_doc_path(doc.track, doc)
+
+      - if last_8_weeks_counts.any?(&:positive?)
+        %section
+          %h3.text-h4.mb-4 Your momentum
+          %p.text-p-base.mb-12 Consistency is the key to progress. Set yourself a realistic target to try and aim for each week, then track your last 8 weeks here.
+          .stats-box
+            .weekly-count
+              .text
+                .count= (last_8_weeks_counts.sum / 8.0).round(1)
+                %h3 Avg. exercises completed per week
+
+              = ReactComponents::Common::ProgressGraph.new(last_8_weeks_counts, 70, 145)
+
 
 
 

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -25,7 +25,6 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "deadlock raises but skips bugsnag" do
-    skip
     exception = assert_raises ActiveRecord::Deadlocked do
       TestDeadlockedJob.perform_now
     end
@@ -34,7 +33,6 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization raises for non-active-record exception" do
-    skip
     exception = assert_raises ActiveJob::DeserializationError do
       TestDeserializationJob.perform_now
     end
@@ -46,7 +44,6 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization drops the job with a missing model" do
-    skip
     # Don't sleep when testing things else we'll be here all day!
     Mocha::Configuration.override(stubbing_non_public_method: :allow) do
       ApplicationJob.any_instance.stubs(:sleep)
@@ -62,7 +59,6 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization drops silently if record is gone" do
-    skip
     # Don't sleep when testing things else we'll be here all day!
     Mocha::Configuration.override(stubbing_non_public_method: :allow) do
       ApplicationJob.any_instance.stubs(:sleep)
@@ -80,7 +76,6 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization retries then runs if model appears successfully" do
-    skip
     user = create :user
     user.destroy
 

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -25,6 +25,7 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "deadlock raises but skips bugsnag" do
+    skip
     exception = assert_raises ActiveRecord::Deadlocked do
       TestDeadlockedJob.perform_now
     end
@@ -33,6 +34,7 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization raises for non-active-record exception" do
+    skip
     exception = assert_raises ActiveJob::DeserializationError do
       TestDeserializationJob.perform_now
     end
@@ -44,6 +46,7 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization drops the job with a missing model" do
+    skip
     # Don't sleep when testing things else we'll be here all day!
     Mocha::Configuration.override(stubbing_non_public_method: :allow) do
       ApplicationJob.any_instance.stubs(:sleep)
@@ -59,6 +62,7 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization drops silently if record is gone" do
+    skip
     # Don't sleep when testing things else we'll be here all day!
     Mocha::Configuration.override(stubbing_non_public_method: :allow) do
       ApplicationJob.any_instance.stubs(:sleep)
@@ -76,6 +80,7 @@ class ApplicationJobTest < ActiveJob::TestCase
   end
 
   test "Deserialization retries then runs if model appears successfully" do
+    skip
     user = create :user
     user.destroy
 


### PR DESCRIPTION
Updates the Track page to include a bit more information on the RHS. The Brief Intro video takes more pride of place, the docs are more fully listed, and the momentum is moved to the bottom. The forum posts will also remain there (I just don't have them on my local machine to show). The links to exercises completed and exercise available move to the LHS.


<img width="1431" alt="Screenshot 2023-11-03 at 14 16 34" src="https://github.com/exercism/website/assets/286476/b5d3ae7d-7391-4edf-a7a4-484dc10f14c3">
