### PR TITLE
Add futhark highlightjs support

### DIFF
--- a/app/javascript/utils/highlight.ts
+++ b/app/javascript/utils/highlight.ts
@@ -15,6 +15,7 @@ import setupArturo from '@exercism/highlightjs-arturo'
 import setupRoc from 'highlightjs-roc'
 import setupUiua from '@exercism/highlightjs-uiua'
 import setupJikiscript from '@exercism/highlightjs-jikiscript'
+import setupFuthark from '@exercism/highlightjs-futhark'
 
 if (isLookbehindSupported()) {
   highlighter.default.registerLanguage('abap', setupABAP)
@@ -31,6 +32,7 @@ if (isLookbehindSupported()) {
   highlighter.default.registerLanguage('roc', setupRoc)
   highlighter.default.registerLanguage('uiua', setupUiua)
   highlighter.default.registerLanguage('jikiscript', setupJikiscript)
+  highlighter.default.registerLanguage('futhark', setupFuthark)
 }
 
 highlighter.default.configure({

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const config = {
     '^.+\\.[t|j]sx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(highlightjs-(bqn|zig|chapel|jq|roc|cobol)|@ballerina/highlightjs-ballerina|@exercism/highlightjs-(arturo|uiua|jikiscript))|@exercism/javascript-browser-test-runner|@marijn/find-cluster-break/)',
+    'node_modules/(?!(highlightjs-(bqn|zig|chapel|jq|roc|cobol)|@ballerina/highlightjs-ballerina|@exercism/highlightjs-(arturo|futhark|uiua|jikiscript))|@exercism/javascript-browser-test-runner|@marijn/find-cluster-break/)',
   ],
   moduleNameMapper: {
     '^[./a-zA-Z0-9$_-]+\\.svg$':

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@exercism/codemirror-lang-uiua": "^0.0.4",
     "@exercism/codemirror-lang-wren": "https://github.com/exercism/codemirror-lang-wren",
     "@exercism/highlightjs-arturo": "^0.0.2",
+    "@exercism/highlightjs-futhark": "^0.0.4",
     "@exercism/highlightjs-gdscript": "^0.0.1",
     "@exercism/highlightjs-jikiscript": "^0.0.2",
     "@exercism/highlightjs-uiua": "^0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,11 @@
   resolved "https://registry.yarnpkg.com/@exercism/highlightjs-arturo/-/highlightjs-arturo-0.0.2.tgz#a053ffebda0a97caeb99654e9a77b792e11176a7"
   integrity sha512-GFb7zlGB0aGr7cEdMQFCZejDE6zuc3+lHpZCll7euuBf4fHRo2kpt2BhST6m1z/E+KK8oPY9n8RpXNkNFHJfsg==
 
+"@exercism/highlightjs-futhark@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@exercism/highlightjs-futhark/-/highlightjs-futhark-0.0.4.tgz#06a3c8198669d653206831896f4b6f5ae453d174"
+  integrity sha512-/QvO/yHoce14cdN47YBE91c8SB4Y8wA2zWYmIS0pSUGb8GIlR0nNoR/DeSXl5mySHoSz7Ov9dvU2Z/PUxtOgjw==
+
 "@exercism/highlightjs-gdscript@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@exercism/highlightjs-gdscript/-/highlightjs-gdscript-0.0.1.tgz#1b10f0b394d406f6f9309ad66eec801ee399e671"
@@ -10717,7 +10722,7 @@ string-similarity-js@^2.1.4:
   resolved "https://registry.yarnpkg.com/string-similarity-js/-/string-similarity-js-2.1.4.tgz#73716330691946f2ebc435859aba8327afd31307"
   integrity sha512-uApODZNjCHGYROzDSAdCmAHf60L/pMDHnP/yk6TAbvGg7JSPZlSto/ceCI7hZEqzc53/juU2aOJFkM2yUVTMTA==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10734,6 +10739,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -10844,7 +10858,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10871,6 +10885,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11820,7 +11841,7 @@ worker-farm@^1.6.0, worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11837,6 +11858,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
I had a lot of issues getting yarn to add the package locally, which I must admit I don't really understood (if only npm package mamagement were a little better...). Could any of you do `yarn add @exercism/highlightjs-futhark`?