### PR TITLE
Handle RecordNotFound in DocsController to render 404

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -1,6 +1,7 @@
 class DocsController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :ensure_onboarded!
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
   before_action :use_track, only: %i[track_index track_show]
   before_action :use_section, only: %i[section show]
 

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -41,9 +41,8 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "section shows 404s for missing document" do
-    assert_raises ActiveRecord::RecordNotFound do
-      get docs_section_path(:mentoring)
-    end
+    get docs_section_path(:mentoring)
+    assert_response :not_found
   end
 
   test "tracks shows when logged out" do
@@ -86,9 +85,8 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "track index shows 404s for unknown track" do
-    assert_raises ActiveRecord::RecordNotFound do
-      get track_docs_path('unknown')
-    end
+    get track_docs_path('unknown')
+    assert_response :not_found
   end
 
   test "track shows when logged out" do
@@ -114,8 +112,7 @@ class DocsControllerTest < ActionDispatch::IntegrationTest
 
   test "track shows 404s for missing document" do
     track = create :track
-    assert_raises ActiveRecord::RecordNotFound do
-      get track_doc_path(track, 'missing')
-    end
+    get track_doc_path(track, 'missing')
+    assert_response :not_found
   end
 end


### PR DESCRIPTION
## Summary
- Add `rescue_from ActiveRecord::RecordNotFound` to `DocsController` so invalid doc slugs (e.g. "contact;", "learning") render a 404 page instead of raising unhandled exceptions to Bugsnag
- Update tests to assert `:not_found` response instead of `assert_raises`

## Test plan
- [ ] `bundle exec rails test test/controllers/docs_controller_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)