### PR TITLE
Stop throwing on highlight.js HTMLInjectionError

### DIFF
--- a/app/javascript/utils/highlight.ts
+++ b/app/javascript/utils/highlight.ts
@@ -36,7 +36,7 @@ if (isLookbehindSupported()) {
 }
 
 highlighter.default.configure({
-  throwUnescapedHTML: true,
+  throwUnescapedHTML: false,
 })
 
 function duplicateMultilineNodes(element: HTMLElement) {


### PR DESCRIPTION
## Summary
- Change `throwUnescapedHTML` from `true` to `false` in the highlight.js configuration
- highlight.js will now log a console warning instead of throwing an unhandled `HTMLInjectionError` when it encounters code blocks with child HTML elements
- Investigation confirmed the codebase properly escapes all code block content — these errors are triggered by browser extensions (translation tools, Grammarly, etc.) injecting elements into `<code>` blocks before highlight.js runs

## Test plan
- [x] `yarn test` passes (160/160 suites)
- [ ] Verify code blocks still highlight correctly on exercise pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)