### PR TITLE
Revert "Style textual content's footnotes"

### DIFF
--- a/app/css/components/textual-content.css
+++ b/app/css/components/textual-content.css
@@ -8,23 +8,12 @@
     }
 
     &.--large {
-        & *:not(.footnotes) {
+        & * {
             @apply text-16;
         }
-        .footnotes * {
-            @apply text-14;
-        }
-
-        .footnotes {
-            @apply border-t-1 border-borderColor6 pt-20 mt-20;
-        }
-
         @screen md {
-            & *:not(.footnotes) {
+            & * {
                 @apply text-18;
-            }
-            .footnotes * {
-                @apply text-16;
             }
         }
         & > * {


### PR DESCRIPTION
Reverts exercism/website#6709

@dem4ron This has broken the heading sizes on the blog posts.