### PR TITLE
Fix Stripe reconciliation: status is not a valid list filter

### DIFF
--- a/app/commands/payments/stripe/reconcile_payments.rb
+++ b/app/commands/payments/stripe/reconcile_payments.rb
@@ -6,10 +6,10 @@ class Payments::Stripe::ReconcilePayments
   def call
     Stripe::PaymentIntent.list({
       limit: 100,
-      status: 'succeeded',
       created: { gte: since.to_i },
       expand: ['data.latest_charge']
     }).auto_paging_each do |payment_intent|
+      next unless payment_intent.status == 'succeeded'
       next if existing_payment_ids.include?(payment_intent.id)
       next unless payment_intent.customer
 

--- a/test/commands/payments/stripe/reconcile_payments_test.rb
+++ b/test/commands/payments/stripe/reconcile_payments_test.rb
@@ -231,7 +231,7 @@ class Payments::Stripe::ReconcilePaymentsTest < Payments::TestBase
 
   def stub_payment_intents_request(body:, created_gte:, starting_after: nil)
     url = "https://api.stripe.com/v1/payment_intents?created%5Bgte%5D=#{created_gte}" \
-          "&expand%5B%5D=data.latest_charge&limit=100&status=succeeded"
+          "&expand%5B%5D=data.latest_charge&limit=100"
     url += "&starting_after=#{starting_after}" if starting_after
 
     stub_request(:get, url).


### PR DESCRIPTION
## Summary
- `Stripe::PaymentIntent.list` doesn't accept a `status` parameter — it raises `Stripe::InvalidRequestError`
- Moved the succeeded check to a client-side filter instead

## Test plan
- [x] `bundle exec rails test test/commands/payments/stripe/reconcile_payments_test.rb` — 12 tests, 18 assertions, 0 failures
- [x] Verified `Stripe::PaymentIntent.list` works without `status` param in production IRB

🤖 Generated with [Claude Code](https://claude.com/claude-code)