### PR TITLE
:memo: Fix development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ We use localstack and opensearch, and run them via Docker.
 Double check versions in `.dockerimages.json`.
 
 ```bash
-docker run -dp 3042:8080 -p 3040:4566 -p 3041:4566 localstack/localstack:2.2.0
-docker run -dp 9200:9200 -e "discovery.type=single-node" opensearchproject/opensearch:2.9.0
+docker run -dp 3042:8080 -p 3040:4566 -p 3041:4566 localstack/localstack:2.3.2
+docker run -dp 9200:9200 -e "discovery.type=single-node" opensearchproject/opensearch:2.11.0
 ```
 
 ### Run the setup script
@@ -106,7 +106,7 @@ On Unix systems we recommend using `overmind` to manage this, which can be insta
 To get everything started you can then run:
 
 ```bash
-overmind -p 3020 Procfile.dev
+overmind start --port 3020 --procfile Procfile.dev
 ```
 
 #### Windows-specific


### PR DESCRIPTION
I did try to setup exercism inside [GitHub Codespace](https://github.com/features/codespaces).

### Setup process

Other things I noted:
1. It is not mentionned that the developper should run `yarn`
2. One can easily run a redis instance with `docker run --publish 6379:6379 --name exercism-redis --detach redis` (`--name` is optionnal)
3. MySQL instance should be local as the application will try to connect directly to its socket at `/var/run/mysqld/mysqld.sock`:
    ```
    # /etc/mysql/my.cnf
    [mysqld]
    socket=/var/run/mysqld/mysqld.sock
    [client]
    socket=/var/run/mysqld/mysqld.sock
    ```
4. I also had to add an entry for `local.exercism.io` into my `/etc/hosts`: `127.0.0.1 local.exercism.io`. Conventions expect `*.local` or `localhost`
5. DB Initialization is not specified, here are the steps I had to follow:
    1. `bin/rails db:environment:set RAILS_ENV=development` (I found this by running the below command (2))
    2. `bundle exec rake db:reset db:migrate db:seed` (I found this in `scripts/docker`, the command looks unresponsive but mysql has activity, after a while there is output for seeding)
    I have the following error during seeding (I may check the issue tomorrow):
      ```text
      rake aborted!
      NameError: uninitialized constant Track::Trophies::Reseed
      /workspaces/website/db/seeds.rb:544:in `<main>'
      /usr/local/rvm/gems/ruby-3.2.1/gems/railties-7.0.4.3/lib/rails/engine.rb:557:in `load'
      /usr/local/rvm/gems/ruby-3.2.1/gems/railties-7.0.4.3/lib/rails/engine.rb:557:in `block in load_seed'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activesupport-7.0.4.3/lib/active_support/execution_wrapper.rb:92:in `wrap'
      /usr/local/rvm/gems/ruby-3.2.1/gems/railties-7.0.4.3/lib/rails/engine.rb:626:in `block (2 levels) in <class:Engine>'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:127:in `instance_exec'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:127:in `block in run_callbacks'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:138:in `run_callbacks'
      /usr/local/rvm/gems/ruby-3.2.1/gems/railties-7.0.4.3/lib/rails/engine.rb:557:in `load_seed'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activerecord-7.0.4.3/lib/active_record/tasks/database_tasks.rb:497:in `load_seed'
      /usr/local/rvm/gems/ruby-3.2.1/gems/activerecord-7.0.4.3/lib/active_record/railties/databases.rake:397:in `block (2 levels) in <main>'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bugsnag-6.25.2/lib/bugsnag/integrations/rake.rb:20:in `execute'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli/exec.rb:58:in `load'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli/exec.rb:58:in `kernel_load'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli/exec.rb:23:in `run'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli.rb:484:in `exec'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli.rb:31:in `dispatch'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/cli.rb:25:in `start'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/exe/bundle:48:in `block in <top (required)>'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
      /usr/local/rvm/gems/ruby-3.2.1/gems/bundler-2.3.7/exe/bundle:36:in `<top (required)>'
      /usr/local/rvm/gems/ruby-3.2.1/bin/bundle:25:in `load'
      /usr/local/rvm/gems/ruby-3.2.1/bin/bundle:25:in `<main>'
      Tasks: TOP => db:reset => db:setup => db:seed
      ```
    3. For the record I did seemingly fix this issue by replacing the call in `db/seeds.rb`:
      ```diff
      - Track::Trophies::Reseed.create!
      + Track::Trophy::Reseed.call()
      ```
    4. This now fails with S33 Bucket issue
### `bundle install`

I had issue during `bundle install` because I had ruby3.2.2 instead of ruby3.2.1.
This `bundle install` was also really long, it looked like this was due to `grpc` which is in version `1.53.0`, I think we should update to `1.60.0` at least so that pre-built binaries can be used (https://github.com/grpc/grpc/issues/34595).

### `Devise.secret_key`

I had an issue:
> Devise.secret_key was not set. Please add the following to your Devise initializer
>   Devise.secret_key = 'a2[...]'

This message gives no hint about where this key should be added. After a quick Google Search I came across https://github.com/lynndylanhurley/devise_token_auth/issues/235 so I added it in `config/secrets.yml` (that does not exist) and because this is a yaml file I also changed it to `Devise.secret_key: '2a[...]'`

### Conclusion

Overall this was rather hard to setup 