### PR TITLE
Show track progress on automation locked tooltip

### DIFF
--- a/app/controllers/mentoring/automation_controller.rb
+++ b/app/controllers/mentoring/automation_controller.rb
@@ -20,7 +20,9 @@ class Mentoring::AutomationController < ApplicationController
   end
 
   def tooltip_locked
-    @finished_mentoring_sessions = @current_user.track_mentorships.maximum(:num_finished_discussions).to_i
+    max_finished_discussions_mentorship = @current_user.track_mentorships.order(num_finished_discussions: :desc).first
+    @finished_mentoring_sessions = max_finished_discussions_mentorship&.num_finished_discussions.to_i
+    @finished_mentoring_sessions_track = max_finished_discussions_mentorship&.track
     @satisfaction_percentage = @current_user.mentor_satisfaction_percentage.to_i
     @min_finished_mentoring_sessions = User::UpdateSupermentorRole::MIN_FINISHED_MENTORING_SESSIONS
     @min_satisfaction_percentage = User::UpdateSupermentorRole::MIN_SATISFACTION_PERCENTAGE

--- a/app/views/mentoring/automation/tooltip_locked.html.haml
+++ b/app/views/mentoring/automation/tooltip_locked.html.haml
@@ -8,7 +8,7 @@
     .bg-gradient-to-r.from-gradientProgressBarA.to-gradientProgressBarB.rounded-8.h-100{ class: "min-w-[6px]", style: "width:#{@finished_mentoring_sessions}%" }
 
 
-  .mb-16 #{@finished_mentoring_sessions}/#{@min_finished_mentoring_sessions}
+  .mb-16 #{@finished_mentoring_sessions}/#{@min_finished_mentoring_sessions} #{"(on the #{@finished_mentoring_sessions_track.title} track)" if @finished_mentoring_sessions.positive?}
 
   %h4.font-semibold.mb-4 What is automation?
 


### PR DESCRIPTION
To help people understand which track they've progressed in most when trying to unlock automation, the tooltip now shows that track's title.

See https://forum.exercism.org/t/finished-vs-completed-and-automation/11506