### PR TITLE
Use padding for iterations footer instead of random margin

### DIFF
--- a/app/css/components/solution-iterations.css
+++ b/app/css/components/solution-iterations.css
@@ -18,8 +18,11 @@
         }
     }
     & .c-iterations-footer {
-        @apply flex-grow-0 mb-8;
-        @apply flex items-center;
+        @apply flex-grow-0;
+        @apply flex items-center py-16;
+        .iterations {
+            @apply py-0;
+        }
 
         & .publish-settings-button {
             @apply ml-auto px-0 border-borderColor6;


### PR DESCRIPTION

<img width="1008" alt="Screenshot 2024-01-19 at 13 45 53" src="https://github.com/exercism/website/assets/66035744/fff17633-91c2-4dd5-bae2-70dfa9bacb0c">
<img width="960" alt="Screenshot 2024-01-19 at 13 49 02" src="https://github.com/exercism/website/assets/66035744/d09362f9-09dc-45e9-9383-3b8a0cfe9362">
<img width="776" alt="Screenshot 2024-01-19 at 13 53 05" src="https://github.com/exercism/website/assets/66035744/5e19be2b-dd20-481e-ae44-f0085a7d36f6">
