### PR TITLE
Fix Bootcamp links

### DIFF
--- a/app/javascript/components/settings/BootcampAffiliateCouponForm.tsx
+++ b/app/javascript/components/settings/BootcampAffiliateCouponForm.tsx
@@ -90,7 +90,7 @@ export function InfoMessage({
         <p className="text-p-base mb-12">
           To thank you for being an Insider and to help increase the amount of
           people signing up to Exercism's{' '}
-          <a href="https://bootcamp.exercism/org">Learn to Code Bootcamp</a>, we
+          <a href="https://bootcamp.exercism.org">Learn to Code Bootcamp</a>, we
           are giving all Insiders an{' '}
           <strong className="font-semibold">Discount Affiliate code</strong>.
         </p>
@@ -121,7 +121,7 @@ export function InfoMessage({
       return (
         <p className="text-p-base mb-16">
           Exercism Insiders can access 20% off Exercism's{' '}
-          <a href="https://bootcamp.exercism/org">Learn to Code Bootcamp</a>,
+          <a href="https://bootcamp.exercism.org">Learn to Code Bootcamp</a>,
           and receive 20% of all sales when someone uses their voucher code.
         </p>
       )

--- a/app/javascript/components/settings/BootcampFreeCouponForm.tsx
+++ b/app/javascript/components/settings/BootcampFreeCouponForm.tsx
@@ -42,7 +42,7 @@ export default function BootcampFreeCouponForm({
       <h2 className="!mb-8">Free Seat on the Bootcamp</h2>
       <p className="text-p-base mb-12">
         As a lifetime insider you're eligible for a free seat on Exercism's{' '}
-        <a href="https://bootcamp.exercism/org">Learn to Code Bootcamp</a>.
+        <a href="https://bootcamp.exercism.org">Learn to Code Bootcamp</a>.
       </p>
       <p className="text-p-base mb-16">
         To claim your free seat, we're providing you with a discount code that


### PR DESCRIPTION
bootcamp.exercism/org -> bootcamp.exercism.org

These appear on https://exercism.org/settings/insiders.