### PR TITLE
Globally handle ActionController::UnknownFormat with 406

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,8 @@ class ApplicationController < ActionController::Base
   # by a gem, which can cause chaos with devise etc.
   protect_from_forgery with: :exception, prepend: true
 
+  rescue_from ActionController::UnknownFormat, with: -> { head :not_acceptable }
+
   def process_action(*args)
     super
   rescue ActionDispatch::Http::MimeNegotiation::InvalidType,


### PR DESCRIPTION
## Summary

- Adds a global `rescue_from ActionController::UnknownFormat` in `ApplicationController` that returns 406 Not Acceptable
- Eliminates Bugsnag noise from bots/misconfigured clients requesting non-HTML formats on HTML-only endpoints
- Replaces the per-controller approach from #8316 with a single one-liner

## Test plan

- [ ] Visit any HTML-only page in a browser — should render normally
- [ ] Request an HTML-only page with `Accept: application/json` — should return 406
- [ ] Endpoints with explicit `respond_to` blocks (blog, errors, jiki) continue working as before
- [ ] No more `ActionController::UnknownFormat` exceptions in Bugsnag

🤖 Generated with [Claude Code](https://claude.com/claude-code)