### PR TITLE
Handle SES errors gracefully in unsubscribe endpoint

### DIFF
--- a/app/controllers/spi/unsubscribe_users_controller.rb
+++ b/app/controllers/spi/unsubscribe_users_controller.rb
@@ -4,10 +4,14 @@ module SPI
       user = User.find_by!(email: params[:email])
       User::UnsubscribeFromAllEmails.(user)
 
-      Exercism.ses_client.put_suppressed_destination({
-        email_address: params[:email],
-        reason: params[:reason].upcase
-      })
+      begin
+        Exercism.ses_client.put_suppressed_destination({
+          email_address: params[:email],
+          reason: params[:reason].upcase
+        })
+      rescue Aws::SESV2::Errors::ServiceError => e
+        Bugsnag.notify(e)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- The SPI unsubscribe endpoint was returning 500 when the SES `put_suppressed_destination` call failed (e.g. due to missing IAM permissions)
- The DB-level unsubscribe (disabling all communication preferences) already succeeds before the SES call
- Now rescues `Aws::SESV2::Errors::ServiceError`, notifies Bugsnag, and returns success instead of crashing

## Test plan
- [x] Existing test passes: `bundle exec rails test test/controllers/spi/unsubscribe_user_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)