### PR TITLE
Rule out empty before

### DIFF
--- a/app/css/pages/exercise-show.css
+++ b/app/css/pages/exercise-show.css
@@ -258,7 +258,9 @@ body.namespace-tracks.controller-exercises.action-show {
             }
         }
 
-        &:before {
+        &.pending:before,
+        &.locked:before,
+        &.completed:before {
             @apply absolute left-[-12px] top-[2px];
             @apply rounded-circle bg-backgroundColorA;
             @apply w-[24px] h-[24px];


### PR DESCRIPTION
<img width="349" alt="Screenshot 2024-01-15 at 16 28 51" src="https://github.com/exercism/website/assets/66035744/f43309cb-0005-4f27-90da-b7931880f6b8">

We need this `:before` here:
<img width="91" alt="Screenshot 2024-01-15 at 16 27 05" src="https://github.com/exercism/website/assets/66035744/3711b592-d3e4-4597-a0c5-1228bec5c4e2">

