### PR TITLE
Update 48in24.html.haml: Fix Exercise Link to use slug

### DIFF
--- a/app/views/challenges/48in24.html.haml
+++ b/app/views/challenges/48in24.html.haml
@@ -20,7 +20,7 @@
           - if featured_exercise
             %h1.text-h1.mb-8 This week, we're featuring #{featured_exercise.title}.
             %p.text-p-xlarge.mb-12
-              For week #{week} of #48in24, we're exploring #{link_to featured_exercise.title, generic_exercise_path(featured_exercise), class: 'underline'}.
+              For week #{week} of #48in24, we're exploring #{link_to featured_exercise.title, generic_exercise_path(featured_exercise.slug), class: 'underline'}.
             %p.text-p-large.mb-12= featured_exercise.learning_opportunity
 
             %p.text-p-large.mb-12


### PR DESCRIPTION
The link on the 48in24 page seems to be linking to a serialized exercise object. This might fix it, if I'm following the other exercise link example correctly.