### PR TITLE
Remove duplicate text from Welcome Modal 

### DIFF
--- a/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasNoLearningModeStep.tsx
+++ b/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasNoLearningModeStep.tsx
@@ -19,7 +19,7 @@ export function HasNoLearningModeStep({
       <p className="mb-12">
         {' '}
         If you&apos;d like to learn {track.title} from scratch, take a look at
-        these{' '}
+        {' '}
         <a
           className="font-semibold text-prominentLinkColor"
           href={links.learningResources}


### PR DESCRIPTION
Starting the AWK Track I noticed some duplicated text in the welcome modal.

I believe this quick change should fix the typo.

Kept the duplicated word "these" in the link to learning resources as I thought it was intended that way.