### PR TITLE
add link to rss feed in head

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -62,3 +62,5 @@
 - if Rails.env.production?
   %script{ async: true, src: "/usage/js/script.js", data: { domain: "exercism.org", api: "/usage/api/event" } }
 
+-# pointer to RSS feed for autodiscovery. See: https://rknight.me/blog/please-expose-your-rss/
+%link{ rel: "alternate", type: "application/rss+xml", title: "Exercism's Blog", href: "https://exercism.org/blog.rss" }


### PR DESCRIPTION
Adding the RSS feed to the `<head>` to it's auto-discoverable by readers.