### PR TITLE
Add racket to languageCompartment.ts

### DIFF
--- a/app/javascript/components/misc/CodeMirror/languageCompartment.ts
+++ b/app/javascript/components/misc/CodeMirror/languageCompartment.ts
@@ -208,6 +208,7 @@ export const loadLanguageCompartment = async (
       const { scala } = await import('@codemirror/legacy-modes/mode/clike')
       return compartment.of(StreamLanguage.define(scala))
     }
+    case 'racket':
     case 'scheme': {
       const { scheme } = await import('@codemirror/legacy-modes/mode/scheme')
       return compartment.of(StreamLanguage.define(scheme))


### PR DESCRIPTION
The Racket track uses the Scheme highlighting from highlight.js so it makes sense to also use the Scheme mode here. 