### PR TITLE
Handle non-HTML format requests in UserOnboardingController#show

### DIFF
--- a/app/controllers/user_onboarding_controller.rb
+++ b/app/controllers/user_onboarding_controller.rb
@@ -5,6 +5,11 @@ class UserOnboardingController < ApplicationController
     return redirect_to dashboard_path if user_signed_in? && current_user.onboarded?
 
     @onboarding = UserOnboardingForm.new
+
+    respond_to do |format|
+      format.html
+      format.any { head :not_acceptable }
+    end
   end
 
   def create


### PR DESCRIPTION
## Summary

- `UserOnboardingController#show` only has an HTML template but receives JSON format requests
- This causes `ActionController::UnknownFormat` errors when bots or misconfigured clients request non-HTML formats
- Added a `respond_to` block that serves HTML normally and returns 406 Not Acceptable for unsupported formats

## Context

The onboarding page is a simple form (terms of service / privacy policy checkboxes) with no meaningful JSON representation. Returning 406 is the correct HTTP semantic for unsupported content types.

Fixes #8305

## Test plan

- [ ] Visit `/user_onboarding` in a browser - should render the HTML form as before
- [ ] Request `/user_onboarding` with `Accept: application/json` header - should return 406
- [ ] Verify no `ActionController::UnknownFormat` exceptions in error tracking