### PR TITLE
Fix CSRF failures on join track buttons and auth forms

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -1,9 +1,17 @@
 module Auth
   class ConfirmationsController < Devise::ConfirmationsController
+    rescue_from ActionController::InvalidAuthenticityToken, with: :handle_csrf_failure
+
     def required; end
 
     def after_resending_confirmation_instructions_path_for(_resource_or_scope)
       user_signed_in? ? settings_path : new_user_session_path
+    end
+
+    private
+    def handle_csrf_failure
+      set_flash_message(:alert, :csrf_failure) if is_navigational_format?
+      redirect_to new_user_session_path
     end
   end
 end

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -4,6 +4,8 @@ module Auth
     before_action :configure_permitted_parameters
     before_action :verify_turnstile!, only: [:create]
 
+    rescue_from ActionController::InvalidAuthenticityToken, with: :handle_csrf_failure
+
     def create
       super do |user|
         if user.persisted?
@@ -24,6 +26,11 @@ module Auth
     end
 
     private
+    def handle_csrf_failure
+      set_flash_message(:alert, :csrf_failure) if is_navigational_format?
+      redirect_to new_user_registration_path
+    end
+
     def verify_turnstile!
       raise "Turnstile: No response token" unless params['cf-turnstile-response'].present?
 

--- a/app/views/tracks/concepts/index.html.haml
+++ b/app/views/tracks/concepts/index.html.haml
@@ -16,9 +16,14 @@
             %p
               = t('.external_cta.description')
 
-          = button_to join_track_path(@track), method: :post, class: "btn-primary btn-m" do
-            = graphical_icon(:plus)
-            = t('.external_cta.join_button', track_title: @track.title)
+          - if user_signed_in?
+            = button_to join_track_path(@track), method: :post, class: "btn-primary btn-m" do
+              = graphical_icon(:plus)
+              = t('.external_cta.join_button', track_title: @track.title)
+          - else
+            = link_to User::GenerateNewSessionPath.(request, controller), class: "btn-primary btn-m" do
+              = graphical_icon(:plus)
+              = t('.external_cta.join_button', track_title: @track.title)
 
     %header.page-header
       .lg-container.container.flex-col.sm:flex-row

--- a/app/views/tracks/exercises/index.html.haml
+++ b/app/views/tracks/exercises/index.html.haml
@@ -16,9 +16,14 @@
             %p
               = t('.external_cta.description', num_exercises: @user_track.num_exercises, track_title: @track.title)
 
-          = button_to join_track_path(@track), method: :post, class: "btn-primary btn-m" do
-            = graphical_icon(:plus)
-            = t('.external_cta.join_track_button', track_title: @track.title)
+          - if user_signed_in?
+            = button_to join_track_path(@track), method: :post, class: "btn-primary btn-m" do
+              = graphical_icon(:plus)
+              = t('.external_cta.join_track_button', track_title: @track.title)
+          - else
+            = link_to User::GenerateNewSessionPath.(request, controller), class: "btn-primary btn-m" do
+              = graphical_icon(:plus)
+              = t('.external_cta.join_track_button', track_title: @track.title)
 
     %header.page-header
       .lg-container.container.flex-col.sm:flex-row

--- a/app/views/tracks/exercises/show/_action_box_join_track.html.haml
+++ b/app/views/tracks/exercises/show/_action_box_join_track.html.haml
@@ -19,5 +19,8 @@
           exercises_link: exercise_link)
 
   .buttons
-    = button_to t('.join_track_button', track_title: track.title), join_track_path(track), method: :post, class: "btn-primary btn-m"
+    - if user_signed_in?
+      = button_to t('.join_track_button', track_title: track.title), join_track_path(track), method: :post, class: "btn-primary btn-m"
+    - else
+      = link_to t('.join_track_button', track_title: track.title), User::GenerateNewSessionPath.(request, controller), class: "btn-primary btn-m"
     = link_to t('.see_all_exercises_button', track_title: track.title), track_exercises_path(track), class: 'btn-secondary btn-m'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -6,6 +6,7 @@ en:
       confirmed: "Your email address has been successfully confirmed. Please sign in below."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      csrf_failure: "Your session expired. Please try again."
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
@@ -46,6 +47,7 @@ en:
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
       captcha_verification_failed: "Captcha verification failed. Please try again."
+      csrf_failure: "Your session expired. Please try again."
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."

--- a/test/controllers/auth/confirmations_controller_test.rb
+++ b/test/controllers/auth/confirmations_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+module Auth
+  class ConfirmationsControllerTest < ActionDispatch::IntegrationTest
+    test "redirects to login page on CSRF failure" do
+      ActionController::Base.allow_forgery_protection = true
+
+      post user_confirmation_path, params: {
+        user: { email: "user@exercism.org" }
+      }
+
+      assert_redirected_to new_user_session_path
+    ensure
+      ActionController::Base.allow_forgery_protection = false
+    end
+  end
+end

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -22,5 +22,23 @@ module Auth
         "cf-turnstile-response": "valid_turnstile_response"
       }
     end
+
+    test "redirects to registration page on CSRF failure" do
+      ActionController::Base.allow_forgery_protection = true
+
+      post user_registration_path, params: {
+        user: {
+          name: "User",
+          handle: "user22",
+          email: "user@exercism.org",
+          password: "password",
+          password_confirmation: "password"
+        }
+      }
+
+      assert_redirected_to new_user_registration_path
+    ensure
+      ActionController::Base.allow_forgery_protection = false
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Root cause fix**: Join track buttons on concepts/index, exercises/index, and exercise show pages rendered `button_to` POST forms for logged-out users. Combined with the `skip_empty_session_cookie` optimization (which skips setting the session cookie for empty sessions), the CSRF token embedded in the form had no matching session on submit. Switched these to `link_to` login links for logged-out users, matching the existing pattern in `tracks/about.html.haml`.

- **Auth safety nets**: Added `rescue_from ActionController::InvalidAuthenticityToken` handlers to confirmations and registrations controllers (sessions already had one) so expired sessions on auth forms show a friendly redirect instead of a 500.

## Test plan

- [x] `bundle exec rails test test/controllers/auth/` — all 4 tests pass
- [x] `bundle exec rubocop --except Metrics app/controllers/auth/` — no offenses
- [ ] Verify logged-out user clicking "Join Track" on `/tracks/python/concepts` redirects to login
- [ ] Verify logged-in user clicking "Join Track" still works as POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)