### PR TITLE
Use sans as fallback to Poppins font

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -34,7 +34,7 @@
 
 :css
   body {
-    --body-font: Poppins, PoppinsInitial, serif;
+    --body-font: Poppins, PoppinsInitial, sans-serif;
     font-family: var(--body-font);
     -webkit-font-smoothing: antialiased;
   }


### PR DESCRIPTION
Fixes the fallback font used by browser in case of unsupported characters by the current subset of the Poppins web font (i.e. latin-ext characters).

**BEFORE:**
![image](https://github.com/exercism/website/assets/11782/c7907d42-6067-45e3-9f81-7f690428380d)

**AFTER:**
![image](https://github.com/exercism/website/assets/11782/63f90890-7634-463f-b4de-91fdbf909782)
