### PR TITLE
Replace billing email heuristic with checkout session check

### DIFF
--- a/app/commands/payments/stripe/payment_intent/handle_success.rb
+++ b/app/commands/payments/stripe/payment_intent/handle_success.rb
@@ -40,12 +40,8 @@ class Payments::Stripe::PaymentIntent::HandleSuccess
   def should_record_payment?
     return true if subscription_data
 
-    charge = Stripe::Charge.retrieve(payment_intent.latest_charge)
-
-    # If there is an email, then it's the Bootcamp.
-    # If there's not an email, then through our integration.
-    # This is terrible, I know.
-    charge.billing_details.email.blank?
+    # Bootcamp payments were created via Checkout Sessions; donations are not.
+    Stripe::Checkout::Session.list({ payment_intent: payment_intent.id }).data.empty?
   rescue StandardError
     true
   end

--- a/app/commands/payments/stripe/reconcile_payments.rb
+++ b/app/commands/payments/stripe/reconcile_payments.rb
@@ -6,10 +6,10 @@ class Payments::Stripe::ReconcilePayments
   def call
     Stripe::PaymentIntent.list({
       limit: 100,
-      status: 'succeeded',
       created: { gte: since.to_i },
       expand: ['data.latest_charge']
     }).auto_paging_each do |payment_intent|
+      next unless payment_intent.status == 'succeeded'
       next if existing_payment_ids.include?(payment_intent.id)
       next unless payment_intent.customer
 

--- a/app/commands/payments/stripe/reconcile_payments.rb
+++ b/app/commands/payments/stripe/reconcile_payments.rb
@@ -41,8 +41,8 @@ class Payments::Stripe::ReconcilePayments
   def should_record_payment?(payment_intent)
     return true if payment_intent.invoice
 
-    charge = payment_intent.latest_charge
-    charge&.billing_details&.email.blank?
+    # Bootcamp payments were created via Checkout Sessions; donations are not.
+    Stripe::Checkout::Session.list({ payment_intent: payment_intent.id }).data.empty?
   rescue StandardError
     true
   end

--- a/test/commands/payments/stripe/reconcile_payments_test.rb
+++ b/test/commands/payments/stripe/reconcile_payments_test.rb
@@ -231,7 +231,7 @@ class Payments::Stripe::ReconcilePaymentsTest < Payments::TestBase
 
   def stub_payment_intents_request(body:, created_gte:, starting_after: nil)
     url = "https://api.stripe.com/v1/payment_intents?created%5Bgte%5D=#{created_gte}" \
-          "&expand%5B%5D=data.latest_charge&limit=100&status=succeeded"
+          "&expand%5B%5D=data.latest_charge&limit=100"
     url += "&starting_after=#{starting_after}" if starting_after
 
     stub_request(:get, url).


### PR DESCRIPTION
## Summary
- The bootcamp payment filter used `billing_details.email` presence to skip bootcamp payments, but some genuine donors also have billing emails - causing their payments to be **silently dropped** with no error
- Bootcamp payments were created via Stripe Checkout Sessions; donations are not. Use that as the heuristic instead
- Fixes both `handle_success.rb` (live payment path) and `reconcile_payments.rb` (backfill path)
- Also removes the invalid `status` parameter from `PaymentIntent.list` in reconciliation (fix from #8336)

## Test plan
- [x] Confirmed in production: all bootcamp payments have checkout sessions, donations do not
- [x] `bundle exec rails test test/commands/payments/stripe/reconcile_payments_test.rb test/commands/payments/stripe/payment_intent/` — 22 tests, 51 assertions, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [ ] Run reconciliation in production after merge to backfill missed payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)