### PR TITLE
Set fixed height on feedback glimpse

### DIFF
--- a/app/css/components/mentor/representer-row.css
+++ b/app/css/components/mentor/representer-row.css
@@ -73,6 +73,7 @@
         }
 
         & .--feedback-glimpse {
+            @apply flex items-center h-48;
             @apply text-right mr-60 leading-150 text-textColor6;
             @apply truncate;
             width: 300px;

--- a/app/javascript/components/mentoring/automation/AutomationListElement.tsx
+++ b/app/javascript/components/mentoring/automation/AutomationListElement.tsx
@@ -75,34 +75,34 @@ export const AutomationListElement = ({
         </div>
       </div>
       {isAdminTab && (
-        <>
-          <div className="flex w-[100px] gap-8">
-            {representation.feedbackAuthor?.handle && (
-              <>
-                <GraphicalIcon
-                  height={14}
-                  width={14}
-                  icon="authoring"
-                  className="filter-textColor6"
-                />
-                <span>{representation.feedbackAuthor?.handle}</span>
-              </>
-            )}
-          </div>
-          <div className="flex w-[100px] gap-8 mr-60">
-            {representation.feedbackEditor?.handle && (
-              <>
-                <GraphicalIcon
-                  height={14}
-                  width={14}
-                  icon="edit"
-                  className="filter-textColor6"
-                />
-                <span>{representation.feedbackEditor?.handle}</span>
-              </>
-            )}
-          </div>
-        </>
+        <div className="flex flex-col gap-8 mr-60 w-[160px] text-left">
+          {representation.feedbackAuthor?.handle && (
+            <div className="flex gap-8 leading-150">
+              <GraphicalIcon
+                height={14}
+                width={14}
+                icon="authoring"
+                className="filter-textColor6"
+              />
+              <span className="truncate">
+                {representation.feedbackAuthor?.handle}
+              </span>
+            </div>
+          )}
+          {representation.feedbackEditor?.handle && (
+            <div className="flex gap-8 leading-150">
+              <GraphicalIcon
+                height={14}
+                width={14}
+                icon="edit"
+                className="filter-textColor6"
+              />
+              <span className="truncate">
+                {representation.feedbackEditor?.handle}
+              </span>
+            </div>
+          )}
+        </div>
       )}
       <div
         className="--feedback-glimpse"

--- a/app/javascript/components/mentoring/automation/AutomationListElement.tsx
+++ b/app/javascript/components/mentoring/automation/AutomationListElement.tsx
@@ -84,7 +84,10 @@ export const AutomationListElement = ({
                 icon="authoring"
                 className="filter-textColor6"
               />
-              <span className="truncate">
+              <span
+                title={representation.feedbackAuthor?.handle}
+                className="truncate"
+              >
                 {representation.feedbackAuthor?.handle}
               </span>
             </div>
@@ -97,7 +100,10 @@ export const AutomationListElement = ({
                 icon="edit"
                 className="filter-textColor6"
               />
-              <span className="truncate">
+              <span
+                title={representation.feedbackEditor?.handle}
+                className="truncate"
+              >
                 {representation.feedbackEditor?.handle}
               </span>
             </div>

--- a/app/javascript/components/mentoring/automation/AutomationListElement.tsx
+++ b/app/javascript/components/mentoring/automation/AutomationListElement.tsx
@@ -107,7 +107,7 @@ export const AutomationListElement = ({
       <div
         className="--feedback-glimpse"
         dangerouslySetInnerHTML={{ __html: representation.feedbackHtml }}
-      ></div>
+      />
       {!isAdminTab && (
         <div className="--occurencies">{ELEMENT_LABELS['counterElement']}</div>
       )}


### PR DESCRIPTION
##### turns this:
<img width="1506" alt="Screenshot 2023-11-10 at 9 44 08" src="https://github.com/exercism/website/assets/66035744/9d005b42-f39f-41d2-a466-d566997d0806">

##### into this:

<img width="1506" alt="Screenshot 2023-11-10 at 9 43 18" src="https://github.com/exercism/website/assets/66035744/5cef0680-2c98-4f22-b692-6a8bc0ed2c41">


#### Fix alignment of editor and author:

<img width="1506" alt="Screenshot 2023-11-10 at 10 18 20" src="https://github.com/exercism/website/assets/66035744/10019023-9a0a-47a6-936a-1fbaa12c013c">

#### Show handle as title on hover:
<img width="1506" alt="Screenshot 2023-11-10 at 10 21 50" src="https://github.com/exercism/website/assets/66035744/b42ef3e9-c906-4f3b-8713-e0c63054b37e">


