### PR TITLE
Fix chevron position in automation

### DIFF
--- a/app/css/components/mentor/representer-row.css
+++ b/app/css/components/mentor/representer-row.css
@@ -1,4 +1,5 @@
 .c-mentor-inbox,
+.c-mentor-automation,
 .c-mentor-queue {
     & .--representer {
         @apply border-backgroundColorC border-t-1;

--- a/app/css/components/mentor/solution-row.css
+++ b/app/css/components/mentor/solution-row.css
@@ -1,4 +1,5 @@
 .c-mentor-inbox,
+.c-mentor-automation,
 .c-training-data,
 .c-mentor-queue {
     & .--solution,

--- a/app/css/pages/mentoring/automation.css
+++ b/app/css/pages/mentoring/automation.css
@@ -26,12 +26,6 @@
             }
         }
 
-        & header.inbox-header {
-            & .c-single-select {
-                margin-left: auto;
-            }
-        }
-
         & header.automation-header {
             & .c-track-select {
                 @apply mr-24;

--- a/app/css/pages/mentoring/automation.css
+++ b/app/css/pages/mentoring/automation.css
@@ -1,4 +1,4 @@
-.c-mentor-inbox {
+.c-mentor-automation {
     & .tabs {
         @apply mb-20;
 
@@ -32,7 +32,6 @@
             }
         }
 
-        /* TODO: break this out into an automation.css */
         & header.automation-header {
             & .c-track-select {
                 @apply mr-24;
@@ -41,6 +40,13 @@
 
             & .current-track {
                 @apply px-16 py-8 font-[600];
+
+                .count {
+                    @apply mr-0;
+                }
+                .c-icon.action-icon {
+                    @apply ml-12;
+                }
             }
         }
 

--- a/app/css/pages/mentoring/inbox.css
+++ b/app/css/pages/mentoring/inbox.css
@@ -35,24 +35,6 @@
                 }
             }
 
-            /* TODO: break this out into an automation.css */
-            & header.automation-header {
-                & .track-title {
-                    @apply text-textColor1;
-                }
-                & .c-track-select {
-                    @apply mr-24;
-                }
-                & .automation-sorter {
-                    & button {
-                        @apply bg-backgroundColorD border-none shadow-none text-textColor6;
-                    }
-                }
-                & .action-icon {
-                    @apply filter-textColor6;
-                }
-            }
-
             & .--no-results {
                 @apply flex flex-col items-center;
                 @apply py-48;

--- a/app/javascript/components/mentoring/automation/Representation.tsx
+++ b/app/javascript/components/mentoring/automation/Representation.tsx
@@ -66,7 +66,7 @@ export function Representations({
   } = useAutomation(representationsRequest, tracks)
 
   return (
-    <div className="c-mentor-inbox">
+    <div className="c-mentor-automation">
       {!isIntroducerHidden && (
         <AutomationIntroducer hideEndpoint={links.hideIntroducer} />
       )}


### PR DESCRIPTION
This PR also removes 2 blocks of unused code, and replaces `c-mentor-inbox` to `c-mentor-automation` on automation page. 

#### The fix:

<img width="1080" alt="Screenshot 2023-11-23 at 10 21 28" src="https://github.com/exercism/website/assets/66035744/84acfd1e-77f9-4ee0-b83b-1bb2aa442ee2">


---

##### These should be unchanged:
<img width="1506" alt="Screenshot 2023-11-23 at 10 26 22" src="https://github.com/exercism/website/assets/66035744/79f9e1ab-4f0f-4bb3-bd37-16c44672c3fc">
<img width="1506" alt="Screenshot 2023-11-23 at 10 26 16" src="https://github.com/exercism/website/assets/66035744/c19298ee-ae05-4713-a310-e8a7dd34cf6a">
<img width="1506" alt="Screenshot 2023-11-23 at 10 26 13" src="https://github.com/exercism/website/assets/66035744/e72f35a5-6f36-490d-9a5f-9005d0bd5a7b">
<img width="1506" alt="Screenshot 2023-11-23 at 10 23 13" src="https://github.com/exercism/website/assets/66035744/d9bc19f8-3fbd-4d10-9b95-1cbf61dfa561">

