### PR TITLE
Disable refetchOnMount for paginated query results

### DIFF
--- a/app/helpers/react_components/mentoring/queue.rb
+++ b/app/helpers/react_components/mentoring/queue.rb
@@ -42,9 +42,7 @@ module ReactComponents
           options: {
             initial_data: {
               tracks: tracks_data
-            },
-            stale_time: 0,
-            cache_time: 0
+            }
           }
         }
       end
@@ -74,9 +72,7 @@ module ReactComponents
           endpoint: Exercism::Routes.api_mentoring_requests_path,
           query:,
           options: {
-            initial_data: AssembleMentorRequests.(mentor, query),
-            stale_time: 0,
-            cache_time: 0
+            initial_data: AssembleMentorRequests.(mentor, query)
           }
         }
       end

--- a/app/helpers/react_components/student/tracks_list.rb
+++ b/app/helpers/react_components/student/tracks_list.rb
@@ -21,7 +21,7 @@ module ReactComponents
         {
           endpoint: Exercism::Routes.api_tracks_path,
           options: {
-            initialData: {
+            initial_data: {
               tracks: SerializeTracks.(tracks, user)
             }
           },

--- a/app/javascript/components/mentoring/queue/useExerciseList.tsx
+++ b/app/javascript/components/mentoring/queue/useExerciseList.tsx
@@ -23,8 +23,6 @@ export const useExerciseList = ({
       endpoint: track?.links.exercises,
       options: {
         enabled: !!track,
-        staleTime: 0,
-        cacheTime: 0,
         initialData: track?.exercises ? track.exercises : undefined,
       },
     }

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -43,12 +43,8 @@ export default ({
     isFetching,
   } = usePaginatedRequestQuery<APIResponse>(CACHE_KEY, {
     ...request,
-    options: { ...request.options, staleTime },
+    options: { ...request.options, refetchOnMount: false },
   })
-
-  useEffect(() => {
-    setTimeout(() => setStaleTime(0), 1000)
-  }, [])
 
   const setTags = useCallback(
     (tags) => {

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -29,6 +29,7 @@ export default ({
   tagOptions: readonly TagOption[]
   request: Request
 }): JSX.Element => {
+  const [staleTime, setStaleTime] = useState(1000)
   const {
     request,
     setCriteria: setRequestCriteria,
@@ -40,7 +41,14 @@ export default ({
     data: resolvedData,
     isError,
     isFetching,
-  } = usePaginatedRequestQuery<APIResponse>(CACHE_KEY, request)
+  } = usePaginatedRequestQuery<APIResponse>(CACHE_KEY, {
+    ...request,
+    options: { ...request.options, staleTime },
+  })
+
+  useEffect(() => {
+    setTimeout(() => setStaleTime(0), 1000)
+  }, [])
 
   const setTags = useCallback(
     (tags) => {

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -41,10 +41,7 @@ export default ({
     data: resolvedData,
     isError,
     isFetching,
-  } = usePaginatedRequestQuery<APIResponse>(CACHE_KEY, {
-    ...request,
-    options: { ...request.options, refetchOnMount: false },
-  })
+  } = usePaginatedRequestQuery<APIResponse>(CACHE_KEY, request)
 
   const setTags = useCallback(
     (tags) => {

--- a/app/javascript/components/student/TracksList.tsx
+++ b/app/javascript/components/student/TracksList.tsx
@@ -29,7 +29,6 @@ export default ({
   tagOptions: readonly TagOption[]
   request: Request
 }): JSX.Element => {
-  const [staleTime, setStaleTime] = useState(1000)
   const {
     request,
     setCriteria: setRequestCriteria,

--- a/app/javascript/hooks/request-query.ts
+++ b/app/javascript/hooks/request-query.ts
@@ -47,6 +47,7 @@ export function usePaginatedRequestQuery<TResult = unknown, TError = unknown>(
     queryKey: key,
     queryFn: handleFetch(request),
     refetchOnWindowFocus: false,
+    refetchOnMount: false,
     keepPreviousData: true,
     ...camelizeKeys(request.options),
   })

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -388,7 +388,10 @@ export const mappings = {
   ),
   'student-tracks-list': (data: any): JSX.Element => (
     <Suspense fallback={RenderLoader()}>
-      <StudentTracksList request={data.request} tagOptions={data.tag_options} />
+      <StudentTracksList
+        request={camelizeKeysAs<Request>(data.request)}
+        tagOptions={data.tag_options}
+      />
     </Suspense>
   ),
   'student-exercise-list': (data: any): JSX.Element => (

--- a/test/helpers/react_components/mentoring/queue_test.rb
+++ b/test/helpers/react_components/mentoring/queue_test.rb
@@ -47,9 +47,7 @@ class ReactComponents::Mentoring::QueueTest < ReactComponentTestCase
             exercise_slug: "bob"
           },
           options: {
-            initial_data: AssembleMentorRequests.(user, params),
-            stale_time: 0,
-            cache_time: 0
+            initial_data: AssembleMentorRequests.(user, params)
           }
         },
         tracks_request: {
@@ -88,9 +86,7 @@ class ReactComponents::Mentoring::QueueTest < ReactComponentTestCase
                   }
                 }
               ]
-            },
-            stale_time: 0,
-            cache_time: 0
+            }
           }
         },
         default_track: {
@@ -180,9 +176,7 @@ class ReactComponents::Mentoring::QueueTest < ReactComponentTestCase
           endpoint: Exercism::Routes.api_mentoring_requests_path,
           query: { track_slug: "csharp" },
           options: {
-            initial_data: AssembleMentorRequests.(user, { track_slug: "csharp" }),
-            stale_time: 0,
-            cache_time: 0
+            initial_data: AssembleMentorRequests.(user, { track_slug: "csharp" })
           }
         },
         tracks_request: {
@@ -211,9 +205,7 @@ class ReactComponents::Mentoring::QueueTest < ReactComponentTestCase
                   }
                 }
               ]
-            },
-            stale_time: 0,
-            cache_time: 0
+            }
           }
         },
         default_track: {


### PR DESCRIPTION
- Fix casing for initial data on student/TracksList
- Manually reset staleTime after mounting
- Better solution
- Disable refetchOnMount generally
