### PR TITLE
Add support for highlightjs-roc

### DIFF
--- a/app/javascript/utils/highlight.ts
+++ b/app/javascript/utils/highlight.ts
@@ -12,6 +12,7 @@ import setupChapel from 'highlightjs-chapel'
 import setupGDScript from '@exercism/highlightjs-gdscript'
 import setupJq from 'highlightjs-jq'
 import setupArturo from '@exercism/highlightjs-arturo'
+import setupRoc from 'highlightjs-roc'
 
 if (isLookbehindSupported()) {
   highlighter.default.registerLanguage('abap', setupABAP)
@@ -25,6 +26,7 @@ if (isLookbehindSupported()) {
   highlighter.default.registerLanguage('chapel', setupChapel)
   highlighter.default.registerLanguage('gdscript', setupGDScript)
   highlighter.default.registerLanguage('jq', setupJq)
+  highlighter.default.registerLanguage('roc', setupRoc)
 }
 
 highlighter.default.configure({

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const config = {
     '^.+\\.[t|j]sx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(highlightjs-(bqn|zig|chapel|jq)|@ballerina/highlightjs-ballerina|@exercism/highlightjs-arturo)/)',
+    'node_modules/(?!(highlightjs-(bqn|zig|chapel|jq|roc)|@ballerina/highlightjs-ballerina|@exercism/highlightjs-arturo)/)',
   ],
   moduleNameMapper: {
     '^[./a-zA-Z0-9$_-]+\\.svg$':

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "highlightjs-cobol": "^0.3.1",
     "highlightjs-jq": "^0.1.0",
     "highlightjs-redbol": "^2.1.2",
+    "highlightjs-roc": "^0.1.0",
     "highlightjs-sap-abap": "^0.2.0",
     "highlightjs-zig": "^1.0.2",
     "humps": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "highlightjs-cobol": "^0.3.1",
     "highlightjs-jq": "^0.1.0",
     "highlightjs-redbol": "^2.1.2",
-    "highlightjs-roc": "^0.1.0",
+    "highlightjs-roc": "^0.2.0",
     "highlightjs-sap-abap": "^0.2.0",
     "highlightjs-zig": "^1.0.2",
     "humps": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,6 +5552,11 @@ highlightjs-redbol@^2.1.2:
   dependencies:
     highlight.js "^11.9.0"
 
+highlightjs-roc@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/highlightjs-roc/-/highlightjs-roc-0.2.0.tgz#dfe1dc2967f472ba1756182688dcb3a427b78c37"
+  integrity sha512-ER14FB9uaH0zuLsm/A9SsBncTAmdSF1sic9CULfpB3bQoq7xQVQT+arqhuXQu4I0ndydqS8JNdKhm9RDJrRRRw==
+
 highlightjs-sap-abap@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/highlightjs-sap-abap/-/highlightjs-sap-abap-0.2.0.tgz#d5291bf777deb7c297683f7dc87c02c8d108cc5b"


### PR DESCRIPTION
The Roc track currently uses syntax highlighting for Elm because there was no highlightjs plugin for Roc. Now [there is one](https://www.npmjs.com/package/highlightjs-roc), so this PR adds support for it. Hopefully we will also have CodeMirror support for Roc soon.