### PR TITLE
Fix NoMethodError when execution_output is nil in TestRun::Process

### DIFF
--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -112,6 +112,8 @@ class Submission::TestRun::Process
 
   memoize
   def results
+    return {} if tooling_job.execution_output.nil?
+
     res = JSON.parse(tooling_job.execution_output['results.json'], allow_invalid_unicode: true)
     res.is_a?(Hash) ? res.symbolize_keys : {}
   rescue StandardError => e

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -43,6 +43,15 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     assert submission.reload.tests_exceptioned?
   end
 
+  test "handle ops error with no execution output" do
+    submission = create :submission
+    job = create_test_runner_job!(submission, execution_status: 500)
+
+    Submission::TestRun::Process.(job)
+
+    assert submission.reload.tests_exceptioned?
+  end
+
   test "handle tests pass" do
     submission = create :submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }


### PR DESCRIPTION
## Summary
- Guard against `nil` `execution_output` in `Submission::TestRun::Process#results`, fixing a production `NoMethodError`
- This matches the existing guard pattern in `Analysis::Process` and `Representation::Process` (added in PR #6696)
- Added test covering ops error with no execution output

## Test plan
- [x] Existing test suite passes (`bundle exec rails test test/commands/submission/test_run/process_test.rb` — 16 tests, 0 failures)
- [x] New test verifies ops error with nil execution_output is handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)