### PR TITLE
store llm tags when generating

### DIFF
--- a/app/commands/training_data/code_tags_sample/generate_tags.rb
+++ b/app/commands/training_data/code_tags_sample/generate_tags.rb
@@ -1,12 +1,12 @@
 class TrainingData::CodeTagsSample::GenerateTags
   include Mandate
 
-  initialize_with :tuple, :model, :openai_key
+  initialize_with :sample, :model, :openai_key
 
   def call
-    return if tuple.safe_to_override?
+    return if sample.safe_to_override?
 
-    tuple.update(tags:, llm_tags: tags, status: :machine_tagged)
+    sample.update(tags:, llm_tags: tags, status: :machine_tagged)
   end
 
   private
@@ -32,7 +32,7 @@ class TrainingData::CodeTagsSample::GenerateTags
   def messages
     [
       { "role": "system", "content": SYSTEM_MESSAGE },
-      { "role": "user", "content": INSTRUCTION % { lang: tuple.track.title, code: tuple.code } }
+      { "role": "user", "content": INSTRUCTION % { lang: sample.track.title, code: sample.code } }
     ]
   end
 

--- a/app/commands/training_data/code_tags_sample/generate_tags.rb
+++ b/app/commands/training_data/code_tags_sample/generate_tags.rb
@@ -4,7 +4,7 @@ class TrainingData::CodeTagsSample::GenerateTags
   initialize_with :sample, :model, :openai_key
 
   def call
-    return if sample.safe_to_override?
+    return unless sample.safe_to_override?
 
     sample.update(tags:, llm_tags: tags, status: :machine_tagged)
   end

--- a/app/commands/training_data/code_tags_sample/generate_tags.rb
+++ b/app/commands/training_data/code_tags_sample/generate_tags.rb
@@ -6,7 +6,7 @@ class TrainingData::CodeTagsSample::GenerateTags
   def call
     return if tuple.safe_to_override?
 
-    tuple.update(tags:, status: :machine_tagged)
+    tuple.update(tags:, llm_tags: tags, status: :machine_tagged)
   end
 
   private

--- a/app/models/training_data/code_tags_sample.rb
+++ b/app/models/training_data/code_tags_sample.rb
@@ -26,9 +26,7 @@ class TrainingData::CodeTagsSample < ApplicationRecord
   def dataset = super.to_sym
   def status = super.to_sym
 
-  def safe_to_override?
-    %i[human_tagged admin_tagged community_checked].include?(status)
-  end
+  def safe_to_override? = %i[untagged machine_tagged].include?(status)
 
   def locked? = locked_until && locked_until > Time.current
   def locked_by?(user) = locked? && locked_by == user

--- a/app/models/training_data/code_tags_sample.rb
+++ b/app/models/training_data/code_tags_sample.rb
@@ -1,4 +1,6 @@
 class TrainingData::CodeTagsSample < ApplicationRecord
+  extend Mandate::Memoize
+
   serialize :tags, JSON
   serialize :llm_tags, JSON
   serialize :files, JSON
@@ -68,4 +70,7 @@ class TrainingData::CodeTagsSample < ApplicationRecord
       status
     end
   end
+
+  memoize
+  def code = files.to_a.pluck("code").join('\n')
 end

--- a/test/commands/training_data/code_tags_sample/generate_tags_test.rb
+++ b/test/commands/training_data/code_tags_sample/generate_tags_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class TrainingData::CodeTagsSample::GenerateTagsTest < ActiveSupport::TestCase
+  test "update tags from openai when safe to override?" do
+    model = 'exercism_tags'
+    openai_key = 'openai_key'
+    tags = ['construct:if', 'paradigm:functional']
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions").
+      with(
+        body: {
+          model:,
+          messages: [
+            {
+              role: "system",
+              content: "You are a expert in EXERCISM_REPRESENTATION_TAGS"
+            },
+            {
+              role: "user",
+              content: "In JSON, list the set of programming concepts, paradigms and techniques as EXERCISM_REPRESENTATION_TAGS for this Ruby code:\n\n---\n\nHello, World!" # rubocop:disable Layout/LineLength
+            }
+          ],
+          temperature: 0.2
+        }.to_json,
+        headers: {
+          'Authorization': "Bearer #{openai_key}",
+          'Content-Type': 'application/json'
+        }
+      ).
+      to_return(
+        status: 200,
+        body: {
+          choices: [
+            { message: { content: tags } }
+          ]
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    sample = create(:training_data_code_tags_sample, status: :untagged)
+
+    TrainingData::CodeTagsSample::GenerateTags.(sample, model, openai_key)
+
+    assert_equal tags, sample.tags
+    assert_equal tags, sample.llm_tags
+    assert_equal :machine_tagged, sample.status
+  end
+
+  test "does not update tags when not safe to override?" do
+    updated_at = Time.current - 1.week
+    sample = create(:training_data_code_tags_sample, status: :human_tagged, updated_at:)
+
+    TrainingData::CodeTagsSample::GenerateTags.(sample, 'exercism_tags', 'openai_key')
+
+    assert_equal updated_at, sample.updated_at
+  end
+end

--- a/test/commands/training_data/code_tags_sample/update_tags_test.rb
+++ b/test/commands/training_data/code_tags_sample/update_tags_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TrainingData::CodeTagsSample::UpdatesTest < ActiveSupport::TestCase
+class TrainingData::CodeTagsSample::UpdateTagsTest < ActiveSupport::TestCase
   test "updates tags when locked by user" do
     user = create :user
     tags = ['construct:if']

--- a/test/models/training_data/code_tags_sample_test.rb
+++ b/test/models/training_data/code_tags_sample_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TrainingData::CodeTagsSampleTest < ActiveSupport::TestCase
   test "llm_tags: not changed when tags are updated" do
     original_tags = '["construct:if"]'
-    sample = create(:training_data_code_tags_sample, tags: original_tags)
+    sample = create(:training_data_code_tags_sample, tags: original_tags, llm_tags: original_tags)
     assert_equal original_tags, sample.tags
     assert_equal original_tags, sample.llm_tags
 
@@ -11,5 +11,19 @@ class TrainingData::CodeTagsSampleTest < ActiveSupport::TestCase
     sample.update(tags: new_tags)
     assert_equal new_tags, sample.tags
     assert_equal original_tags, sample.llm_tags
+  end
+
+  %i[human_tagged community_checked admin_checked].each do |status|
+    test "safe_to_override? is false when status is #{status}" do
+      sample = create(:training_data_code_tags_sample, status:)
+      refute sample.safe_to_override?
+    end
+  end
+
+  %i[untagged machine_tagged].each do |status|
+    test "safe_to_override? is true when status is #{status}" do
+      sample = create(:training_data_code_tags_sample, status:)
+      assert sample.safe_to_override?
+    end
   end
 end


### PR DESCRIPTION
- Store LLM tags when generating tags
- Fix typo
- Rename tuple to sample
- Fix broken test
- Update safe_to_override? logic
- Add tests for generating tags
