### PR TITLE
Remove dead mentoring requests tracks endpoint

### DIFF
--- a/app/controllers/api/mentoring/requests_controller.rb
+++ b/app/controllers/api/mentoring/requests_controller.rb
@@ -12,10 +12,6 @@ class API::Mentoring::RequestsController < API::BaseController
     render json: AssembleMentorRequests.(current_user, params)
   end
 
-  def tracks
-    render json: Mentor::Request::RetrieveTracks.(current_user)
-  end
-
   def exercises
     render json: Mentor::Request::RetrieveExercises.(current_user, params[:track_slug])
   end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -216,7 +216,6 @@ namespace :api do
 
       resources :requests, only: %i[index], param: :uuid do
         collection do
-          get :tracks
           get :exercises
         end
         member do


### PR DESCRIPTION
## Summary
- Removed the `tracks` action from `API::Mentoring::RequestsController` which called `Mentor::Request::RetrieveTracks` — a command deleted in 2021
- Removed the corresponding `get :tracks` route from the requests collection
- The frontend already uses `API::Mentoring::TracksController#mentored` for this functionality

Fixes #8324

## Test plan
- [x] `bundle exec rails test test/controllers/api/mentoring/requests_controller_test.rb` — all 14 tests pass
- [x] `bundle exec rails test:zeitwerk` — autoloading OK
- [x] `bundle exec rubocop --except Metrics` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)