### PR TITLE
Remove margin top from `.c-textual-content.--large`

### DIFF
--- a/app/css/components/textual-content.css
+++ b/app/css/components/textual-content.css
@@ -17,9 +17,6 @@
             }
         }
         & > * {
-            &:not(:first-child) {
-                @apply mt-16;
-            }
             @apply mb-16;
             &:last-child {
                 @apply mb-0;


### PR DESCRIPTION
#### Affected places:

<img width="822" alt="Screenshot 2024-01-04 at 14 37 52" src="https://github.com/exercism/website/assets/66035744/d05bc798-a28c-4fc1-8d8e-88d036aa2210">
<img width="1056" alt="Screenshot 2024-01-04 at 14 37 19" src="https://github.com/exercism/website/assets/66035744/ea044165-3f07-4b30-a4d6-d771b85d33c8">
<img width="1117" alt="Screenshot 2024-01-04 at 14 37 01" src="https://github.com/exercism/website/assets/66035744/bd4d8f1b-eb3d-4d75-941f-ad00abcbaa50">
<img width="844" alt="Screenshot 2024-01-04 at 14 34 33" src="https://github.com/exercism/website/assets/66035744/a3718615-bc46-441e-9a4e-96a6c8346717">
<img width="803" alt="Screenshot 2024-01-04 at 14 33 35" src="https://github.com/exercism/website/assets/66035744/6862146b-cce7-407a-815e-60b4815dbac1">
<img width="902" alt="Screenshot 2024-01-04 at 14 31 55" src="https://github.com/exercism/website/assets/66035744/4985ff97-4c46-4d5f-ab25-eed4fc6b7225">
<img width="1029" alt="Screenshot 2024-01-04 at 14 29 25" src="https://github.com/exercism/website/assets/66035744/090941e4-c036-4c91-87f0-008f139b7a22">
<img width="878" alt="Screenshot 2024-01-04 at 14 26 38" src="https://github.com/exercism/website/assets/66035744/539f50cf-41aa-4542-873d-b4b29b7cb742">
<img width="1252" alt="Screenshot 2024-01-04 at 14 25 32" src="https://github.com/exercism/website/assets/66035744/44f1bec3-7d0f-428b-b07b-5585f40867b0">
