### PR TITLE
Fix: corrected misspelt word: platfrom -> platform

### DIFF
--- a/app/javascript/i18n/en/components-modals-track-welcome-modal-LHS.ts
+++ b/app/javascript/i18n/en/components-modals-track-welcome-modal-LHS.ts
@@ -4,7 +4,7 @@ export default {
   'bootcampRecommendation.tracksAudience':
     "Exercism's tracks are designed for people who <strong>already know how to code</strong> and are practicing or learning new languages.",
   'bootcampRecommendation.codingJourney':
-    "If you're just starting out on your coding journey, our new platfrom <strong>Jiki</strong> might be a better fit for you.",
+    "If you're just starting out on your coding journey, our new platform <strong>Jiki</strong> might be a better fit for you.",
   'bootcampRecommendation.selfPaced':
     "It launches in January 2026 and you can sign up for the waiting list now! And best of all, <strong>it's free!</strong>",
   'bootcampRecommendation.cta.checkOutCourse': 'Join the Waiting List',


### PR DESCRIPTION
I as a regular user noticed a small typo in the popup containing the text I fixed.

If you are reading this; I wish you a great day.
