### PR TITLE
Add delimiters on landing page

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -45,7 +45,7 @@
           = link_to track_path(track), class: 'track' do
             = track_icon(track)
             .title= track.title
-            .students-count #{track.num_students} students
+            .students-count #{number_with_delimiter(track.num_students)} students
       .cta.border-t-3.border-veryLightBlue
         = render ViewComponents::ProminentLink.new("See all #{@num_tracks} Language Tracks", tracks_path, with_bg: true)
 
@@ -57,7 +57,7 @@
             = graphical_icon :exercises, hex: true
             %h2.text-h2
               Over
-              %strong #{Exercise.available.count} coding exercises.
+              %strong #{number_with_delimiter(Exercise.available.count)} coding exercises.
               %br
               From "Allergies" to "Zebra Puzzle".
             %hr.c-divider


### PR DESCRIPTION
<img width="594" alt="Screenshot 2024-10-01 at 09 31 22" src="https://github.com/user-attachments/assets/5e51a098-a9a6-40e7-a14c-8d43ac0b3dcc">
<img width="1394" alt="Screenshot 2024-10-01 at 09 31 18" src="https://github.com/user-attachments/assets/07fc2304-8333-413a-b9ed-4f80015de772">
