### PR TITLE
Handle Octokit::NotFound in GithubSolutionSyncer::CreatePullRequest

### DIFF
--- a/app/commands/user/github_solution_syncer/create_pull_request.rb
+++ b/app/commands/user/github_solution_syncer/create_pull_request.rb
@@ -23,6 +23,9 @@ class User::GithubSolutionSyncer
         pr_title,
         pr_message
       )
+    rescue Octokit::NotFound
+      # Repo may have been deleted or renamed — nothing to sync to
+      nil
     end
 
     private

--- a/test/commands/user/github_solution_syncer/create_pull_request_test.rb
+++ b/test/commands/user/github_solution_syncer/create_pull_request_test.rb
@@ -36,5 +36,22 @@ class User::GithubSolutionSyncer
 
       User::GithubSolutionSyncer::CreatePullRequest.(syncer, pr_title, pr_body, &block)
     end
+
+    test "returns nil when repo not found" do
+      syncer = create :user_github_solution_syncer
+
+      token = "fake-token-#{SecureRandom.uuid}"
+      GithubApp.expects(:generate_installation_token!).with(syncer.installation_id).returns(token)
+
+      client = mock
+      Octokit::Client.expects(:new).with(access_token: token).returns(client).at_least_once
+      client.expects(:repository).with(syncer.repo_full_name).raises(Octokit::NotFound)
+
+      block = ->(_, _) {}
+      block.expects(:call).never
+
+      result = User::GithubSolutionSyncer::CreatePullRequest.(syncer, "title", "body", &block)
+      assert_nil result
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Rescue `Octokit::NotFound` in `CreatePullRequest#call` so that when a user's configured GitHub repo has been deleted or renamed, the sync silently returns nil instead of raising an unhandled exception through Sidekiq
- Adds test for the not-found case

## Test plan
- [x] Existing test still passes
- [x] New test verifies `Octokit::NotFound` is caught and returns nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)