### PR TITLE
Style textual content's footnotes

### DIFF
--- a/app/css/components/textual-content.css
+++ b/app/css/components/textual-content.css
@@ -8,12 +8,23 @@
     }
 
     &.--large {
-        & * {
+        & *:not(.footnotes) {
             @apply text-16;
         }
+        .footnotes * {
+            @apply text-14;
+        }
+
+        .footnotes {
+            @apply border-t-1 border-borderColor6 pt-20 mt-20;
+        }
+
         @screen md {
-            & * {
+            & *:not(.footnotes) {
                 @apply text-18;
+            }
+            .footnotes * {
+                @apply text-16;
             }
         }
         & > * {


### PR DESCRIPTION
<img width="995" alt="Screenshot 2024-01-22 at 12 44 31" src="https://github.com/exercism/website/assets/66035744/1668f7c0-750c-4820-9309-43b5ba071ce5">
