### PR TITLE
Spelling correction: "congratulates"

### DIFF
--- a/app/javascript/components/mentoring/representation/right-pane/RadioGroup.tsx
+++ b/app/javascript/components/mentoring/representation/right-pane/RadioGroup.tsx
@@ -32,7 +32,7 @@ const RADIO_DATA = [
     value: 'celebratory',
     tooltip: {
       title: 'If you mark this as Celebratory',
-      body: 'Student is not prompted to action this before proceeding, congratules the student on their solution.',
+      body: 'Student is not prompted to action this before proceeding, congratulates the student on their solution.',
     },
   },
 ]


### PR DESCRIPTION
The Radio List says that it "congratule" the student, but I could not find this word in English, I checked several dictionaries and even online, and everything seems to point to "congratulate".