### PR TITLE
Simplify track creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ env:
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/app/commands/github/dispatch_workflow.rb
+++ b/app/commands/github/dispatch_workflow.rb
@@ -1,11 +1,11 @@
 class Github::DispatchWorkflow
   include Mandate
 
-  initialize_with :repo, :workflow_id
+  initialize_with :repo, :workflow_id, ref: "main"
 
   def call = Exercism.octokit_client.post(api_url, body)
 
   private
   def api_url = "https://api.github.com/repos/exercism/#{repo}/actions/workflows/#{workflow_id}/dispatches"
-  def body = { ref: "main" }.to_json
+  def body = { ref: }.to_json
 end

--- a/app/commands/github/dispatch_workflow.rb
+++ b/app/commands/github/dispatch_workflow.rb
@@ -1,0 +1,11 @@
+class Github::DispatchWorkflow
+  include Mandate
+
+  initialize_with :repo, :workflow_id
+
+  def call = Exercism.octokit_client.post(api_url, body)
+
+  private
+  def api_url = "https://api.github.com/repos/exercism/#{repo}/actions/workflows/configlet.yml/dispatches"
+  def body = { ref: "main" }.to_json
+end

--- a/app/commands/github/dispatch_workflow.rb
+++ b/app/commands/github/dispatch_workflow.rb
@@ -6,6 +6,6 @@ class Github::DispatchWorkflow
   def call = Exercism.octokit_client.post(api_url, body)
 
   private
-  def api_url = "https://api.github.com/repos/exercism/#{repo}/actions/workflows/configlet.yml/dispatches"
+  def api_url = "https://api.github.com/repos/exercism/#{repo}/actions/workflows/#{workflow_id}/dispatches"
   def body = { ref: "main" }.to_json
 end

--- a/app/commands/infrastructure/trigger_redeploy.rb
+++ b/app/commands/infrastructure/trigger_redeploy.rb
@@ -1,0 +1,5 @@
+class Infrastructure::TriggerRedeploy
+  include Mandate
+
+  def call = Github::DispatchWorkflow.("website-deployer", "deploy.yml")
+end

--- a/app/commands/track/create.rb
+++ b/app/commands/track/create.rb
@@ -6,6 +6,8 @@ class Track::Create
   end
 
   def call
+    add_safe_directory!
+
     Track.create!(
       slug: git_track.slug,
       repo_url:,
@@ -24,4 +26,8 @@ class Track::Create
 
   memoize
   def git_track = Git::Track.new("HEAD", repo_url:)
+
+  def add_safe_directory!
+    system("git config --global --add safe.directory #{slug}")
+  end
 end

--- a/app/commands/track/create.rb
+++ b/app/commands/track/create.rb
@@ -1,7 +1,9 @@
 class Track::Create
   include Mandate
 
-  initialize_with :repo_url
+  initialize_with :slug, repo_url: nil do
+    @repo_url ||= "https://github.com/exercism/#{slug}"
+  end
 
   def call
     Track.create!(

--- a/app/commands/track/create.rb
+++ b/app/commands/track/create.rb
@@ -6,8 +6,6 @@ class Track::Create
   end
 
   def call
-    add_safe_directory!
-
     Track.create!(
       slug: git_track.slug,
       repo_url:,
@@ -19,6 +17,7 @@ class Track::Create
       # We need to force_sync due to the synced_to_git_sha value set to the HEAD commit
       Git::SyncTrack.(track, force_sync: true)
       Track::CreateForumCategory.(track)
+      Track::SetFileSystemPermissions.(track)
     end
   rescue ActiveRecord::RecordNotUnique
     Track.find_by!(slug: git_track.slug)
@@ -26,8 +25,4 @@ class Track::Create
 
   memoize
   def git_track = Git::Track.new("HEAD", repo_url:)
-
-  def add_safe_directory!
-    system("git config --global --add safe.directory #{slug}")
-  end
 end

--- a/app/commands/track/set_file_system_permissions.rb
+++ b/app/commands/track/set_file_system_permissions.rb
@@ -21,9 +21,7 @@ class Track::SetFileSystemPermissions
     Kernel.system("git config --global --add safe.directory #{safe_directory}")
   end
 
-  def trigger_redeploy!
-    Github::DispatchWorkflow.("website", "deploy.yml")
-  end
+  def trigger_redeploy! = Infrastructure::TriggerRedeploy.()
 
   def safe_directory = "/mnt/efs/repos/#{track.slug}"
 end

--- a/app/commands/track/set_file_system_permissions.rb
+++ b/app/commands/track/set_file_system_permissions.rb
@@ -1,0 +1,19 @@
+class Track::SetFileSystemPermissions
+  include Mandate
+
+  initialize_with :track
+
+  def call
+    add_safe_directory!
+    trigger_redeploy!
+  end
+
+  private
+  def add_safe_directory!
+    Kernel.system("git config --global --add safe.directory /mnt/efs/repos/#{track.slug}")
+  end
+
+  def trigger_redeploy!
+    Github::DispatchWorkflow.("website", "deploy.yml")
+  end
+end

--- a/app/commands/track/set_file_system_permissions.rb
+++ b/app/commands/track/set_file_system_permissions.rb
@@ -5,6 +5,8 @@ class Track::SetFileSystemPermissions
 
   def call
     add_safe_directory!
+
+    # A redeploy of the website is required to pick up the new safe directory
     trigger_redeploy!
   end
 

--- a/app/commands/track/set_file_system_permissions.rb
+++ b/app/commands/track/set_file_system_permissions.rb
@@ -4,6 +4,8 @@ class Track::SetFileSystemPermissions
   initialize_with :track
 
   def call
+    return if safe_directory_already_set?
+
     add_safe_directory!
 
     # A redeploy of the website is required to pick up the new safe directory
@@ -11,11 +13,17 @@ class Track::SetFileSystemPermissions
   end
 
   private
+  def safe_directory_already_set?
+    Kernel.system("git config --global --get safe.directory #{safe_directory}")
+  end
+
   def add_safe_directory!
-    Kernel.system("git config --global --add safe.directory /mnt/efs/repos/#{track.slug}")
+    Kernel.system("git config --global --add safe.directory #{safe_directory}")
   end
 
   def trigger_redeploy!
     Github::DispatchWorkflow.("website", "deploy.yml")
   end
+
+  def safe_directory = "/mnt/efs/repos/#{track.slug}"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -131,7 +131,7 @@ track_slugs.each do |track_slug|
 
   begin
     puts "Adding Track: #{track_slug}"
-    Track::Create.("https://github.com/exercism/#{track_slug}")
+    Track::Create.(track_slug)
   rescue StandardError => e
     # puts e.message
     # puts e.backtrace

--- a/test/commands/github/dispatch_workflow_test.rb
+++ b/test/commands/github/dispatch_workflow_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class Github::DispatchWorkflowTest < ActiveJob::TestCase
+  test "dispatch workflow" do
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby/actions/workflows/configlet.yml/dispatches").
+      with(body: '{"ref":"main"}')
+
+    Github::DispatchWorkflow.("ruby", "configlet.yml")
+  end
+end

--- a/test/commands/github/dispatch_workflow_test.rb
+++ b/test/commands/github/dispatch_workflow_test.rb
@@ -7,4 +7,12 @@ class Github::DispatchWorkflowTest < ActiveJob::TestCase
 
     Github::DispatchWorkflow.("ruby", "configlet.yml")
   end
+
+  test "custom ref" do
+    ref = 'my-branch'
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby/actions/workflows/deploy.yml/dispatches").
+      with(body: '{"ref":"my-branch"}')
+
+    Github::DispatchWorkflow.("ruby", "deploy.yml", ref:)
+  end
 end

--- a/test/commands/infrastructure/trigger_redeploy_test.rb
+++ b/test/commands/infrastructure/trigger_redeploy_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class Infrastructure::TriggerRedeployTest < ActiveSupport::TestCase
+  test "calls GHA deploy workflow" do
+    Github::DispatchWorkflow.expects(:call).with("website-deployer", "deploy.yml")
+
+    Infrastructure::TriggerRedeploy.()
+  end
+end

--- a/test/commands/track/create_test.rb
+++ b/test/commands/track/create_test.rb
@@ -4,6 +4,7 @@ class Track::CreateTest < ActiveSupport::TestCase
   test "creates track" do
     repo_url = TestHelpers.git_repo_url("track")
     Track::CreateForumCategory.stubs(:call)
+    Track::SetFileSystemPermissions.stubs(:call)
 
     Track::Create.('ruby', repo_url:)
 
@@ -22,6 +23,7 @@ class Track::CreateTest < ActiveSupport::TestCase
 
   test "syncs track" do
     Track::CreateForumCategory.stubs(:call)
+    Track::SetFileSystemPermissions.stubs(:call)
 
     Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
 
@@ -32,12 +34,21 @@ class Track::CreateTest < ActiveSupport::TestCase
 
   test "adds track to forum" do
     Track::CreateForumCategory.expects(:call).once
+    Track::SetFileSystemPermissions.stubs(:call)
+
+    Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
+  end
+
+  test "sets file system permissions" do
+    Track::SetFileSystemPermissions.expects(:call).once
+    Track::CreateForumCategory.stubs(:call)
 
     Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
   end
 
   test "idempotent" do
     Track::CreateForumCategory.stubs(:call)
+    Track::SetFileSystemPermissions.stubs(:call)
 
     assert_idempotent_command do
       Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
@@ -46,6 +57,7 @@ class Track::CreateTest < ActiveSupport::TestCase
 
   test "use http repo url when not passed in" do
     Track::CreateForumCategory.stubs(:call)
+    Track::SetFileSystemPermissions.stubs(:call)
     Git::SyncTrack.stubs(:call)
 
     git_track = Git::Track.new("HEAD", repo_url: TestHelpers.git_repo_url("track"))

--- a/test/commands/track/create_test.rb
+++ b/test/commands/track/create_test.rb
@@ -5,7 +5,7 @@ class Track::CreateTest < ActiveSupport::TestCase
     repo_url = TestHelpers.git_repo_url("track")
     Track::CreateForumCategory.stubs(:call)
 
-    Track::Create.(repo_url)
+    Track::Create.('ruby', repo_url:)
 
     assert_equal 1, Track.count
     track = Track.last
@@ -23,7 +23,7 @@ class Track::CreateTest < ActiveSupport::TestCase
   test "syncs track" do
     Track::CreateForumCategory.stubs(:call)
 
-    Track::Create.(TestHelpers.git_repo_url("track"))
+    Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
 
     track = Track.last
     assert_equal track.git.concept_exercises.count, track.concept_exercises.count
@@ -33,14 +33,24 @@ class Track::CreateTest < ActiveSupport::TestCase
   test "adds track to forum" do
     Track::CreateForumCategory.expects(:call).once
 
-    Track::Create.(TestHelpers.git_repo_url("track"))
+    Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
   end
 
   test "idempotent" do
     Track::CreateForumCategory.stubs(:call)
 
     assert_idempotent_command do
-      Track::Create.(TestHelpers.git_repo_url("track"))
+      Track::Create.('ruby', repo_url: TestHelpers.git_repo_url("track"))
     end
+  end
+
+  test "use http repo url when not passed in" do
+    Track::CreateForumCategory.stubs(:call)
+    Git::SyncTrack.stubs(:call)
+
+    git_track = Git::Track.new("HEAD", repo_url: TestHelpers.git_repo_url("track"))
+    Git::Track.expects(:new).with("HEAD", repo_url: "https://github.com/exercism/ruby").returns(git_track)
+
+    Track::Create.('ruby')
   end
 end

--- a/test/commands/track/set_file_system_permissions_test.rb
+++ b/test/commands/track/set_file_system_permissions_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Track::SetFileSystemPermissionsTest < ActiveSupport::TestCase
+  test "adds track repo to git safe directories" do
+    track = create :track
+
+    Github::DispatchWorkflow.stubs(:call)
+    Kernel.expects(:system).with("git config --global --add safe.directory /mnt/efs/repos/#{track.slug}")
+
+    Track::SetFileSystemPermissions.(track)
+  end
+
+  test "dispatches deploy workflow" do
+    track = create :track
+
+    Github::DispatchWorkflow.expects(:call).with("website", "deploy.yml")
+    Kernel.stubs(:system)
+
+    Track::SetFileSystemPermissions.(track)
+  end
+end

--- a/test/commands/track/set_file_system_permissions_test.rb
+++ b/test/commands/track/set_file_system_permissions_test.rb
@@ -24,7 +24,7 @@ class Track::SetFileSystemPermissionsTest < ActiveSupport::TestCase
   test "dispatches deploy workflow" do
     track = create :track
 
-    Github::DispatchWorkflow.expects(:call).with("website", "deploy.yml")
+    Infrastructure::TriggerRedeploy.expects(:call)
     Kernel.stubs(:system)
 
     Track::SetFileSystemPermissions.(track)

--- a/test/commands/track/set_file_system_permissions_test.rb
+++ b/test/commands/track/set_file_system_permissions_test.rb
@@ -1,11 +1,22 @@
 require "test_helper"
 
 class Track::SetFileSystemPermissionsTest < ActiveSupport::TestCase
-  test "adds track repo to git safe directories" do
+  test "adds track repo to git safe directories if not already added" do
     track = create :track
 
     Github::DispatchWorkflow.stubs(:call)
+    Kernel.stubs(:system).with("git config --global --get safe.directory /mnt/efs/repos/#{track.slug}").returns(false)
     Kernel.expects(:system).with("git config --global --add safe.directory /mnt/efs/repos/#{track.slug}")
+
+    Track::SetFileSystemPermissions.(track)
+  end
+
+  test "does not add track repo to git safe directories if already added" do
+    track = create :track
+
+    Github::DispatchWorkflow.expects(:call).never
+    Kernel.stubs(:system).with("git config --global --get safe.directory /mnt/efs/repos/#{track.slug}").returns(true)
+    Kernel.expects(:system).with("git config --global --add safe.directory /mnt/efs/repos/#{track.slug}").never
 
     Track::SetFileSystemPermissions.(track)
   end


### PR DESCRIPTION
With this PR, one can just pass in a track's slug to create a new track (as opposed to passing in the repo url).

It also adds the track directory to the git safe directories list, and the triggers a new deploy, which is needed for the permissions to apply.