### PR TITLE
Handle new modal states

### DIFF
--- a/app/controllers/api/bootcamp/solutions_controller.rb
+++ b/app/controllers/api/bootcamp/solutions_controller.rb
@@ -5,23 +5,18 @@ class API::Bootcamp::SolutionsController < API::Bootcamp::BaseController
     old_level_idx = current_user.bootcamp_data.level_idx
     Bootcamp::Solution::Complete.(@solution)
     new_level_idx = current_user.bootcamp_data.reload.level_idx
+    next_exercise = Bootcamp::SelectNextExercise.(current_user)
 
-    if new_level_idx.nil? || old_level_idx == new_level_idx
-      # If we've completed all the levels, or we're on the
-      # same level still, find the next exercise.
-      next_exercise = Bootcamp::SelectNextExercise.(current_user)
-    end
-
-    # If they've moved forward, add those two things to the data
+    # If they've moved forward, add the completed/new levels to the data
     if old_level_idx != new_level_idx
       completed_level_idx = old_level_idx
       next_level_idx = Bootcamp::Settings.level_idx >= new_level_idx ? new_level_idx : nil
     end
 
     render json: {
+      next_exercise: SerializeBootcampExercise.(next_exercise),
       completed_level_idx:,
-      next_level_idx:,
-      next_exercise: SerializeBootcampExercise.(next_exercise)
+      next_level_idx:
     }, status: :ok
   end
 

--- a/app/controllers/api/bootcamp/solutions_controller.rb
+++ b/app/controllers/api/bootcamp/solutions_controller.rb
@@ -6,11 +6,14 @@ class API::Bootcamp::SolutionsController < API::Bootcamp::BaseController
     Bootcamp::Solution::Complete.(@solution)
     new_level_idx = current_user.bootcamp_data.reload.level_idx
 
-    # If we're on the same level still, find the next exercise
-    # Otherwise we'll tell the student they've completed the level
-    if old_level_idx == new_level_idx
+    if new_level_idx.nil? || old_level_idx == new_level_idx
+      # If we've completed all the levels, or we're on the
+      # same level still, find the next exercise.
       next_exercise = Bootcamp::SelectNextExercise.(current_user)
-    else
+    end
+
+    # If they've moved forward, add those two things to the data
+    if old_level_idx != new_level_idx
       completed_level_idx = old_level_idx
       next_level_idx = Bootcamp::Settings.level_idx >= new_level_idx ? new_level_idx : nil
     end

--- a/app/css/bootcamp/components/exercise-widget.css
+++ b/app/css/bootcamp/components/exercise-widget.css
@@ -108,7 +108,7 @@
 
         mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/400% 100%;
         background-repeat: no-repeat;
-        animation: shimmer 10s infinite;
+        animation: shimmer 7s infinite;
 
         .tag {
             border: none;
@@ -141,7 +141,7 @@
     0% {
         mask-position: right/300% 100%;
     }
-    15% {
+    20% {
         mask-position: left;
     }
     100% {

--- a/app/javascript/components/bootcamp/SolveExercisePage/Tasks/useTasks.tsx
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Tasks/useTasks.tsx
@@ -17,6 +17,8 @@ export type FinishLessonModalView =
   | 'initial'
   | 'completedExercise'
   | 'completedLevel'
+  | 'completedAllLevels'
+  | 'completedEverything'
 
 export function useTasks() {
   const [isFinishModalOpen, setIsFinishModalOpen] = useState(false)
@@ -105,9 +107,13 @@ export function useTasks() {
       if (completedData.completed_level_idx) {
         setModalView('completedLevel')
         setCompletedLevelIdx(completedData.completed_level_idx)
-        return
+      } else {
+        setModalView(
+          completedData.next_exercise
+            ? 'completedExercise'
+            : 'completedEverything'
+        )
       }
-      setModalView('completedExercise')
     } catch (e) {
       console.error('Error completing solution: ', e)
     }

--- a/app/javascript/components/bootcamp/SolveExercisePage/Tasks/useTasks.tsx
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Tasks/useTasks.tsx
@@ -108,11 +108,7 @@ export function useTasks() {
         setModalView('completedLevel')
         setCompletedLevelIdx(completedData.completed_level_idx)
       } else {
-        setModalView(
-          completedData.next_exercise
-            ? 'completedExercise'
-            : 'completedEverything'
-        )
+        setModalView('completedExercise')
       }
     } catch (e) {
       console.error('Error completing solution: ', e)

--- a/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
+++ b/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
@@ -6,6 +6,7 @@ import animation from '@/../animations/finish-lesson-modal-top.json'
 import { FinishLessonModalContext } from './FinishLessonModalContextWrapper'
 import { useContext } from 'react'
 import { SolveExercisePageContext } from '@/components/bootcamp/SolveExercisePage/SolveExercisePageContextWrapper'
+import { NextExercise } from '../../SolveExercisePage/Tasks/completeSolution'
 // import { playAudio } from "@/utils/play-audio";
 // @ts-ignore
 // import celebrationSound from "/task-completed-sound.aac";
@@ -36,14 +37,24 @@ export function FinishLessonModal() {
 
 function Inner() {
   const { modalView } = useContext(FinishLessonModalContext)
-
+  const { nextLevelIdx, nextExerciseData } = useContext(
+    FinishLessonModalContext
+  )
   switch (modalView) {
     case 'initial':
       return <InitialView />
     case 'completedExercise':
-      return <CompletedExerciseView />
+      return <CompletedExerciseView nextExerciseData={nextExerciseData!} />
     case 'completedLevel':
-      return <CompletedLevelView />
+      if (nextLevelIdx) {
+        return <CompletedLevelView nextLevelIdx={nextLevelIdx} />
+      }
+
+      if (nextExerciseData) {
+        return <CompletedAllLevelsView nextExerciseData={nextExerciseData} />
+      } else {
+        return <CompletedEverythingView />
+      }
   }
 }
 
@@ -86,58 +97,42 @@ function InitialView() {
   )
 }
 
-function CompletedExerciseView() {
-  const { nextExerciseData } = useContext(FinishLessonModalContext)
+function CompletedExerciseView({
+  nextExerciseData,
+}: {
+  nextExerciseData: NextExercise
+}) {
   const { links } = useContext(SolveExercisePageContext)
   return (
     <div>
       <h2 className="text-[25px] mb-12 font-semibold">Congratulations!</h2>
 
-      {nextExerciseData ? (
-        <>
-          <p className="text-18 leading-140 mb-8">
-            The next exercise is{' '}
-            <strong className="font-semibold">{nextExerciseData.title}.</strong>
-          </p>
-          <p className="text-18 leading-140 mb-20">
-            Do you want to start it now, or would you rather go back to the
-            projects list?
-          </p>
+      <p className="text-18 leading-140 mb-8">
+        The next exercise is{' '}
+        <strong className="font-semibold">{nextExerciseData.title}.</strong>
+      </p>
+      <p className="text-18 leading-140 mb-20">
+        Do you want to start it now, or would you rather go back to the
+        dashboard?
+      </p>
 
-          <div className="flex items-center gap-8 self-stretch">
-            <a href={links.dashboardIndex} className="btn-l btn-secondary">
-              Back to dashboard
-            </a>
-            <a
-              href={nextExerciseData.solve_url}
-              className="btn-l btn-primary flex-grow"
-            >
-              Start Next Exercise
-            </a>
-          </div>
-        </>
-      ) : (
-        <>
-          <p className="text-18 leading-140 mb-20">
-            Well done! You've finished all the exercises available to you right
-            now.
-          </p>
-
-          <div className="flex flex-col items-stretch self-stretch">
-            <a href={links.dashboardIndex} className="btn-l btn-primary">
-              Back to dashboard
-            </a>
-          </div>
-        </>
-      )}
+      <div className="flex items-center gap-8 self-stretch">
+        <a href={links.dashboardIndex} className="btn-l btn-secondary">
+          Back to dashboard
+        </a>
+        <a
+          href={nextExerciseData.solve_url}
+          className="btn-l btn-primary flex-grow"
+        >
+          Start Next Exercise
+        </a>
+      </div>
     </div>
   )
 }
 
-function CompletedLevelView() {
-  const { nextLevelIdx, completedLevelIdx } = useContext(
-    FinishLessonModalContext
-  )
+function CompletedLevelView({ nextLevelIdx }: { nextLevelIdx: number }) {
+  const { completedLevelIdx } = useContext(FinishLessonModalContext)
   const { links } = useContext(SolveExercisePageContext)
   return (
     <div>
@@ -149,40 +144,80 @@ function CompletedLevelView() {
           Congratulations! That's a big achievement 🎉
         </strong>
       </p>
-      {nextLevelIdx ? (
-        <>
-          <p className="text-18 leading-140 mb-20">
-            You're now onto Level {nextLevelIdx} - a brand new challenge!
-            Remember to watch the teaching video in full before starting the
-            exercises.
-          </p>
+      <p className="text-18 leading-140 mb-20">
+        You're now onto Level {nextLevelIdx} - a brand new challenge! Remember
+        to watch the teaching video in full before starting the exercises.
+      </p>
 
-          <div className="flex items-center gap-8 self-stretch">
-            <a
-              href={links.bootcampLevelUrl.replace(
-                'idx',
-                nextLevelIdx.toString()
-              )}
-              className="btn-l btn-primary flex-grow"
-            >
-              Start Level {nextLevelIdx}
-            </a>
-          </div>
-        </>
-      ) : (
-        <>
-          <p className="text-18 leading-140 mb-20">
-            You've completed all the levels available to you right now. Great
-            job!
-          </p>
+      <div className="flex items-center gap-8 self-stretch">
+        <a
+          href={links.bootcampLevelUrl.replace('idx', nextLevelIdx.toString())}
+          className="btn-l btn-primary flex-grow"
+        >
+          Start Level {nextLevelIdx}
+        </a>
+      </div>
+    </div>
+  )
+}
 
-          <div className="flex flex-col items-stretch self-stretch">
-            <a href={links.dashboardIndex} className="btn-l btn-primary">
-              Back to dashboard
-            </a>
-          </div>
-        </>
-      )}
+function CompletedAllLevelsView({
+  nextExerciseData,
+}: {
+  nextExerciseData: NextExercise
+}) {
+  const { completedLevelIdx } = useContext(FinishLessonModalContext)
+  const { links } = useContext(SolveExercisePageContext)
+  return (
+    <div>
+      <h2 className="text-[25px] mb-12 font-semibold">
+        You've completed level {completedLevelIdx}!
+      </h2>
+      <p className="text-18 leading-140 mb-8">
+        <strong className="font-semibold">
+          Congratulations! That's a big achievement 🎉
+        </strong>
+      </p>
+      <p className="text-18 leading-140 mb-20">
+        You've completed all the levels available to you right now, but you
+        still have some exercises outstanding. The next exercise is{' '}
+        <strong className="font-semibold">{nextExerciseData.title}.</strong>
+      </p>
+      <p className="text-18 leading-140 mb-20">
+        Do you want to start it now, or would you rather go back to the projects
+        list?
+      </p>
+
+      <div className="flex items-center gap-8 self-stretch">
+        <a href={links.dashboardIndex} className="btn-l btn-secondary">
+          Back to dashboard
+        </a>
+        <a
+          href={nextExerciseData.solve_url}
+          className="btn-l btn-primary flex-grow"
+        >
+          Start Next Exercise
+        </a>
+      </div>
+    </div>
+  )
+}
+
+function CompletedEverythingView() {
+  const { links } = useContext(SolveExercisePageContext)
+
+  return (
+    <div>
+      <h2 className="text-[25px] mb-12 font-semibold">Congratulations!</h2>
+      <p className="text-18 leading-140 mb-20">
+        Well done! You've finished all the exercises available to you right now.
+      </p>
+
+      <div className="flex flex-col items-stretch self-stretch">
+        <a href={links.dashboardIndex} className="btn-l btn-primary">
+          Back to dashboard
+        </a>
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
+++ b/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
@@ -44,7 +44,11 @@ function Inner() {
     case 'initial':
       return <InitialView />
     case 'completedExercise':
-      return <CompletedExerciseView nextExerciseData={nextExerciseData!} />
+      if (nextExerciseData) {
+        return <CompletedExerciseView nextExerciseData={nextExerciseData} />
+      } else {
+        return <CompletedEverythingView />
+      }
     case 'completedLevel':
       if (nextLevelIdx) {
         return <CompletedLevelView nextLevelIdx={nextLevelIdx} />

--- a/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
+++ b/app/javascript/components/bootcamp/modals/FinishLessonModal/FinishLessonModal.tsx
@@ -36,8 +36,7 @@ export function FinishLessonModal() {
 }
 
 function Inner() {
-  const { modalView } = useContext(FinishLessonModalContext)
-  const { nextLevelIdx, nextExerciseData } = useContext(
+  const { modalView, nextLevelIdx, nextExerciseData } = useContext(
     FinishLessonModalContext
   )
   switch (modalView) {

--- a/test/controllers/api/bootcamp/solutions_controller_test.rb
+++ b/test/controllers/api/bootcamp/solutions_controller_test.rb
@@ -11,9 +11,9 @@ class API::Bootcamp::SolutionsControllerTest < API::BaseTestCase
 
       assert_response :ok
       assert_json_response({
+        next_exercise: nil,
         completed_level_idx: 1,
-        next_level_idx: nil,
-        next_exercise: nil
+        next_level_idx: nil
       })
     end
   end
@@ -31,9 +31,9 @@ class API::Bootcamp::SolutionsControllerTest < API::BaseTestCase
 
       assert_response :ok
       assert_json_response({
+        next_exercise: SerializeBootcampExercise.(next_exercise),
         completed_level_idx: nil,
-        next_level_idx: nil,
-        next_exercise: SerializeBootcampExercise.(next_exercise)
+        next_level_idx: nil
       })
     end
   end
@@ -55,25 +55,25 @@ class API::Bootcamp::SolutionsControllerTest < API::BaseTestCase
       patch complete_api_bootcamp_solution_url(solutions.first), headers: @headers
       assert_response :ok
       assert_json_response({
+        next_exercise: SerializeBootcampExercise.(l1e2),
         completed_level_idx: nil,
-        next_level_idx: nil,
-        next_exercise: SerializeBootcampExercise.(l1e2)
+        next_level_idx: nil
       })
 
       patch complete_api_bootcamp_solution_url(solutions.second), headers: @headers
       assert_response :ok
       assert_json_response({
+        next_exercise: SerializeBootcampExercise.(l2e1),
         completed_level_idx: 1,
-        next_level_idx: 2,
-        next_exercise: nil
+        next_level_idx: 2
       })
 
       patch complete_api_bootcamp_solution_url(solutions.third), headers: @headers
       assert_response :ok
       assert_json_response({
+        next_exercise: nil,
         completed_level_idx: 2,
-        next_level_idx: nil,
-        next_exercise: nil
+        next_level_idx: nil
       })
     end
   end


### PR DESCRIPTION
It is now possible to have more states with the finish modals.

You can:

| `next_level_idx` | `completed_level_idx` | `next_exercise` | Modal                          | Description                                                                                  |
|-------------------|----------------------|------------------|--------------------------------|------------------------------------------------------------------------------------------------|
| `null`            | `not null`              | `null`          | Completed Everything    | Complete exercise, complete final level, and have no more exercises available                  |
| `null`            | `not null`              | `not null`        | Completed All Levels    | Complete exercise, complete final level, but have bonus exercises available                    |
| `not null`          | `not null`              | `irrelevant`      | Completed Level         | Complete exercise, complete non-final level, have a new level                                   |
| `null`            | `null`                | `null`          | Completed Everything    | Complete exercise, not complete a level, have no more exercises                                 |
| `null`            | `null`                | `not null`        | Completed Exercise      | Complete exercise, not complete a level, have a bonus exercise                                  |

This all means, we need to start by seeing if there's a `completed_level_idx` and then do some pivoting based on that.

This PR does that. I'm pretty sure it's right but I've not tested it. I wasn't sure of the best way to do it, so I just got it how to the point I think makes sense and you can tweak it however.

Note that this is part of a bigger PR chain, and isn't going onto `main`