### PR TITLE
Fix Accessibility Violations: Add Accessible Labels to Social Media Links

### DIFF
--- a/app/views/components/footer/shared.html.haml
+++ b/app/views/components/footer/shared.html.haml
@@ -70,11 +70,11 @@
           %li= link_to t('.site_links.get_help.cli_walkthrough_link'), cli_walkthrough_path
 
   .socials.mt-24.mb-40.md:mb-56
-    = link_to "https://twitter.com/exercism_io", class: 'icon twitter' do
+    = link_to "https://twitter.com/exercism_io", class: 'icon twitter', aria: { label: 'Exercism on Twitter' } do
       = graphical_icon 'external-site-twitter'
-    = link_to "https://facebook.com/exercism.io", class: 'icon facebook' do
+    = link_to "https://facebook.com/exercism.io", class: 'icon facebook', aria: { label: 'Exercism on Facebook' } do
       = graphical_icon 'external-site-facebook'
-    = link_to "https://github.com/exercism", class: 'icon github' do
+    = link_to "https://github.com/exercism", class: 'icon github', aria: { label: 'Exercism on GitHub' } do
       = graphical_icon 'external-site-github'
 
   %hr


### PR DESCRIPTION
## Summary
This PR fixes accessibility violations in the footer of [website homepage](https://exercism.org/) where social media icon links lacked accessible names, making them unusable for screen reader users.
<img width="2560" height="920" alt="image-1" src="https://github.com/user-attachments/assets/5e1a9984-5d39-4009-b40e-0f324dd880e0" />
**Why is this important?**
When the purpose of a link is clear users can easily navigate links on the page without having to see the surrounding information for context.

## Problem
The IBM Equal Access Accessibility Checker identified critical violations:

- Issue: Hyperlinks have no accessible name for their purpose
- Elements: Twitter, Facebook, and GitHub icon links in the footer
- Impact: Screen reader users cannot identify or understand the purpose of these links, as they only contain decorative SVG icons without text alternatives

## Solution
Added descriptive aria-label attributes to each social media link to provide clear, accessible names:

- Twitter link: Added `aria-label="Exercism on Twitter"`
- Facebook link: Added `aria-label="Exercism on Facebook"`
- GitHub link: Added `aria-label="Exercism on GitHub"`

## Additional Info:
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications.