### PR TITLE
at at deduped

### DIFF
--- a/bootcamp_content/projects/string-puzzles/exercises/guest-list/introduction.md
+++ b/bootcamp_content/projects/string-puzzles/exercises/guest-list/introduction.md
@@ -1,6 +1,6 @@
 # Guest List
 
-You're a bouncer at at the Oscars, and need a function to check if someone is on the Guest List.
+You're a bouncer at the Oscars, and need a function to check if someone is on the Guest List.
 
 To help you, you need to write a function called `on_guest_list`.
 


### PR DESCRIPTION
In the Guest List introduction text, there is a repeated "at at" that I noticed during the video today.  This corrects that by removing the second (or is it the first) "at".