### PR TITLE
Fix Stripe payment success - replace removed .charges accessor

### DIFF
--- a/app/commands/payments/stripe/payment/create.rb
+++ b/app/commands/payments/stripe/payment/create.rb
@@ -19,7 +19,12 @@ class Payments::Stripe::Payment::Create
 
   private
   def external_id = stripe_data.id
-  def external_receipt_url = stripe_data.charges.first.receipt_url
+
+  def external_receipt_url
+    charge = Stripe::Charge.retrieve(stripe_data.latest_charge)
+    charge.receipt_url
+  end
+
   def amount_in_cents = stripe_data.amount
 
   memoize

--- a/test/commands/payments/test_base.rb
+++ b/test/commands/payments/test_base.rb
@@ -39,13 +39,13 @@ class Payments::TestBase < ActiveSupport::TestCase
   end
 
   def mock_stripe_payment(id, amount, receipt_url, invoice_id: nil)
+    charge_id = "ch_#{SecureRandom.hex(12)}"
+    Stripe::Charge.stubs(:retrieve).with(charge_id).returns(OpenStruct.new(receipt_url:))
     OpenStruct.new(
       id:,
       amount:,
       invoice: invoice_id,
-      charges: [
-        OpenStruct.new(receipt_url:)
-      ]
+      latest_charge: charge_id
     )
   end
 


### PR DESCRIPTION
## Summary
- The stripe gem upgrade from v8 to v15 (June 2025) removed the `.charges` list from `PaymentIntent` objects, breaking both one-off donations and subscription payment recording
- Replaced `stripe_data.charges.first.receipt_url` with `Stripe::Charge.retrieve(stripe_data.latest_charge).receipt_url` in `Payment::Create`, matching the pattern already used in `handle_success.rb`
- Updated test mock to reflect the new API shape

## Test plan
- [x] `bundle exec rails test test/commands/payments/stripe/payment/create_test.rb` — 8 tests, 37 assertions, 0 failures
- [x] `bundle exec rubocop app/commands/payments/stripe/payment/create.rb` — no offenses
- [ ] Verify donate form shows success for one-off donations in staging
- [ ] Verify donate form shows success for subscription creation in staging
- [ ] Confirm `SyncPaymentsJob` picks up missed payments from last 30 days after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)