### PR TITLE
Change bootcamp code columns from text to mediumtext

### DIFF
--- a/db/migrate/20260124204846_change_code_to_mediumtext_in_bootcamp_tables.rb
+++ b/db/migrate/20260124204846_change_code_to_mediumtext_in_bootcamp_tables.rb
@@ -1,0 +1,6 @@
+class ChangeCodeToMediumtextInBootcampTables < ActiveRecord::Migration[7.1]
+  def change
+    change_column :bootcamp_submissions, :code, :text, limit: 16.megabytes - 1, null: false
+    change_column :bootcamp_solutions, :code, :text, limit: 16.megabytes - 1, null: false
+  end
+end


### PR DESCRIPTION
## Summary

- The `code` column in `bootcamp_submissions` and `bootcamp_solutions` uses MySQL `TEXT` type (65,535 byte limit with utf8mb4)
- When users submit code exceeding this limit, it raises `ActiveRecord::ValueTooLong` (Mysql2::Error: Data too long for column 'code')
- This migration changes both columns to `mediumtext` (16MB limit) to accommodate larger submissions

## Context

The error occurs in `Bootcamp::Submission::Create#create_submission` when persisting user code. The same command also writes code to `bootcamp_solutions`, so both tables are updated for consistency.

Fixes #8300

## Test plan

- [ ] Run `bundle exec rails db:migrate` to apply the migration
- [ ] Verify the column type changed to `mediumtext` in both tables
- [ ] Submit a bootcamp solution with code exceeding 65KB to confirm no error