### PR TITLE
Handle RecordNotFound in SPI UnsubscribeUsersController

### DIFF
--- a/app/controllers/spi/unsubscribe_users_controller.rb
+++ b/app/controllers/spi/unsubscribe_users_controller.rb
@@ -1,7 +1,9 @@
 module SPI
   class UnsubscribeUsersController < BaseController
     def unsubscribe_by_email
-      user = User.find_by!(email: params[:email])
+      user = User.find_by(email: params[:email])
+      return head :ok unless user
+
       User::UnsubscribeFromAllEmails.(user)
 
       begin

--- a/test/controllers/spi/unsubscribe_user_test.rb
+++ b/test/controllers/spi/unsubscribe_user_test.rb
@@ -18,4 +18,13 @@ class SPI::UnsubscribeUserTest < ActionDispatch::IntegrationTest
       reason: :bounce
     )
   end
+
+  test "returns 200 when user does not exist" do
+    patch spi_unsubscribe_user_path(
+      email: "nonexistent@example.com",
+      reason: :bounce
+    )
+
+    assert_response :ok
+  end
 end


### PR DESCRIPTION
## Summary
- Gracefully handle `ActiveRecord::RecordNotFound` when AWS SES sends a bounce/complaint notification for an email that doesn't belong to any user
- Changed `find_by!` to `find_by` with early return (`head :ok`) when the user doesn't exist
- Added test for the missing-user case

## Test plan
- [x] Existing test continues to pass
- [x] New test verifies 200 response for nonexistent email

🤖 Generated with [Claude Code](https://claude.com/claude-code)