### PR TITLE
Show whitespace in diff

### DIFF
--- a/app/css/bootcamp/components/scenario.css
+++ b/app/css/bootcamp/components/scenario.css
@@ -83,6 +83,10 @@
                 @apply bg-bootcamp-fail-light;
             }
 
+            span.added-part,
+            span.removed-part {
+                @apply whitespace-pre;
+            }
             span.added-part {
                 @apply bg-bootcamp-success-light;
                 @apply border-b-1 border-bootcamp-success-dark;


### PR DESCRIPTION
Without this, the red underlined bit doesn't show. @dem4ron Please could you check for anywhere else we use diff and see if this needs adding there too please (I think it's probably just here, but 🤷‍♂️)

<img width="685" alt="Screenshot 2025-03-05 at 01 25 55" src="https://github.com/user-attachments/assets/3a5139c6-5104-411e-a660-ff3a079aa657" />
