### PR TITLE
Handle RecordNotFound in ImagesController#solution

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,6 @@
 class ImagesController < ApplicationController
   skip_before_action :authenticate_user!
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   layout 'images'
 


### PR DESCRIPTION
## Summary
- Add `rescue_from ActiveRecord::RecordNotFound, with: :render_404` to `ImagesController`
- `Solution.for!` raises `RecordNotFound` when given invalid user/track/exercise slugs, which was causing unhandled 500 errors
- Follows the same pattern used in `DocsController`, `LegacyController`, etc.

## Test plan
- [ ] Visit an image solution URL with an invalid user handle, track slug, or exercise slug — should render 404 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)