### PR TITLE
Award discourser badge after 30s

### DIFF
--- a/app/controllers/discourse_controller.rb
+++ b/app/controllers/discourse_controller.rb
@@ -11,6 +11,8 @@ class DiscourseController < ApplicationController
     sso.bio = current_user.bio
     sso.sso_secret = secret
 
+    # Wait 30s on these so we don't get a race condition from Discourse
+    # not having updated its data by the time we run things.
     User::SetDiscourseGroups.defer(current_user, wait: 30.seconds)
     AwardBadgeJob.set(wait: 30.seconds).perform_later(current_user, :discourser)
 

--- a/app/controllers/discourse_controller.rb
+++ b/app/controllers/discourse_controller.rb
@@ -12,7 +12,7 @@ class DiscourseController < ApplicationController
     sso.sso_secret = secret
 
     User::SetDiscourseGroups.defer(current_user, wait: 30.seconds)
-    AwardBadgeJob.perform_later(current_user, :discourser)
+    AwardBadgeJob.set(wait: 30.seconds).perform_later(current_user, :discourser)
 
     redirect_to sso.to_url("https://forum.exercism.org/session/sso_login"), allow_other_host: true
   end


### PR DESCRIPTION
Seems like we've not been awarding this badge some times due to race conditions.

@ErikSchierboom Could you get the external ids of the users for this please. I'll tell you how to access the database directly save having to use the (terrible) API.