### PR TITLE
Enable syntax highlight for red

### DIFF
--- a/app/javascript/utils/highlight.ts
+++ b/app/javascript/utils/highlight.ts
@@ -1,12 +1,12 @@
 import * as highlighter from 'highlight.js'
 import { useLayoutEffect, useRef } from 'react'
+import { areAllRegExpFeaturesSupported } from './regex-check'
 import setupABAP from 'highlightjs-sap-abap'
 import setupCobol from 'highlightjs-cobol'
 import setupBqn from 'highlightjs-bqn'
 import setupZig from 'highlightjs-zig'
 import setupGleam from '@gleam-lang/highlight.js-gleam'
 import setupBallerina from '@ballerina/highlightjs-ballerina'
-import { areAllRegExpFeaturesSupported } from './regex-check'
 import setupRed from 'highlightjs-redbol'
 
 if (areAllRegExpFeaturesSupported()) {

--- a/app/javascript/utils/highlight.ts
+++ b/app/javascript/utils/highlight.ts
@@ -7,6 +7,7 @@ import setupZig from 'highlightjs-zig'
 import setupGleam from '@gleam-lang/highlight.js-gleam'
 import setupBallerina from '@ballerina/highlightjs-ballerina'
 import { areAllRegExpFeaturesSupported } from './regex-check'
+import setupRed from 'highlightjs-redbol'
 
 if (areAllRegExpFeaturesSupported()) {
   highlighter.default.registerLanguage('abap', setupABAP)
@@ -15,6 +16,7 @@ if (areAllRegExpFeaturesSupported()) {
   highlighter.default.registerLanguage('zig', setupZig)
   highlighter.default.registerLanguage('gleam', setupGleam)
   highlighter.default.registerLanguage('ballerina', setupBallerina)
+  highlighter.default.registerLanguage('red', setupRed)
 }
 
 highlighter.default.configure({

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "highlight.js": "11.9.0",
     "highlightjs-bqn": "^0.0.1",
     "highlightjs-cobol": "^0.3.1",
-    "highlightjs-redbol": "^2.1.1",
+    "highlightjs-redbol": "^2.1.2",
     "highlightjs-sap-abap": "^0.2.0",
     "highlightjs-zig": "^1.0.2",
     "humps": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "highlight.js": "11.9.0",
     "highlightjs-bqn": "^0.0.1",
     "highlightjs-cobol": "^0.3.1",
-    "highlightjs-redbol": "^2.0.3",
+    "highlightjs-redbol": "^2.1.1",
     "highlightjs-sap-abap": "^0.2.0",
     "highlightjs-zig": "^1.0.2",
     "humps": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "highlight.js": "11.9.0",
     "highlightjs-bqn": "^0.0.1",
     "highlightjs-cobol": "^0.3.1",
+    "highlightjs-redbol": "^2.0.3",
     "highlightjs-sap-abap": "^0.2.0",
     "highlightjs-zig": "^1.0.2",
     "humps": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5467,10 +5467,10 @@ highlightjs-cobol@^0.3.1:
     minimist ">=1.2.6"
     mkdirp "^1.0.4"
 
-highlightjs-redbol@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/highlightjs-redbol/-/highlightjs-redbol-2.1.1.tgz#28fca78a342c5d851bd80d0c3e60bcb1d2bb623e"
-  integrity sha512-j9ULplkN12Ln3tl04W8HIcBUjjZyUg7h5dEFIR7q1+UycJUjPCfZgMIIuoTJTOhz0/rYDuxenj0pLMWA3xXoAQ==
+highlightjs-redbol@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/highlightjs-redbol/-/highlightjs-redbol-2.1.2.tgz#5f4eb1fdcf9c7259d9cc1337b231272b2fe7621e"
+  integrity sha512-MMhBycvOQawsPj26sVmUOH09urnYoVlZVKWS5cYA8ah2lg7v9PLMC9y07QHOyoUkQ0AhKDyuyOncMQ/Cvr/G0A==
   dependencies:
     highlight.js "^11.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5449,7 +5449,7 @@ highlight.js@11.2.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.2.0.tgz#a7e3b8c1fdc4f0538b93b2dc2ddd53a40c6ab0f0"
   integrity sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==
 
-highlight.js@11.9.0:
+highlight.js@11.9.0, highlight.js@^11.9.0:
   version "11.9.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.9.0.tgz#04ab9ee43b52a41a047432c8103e2158a1b8b5b0"
   integrity sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==
@@ -5466,6 +5466,13 @@ highlightjs-cobol@^0.3.1:
   dependencies:
     minimist ">=1.2.6"
     mkdirp "^1.0.4"
+
+highlightjs-redbol@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/highlightjs-redbol/-/highlightjs-redbol-2.0.3.tgz#8a5ff684749c4a8ec72df10bd072a09ec140956b"
+  integrity sha512-9bTVliGtabxrZS6BhoUBDi1oiDw3SDg+ywLQHxbBkxeH9dytssKZm7OigKEl8enCWlwzqrreOKPe10NDyG6A/A==
+  dependencies:
+    highlight.js "^11.9.0"
 
 highlightjs-sap-abap@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5467,10 +5467,10 @@ highlightjs-cobol@^0.3.1:
     minimist ">=1.2.6"
     mkdirp "^1.0.4"
 
-highlightjs-redbol@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/highlightjs-redbol/-/highlightjs-redbol-2.0.3.tgz#8a5ff684749c4a8ec72df10bd072a09ec140956b"
-  integrity sha512-9bTVliGtabxrZS6BhoUBDi1oiDw3SDg+ywLQHxbBkxeH9dytssKZm7OigKEl8enCWlwzqrreOKPe10NDyG6A/A==
+highlightjs-redbol@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/highlightjs-redbol/-/highlightjs-redbol-2.1.1.tgz#28fca78a342c5d851bd80d0c3e60bcb1d2bb623e"
+  integrity sha512-j9ULplkN12Ln3tl04W8HIcBUjjZyUg7h5dEFIR7q1+UycJUjPCfZgMIIuoTJTOhz0/rYDuxenj0pLMWA3xXoAQ==
   dependencies:
     highlight.js "^11.9.0"
 


### PR DESCRIPTION
@dem4ron I'm trying to add syntax highlighting for the Red language, but it appears that the plugin works somewhat differently then the other plugins in that it does not export a "setupX" function.
See https://github.com/oldes/highlightjs-redbol for usage information.

If I try to just import it, I get: 

```
chunk-ESSQIN74.js:825 Uncaught ReferenceError: hljs is not defined
    at chunk-XPBYWIPF.js:874:7
    at node_modules/highlightjs-redbol/src/languages/redbol.js (chunk-XPBYWIPF.js:875:7)
    at __require2 (chunk-WNHRPDVC.js:45:50)
    at chunk-XPBYWIPF.js:1507:9
```