### PR TITLE
Update track name for Mac

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -162,7 +162,7 @@ class Track < ApplicationRecord
     },
     platform: {
       windows: "Windows",
-      mac: "Mac OSX",
+      mac: "macOS",
       linux: "Linux",
       ios: "iOS",
       android: "Android",


### PR DESCRIPTION
Mac OS X was changed to "macOS" in 2016. I think the current name would be a more appropriate term, but let me know your thoughts