### PR TITLE
Remove w-arbitary from external exercise show

### DIFF
--- a/app/views/tracks/exercises/show/_external.html.haml
+++ b/app/views/tracks/exercises/show/_external.html.haml
@@ -1,5 +1,5 @@
 .lg-container.flex.flex-col.lg:flex-row
-  %section.lg:mr-32.w-arbitary.flex-grow
+  %section.lg:mr-32.flex-grow
     = render("tracks/exercises/show/instructions", track:, exercise:, solution: nil)
   .flex-shrink-0.mb-32.lg:mb-0.lg:w-1-3
     - if user_signed_in?


### PR DESCRIPTION


https://github.com/exercism/website/assets/66035744/2aff1202-8510-4eaf-8910-6fdc3954ae14

Turns this:

<img width="444" alt="Screenshot 2024-01-24 at 10 42 15" src="https://github.com/exercism/website/assets/66035744/0d519f65-3bb4-4ffc-b0bf-e683ac6bffa3">

Into this:

<img width="429" alt="Screenshot 2024-01-24 at 10 42 33" src="https://github.com/exercism/website/assets/66035744/ab7c76b0-264e-43a2-a383-abcf896c5291">

