### PR TITLE
Fix syntax-highlighting on Editor/Instructions tab

### DIFF
--- a/app/javascript/components/editor/InstructionsPanel.tsx
+++ b/app/javascript/components/editor/InstructionsPanel.tsx
@@ -19,7 +19,7 @@ export const InstructionsPanel = ({
   const ref = useHighlighting<HTMLDivElement>()
 
   return (
-    <Tab.Panel id="instructions" context={TabsContext}>
+    <Tab.Panel id="instructions" context={TabsContext} alwaysAttachToDOM>
       <section className="instructions-pane" ref={ref}>
         <div className="c-textual-content --small">
           <Introduction introduction={introduction} />


### PR DESCRIPTION

https://github.com/exercism/website/assets/66035744/b0595720-6c17-4a71-be63-e4968bb4c260

