### PR TITLE
Automatically prepend 'h-' to internal links with hash

### DIFF
--- a/app/commands/markdown/render_html.rb
+++ b/app/commands/markdown/render_html.rb
@@ -91,7 +91,11 @@ class Markdown::RenderHTML
 
     def link_href(uri)
       return '' if uri.nil?
+      return escape_href(uri.to_s) if uri.fragment.blank? || uri.fragment.start_with?('h-')
+      return escape_href(uri.to_s) if external_url?(uri)
+      return escape_href(uri.to_s) if uri.path.present? && !HEADING_ID_PATHS_REGEX.match(uri.path)
 
+      uri.fragment = "h-#{uri.fragment}"
       escape_href(uri.to_s)
     end
 
@@ -170,6 +174,7 @@ class Markdown::RenderHTML
     IMAGE_CLASS_INVERTIBLE = 'c-img-invertible'.freeze
     IMAGE_CLASS_LIGHT_THEME = 'c-img-light-theme'.freeze
     IMAGE_CLASS_DARK_THEME = 'c-img-dark-theme'.freeze
+    HEADING_ID_PATHS_REGEX = %r{^(/docs/|/tracks/[^/]+/(concepts|exercises)/)}
     private_constant :NOTE_BLOCK_FENCES, :IMAGE_URL_REGEX, :IMAGE_CLASS_INVERTIBLE,
       :IMAGE_CLASS_LIGHT_THEME, :IMAGE_CLASS_DARK_THEME
   end

--- a/app/commands/markdown/render_html.rb
+++ b/app/commands/markdown/render_html.rb
@@ -76,7 +76,7 @@ class Markdown::RenderHTML
 
       uri = Addressable::URI.parse(node.url)
 
-      out('<a href="', node.url.nil? ? '' : escape_href(node.url), '"')
+      out('<a href="', link_href(uri), '"')
       out(' title="', escape_html(node.title), '"') if node.title.present?
       if external_url?(uri)
         out(' target="_blank"')
@@ -87,6 +87,12 @@ class Markdown::RenderHTML
       end
       out(link_tooltip_attributes(node))
       out('>', :children, '</a>')
+    end
+
+    def link_href(uri)
+      return '' if uri.nil?
+
+      escape_href(uri.to_s)
     end
 
     def table(node)

--- a/test/commands/markdown/parse_test.rb
+++ b/test/commands/markdown/parse_test.rb
@@ -158,7 +158,7 @@ Done')
   end
 
   test 'adds data-turbo="false" to internal links with anchor' do
-    expected = '<p><a href="https://exercism.org#about" data-turbo="false">Some link</a></p>'
+    expected = '<p><a href="https://exercism.org#h-about" data-turbo="false">Some link</a></p>'
     assert_equal expected.chomp, Markdown::Parse.('[Some link](https://exercism.org#about)').chomp
   end
 
@@ -255,7 +255,7 @@ Done')
   end
 
   test "render internal link ending with hash" do
-    expected = %(<p><a href="https://exercism.org/tracks/ruby/concepts/basics#intro" data-turbo="false" data-tooltip-type="concept" data-endpoint="/tracks/ruby/concepts/basics/tooltip">basics</a></p>\n) # rubocop:disable Layout/LineLength
+    expected = %(<p><a href="https://exercism.org/tracks/ruby/concepts/basics#h-intro" data-turbo="false" data-tooltip-type="concept" data-endpoint="/tracks/ruby/concepts/basics/tooltip">basics</a></p>\n) # rubocop:disable Layout/LineLength
     assert_equal expected, Markdown::Parse.("[basics](https://exercism.org/tracks/ruby/concepts/basics#intro)")
   end
 
@@ -435,6 +435,40 @@ Done')
   test "heading id for same titles uses sequential numbering" do
     expected = %(<h2 id="h-my-title">my title</h2>\n<h2 id="h-my-title-1">my title</h2>\n<h2 id="h-my-title-2">my title</h2>\n)
     assert_equal expected, Markdown::Parse.("## my title\n\n## my title\n\n## my title", heading_ids: true, lower_heading_levels_by: 0)
+  end
+
+  ["", "/docs/", "/tracks/csharp/exercises/", "/tracks/csharp/concepts/"].each do |path|
+    test "inline link for #{path} path with hash but not prefixed with 'h-'" do
+      expected = %(<p><a href="#{path}#h-test" data-turbo="false">Link</a></p>\n)
+      assert_equal expected, Markdown::Parse.("[Link](#{path}#test)")
+    end
+
+    test "inline link for #{path} path with hash but no domain prefixed with 'h-'" do
+      expected = %(<p><a href="#{path}#h-test" data-turbo="false">Link</a></p>\n)
+      assert_equal expected, Markdown::Parse.("[Link](#{path}#test)")
+    end
+
+    test "inline link for #{path} path with hash prefixed with 'h-' does not add another 'h-' prefix" do
+      expected = %(<p><a href="#{path}#h-test" data-turbo="false">Link</a></p>\n)
+      assert_equal expected, Markdown::Parse.("[Link](#{path}#h-test)")
+    end
+
+    %w[exercism.org exercism.io].each do |domain|
+      test "inline link for #{path} path with hash and #{domain} domain prefixed with 'h-'" do
+        expected = %(<p><a href=\"https://#{domain}#{path}#h-test\" data-turbo=\"false\">Link</a></p>\n)
+        assert_equal expected, Markdown::Parse.("[Link](https://#{domain}#{path}#test)")
+      end
+    end
+  end
+
+  test "inline link with hash for non-special path not prefixed with 'h-'" do
+    expected = %(<p><a href="https://exercism.org/about/#test" data-turbo="false">Link</a></p>\n)
+    assert_equal expected, Markdown::Parse.("[Link](https://exercism.org/about/#test)")
+  end
+
+  test "inline link with hash and non-exercism domain not prefixed with 'h-'" do
+    expected = %(<p><a href="https://test.org/docs/#test" target="_blank" rel="noreferrer">Link</a></p>\n)
+    assert_equal expected, Markdown::Parse.("[Link](https://test.org/docs/#test)")
   end
 
   test "render youtube video for mail with link" do


### PR DESCRIPTION
- Create separate method for markdown link href
- Automatically prepend 'h-' to internal links with hash
