### PR TITLE
Gracefully handle images with query string or malformed url

### DIFF
--- a/app/commands/markdown/render_html.rb
+++ b/app/commands/markdown/render_html.rb
@@ -35,9 +35,10 @@ class Markdown::RenderHTML
         image_with_class(node, class_name: IMAGE_CLASS_INVERTIBLE)
       elsif m[:path].end_with?('-light')
         image_with_class(node, class_name: IMAGE_CLASS_LIGHT_THEME)
-        image_with_class(node, url: "#{m[:path][0..-7]}-dark.#{m[:extension]}", class_name: IMAGE_CLASS_DARK_THEME)
+        image_with_class(node, url: "#{m[:path][0..-7]}-dark.#{m[:extension]}#{m[:query_string]}", class_name: IMAGE_CLASS_DARK_THEME)
       elsif m[:path].end_with?('-dark')
-        image_with_class(node, url: "#{m[:path][0..-6]}-light.#{m[:extension]}", class_name: IMAGE_CLASS_LIGHT_THEME)
+        image_with_class(node, url: "#{m[:path][0..-6]}-light.#{m[:extension]}#{m[:query_string]}",
+          class_name: IMAGE_CLASS_LIGHT_THEME)
         image_with_class(node, class_name: IMAGE_CLASS_DARK_THEME)
       else
         image_with_class(node)
@@ -159,7 +160,7 @@ class Markdown::RenderHTML
     end
 
     NOTE_BLOCK_FENCES = %w[exercism/note exercism/caution exercism/advanced].freeze
-    IMAGE_URL_REGEX = /^(?<path>.+)\.(?<extension>jpe?g|png|gif|svg)$/i
+    IMAGE_URL_REGEX = /^(?<path>.+)\.(?<extension>jpe?g|png|gif|svg)(?<query_string>\?.+)?$/i
     IMAGE_CLASS_INVERTIBLE = 'c-img-invertible'.freeze
     IMAGE_CLASS_LIGHT_THEME = 'c-img-light-theme'.freeze
     IMAGE_CLASS_DARK_THEME = 'c-img-dark-theme'.freeze

--- a/app/commands/markdown/render_html.rb
+++ b/app/commands/markdown/render_html.rb
@@ -29,6 +29,7 @@ class Markdown::RenderHTML
 
     def image(node)
       m = IMAGE_URL_REGEX.match(node.url)
+      return image_with_class(node) if m.nil?
 
       if m[:path].end_with?('-invertible')
         image_with_class(node, class_name: IMAGE_CLASS_INVERTIBLE)

--- a/test/commands/markdown/parse_test.rb
+++ b/test/commands/markdown/parse_test.rb
@@ -464,9 +464,19 @@ Done')
       assert_equal expected, Markdown::Parse.("![Tic Tac Toe board](tic-tac-toe-light.#{extension})")
     end
 
+    test "render light #{extension} image with query string in url" do
+      expected = %(<p><img src="tic-light.#{extension}?raw=true" alt="Tic" class="c-img-light-theme"><img src="tic-dark.#{extension}?raw=true" alt="Tic" class="c-img-dark-theme"></p>\n) # rubocop:disable Layout/LineLength
+      assert_equal expected, Markdown::Parse.("![Tic](tic-light.#{extension}?raw=true)")
+    end
+
     test "render regular #{extension} image" do
       expected = %(<p><img src="tic-tac-toe.#{extension}" alt="Tic Tac Toe board"></p>\n)
       assert_equal expected, Markdown::Parse.("![Tic Tac Toe board](tic-tac-toe.#{extension})")
+    end
+
+    test "render regular #{extension} image with query string in url" do
+      expected = %(<p><img src="tic.#{extension}?raw=true" alt="Tic"></p>\n)
+      assert_equal expected, Markdown::Parse.("![Tic](tic.#{extension}?raw=true)")
     end
   end
 end


### PR DESCRIPTION
- Gracefully handle image when regex doesn't match
- Handle images with query string
