### PR TITLE
update track reset modal to mention keeping badges

### DIFF
--- a/app/javascript/components/dropdowns/track-menu/ResetTrackModal.tsx
+++ b/app/javascript/components/dropdowns/track-menu/ResetTrackModal.tsx
@@ -98,16 +98,16 @@ export const ResetTrackModal = ({
             </li>
           </ul>
           <p>
-            <strong>You will keep:</strong>
+            <strong>However:</strong>
           </p>
           <ul>
             <li>
-              The local version of any {track.title} solutions you wrote outside
-              Exercism
+              Any local versions of solutions stored on your machine will be
+              unaffected
             </li>
             <li>
-              Any badges earned as a result of your work on the {track.title}{' '}
-              track
+              You will keep any badges earned as a result of your work on the{' '}
+              {track.title} track
             </li>
           </ul>
         </div>

--- a/app/javascript/components/dropdowns/track-menu/ResetTrackModal.tsx
+++ b/app/javascript/components/dropdowns/track-menu/ResetTrackModal.tsx
@@ -97,6 +97,19 @@ export const ResetTrackModal = ({
               {track.title}
             </li>
           </ul>
+          <p>
+            <strong>You will keep:</strong>
+          </p>
+          <ul>
+            <li>
+              The local version of any {track.title} solutions you wrote outside
+              Exercism
+            </li>
+            <li>
+              Any badges earned as a result of your work on the {track.title}{' '}
+              track
+            </li>
+          </ul>
         </div>
         <hr />
         <label htmlFor="confirmation">


### PR DESCRIPTION
Per [discussion on the forum](https://forum.exercism.org/t/does-resetting-a-track-affect-earned-badges/8905), adds a section to the "reset track" modal to mention that badges are kept (even if resetting the track would cause you to no longer qualify). I also added a bullet to note that any local solutions don't get like, wiped from your computer. Feel free to tweak any copy as needed.

## Before:

<img width="806" alt="image" src="https://github.com/exercism/website/assets/1231935/49a11845-bf65-4eda-af65-d50bc65b1d80">

## After:

<img width="804" alt="image" src="https://github.com/exercism/website/assets/1231935/652b1cba-da05-407b-af1a-1a55a8175e51">
