### PR TITLE
:bug: Fix number localization for "mentoring discussions"

### DIFF
--- a/app/views/about/impact.html.haml
+++ b/app/views/about/impact.html.haml
@@ -37,7 +37,8 @@
 
           .py-12.px-32
             %h3.label-large Mentoring Discussions
-            .text-purple.font-semibold.text-40.leading-150= number_with_delimiter(Metrics.num_discussions.to_i)
+            .text-purple.font-semibold.text-40.leading-150
+              = render ReactComponents::Impact::Stat.new(:mentoring_discussions_metric, Metrics.num_discussions.to_i)
 
         .bg-backgroundColorB.shadow-base.py-16.px-24
           %p.text-p-large.mb-8


### PR DESCRIPTION
This should solve https://forum.exercism.org/t/the-numbers-in-impact-does-not-share-the-same-formatting/9025

Note that I did try to setup Exercism in a GitHub codespace, but I failed !6659. So this is not tested. Testing this should be rater easy:
1. navigate to /about/impact page
2. change browser's location https://developer.chrome.com/docs/devtools/settings/locations to France/Paris
3. Check whether the 3 numbers are displaying the same (space as thousands separators, not comma)

Also it looks like most of the metrics are declared in `/app/javascript/components/impact/map.tsx`, but from what I understand there is no need to declare this one here.