### PR TITLE
Filter dynamic import errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -26,6 +26,12 @@ if (process.env.SENTRY_DSN) {
     enabled: process.env.NODE_ENV === 'production',
     sendDefaultPii: false,
     beforeSend: (event) => {
+      // Drop non-actionable dynamic import failures (network issues, stale chunks)
+      const isDynamicImportError = event.exception?.values?.some((ex) =>
+        ex.value?.includes('Failed to fetch dynamically imported module')
+      )
+      if (isDynamicImportError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
## Summary
- Drops `Failed to fetch dynamically imported module` errors in the Sentry `beforeSend` hook
- These are transient network issues (flaky connections, ad blockers, deploys invalidating cached chunk names) and are not actionable

## Test plan
- [x] `yarn test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)