### PR TITLE
Add runtime regex check to prevent SyntaxError on older browsers

### DIFF
--- a/app/javascript/utils/regex-check.ts
+++ b/app/javascript/utils/regex-check.ts
@@ -37,6 +37,8 @@ function compareVersions(versionA: string, versionB: string): number {
 }
 
 export function isLookbehindSupported(): boolean {
+  if (!areAllRegExpFeaturesSupported()) return false
+
   const parser = new UAParser().getBrowser()
 
   switch (parser.name) {


### PR DESCRIPTION
## Summary
- Fixes `SyntaxError: Invalid regular expression: invalid group specifier name` reported on `/journey` (and likely other pages)
- The `isLookbehindSupported()` function uses UA sniffing which can incorrectly return `true` for browsers that don't support lookbehinds (e.g. in-app WebViews, Chrome on old iOS using WebKit). This causes `highlight.ts` to load `highlightjs-roc`, which contains regex **literals** with lookbehind assertions, triggering a fatal parse-time `SyntaxError`
- Adds the existing `areAllRegExpFeaturesSupported()` runtime check (which was previously unused) as the first guard in `isLookbehindSupported()`, so even when UA detection fails the runtime check catches it

## Test plan
- [x] `yarn test` passes (all failures are pre-existing `@bugsnag/js` module resolution issues)
- On a browser without lookbehind support: `areAllRegExpFeaturesSupported()` returns `false` → `isLookbehindSupported()` returns `false` → `lazyHighlightAll()` exits early → `highlight.ts` never loaded → no parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)