### PR TITLE
Add initial data to TrainingData Dashboard

### DIFF
--- a/app/assemblers/assemble_code_tag_samples.rb
+++ b/app/assemblers/assemble_code_tag_samples.rb
@@ -1,0 +1,27 @@
+class AssembleCodeTagSamples
+  include Mandate
+
+  initialize_with :params
+
+  def call
+    SerializePaginatedCollection.(
+      samples,
+      serializer: SerializeCodeTagsSamples,
+      serializer_kwargs: { status: }
+    )
+  end
+
+  private
+  def samples
+    TrainingData::CodeTagsSample::Retrieve.(
+      status,
+      criteria: params[:criteria],
+      track:,
+      page:
+    )
+  end
+
+  def track = params[:track_slug].present? && Track.find(params[:track_slug])
+  def status = params.fetch(:status, :needs_tagging).to_sym
+  def page = [params[:page].to_i, 1].max
+end

--- a/app/controllers/api/training_data/code_tags_samples_controller.rb
+++ b/app/controllers/api/training_data/code_tags_samples_controller.rb
@@ -4,18 +4,7 @@ class API::TrainingData::CodeTagsSamplesController < API::BaseController
   before_action :ensure_trainer!
 
   def index
-    samples = ::TrainingData::CodeTagsSample::Retrieve.(
-      status,
-      criteria: params[:criteria],
-      track: @track,
-      page:
-    )
-
-    render json: SerializePaginatedCollection.(
-      samples,
-      serializer: SerializeCodeTagsSamples,
-      serializer_kwargs: { status: }
-    )
+    render json: AssembleCodeTagSamples.(params)
   end
 
   def update_tags

--- a/app/helpers/react_components/training_data/dashboard.rb
+++ b/app/helpers/react_components/training_data/dashboard.rb
@@ -20,7 +20,10 @@ module ReactComponents
             criteria: params[:criteria],
             page: params[:page] ? params[:page].to_i : 1,
             track_slug: params[:track_slug]
-          }.compact
+          }.compact,
+          options: {
+            initial_data:
+          }
         }
       end
 
@@ -31,6 +34,23 @@ module ReactComponents
 
       DEFAULT_STATUS = :needs_tagging
       private_constant :DEFAULT_STATUS
+
+      def initial_data
+        status = params.fetch(:status, :needs_tagging).to_sym
+        page = [params[:page].to_i, 1].max
+        samples = ::TrainingData::CodeTagsSample::Retrieve.(
+          status,
+          criteria: params[:criteria],
+          track: @track,
+          page:
+        )
+
+        SerializePaginatedCollection.(
+          samples,
+          serializer: SerializeCodeTagsSamples,
+          serializer_kwargs: { status: }
+        )
+      end
     end
   end
 end

--- a/app/helpers/react_components/training_data/dashboard.rb
+++ b/app/helpers/react_components/training_data/dashboard.rb
@@ -32,25 +32,10 @@ module ReactComponents
         AssembleTracksForSelect.(tracks)
       end
 
+      def initial_data = AssembleCodeTagSamples.(params)
+
       DEFAULT_STATUS = :needs_tagging
       private_constant :DEFAULT_STATUS
-
-      def initial_data
-        status = params.fetch(:status, :needs_tagging).to_sym
-        page = [params[:page].to_i, 1].max
-        samples = ::TrainingData::CodeTagsSample::Retrieve.(
-          status,
-          criteria: params[:criteria],
-          track: @track,
-          page:
-        )
-
-        SerializePaginatedCollection.(
-          samples,
-          serializer: SerializeCodeTagsSamples,
-          serializer_kwargs: { status: }
-        )
-      end
     end
   end
 end

--- a/app/javascript/components/training-data/Dashboard.tsx
+++ b/app/javascript/components/training-data/Dashboard.tsx
@@ -22,7 +22,6 @@ export default function Dashboard({
     criteria,
     setCriteria,
     setTrack,
-    setOrder,
   } = useDashboard({ trainingDataRequest })
 
   return (
@@ -39,7 +38,6 @@ export default function Dashboard({
           setCriteria={setCriteria}
           tracks={tracks}
           setTrack={setTrack}
-          setPage={setPage}
         />
         <ResultsZone isFetching={isFetching}>
           <TaggableCodeList

--- a/app/javascript/components/training-data/dashboard/Dashboard.types.ts
+++ b/app/javascript/components/training-data/dashboard/Dashboard.types.ts
@@ -9,15 +9,13 @@ export type DashboardProps = {
 }
 
 export type TrainingDataStatus =
-  | 'untagged'
-  | 'machine_tagged'
-  | 'human_tagged'
-  | 'community_checked'
-  | 'admin_checked'
+  | 'needs_tagging'
+  | 'needs_checking'
+  | 'needs_checking_admin'
 
 export type DashboardHeaderProps = Pick<
   useDashboardReturnType,
-  'setTrack' | 'criteria' | 'setCriteria' | 'setPage' | 'request'
+  'setTrack' | 'criteria' | 'setCriteria' | 'request'
 > & {
   tracks: Track[]
 }

--- a/app/javascript/components/training-data/dashboard/useDashboard.ts
+++ b/app/javascript/components/training-data/dashboard/useDashboard.ts
@@ -47,11 +47,11 @@ export function useDashboard({
   useHistory({ pushOn: removeEmpty(request.query) })
 
   const setTrack = (trackSlug: string | null) => {
-    setQuery({ ...request.query, trackSlug: trackSlug, page: undefined })
+    setQuery({ ...request.query, trackSlug, page: undefined })
   }
 
   const setStatus = (status: TrainingDataStatus) => {
-    setQuery({ ...request.query, status: status, page: undefined })
+    setQuery({ ...request.query, status, page: undefined })
   }
 
   return {


### PR DESCRIPTION
This PR eliminates the unnecessary initial fetch of data by providing initial data and adjusts types to current statuses.

https://github.com/exercism/website/assets/66035744/506eeac0-76cf-457b-bb4e-b430a54815c1

