### PR TITLE
Add missing bg to box on Impact-page

### DIFF
--- a/app/views/about/impact.html.haml
+++ b/app/views/about/impact.html.haml
@@ -24,7 +24,7 @@
   .md-container.mb-48
     .flex.flex-col.md:flex-row.md:items-stretch
       .md:mr-32.mb-40.md:mb-0{ class: 'w-fill md:max-w-[380px]' }
-        .shadow-lgZ1.py-8.rounded-16.mb-32
+        .shadow-lgZ1.py-8.rounded-16.mb-32.bg-backgroundColorA.overflow-hidden
           .py-12.px-32.bg-backgroundColorF
             %h3.label-large Students
             .text-purple.font-semibold.text-40.leading-150{ class: 'h-[60px]' }


### PR DESCRIPTION
<img width="1326" alt="Screenshot 2024-01-08 at 9 31 26" src="https://github.com/exercism/website/assets/66035744/1d2607b2-806d-4339-ad3d-0c34fffb417d">
