### PR TITLE
Handle 404 errors gracefully in AvatarsController

### DIFF
--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -29,6 +29,11 @@ class AvatarsController < ActionController::Base # rubocop:disable Rails/Applica
     send_data data, type: content_type, disposition: 'inline'
   rescue ActiveRecord::RecordNotFound
     head :not_found
+  rescue OpenURI::HTTPError
+    url = "#{Exercism.config.website_icons_host}/placeholders/user-avatar.svg"
+    file = URI.parse(url).open
+    expires_in 5.minutes, public: true
+    send_data file.read, type: file.content_type, disposition: 'inline'
   rescue StandardError => e
     Bugsnag.notify(e)
     head :internal_server_error


### PR DESCRIPTION
## Summary
- When a user's `avatar_url` points to a dead link (deleted GitHub avatar, etc.), the `open-uri` fetch raises `OpenURI::HTTPError`
- Previously caught by the broad `StandardError` rescue — reported to Bugsnag (noise) and returned HTTP 500 (broken image)
- Now specifically rescues `OpenURI::HTTPError` and falls back to serving the placeholder avatar with a short cache TTL (5 minutes)

## Test plan
- [ ] Verify rubocop passes on `app/controllers/avatars_controller.rb`
- [ ] Verify that valid avatar URLs still work normally with 5-year cache
- [ ] Verify that a 404 avatar URL serves the placeholder SVG with 5-minute cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)