### PR TITLE
Handle 404 from GitHub when syncer installation is removed

### DIFF
--- a/app/commands/user/github_solution_syncer/github_app.rb
+++ b/app/commands/user/github_solution_syncer/github_app.rb
@@ -3,6 +3,8 @@ require "jwt"
 require "rest-client"
 
 module User::GithubSolutionSyncer::GithubApp
+  class InstallationNotFoundError < StandardError; end
+
   def self.generate_jwt
     app_id = Exercism.secrets.github_solution_syncer_app_id
     private_key = OpenSSL::PKey::RSA.new(Exercism.secrets.github_solution_syncer_private_key.gsub("\\n", "\n"))
@@ -29,5 +31,7 @@ module User::GithubSolutionSyncer::GithubApp
     )
 
     JSON.parse(response.body)["token"]
+  rescue RestClient::NotFound
+    raise InstallationNotFoundError, "GitHub App installation #{installation_id} not found"
   end
 end

--- a/app/commands/user/github_solution_syncer/sync_everything.rb
+++ b/app/commands/user/github_solution_syncer/sync_everything.rb
@@ -15,6 +15,8 @@ class User::GithubSolutionSyncer
           sync_everything(pr_branch_name, token)
         end
       end
+    rescue GithubApp::InstallationNotFoundError
+      # noop - installation may have been removed or GitHub may be having issues
     end
 
     def sync_everything(branch_name, token = nil)

--- a/app/commands/user/github_solution_syncer/sync_iteration.rb
+++ b/app/commands/user/github_solution_syncer/sync_iteration.rb
@@ -18,6 +18,8 @@ class User::GithubSolutionSyncer
           CreateCommit.(syncer, files, commit_message, pr_branch_name, token:)
         end
       end
+    rescue GithubApp::InstallationNotFoundError
+      # noop - installation may have been removed or GitHub may be having issues
     end
 
     private

--- a/app/commands/user/github_solution_syncer/sync_solution.rb
+++ b/app/commands/user/github_solution_syncer/sync_solution.rb
@@ -15,6 +15,8 @@ class User::GithubSolutionSyncer
           sync_iterations(pr_branch_name, token)
         end
       end
+    rescue GithubApp::InstallationNotFoundError
+      # noop - installation may have been removed or GitHub may be having issues
     end
 
     private

--- a/app/commands/user/github_solution_syncer/sync_track.rb
+++ b/app/commands/user/github_solution_syncer/sync_track.rb
@@ -15,6 +15,8 @@ class User::GithubSolutionSyncer
           sync_solutions(pr_branch_name, token)
         end
       end
+    rescue GithubApp::InstallationNotFoundError
+      # noop - installation may have been removed or GitHub may be having issues
     end
 
     private

--- a/test/commands/user/github_solution_syncer/github_app_test.rb
+++ b/test/commands/user/github_solution_syncer/github_app_test.rb
@@ -15,4 +15,16 @@ class User::GithubSolutionSyncer::GithubAppTest < ActiveSupport::TestCase
     token = User::GithubSolutionSyncer::GithubApp.generate_installation_token!(installation_id)
     assert_equal expected_token, token
   end
+
+  test "raises InstallationNotFoundError on 404" do
+    installation_id = 123_456
+
+    User::GithubSolutionSyncer::GithubApp.stubs(:generate_jwt).returns("fake.jwt.token")
+    stub_request(:post, "https://api.github.com/app/installations/#{installation_id}/access_tokens").
+      to_return(status: 404, body: { message: "Not Found" }.to_json)
+
+    assert_raises(User::GithubSolutionSyncer::GithubApp::InstallationNotFoundError) do
+      User::GithubSolutionSyncer::GithubApp.generate_installation_token!(installation_id)
+    end
+  end
 end

--- a/test/commands/user/github_solution_syncer/sync_everything_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_everything_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class User::GithubSolutionSyncer
+  class SyncEverythingTest < ActiveSupport::TestCase
+    test "noops when installation token returns 404" do
+      user = create(:user)
+      create(:user_github_solution_syncer, user:)
+
+      GithubApp.stubs(:generate_installation_token!).raises(GithubApp::InstallationNotFoundError)
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncEverything.(user)
+    end
+  end
+end

--- a/test/commands/user/github_solution_syncer/sync_iteration_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_iteration_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class User::GithubSolutionSyncer
+  class SyncIterationTest < ActiveSupport::TestCase
+    test "noops when installation token returns 404" do
+      user = create(:user)
+      track = create(:track, slug: "ruby")
+      exercise = create(:practice_exercise, track:, slug: "two-fer")
+      solution = create(:practice_solution, user:, exercise:)
+      submission = create(:submission, solution:)
+      iteration = create(:iteration, user:, solution:, submission:)
+      create(:user_github_solution_syncer, user:)
+
+      GithubApp.stubs(:generate_installation_token!).raises(GithubApp::InstallationNotFoundError)
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncIteration.(iteration)
+    end
+  end
+end

--- a/test/commands/user/github_solution_syncer/sync_solution_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_solution_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class User::GithubSolutionSyncer
+  class SyncSolutionTest < ActiveSupport::TestCase
+    test "noops when installation token returns 404" do
+      user = create(:user)
+      track = create(:track, slug: "ruby")
+      exercise = create(:practice_exercise, track:, slug: "two-fer")
+      solution = create(:practice_solution, user:, exercise:)
+      create(:user_github_solution_syncer, user:)
+
+      GithubApp.stubs(:generate_installation_token!).raises(GithubApp::InstallationNotFoundError)
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncSolution.(solution)
+    end
+  end
+end

--- a/test/commands/user/github_solution_syncer/sync_track_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_track_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class User::GithubSolutionSyncer
+  class SyncTrackTest < ActiveSupport::TestCase
+    test "noops when installation token returns 404" do
+      user = create(:user)
+      track = create(:track, slug: "ruby")
+      user_track = create(:user_track, user:, track:)
+      create(:user_github_solution_syncer, user:)
+
+      GithubApp.stubs(:generate_installation_token!).raises(GithubApp::InstallationNotFoundError)
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncTrack.(user_track)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- When a user uninstalls the Exercism GitHub App from their GitHub account, the stored `installation_id` becomes stale and `generate_installation_token!` gets a 404 from GitHub's API, causing unhandled `RestClient::NotFound` exceptions in production.
- Added `InstallationNotFoundError` custom exception to `GithubApp`, raised on 404.
- All 4 sync commands (`SyncIteration`, `SyncSolution`, `SyncTrack`, `SyncEverything`) now rescue this and noop gracefully.

## Test plan
- [x] `generate_installation_token!` raises `InstallationNotFoundError` on 404
- [x] Each sync command catches the error without raising
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)