### PR TITLE
Add site-header and track menu skeletons

### DIFF
--- a/app/javascript/components/common/skeleton/components/SkeletonShape.tsx
+++ b/app/javascript/components/common/skeleton/components/SkeletonShape.tsx
@@ -3,14 +3,18 @@ import { assembleClassNames } from '@/utils/assemble-classnames'
 
 export function SkeletonShape({
   shape,
+  children,
   ...props
 }: {
+  children?: React.ReactNode
   shape: 'rect' | 'circle' | 'tag' | 'hex'
 } & React.HTMLProps<HTMLDivElement>): JSX.Element {
   return (
     <div
       {...props}
       className={assembleClassNames('skeleton-box', shape, props.className)}
-    />
+    >
+      {children}
+    </div>
   )
 }

--- a/app/javascript/components/common/skeleton/skeletons/NotificationsDropdownSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/NotificationsDropdownSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { SkeletonShape } from '../components/SkeletonShape'
+import { SkeletonLoader } from '../components/SkeletonLoader'
+
+export function NotificationsDropdownSkeleton() {
+  return (
+    <SkeletonLoader>
+      <SkeletonShape
+        shape="rect"
+        style={{
+          borderRadius: '8px',
+          height: '37px',
+          width: '41px',
+          marginRight: '48px',
+          marginLeft: '8px',
+        }}
+      />
+    </SkeletonLoader>
+  )
+}

--- a/app/javascript/components/common/skeleton/skeletons/ReputationDropdownSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/ReputationDropdownSkeleton.tsx
@@ -1,17 +1,29 @@
 import React from 'react'
 import { SkeletonShape } from '../components/SkeletonShape'
 import { SkeletonLoader } from '../components/SkeletonLoader'
+import { useLogger } from '@/hooks'
+import { getTextWidth } from '@/utils/get-text-width'
 
-export function ReputationDropdownSkeleton() {
+// pl-70 comes from:
+// px-16 + 24px icon with mr-8 + 3px border
+// 32 + 24 + 8 + 6
+export function ReputationDropdownSkeleton({
+  reputation,
+}: {
+  reputation: string
+}) {
+  useLogger('reputation', reputation)
   return (
     <SkeletonLoader>
       <SkeletonShape
         shape="tag"
+        className="font-bold text-16 pl-[70px]"
         style={{
           height: '38px',
-          width: '100px',
         }}
-      />
+      >
+        {reputation}
+      </SkeletonShape>
     </SkeletonLoader>
   )
 }

--- a/app/javascript/components/common/skeleton/skeletons/ReputationDropdownSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/ReputationDropdownSkeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { SkeletonShape } from '../components/SkeletonShape'
+import { SkeletonLoader } from '../components/SkeletonLoader'
+
+export function ReputationDropdownSkeleton() {
+  return (
+    <SkeletonLoader>
+      <SkeletonShape
+        shape="tag"
+        style={{
+          height: '38px',
+          width: '100px',
+        }}
+      />
+    </SkeletonLoader>
+  )
+}

--- a/app/javascript/components/common/skeleton/skeletons/ThemeToggleButtonSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/ThemeToggleButtonSkeleton.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { SkeletonShape } from '../components/SkeletonShape'
+import { SkeletonLoader } from '../components/SkeletonLoader'
+
+export function ThemeToggleButtonSkeleton() {
+  return (
+    <SkeletonLoader>
+      <SkeletonShape
+        shape="tag"
+        className="ml-24"
+        style={{ width: '52px', height: '26px' }}
+      />
+    </SkeletonLoader>
+  )
+}

--- a/app/javascript/components/common/skeleton/skeletons/TrackMenuDropdownSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/TrackMenuDropdownSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { SkeletonShape } from '../components/SkeletonShape'
+import { SkeletonLoader } from '../components/SkeletonLoader'
+
+export function TrackMenuDropdownSkeleton() {
+  return (
+    <SkeletonLoader>
+      <SkeletonShape
+        shape="rect"
+        style={{ width: '32px', height: '32px', borderRadius: '5px' }}
+      />
+    </SkeletonLoader>
+  )
+}

--- a/app/javascript/components/common/skeleton/skeletons/UserMenuDropdownSkeleton.tsx
+++ b/app/javascript/components/common/skeleton/skeletons/UserMenuDropdownSkeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { SkeletonShape } from '../components/SkeletonShape'
+import { SkeletonLoader } from '../components/SkeletonLoader'
+
+export function UserMenuDropdownSkeleton() {
+  return (
+    <SkeletonLoader>
+      <SkeletonShape
+        shape="circle"
+        style={{
+          height: '42px',
+          width: '42px',
+        }}
+      />
+    </SkeletonLoader>
+  )
+}

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -528,7 +528,7 @@ export const mappings = {
     </Suspense>
   ),
   'dropdowns-dropdown': (data: any): JSX.Element => (
-    <Suspense fallback={RenderLoader()}>
+    <Suspense fallback={<UserMenuDropdownSkeleton />}>
       <Dropdown menuButton={data.menu_button} menuItems={data.menu_items} />
     </Suspense>
   ),
@@ -741,6 +741,7 @@ import { ExerciseListSkeleton } from '@/components/common/skeleton/skeletons/Exe
 import { ExerciseStatusChartSkeleton } from '@/components/common/skeleton/skeletons/ExerciseStatusChartSkeleton'
 import { TracksListSkeleton } from '@/components/common/skeleton/skeletons/TracksListSkeleton'
 import { ThemeToggleButtonSkeleton } from '@/components/common/skeleton/skeletons/ThemeToggleButtonSkeleton'
+import { UserMenuDropdownSkeleton } from '@/components/common/skeleton/skeletons/UserMenuDropdownSkeleton'
 
 document.addEventListener('turbo:load', () => {
   showSiteFooter()

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -543,7 +543,7 @@ export const mappings = {
       default_theme: string
     }
   ): JSX.Element => (
-    <Suspense fallback={RenderLoader()}>
+    <Suspense fallback={<ThemeToggleButtonSkeleton />}>
       <ThemeToggleButton {...data} defaultTheme={data.default_theme} />
     </Suspense>
   ),
@@ -740,6 +740,7 @@ import { ConceptMapSkeleton } from '@/components/common/skeleton/skeletons/Conce
 import { ExerciseListSkeleton } from '@/components/common/skeleton/skeletons/ExerciseListSkeleton'
 import { ExerciseStatusChartSkeleton } from '@/components/common/skeleton/skeletons/ExerciseStatusChartSkeleton'
 import { TracksListSkeleton } from '@/components/common/skeleton/skeletons/TracksListSkeleton'
+import { ThemeToggleButtonSkeleton } from '@/components/common/skeleton/skeletons/ThemeToggleButtonSkeleton'
 
 document.addEventListener('turbo:load', () => {
   showSiteFooter()

--- a/app/javascript/packs/internal.tsx
+++ b/app/javascript/packs/internal.tsx
@@ -204,6 +204,7 @@ const UnpublishSolutionModalButton = lazy(
 import { RenderLoader } from '@/components/common'
 import { ScreenSizeWrapper } from '@/components/mentoring/session/ScreenSizeContext'
 import { TrackMenuDropdownSkeleton } from '@/components/common/skeleton/skeletons/TrackMenuDropdownSkeleton'
+import { NotificationsDropdownSkeleton } from '@/components/common/skeleton/skeletons/NotificationsDropdownSkeleton'
 
 // Add all react components here.
 // Each should map 1-1 to a component in app/helpers/components
@@ -487,7 +488,7 @@ initReact({
     </Suspense>
   ),
   'dropdowns-notifications': (data: any) => (
-    <Suspense fallback={RenderLoader()}>
+    <Suspense fallback={<NotificationsDropdownSkeleton />}>
       <NotificationsDropdown endpoint={data.endpoint} />
     </Suspense>
   ),

--- a/app/javascript/packs/internal.tsx
+++ b/app/javascript/packs/internal.tsx
@@ -494,12 +494,16 @@ initReact({
     </Suspense>
   ),
   'dropdowns-reputation': (data: any) => (
-    <Suspense fallback={<ReputationDropdownSkeleton />}>
-      <ReputationDropdown
-        endpoint={data.endpoint}
-        defaultIsSeen={data.is_seen}
-        defaultReputation={data.reputation}
-      />
+    <Suspense
+      fallback={<ReputationDropdownSkeleton reputation={data.reputation} />}
+    >
+      <div className="flex gap-8">
+        <ReputationDropdown
+          endpoint={data.endpoint}
+          defaultIsSeen={data.is_seen}
+          defaultReputation={data.reputation}
+        />
+      </div>
     </Suspense>
   ),
   'dropdowns-track-menu': (data: any) => (

--- a/app/javascript/packs/internal.tsx
+++ b/app/javascript/packs/internal.tsx
@@ -203,6 +203,7 @@ const UnpublishSolutionModalButton = lazy(
 
 import { RenderLoader } from '@/components/common'
 import { ScreenSizeWrapper } from '@/components/mentoring/session/ScreenSizeContext'
+import { TrackMenuDropdownSkeleton } from '@/components/common/skeleton/skeletons/TrackMenuDropdownSkeleton'
 
 // Add all react components here.
 // Each should map 1-1 to a component in app/helpers/components
@@ -500,7 +501,7 @@ initReact({
     </Suspense>
   ),
   'dropdowns-track-menu': (data: any) => (
-    <Suspense fallback={RenderLoader()}>
+    <Suspense fallback={<TrackMenuDropdownSkeleton />}>
       <TrackMenuDropdown
         track={data.track}
         links={camelizeKeysAs<TrackMenuLinks>(data.links)}

--- a/app/javascript/packs/internal.tsx
+++ b/app/javascript/packs/internal.tsx
@@ -205,6 +205,7 @@ import { RenderLoader } from '@/components/common'
 import { ScreenSizeWrapper } from '@/components/mentoring/session/ScreenSizeContext'
 import { TrackMenuDropdownSkeleton } from '@/components/common/skeleton/skeletons/TrackMenuDropdownSkeleton'
 import { NotificationsDropdownSkeleton } from '@/components/common/skeleton/skeletons/NotificationsDropdownSkeleton'
+import { ReputationDropdownSkeleton } from '@/components/common/skeleton/skeletons/ReputationDropdownSkeleton'
 
 // Add all react components here.
 // Each should map 1-1 to a component in app/helpers/components
@@ -493,7 +494,7 @@ initReact({
     </Suspense>
   ),
   'dropdowns-reputation': (data: any) => (
-    <Suspense fallback={RenderLoader()}>
+    <Suspense fallback={<ReputationDropdownSkeleton />}>
       <ReputationDropdown
         endpoint={data.endpoint}
         defaultIsSeen={data.is_seen}


### PR DESCRIPTION

https://github.com/exercism/website/assets/66035744/ca801920-5670-42b5-95cc-86230158ef67

<img width="635" alt="Screenshot 2023-12-04 at 11 49 29" src="https://github.com/exercism/website/assets/66035744/ac13b623-9063-4f26-823c-3572048d6f75">

https://github.com/exercism/website/assets/66035744/6e72b98c-20af-414f-975c-e5fd6dc6df86


https://github.com/exercism/website/assets/66035744/c13584e1-9efb-40c7-a2e2-dba81a8f99f0


https://github.com/exercism/website/assets/66035744/e597afaf-8cec-4a89-abef-1b9e8ec0844a


https://github.com/exercism/website/assets/66035744/c92fe368-8279-4de7-8e1a-df7364e5947f

<img width="402" alt="Screenshot 2023-12-04 at 11 04 39" src="https://github.com/exercism/website/assets/66035744/66b05177-6fd4-4f2b-ba81-8d0c7af7a5d7">
