### PR TITLE
Handle CSRF token failures gracefully on login page

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -14,6 +14,10 @@ module Auth
       set_flash_message(:alert, :invalid_hash) if is_navigational_format?
 
       redirect_to new_user_session_path
+    rescue ActionController::InvalidAuthenticityToken
+      set_flash_message(:alert, :csrf_failure) if is_navigational_format?
+
+      redirect_to new_user_session_path
     end
 
     def store_referer!

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -6,6 +6,8 @@ module Auth
 
     include Devise::Controllers::Rememberable
 
+    rescue_from ActionController::InvalidAuthenticityToken, with: :handle_csrf_failure
+
     def create
       super do |user|
         remember_me(user)
@@ -14,16 +16,18 @@ module Auth
       set_flash_message(:alert, :invalid_hash) if is_navigational_format?
 
       redirect_to new_user_session_path
-    rescue ActionController::InvalidAuthenticityToken
-      set_flash_message(:alert, :csrf_failure) if is_navigational_format?
-
-      redirect_to new_user_session_path
     end
 
     def store_referer!
       return unless params[:auth_return_to].present?
 
       store_location_for(:user, params[:auth_return_to])
+    end
+
+    private
+    def handle_csrf_failure
+      set_flash_message(:alert, :csrf_failure) if is_navigational_format?
+      redirect_to new_user_session_path
     end
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -51,6 +51,7 @@ en:
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
       invalid_hash: "Your account does not have a password. Please use OAuth."
+      csrf_failure: "Your login session expired. Please try again."
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."

--- a/test/controllers/auth/sessions_controller_test.rb
+++ b/test/controllers/auth/sessions_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+module Auth
+  class SessionsControllerTest < ActionDispatch::IntegrationTest
+    test "redirects to login page on CSRF failure" do
+      Auth::SessionsController.any_instance.stubs(:verify_authenticity_token).raises(
+        ActionController::InvalidAuthenticityToken
+      )
+
+      post user_session_path, params: {
+        user: {
+          email: "user@exercism.org",
+          password: "password"
+        }
+      }
+
+      assert_redirected_to new_user_session_path
+    end
+  end
+end

--- a/test/controllers/auth/sessions_controller_test.rb
+++ b/test/controllers/auth/sessions_controller_test.rb
@@ -3,9 +3,7 @@ require "test_helper"
 module Auth
   class SessionsControllerTest < ActionDispatch::IntegrationTest
     test "redirects to login page on CSRF failure" do
-      Auth::SessionsController.any_instance.stubs(:verify_authenticity_token).raises(
-        ActionController::InvalidAuthenticityToken
-      )
+      ActionController::Base.allow_forgery_protection = true
 
       post user_session_path, params: {
         user: {
@@ -15,6 +13,8 @@ module Auth
       }
 
       assert_redirected_to new_user_session_path
+    ensure
+      ActionController::Base.allow_forgery_protection = false
     end
   end
 end


### PR DESCRIPTION
## Summary
- Rescue `ActionController::InvalidAuthenticityToken` in `Auth::SessionsController#create` and redirect back to the login page with a flash message instead of showing a 422 error
- Handles common cases: stale sessions, browser back button, multiple tabs, bot traffic
- Follows the identical pattern already used for `BCrypt::Errors::InvalidHash` in the same method

## Test plan
- [ ] Verify the new test passes: `bundle exec rails test test/controllers/auth/sessions_controller_test.rb`
- [ ] Confirm login still works normally with valid CSRF tokens
- [ ] Confirm that submitting a stale login form now redirects to login with "Your login session expired. Please try again." flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)