### PR TITLE
Handle RecordNotFound in LegacyController

### DIFF
--- a/app/controllers/legacy_controller.rb
+++ b/app/controllers/legacy_controller.rb
@@ -6,6 +6,8 @@ class LegacyController < ApplicationController
     return render_404 unless solution.published?
 
     redirect_to Exercism::Routes.published_solution_url(solution)
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def my_solution
@@ -13,6 +15,8 @@ class LegacyController < ApplicationController
     return render_404 unless solution.user_id == current_user.id
 
     redirect_to Exercism::Routes.private_solution_url(solution)
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def mentor_solution
@@ -21,5 +25,7 @@ class LegacyController < ApplicationController
     return render_404 unless discussion
 
     redirect_to mentoring_discussion_url(discussion)
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 end

--- a/test/controllers/legacy_controller_test.rb
+++ b/test/controllers/legacy_controller_test.rb
@@ -65,6 +65,25 @@ class LegacyControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "solution with nonexistent uuid returns 404" do
+    get "/solutions/nonexistent-uuid"
+    assert_response :not_found
+  end
+
+  test "my_solution with nonexistent uuid returns 404" do
+    user = create :user
+    sign_in!(user)
+    get "/my/solutions/nonexistent-uuid"
+    assert_response :not_found
+  end
+
+  test "mentor_solution with nonexistent uuid returns 404" do
+    user = create :user
+    sign_in!(user)
+    get "/mentor/solutions/nonexistent-uuid"
+    assert_response :not_found
+  end
+
   test "mentor solution with discussion" do
     solution = create :concept_solution
     discussion = create :mentor_discussion, solution:, mentor: solution.user


### PR DESCRIPTION
## Summary
- Legacy solution URLs (`/solutions/:uuid`) with invalid/deleted UUIDs raise `ActiveRecord::RecordNotFound` which Bugsnag captures as "unhandled" before Rails' `ShowExceptions` middleware converts it to a 404
- Added explicit `rescue ActiveRecord::RecordNotFound` → `render_404` to all three actions (`solution`, `my_solution`, `mentor_solution`), matching the convention used across 50+ other controllers
- Added test coverage for missing UUID cases

## Test plan
- [ ] `bundle exec rails test test/controllers/legacy_controller_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)