### PR TITLE
Filter ActiveStorage RecordNotFound errors from Bugsnag

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,6 +1,17 @@
+BUGSNAG_ACTIVE_STORAGE_FILTER = proc do |event|
+  next if event.errors.empty?
+
+  error_class = event.errors.first.error_class
+  request_url = event.request&.dig(:url) || ''
+
+  next false if error_class == 'ActiveRecord::RecordNotFound' && request_url.include?('/rails/active_storage/')
+end
+
 if Rails.env.production?
   Bugsnag.configure do |config|
     config.api_key = "5564ad0d9fde96c4378bc555eaf88313"
     config.notify_release_stages = ["production"]
+
+    config.add_on_error(BUGSNAG_ACTIVE_STORAGE_FILTER)
   end
 end

--- a/test/initializers/bugsnag_test.rb
+++ b/test/initializers/bugsnag_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class BugsnagActiveStorageFilterTest < ActiveSupport::TestCase
+  test "discards RecordNotFound from ActiveStorage paths" do
+    event = mock_bugsnag_event(
+      error_class: "ActiveRecord::RecordNotFound",
+      url: "https://exercism.org/rails/active_storage/representations/redirect/abc123/variant/avatar.jpg"
+    )
+
+    result = BUGSNAG_ACTIVE_STORAGE_FILTER.(event)
+    refute result
+  end
+
+  test "allows RecordNotFound from non-ActiveStorage paths" do
+    event = mock_bugsnag_event(
+      error_class: "ActiveRecord::RecordNotFound",
+      url: "https://exercism.org/tracks/ruby"
+    )
+
+    result = BUGSNAG_ACTIVE_STORAGE_FILTER.(event)
+    refute_equal false, result
+  end
+
+  test "allows other errors from ActiveStorage paths" do
+    event = mock_bugsnag_event(
+      error_class: "StandardError",
+      url: "https://exercism.org/rails/active_storage/representations/redirect/abc123/variant/avatar.jpg"
+    )
+
+    result = BUGSNAG_ACTIVE_STORAGE_FILTER.(event)
+    refute_equal false, result
+  end
+
+  test "handles events with no errors" do
+    event = stub(errors: [])
+
+    result = BUGSNAG_ACTIVE_STORAGE_FILTER.(event)
+    refute_equal false, result
+  end
+
+  private
+  def mock_bugsnag_event(error_class:, url:)
+    error = stub(error_class: error_class)
+    stub(errors: [error], request: { url: url })
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a Bugsnag `on_error` callback that suppresses `ActiveRecord::RecordNotFound` errors from ActiveStorage paths (`/rails/active_storage/`)
- These errors are expected when blobs are deleted but still referenced (e.g., cached/hardcoded URLs), and Rails already serves a proper 404 page via `config.exceptions_app`
- All other `RecordNotFound` errors continue to be reported to Bugsnag

## Test plan
- [x] New test file `test/initializers/bugsnag_test.rb` with 4 cases: discards ActiveStorage RecordNotFound, allows non-ActiveStorage RecordNotFound, allows other errors from ActiveStorage paths, handles empty errors
- [x] Rubocop passes
- [ ] Verify in production that these errors stop appearing in Bugsnag

🤖 Generated with [Claude Code](https://claude.com/claude-code)