### PR TITLE
Be very certain tasks are completed before showing modal

### DIFF
--- a/app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/processTasks.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/processTasks.ts
@@ -33,8 +33,13 @@ export function processTasks(
       continue
     }
 
-    // always set the task to completed if all tests are passing
-    if (task.tests.every((test) => passingTests.has(test.name))) {
+    // Always set the task to completed if all tests are passing.
+    // Unless there are no tests, in which case we're in a weird state,
+    // but we shouldn't mark the whole thing as passing.
+    if (
+      task.tests.length > 0 &&
+      task.tests.every((test) => passingTests.has(test.name))
+    ) {
       updatedTasks.push({ ...task, status: 'completed' })
       numberOfCompletedTasks++
       continue
@@ -58,10 +63,10 @@ export function processTasks(
     updatedTasks.push(task)
   }
 
-  let areAllTasksCompleted = false
-  if (updatedTasks.length > 0) {
-    areAllTasksCompleted = numberOfCompletedTasks === updatedTasks.length
-  }
+  // Ensure that we have **some** completed tasks to mark this as true.
+  // A lack of completed tasks should not mark the whole thing as completed.
+  const areAllTasksCompleted =
+    numberOfCompletedTasks > 0 && numberOfCompletedTasks === updatedTasks.length
 
   return {
     updatedTasks,

--- a/app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/processTasks.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/processTasks.ts
@@ -14,7 +14,7 @@ export function processTasks(
     return {
       updatedTasks: [],
       numberOfCompletedTasks: 0,
-      areAllTasksCompleted: true,
+      areAllTasksCompleted: false,
       activeTaskIndex: 0,
     }
   }
@@ -58,7 +58,10 @@ export function processTasks(
     updatedTasks.push(task)
   }
 
-  const areAllTasksCompleted = numberOfCompletedTasks === updatedTasks.length
+  let areAllTasksCompleted = false
+  if (updatedTasks.length > 0) {
+    areAllTasksCompleted = numberOfCompletedTasks === updatedTasks.length
+  }
 
   return {
     updatedTasks,


### PR DESCRIPTION
There logically HAS to be a place where `areAllTasksCompleted` is incorrectly being set to `true` for the completed modal to appear at the wrong time.

As far as I can tell, there are three files that the issue could be in. I've gone through them.

### app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/getInitialTasks.ts
- L16: Default to `false`
- L35 proxies to processTasks

### app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/processTasks.ts
- L17: Changed default to `false`
- L41: Increments the numberOfCompletedTasks guard. This could flip to `true` if there are no tests in the task for some reason. I've guarded that.
- L61/63 - Changed to add a guard.

### app/javascript/components/bootcamp/SolveExercisePage/store/taskStore/taskStore.ts
- L11: Sets to `undefined` - I've checked and we're never doing `=== false` so this is ok. 
- L41 proxies to processTasks above