### PR TITLE
Add Stripe payment reconciliation command

### DIFF
--- a/app/commands/payments/stripe/reconcile_payments.rb
+++ b/app/commands/payments/stripe/reconcile_payments.rb
@@ -1,0 +1,65 @@
+class Payments::Stripe::ReconcilePayments
+  include Mandate
+
+  initialize_with since: 90.days.ago
+
+  def call
+    Stripe::PaymentIntent.list({
+      limit: 100,
+      status: 'succeeded',
+      created: { gte: since.to_i },
+      expand: ['data.latest_charge']
+    }).auto_paging_each do |payment_intent|
+      next if existing_payment_ids.include?(payment_intent.id)
+      next unless payment_intent.customer
+
+      sync_payment_intent(payment_intent)
+    rescue StandardError => e
+      Bugsnag.notify(e)
+    end
+  end
+
+  private
+  def sync_payment_intent(payment_intent)
+    return unless should_record_payment?(payment_intent)
+
+    user = find_user(payment_intent)
+    return unless user
+
+    subscription = find_subscription(user, payment_intent)
+    receipt_url = payment_intent.latest_charge&.receipt_url
+
+    Payments::Payment::Create.(
+      user, :stripe, payment_intent.id,
+      payment_intent.amount, receipt_url,
+      subscription:,
+      donated_at: Time.at(payment_intent.created).utc,
+      send_email: false
+    )
+  end
+
+  def should_record_payment?(payment_intent)
+    return true if payment_intent.invoice
+
+    charge = payment_intent.latest_charge
+    charge&.billing_details&.email.blank?
+  rescue StandardError
+    true
+  end
+
+  def find_user(payment_intent)
+    User.with_data.find_by(data: { stripe_customer_id: payment_intent.customer })
+  end
+
+  def find_subscription(user, payment_intent)
+    return nil unless payment_intent.invoice
+
+    invoice = Stripe::Invoice.retrieve(payment_intent.invoice)
+    return nil unless invoice.subscription
+
+    user.subscriptions.find_by(external_id: invoice.subscription, provider: :stripe)
+  end
+
+  memoize
+  def existing_payment_ids = Payments::Payment.stripe.pluck(:external_id).to_set
+end

--- a/app/commands/user/insiders_status/determine_eligibility_status.rb
+++ b/app/commands/user/insiders_status/determine_eligibility_status.rb
@@ -52,6 +52,8 @@ class User::InsidersStatus::DetermineEligibilityStatus
   end
 
   def recent_donation?
+    # Important note: We use *created_at* here, not *donated_at*, so if we reconcile
+    # old payments that weren't logged, they're honoured from today, not from back then.
     user.payments.sort { |p| -p.id }.each do |donation|
       # For every 9.99 donation before Insiders launched, give a month of access
       # from the launch date. Plus one free month for everyone who's ever donated.

--- a/test/commands/payments/stripe/reconcile_payments_test.rb
+++ b/test/commands/payments/stripe/reconcile_payments_test.rb
@@ -1,0 +1,265 @@
+require_relative '../test_base'
+
+class Payments::Stripe::ReconcilePaymentsTest < Payments::TestBase
+  test "syncs succeeded payment intents and creates payment records" do
+    freeze_time do
+      user = create :user, stripe_customer_id: "cus_123"
+      pi_id = "pi_#{SecureRandom.hex(8)}"
+      receipt_url = "https://receipt.stripe.com/#{SecureRandom.hex(8)}"
+      since = 90.days.ago
+
+      pis = [build_payment_intent(pi_id, customer: "cus_123", amount: 1500, receipt_url:)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 1, Payments::Payment.count
+      payment = Payments::Payment.last
+      assert_equal pi_id, payment.external_id
+      assert_equal 1500, payment.amount_in_cents
+      assert_equal receipt_url, payment.external_receipt_url
+      assert_equal user, payment.user
+      assert_equal :stripe, payment.provider
+    end
+  end
+
+  test "skips payment intents already in the database" do
+    freeze_time do
+      user = create :user, stripe_customer_id: "cus_123"
+      pi_id = "pi_#{SecureRandom.hex(8)}"
+      since = 90.days.ago
+      create :payments_payment, :stripe, external_id: pi_id, user: user
+
+      pis = [build_payment_intent(pi_id, customer: "cus_123", amount: 1500)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 1, Payments::Payment.count
+    end
+  end
+
+  test "skips bootcamp payments with billing email" do
+    freeze_time do
+      create :user, stripe_customer_id: "cus_123"
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_bootcamp", customer: "cus_123",
+        amount: 4900, billing_email: "buyer@example.com")]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 0, Payments::Payment.count
+    end
+  end
+
+  test "skips payment intents without a customer" do
+    freeze_time do
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_no_cus", customer: nil, amount: 500)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 0, Payments::Payment.count
+    end
+  end
+
+  test "skips payment intents for unknown customers" do
+    freeze_time do
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_unknown", customer: "cus_unknown", amount: 1000)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 0, Payments::Payment.count
+    end
+  end
+
+  test "associates subscription for invoice-linked payments" do
+    freeze_time do
+      user = create :user, stripe_customer_id: "cus_123"
+      subscription = create :payments_subscription, user: user, external_id: "sub_abc", provider: :stripe
+      invoice_id = "in_#{SecureRandom.hex(8)}"
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_sub", customer: "cus_123", amount: 999, invoice: invoice_id)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      stub_request(:get, "https://api.stripe.com/v1/invoices/#{invoice_id}").
+        to_return(
+          status: 200,
+          body: { id: invoice_id, object: "invoice", subscription: "sub_abc" }.to_json,
+          headers: { 'Content-Type': 'application/json' }
+        )
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 1, Payments::Payment.count
+      assert_equal subscription, Payments::Payment.last.subscription
+    end
+  end
+
+  test "handles pagination across multiple pages" do
+    freeze_time do
+      create :user, stripe_customer_id: "cus_123"
+      since = 90.days.ago
+      pi_1 = build_payment_intent("pi_page1", customer: "cus_123", amount: 100)
+      pi_2 = build_payment_intent("pi_page2", customer: "cus_123", amount: 200)
+
+      stub_payment_intents_request(
+        created_gte: since.to_i,
+        body: { object: "list", data: [pi_1], has_more: true, url: "/v1/payment_intents" }
+      )
+
+      stub_payment_intents_request(
+        created_gte: since.to_i,
+        starting_after: "pi_page1",
+        body: { object: "list", data: [pi_2], has_more: false, url: "/v1/payment_intents" }
+      )
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 2, Payments::Payment.count
+    end
+  end
+
+  test "continues processing after individual payment errors" do
+    freeze_time do
+      create :user, stripe_customer_id: "cus_123"
+      since = 90.days.ago
+
+      pis = [
+        build_payment_intent("pi_fail", customer: "cus_123", amount: 100),
+        build_payment_intent("pi_ok", customer: "cus_123", amount: 200)
+      ]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      User::InsidersStatus::UpdateForPayment.stubs(:call).
+        raises(RuntimeError.new("test error")).then.returns(nil)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      # Both payments are created (DB insert happens before the error),
+      # and the second payment is still processed despite the first one's side effects failing
+      assert_equal 2, Payments::Payment.count
+      assert Payments::Payment.exists?(external_id: "pi_ok")
+    end
+  end
+
+  test "records subscription payment even with billing email" do
+    freeze_time do
+      user = create :user, stripe_customer_id: "cus_123"
+      create :payments_subscription, user: user, external_id: "sub_abc", provider: :stripe
+      invoice_id = "in_sub_email"
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_sub_email", customer: "cus_123", amount: 999,
+        billing_email: "someone@example.com", invoice: invoice_id)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      stub_request(:get, "https://api.stripe.com/v1/invoices/#{invoice_id}").
+        to_return(
+          status: 200,
+          body: { id: invoice_id, object: "invoice", subscription: "sub_abc" }.to_json,
+          headers: { 'Content-Type': 'application/json' }
+        )
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal 1, Payments::Payment.count
+    end
+  end
+
+  test "does not send thank-you emails" do
+    freeze_time do
+      create :user, stripe_customer_id: "cus_123"
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_no_email", customer: "cus_123", amount: 1500)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Payment::SendEmail.expects(:defer).never
+
+      Payments::Stripe::ReconcilePayments.(since:)
+    end
+  end
+
+  test "passes actual Stripe payment date as donated_at" do
+    freeze_time do
+      user = create :user, stripe_customer_id: "cus_123"
+      stripe_created = 1_700_000_000
+      since = 90.days.ago
+
+      pis = [build_payment_intent("pi_dated", customer: "cus_123", amount: 1500, created: stripe_created)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+
+      assert_equal Time.at(stripe_created).utc, user.reload.first_donated_at
+    end
+  end
+
+  test "respects custom since parameter" do
+    freeze_time do
+      create :user, stripe_customer_id: "cus_123"
+      since = 1.year.ago
+
+      pis = [build_payment_intent("pi_old", customer: "cus_123", amount: 500)]
+      stub_payment_intents_list(pis, created_gte: since.to_i)
+
+      Payments::Stripe::ReconcilePayments.(since:)
+    end
+  end
+
+  private
+  def stub_payment_intents_list(payment_intents, created_gte:)
+    stub_payment_intents_request(
+      created_gte:,
+      body: {
+        object: "list",
+        data: payment_intents,
+        has_more: false,
+        url: "/v1/payment_intents"
+      }
+    )
+  end
+
+  def stub_payment_intents_request(body:, created_gte:, starting_after: nil)
+    url = "https://api.stripe.com/v1/payment_intents?created%5Bgte%5D=#{created_gte}" \
+          "&expand%5B%5D=data.latest_charge&limit=100&status=succeeded"
+    url += "&starting_after=#{starting_after}" if starting_after
+
+    stub_request(:get, url).
+      to_return(
+        status: 200,
+        body: body.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+  end
+
+  def build_payment_intent(id, customer:, amount:, receipt_url: nil,
+                           billing_email: nil, invoice: nil, created: Time.current.to_i)
+    {
+      id:,
+      object: "payment_intent",
+      amount:,
+      customer:,
+      status: "succeeded",
+      created:,
+      invoice:,
+      latest_charge: {
+        id: "ch_#{SecureRandom.hex(8)}",
+        object: "charge",
+        receipt_url:,
+        billing_details: {
+          email: billing_email
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Payments::Stripe::ReconcilePayments` command that iterates over actual Stripe PaymentIntents (not events) for manual reconciliation of missed payments
- Default 90-day window, configurable via `since:` parameter (e.g. `since: 1.year.ago` or `since: Time.at(0)` for all history)
- Add `donated_at:` and `send_email:` params to `Payments::Payment::Create` so reconciliation can set correct `first_donated_at` from the actual Stripe payment date and suppress thank-you emails

## Key behaviours
- Skips bootcamp payments (billing_details.email present on charge)
- Links subscription payments via invoice lookup
- Triggers insiders status/badges from today (not historical date)
- Errors on individual payments are caught and reported via Bugsnag without stopping the batch

## Usage
```ruby
Payments::Stripe::ReconcilePayments.()                  # last 90 days
Payments::Stripe::ReconcilePayments.(since: 1.year.ago) # last year
Payments::Stripe::ReconcilePayments.(since: Time.at(0)) # all history
```

## Test plan
- [x] 12 tests for ReconcilePayments (pagination, skip logic, subscription linking, no emails, donated_at, error handling)
- [x] 3 new tests for Payment::Create (donated_at, send_email flag)
- [x] All existing Payment::Create tests still pass
- [x] Rubocop clean
- [x] Zeitwerk happy

🤖 Generated with [Claude Code](https://claude.com/claude-code)