### PR TITLE
Improve code search

### DIFF
--- a/app/commands/infrastructure/escape_opensearch_simple_query_string_term.rb
+++ b/app/commands/infrastructure/escape_opensearch_simple_query_string_term.rb
@@ -3,5 +3,8 @@ class Infrastructure::EscapeOpensearchSimpleQueryStringTerm
 
   initialize_with :term
 
-  def call = term.gsub(/[|+\-"*()~\\]/) { |c| "\\#{c}" }
+  def call
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax
+    term.gsub(/[|+\-"*()~\\]/) { |c| "\\#{c}" }
+  end
 end

--- a/app/commands/infrastructure/escape_opensearch_simple_query_string_term.rb
+++ b/app/commands/infrastructure/escape_opensearch_simple_query_string_term.rb
@@ -1,0 +1,7 @@
+class Infrastructure::EscapeOpensearchSimpleQueryStringTerm
+  include Mandate
+
+  initialize_with :term
+
+  def call = term.gsub(/[|+\-"*()~\\]/) { |c| "\\#{c}" }
+end

--- a/app/commands/solution/search_via_representations.rb
+++ b/app/commands/solution/search_via_representations.rb
@@ -14,7 +14,7 @@ class Solution::SearchViaRepresentations
     @page = page.present? && page.to_i.positive? ? page.to_i : DEFAULT_PAGE
     @per = per.present? && per.to_i.positive? ? per.to_i : self.class.default_per
     @order = order&.to_sym || :most_popular
-    @criteria = criteria&.split.to_a
+    @criteria = criteria&.strip
     @tags = tags.present? && tags.is_a?(String) ? tags.split : tags.to_a
   end
 
@@ -73,12 +73,7 @@ class Solution::SearchViaRepresentations
       { term: { 'exercise.id': exercise.id } }
     ]
 
-    # We match criteria via wildcards to allow for partial matching
-    criteria.each do |value|
-      next if value.size < MIN_CRITERIA_LEN
-
-      parts << { wildcard: { code: { value: "*#{value}*" } } }
-    end
+    parts << { match: { code: { query: criteria, fuzziness: 1 } } } if criteria.size >= MIN_CRITERIA_LEN
 
     # Tags are matched exactly
     tags.each do |tag|

--- a/app/commands/solution/search_via_representations.rb
+++ b/app/commands/solution/search_via_representations.rb
@@ -14,7 +14,7 @@ class Solution::SearchViaRepresentations
     @page = page.present? && page.to_i.positive? ? page.to_i : DEFAULT_PAGE
     @per = per.present? && per.to_i.positive? ? per.to_i : self.class.default_per
     @order = order&.to_sym || :most_popular
-    @criteria = criteria&.strip
+    @criteria = criteria&.split.to_a
     @tags = tags.present? && tags.is_a?(String) ? tags.split : tags.to_a
   end
 
@@ -73,7 +73,11 @@ class Solution::SearchViaRepresentations
       { term: { 'exercise.id': exercise.id } }
     ]
 
-    parts << { match: { code: { query: criteria, fuzziness: 1 } } } if criteria.size >= MIN_CRITERIA_LEN
+    criteria.each do |value|
+      next if value.size < MIN_CRITERIA_LEN
+
+      parts << { wildcard: { code: { value: "*#{value}*" } } }
+    end
 
     # Tags are matched exactly
     tags.each do |tag|

--- a/app/commands/solution/search_via_representations.rb
+++ b/app/commands/solution/search_via_representations.rb
@@ -73,11 +73,7 @@ class Solution::SearchViaRepresentations
       { term: { 'exercise.id': exercise.id } }
     ]
 
-    criteria.each do |value|
-      next if value.size < MIN_CRITERIA_LEN
-
-      parts << { wildcard: { code: { value: "*#{value}*" } } }
-    end
+    parts << criteria_query if criteria_query.present?
 
     # Tags are matched exactly
     tags.each do |tag|
@@ -102,15 +98,33 @@ class Solution::SearchViaRepresentations
     end
   end
 
-  def to_terms(value)
-    return value.split if value.is_a?(String)
+  memoize
+  def criteria_query
+    return if criteria_query_terms.empty?
 
-    [value].flatten
+    {
+      simple_query_string: {
+        query: criteria_query_terms.join(' + '),
+        fields: ["code"],
+        analyze_wildcard: true
+      }
+    }
+  end
+
+  memoize
+  def criteria_query_terms
+    criteria.filter_map do |value|
+      next if value.size < MIN_CRITERIA_LEN
+
+      term = Infrastructure::EscapeOpensearchSimpleQueryStringTerm.(value)
+      "#{term}~#{CODE_TERM_FUZZINESS}"
+    end
   end
 
   TIMEOUT = '400ms'.freeze
   MIN_CRITERIA_LEN = 3
-  private_constant :TIMEOUT, :MIN_CRITERIA_LEN
+  CODE_TERM_FUZZINESS = 1
+  private_constant :TIMEOUT, :MIN_CRITERIA_LEN, :CODE_TERM_FUZZINESS
 
   class Fallback
     include Mandate

--- a/test/commands/infrastructure/escape_opensearch_simple_query_string_term_test.rb
+++ b/test/commands/infrastructure/escape_opensearch_simple_query_string_term_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class Infrastructure::EscapeOpensearchSimpleQueryStringTermTest < ActiveSupport::TestCase
+  [
+    ['abc', 'abc'],
+    ['a+c', 'a\\+c'],
+    ['a|c', 'a\\|c'],
+    ['a-c', 'a\\-c'],
+    ['a"c', 'a\\"c'],
+    ['a*c', 'a\\*c'],
+    ['a(c', 'a\\(c'],
+    ['a)c', 'a\\)c'],
+    ['a~c', 'a\\~c'],
+    ['a\\c', 'a\\\\c']
+  ].each do |(term, expected)|
+    test "escape '#{term}' as '#{expected}'" do
+      assert_equal expected, Infrastructure::EscapeOpensearchSimpleQueryStringTerm.(term)
+    end
+  end
+end
+
+# + signifies AND operation
+# | signifies OR operation
+# - negates a single token
+# " wraps a number of tokens to signify a phrase for searching
+# * at the end of a term signifies a prefix query
+# ( and ) signify precedence
+# ~N after a word signifies edit distance (fuzziness)
+# ~N after a phrase signifies slop amount

--- a/test/commands/infrastructure/escape_opensearch_simple_query_string_term_test.rb
+++ b/test/commands/infrastructure/escape_opensearch_simple_query_string_term_test.rb
@@ -18,12 +18,3 @@ class Infrastructure::EscapeOpensearchSimpleQueryStringTermTest < ActiveSupport:
     end
   end
 end
-
-# + signifies AND operation
-# | signifies OR operation
-# - negates a single token
-# " wraps a number of tokens to signify a phrase for searching
-# * at the end of a term signifies a prefix query
-# ( and ) signify precedence
-# ~N after a word signifies edit distance (fuzziness)
-# ~N after a phrase signifies slop amount

--- a/test/commands/solution/search_via_representations_test.rb
+++ b/test/commands/solution/search_via_representations_test.rb
@@ -116,7 +116,8 @@ class Solution::SearchViaRepresentationsTest < ActiveSupport::TestCase
     assert_equal [data[:your][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'your_main')
     assert_equal [data[:another][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'another_main')
     assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: '#class')
-    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: '#clasz')
+    assert_equal [data[:my][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'my_maan')
+    assert_equal [data[:my][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'my_main class')
   end
 
   test "filter: criteria ignored when length less than three" do

--- a/test/commands/solution/search_via_representations_test.rb
+++ b/test/commands/solution/search_via_representations_test.rb
@@ -115,8 +115,8 @@ class Solution::SearchViaRepresentationsTest < ActiveSupport::TestCase
     assert_equal [data[:my][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'my_main')
     assert_equal [data[:your][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'your_main')
     assert_equal [data[:another][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'another_main')
-    assert_equal data.values.map { |d| d[:solution] }, Solution::SearchViaRepresentations.(exercise, criteria: 'main')
-    assert_equal data.values.map { |d| d[:solution] }, Solution::SearchViaRepresentations.(exercise, criteria: 'mai')
+    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: 'main')
+    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: 'mai')
   end
 
   test "filter: criteria ignored when length less than three" do

--- a/test/commands/solution/search_via_representations_test.rb
+++ b/test/commands/solution/search_via_representations_test.rb
@@ -92,7 +92,7 @@ class Solution::SearchViaRepresentationsTest < ActiveSupport::TestCase
         git_important_files_hash: exercise.git_important_files_hash,
         published_iteration_head_tests_status: :passed
       submission = create :submission, solution:, tests_status: :passed
-      create :submission_file, submission:, filename: "main.rb", content: "def #{word}_main; end"
+      create :submission_file, submission:, filename: "main.rb", content: "def #{word}_main;\n#class\nend"
       create(:iteration, solution:, submission:)
 
       representation = create(:exercise_representation, exercise:, source_submission: submission)
@@ -115,8 +115,8 @@ class Solution::SearchViaRepresentationsTest < ActiveSupport::TestCase
     assert_equal [data[:my][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'my_main')
     assert_equal [data[:your][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'your_main')
     assert_equal [data[:another][:solution]], Solution::SearchViaRepresentations.(exercise, criteria: 'another_main')
-    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: 'main')
-    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: 'mai')
+    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: '#class')
+    assert_equal data.values.pluck(:solution), Solution::SearchViaRepresentations.(exercise, criteria: '#clasz')
   end
 
   test "filter: criteria ignored when length less than three" do


### PR DESCRIPTION
- Extract criteria less than length three to separate test
- Simplify unit tests
- Switch to match
- Add command to escape opensearch simple query string
- Improve code search
