### PR TITLE
Fix overflowing text on concept tooltip

### DIFF
--- a/app/css/tooltips/concept.css
+++ b/app/css/tooltips/concept.css
@@ -77,7 +77,7 @@
         }
     }
     & .available {
-        @apply text-textColor1 font-semibold whitespace-nowrap;
+        @apply text-textColor1 font-semibold;
         & .icon {
             @apply shadow-none;
         }

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -36,8 +36,9 @@
       You’ve learnt #{@concept.name}.
   - else
     .info.available
-      .icon.c-ed.--available.--concept.disabled
-      #{@concept.name} is available for you to learn.
+      .icon.c-ed.--available.--concept.disabled.shrink-0
+      .truncate{ style: 'width: 410px' }
+        #{@concept.name} is available for you to learn.
 
 
 = link_to Exercism::Routes.track_concept_path(@track, @concept), class: 'explore-concept-button btn-xs btn-secondary mt-16' do

--- a/app/views/tracks/concepts/tooltip.html.haml
+++ b/app/views/tracks/concepts/tooltip.html.haml
@@ -37,8 +37,7 @@
   - else
     .info.available
       .icon.c-ed.--available.--concept.disabled.shrink-0
-      .truncate{ style: 'width: 410px' }
-        #{@concept.name} is available for you to learn.
+      #{@concept.name} is available for you to learn.
 
 
 = link_to Exercism::Routes.track_concept_path(@track, @concept), class: 'explore-concept-button btn-xs btn-secondary mt-16' do


### PR DESCRIPTION
Issue: [Concept tree concept popup: text exceeds box width](https://forum.exercism.org/t/concept-tree-concept-popup-text-exceeds-box-width/10499)

<img width="410" alt="Screenshot 2024-03-28 at 15 35 09" src="https://github.com/exercism/website/assets/66035744/218017aa-6a5e-4ee1-be45-4af156c656c9">

