### PR TITLE
Always show error regardless of animation timeline

### DIFF
--- a/app/javascript/components/bootcamp/SolveExercisePage/CodeMirror/CodeMirror.tsx
+++ b/app/javascript/components/bootcamp/SolveExercisePage/CodeMirror/CodeMirror.tsx
@@ -188,13 +188,13 @@ export const CodeMirror = forwardRef(function _CodeMirror(
           Ext.multiHighlightLine({ from: 0, to: 0 }),
           readonlyCompartment.of([EditorView.editable.of(!readonly)]),
           onEditorFocus(
-            () => setShouldShowInformationWidget(false),
-            () =>
-              setInformationWidgetData({
-                html: '',
-                line: 0,
-                status: 'SUCCESS',
-              })
+            () => setShouldShowInformationWidget(false)
+            // () =>
+            //   setInformationWidgetData({
+            //     html: '',
+            //     line: 0,
+            //     status: 'SUCCESS',
+            //   })
           ),
           onEditorChange(
             () => setHighlightedLine(0),

--- a/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
@@ -41,11 +41,16 @@ export function useScrubber({
 
   // this effect is responsible for updating the highlighted line and information widget based on currentFrame
   useEffect(() => {
-    let currentFrame: Frame | undefined
-    if (testResult.animationTimeline) {
-      currentFrame = testResult.animationTimeline.currentFrame
-    } else {
-      currentFrame = testResult.frames[value]
+    let currentFrame: Frame | undefined = testResult.frames.find(
+      (f) => f.status === 'ERROR'
+    )
+
+    if (!currentFrame) {
+      if (testResult.animationTimeline) {
+        currentFrame = testResult.animationTimeline.currentFrame
+      } else {
+        currentFrame = testResult.frames[value]
+      }
     }
     if (currentFrame) {
       setHighlightedLine(currentFrame.line)
@@ -76,6 +81,7 @@ export function useScrubber({
     testResult.view?.id,
     value,
     testResult.animationTimeline?.currentFrameIndex,
+    testResult.frames,
   ])
 
   const handleScrubToCurrentTime = useCallback(

--- a/app/javascript/components/bootcamp/SolveExercisePage/test-runner/generateAndRunTestSuite/generateExpects.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/test-runner/generateAndRunTestSuite/generateExpects.ts
@@ -66,7 +66,7 @@ function generateExpectsForStateTests(
           : argsString.split(',').map((arg) => safe_eval(arg.trim()))
 
       // And then we get the function and call it.
-      console.log(fnName)
+      // console.log(fnName)
       const fn = exercise[fnName]
       actual = fn.bind(exercise).call(exercise, interpreterResult, ...args)
     }


### PR DESCRIPTION
- **Don't remove info data on focus**
- **Find first error frame and show it regardless of anything else**
