### PR TITLE
Scrolling patches

### DIFF
--- a/app/javascript/components/bootcamp/DrawingPage/useDrawingEditorHandler.ts
+++ b/app/javascript/components/bootcamp/DrawingPage/useDrawingEditorHandler.ts
@@ -77,6 +77,7 @@ export function useDrawingEditorHandler() {
           setInformationWidgetData,
           setShouldShowInformationWidget,
           setUnderlineRange,
+          editorView: editorViewRef.current,
         })
 
         setAnimationTimeline(null)

--- a/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/InformationWidgetToggleButton.tsx
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/InformationWidgetToggleButton.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useCallback } from 'react'
 import useEditorStore from '../store/editorStore'
 import useTestStore from '../store/testStore'
-import { scrollToHighlightedLine } from './scrollToHighlightedLine'
+import { SolveExercisePageContext } from '../SolveExercisePageContextWrapper'
+import { scrollToLine } from '../CodeMirror/scrollToLine'
 
 export function InformationWidgetToggleButton({
   disabled,
@@ -15,13 +16,15 @@ export function InformationWidgetToggleButton({
     setHighlightedLine,
   } = useEditorStore()
   const { inspectedTestResult } = useTestStore()
+  const { editorView } = useContext(SolveExercisePageContext)
+  const { highlightedLine } = useEditorStore()
   const handleToggleShouldShowInformationWidget = useCallback(() => {
     toggleShouldShowInformationWidget()
 
-    // if previeous state is off - which means we are about to turn it on
+    // if previous toggle state is `off` - which means we are about to turn it `on`...
     // scroll to the highlighted line
     if (!shouldShowInformationWidget) {
-      scrollToHighlightedLine()
+      scrollToLine(editorView, highlightedLine)
     }
 
     if (!inspectedTestResult) return
@@ -37,7 +40,7 @@ export function InformationWidgetToggleButton({
         setHighlightedLine(0)
       }
     }
-  }, [shouldShowInformationWidget, inspectedTestResult])
+  }, [shouldShowInformationWidget, inspectedTestResult, highlightedLine])
   return (
     <label data-ci="information-widget-toggle" className="switch">
       <input

--- a/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
@@ -7,7 +7,6 @@ import type { Frame } from '@/interpreter/frames'
 import { showError } from '../utils/showError'
 import type { StaticError } from '@/interpreter/error'
 import { INFO_HIGHLIGHT_COLOR } from '../CodeMirror/extensions/lineHighlighter'
-import { scrollToHighlightedLine } from './scrollToHighlightedLine'
 import useAnimationTimelineStore from '../store/animationTimelineStore'
 import useTestStore from '../store/testStore'
 import { SolveExercisePageContext } from '../SolveExercisePageContextWrapper'
@@ -288,7 +287,8 @@ export function useScrubber({
           animationTimeline.seek(animatedTime)
         },
       })
-      scrollToHighlightedLine()
+      const targetFrame = animationTimeline.frameAtTime(targetTime)
+      scrollToLine(editorView, targetFrame.line)
     },
     [value]
   )
@@ -327,7 +327,8 @@ export function useScrubber({
           animationTimeline.seek(animatedTime)
         },
       })
-      scrollToHighlightedLine()
+      const targetFrame = animationTimeline.frameAtTime(targetTime)
+      scrollToLine(editorView, targetFrame.line)
     },
     [value]
   )
@@ -337,7 +338,8 @@ export function useScrubber({
       if (animationTimeline) {
         animationTimeline.pause()
         animationTimeline.seekFirstFrame()
-        scrollToHighlightedLine()
+        const firstFrame = animationTimeline.getFrames()[0]
+        scrollToLine(editorView, firstFrame.line)
       }
     },
     []
@@ -348,7 +350,9 @@ export function useScrubber({
       if (animationTimeline) {
         animationTimeline.pause()
         animationTimeline.seekEndOfTimeline()
-        scrollToHighlightedLine()
+        const frames = animationTimeline.getFrames()
+        const lastFrame = frames[frames.length - 1]
+        scrollToLine(editorView, lastFrame.line)
       }
     },
     []

--- a/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
@@ -26,6 +26,8 @@ export function useScrubber({
   frames: Frame[]
   hasCodeBeenEdited: boolean
 }) {
+  // if there is an animation timeline, we use time as value
+  // if there is no animation timeline, we use frame index as value
   const [value, setValue] = useState(0)
   const {
     setHighlightedLine,
@@ -66,6 +68,10 @@ export function useScrubber({
     if (frames.some((frame) => frame.status === 'ERROR')) {
       const newValue = frames.findIndex((frame) => frame.status === 'ERROR')
       const error = frames[newValue].error
+      if (animationTimeline) {
+        animationTimeline.seek(frames[newValue].time)
+      }
+      setValue(newValue)
       showError({
         error: error as StaticError,
         setHighlightedLine,
@@ -75,10 +81,6 @@ export function useScrubber({
         setUnderlineRange,
         editorView,
       })
-      if (animationTimeline) {
-        animationTimeline.seek(frames[newValue].time)
-      }
-      setValue(frames[newValue].time)
     }
   }, [frames, animationTimeline])
 
@@ -115,7 +117,12 @@ export function useScrubber({
         }
       }
     }
-  }, [value, animationTimeline?.currentFrameIndex, inspectedTestResult])
+  }, [
+    value,
+    animationTimeline?.currentFrameIndex,
+    animationTimeline?.currentFrame,
+    inspectedTestResult,
+  ])
 
   // when user switches between test results, scrub to animation timeline's persisted currentTime
   useEffect(() => {
@@ -361,8 +368,8 @@ export function useScrubber({
   )
 
   /*
-   when holding a key down, store it in a set and escape invoking frame-stepping handlers.
-   let user browse scrubber freely
+   when holding a key down, store it in a Set and escape invoking frame-stepping handlers.
+   let user browse the scrubber freely
    */
   const [heldKeys, setHeldKeys] = useState(new Set<string>())
   const handleOnKeyUp = useCallback(

--- a/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/Scrubber/useScrubber.ts
@@ -73,6 +73,7 @@ export function useScrubber({
         setInformationWidgetData,
         setShouldShowInformationWidget,
         setUnderlineRange,
+        editorView,
       })
       if (animationTimeline) {
         animationTimeline.seek(frames[newValue].time)
@@ -109,6 +110,7 @@ export function useScrubber({
             setInformationWidgetData,
             setShouldShowInformationWidget,
             setUnderlineRange,
+            editorView,
           })
         }
       }

--- a/app/javascript/components/bootcamp/SolveExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
@@ -64,6 +64,7 @@ export function useConstructRunCode({
       setInformationWidgetData,
       setShouldShowInformationWidget,
       setUnderlineRange,
+      editorView,
     })
 
     setTestSuiteResult(null)

--- a/app/javascript/components/bootcamp/SolveExercisePage/utils/showError.ts
+++ b/app/javascript/components/bootcamp/SolveExercisePage/utils/showError.ts
@@ -2,6 +2,8 @@ import type { StaticError } from '@/interpreter/error'
 import { describeError } from '../CodeMirror/extensions/end-line-information/describeError'
 import type { InformationWidgetData } from '../CodeMirror/extensions/end-line-information/line-information'
 import { ERROR_HIGHLIGHT_COLOR } from '../CodeMirror/extensions/lineHighlighter'
+import { scrollToLine } from '../CodeMirror/scrollToLine'
+import { EditorView } from '@codemirror/view'
 
 // TODO: maybe move this into exercise store
 export function showError({
@@ -11,6 +13,7 @@ export function showError({
   setInformationWidgetData,
   setShouldShowInformationWidget,
   error,
+  editorView,
 }: {
   error: StaticError
   setUnderlineRange: (range: { from: number; to: number }) => void
@@ -18,6 +21,7 @@ export function showError({
   setHighlightedLineColor: (color: string) => void
   setInformationWidgetData: (data: InformationWidgetData) => void
   setShouldShowInformationWidget: (shouldShow: boolean) => void
+  editorView: EditorView | null
 }) {
   if (!error.location) {
     console.error('Error location is missing')
@@ -28,6 +32,7 @@ export function showError({
     to: Math.max(0, error.location.absolute.end - 1),
   })
 
+  scrollToLine(editorView, error.location.line)
   setHighlightedLine(error.location.line)
   setHighlightedLineColor(ERROR_HIGHLIGHT_COLOR)
   setInformationWidgetData({


### PR DESCRIPTION
- **Replace old scrollToLine methods**
- **Fix editor sometimes not scrolling to the error line if it's very much out of viewport**
- **Remove console.log**
