### PR TITLE
Rescue RecordNotFound in BlogPostsController#show

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -16,5 +16,7 @@ class BlogPostsController < ApplicationController
   def show
     @post = BlogPost.published.find(params[:id])
     @other_posts = BlogPost.published.ordered_by_recency.includes(:author).where.not(id: @post.id).limit(6)
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 end


### PR DESCRIPTION
## Summary
- Adds `rescue ActiveRecord::RecordNotFound` to `BlogPostsController#show` to render a clean 404 instead of raising to the error tracker
- Fixes noise from bots/crawlers hitting `/blog/feed` and other invalid blog post slugs

## Test plan
- [x] Visit `/blog/feed` — should show 404 page instead of raising an error
- [x] Visit a valid blog post — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)