### PR TITLE
Reject unauthorized IterationChannel subscriptions gracefully

### DIFF
--- a/app/channels/iteration_channel.rb
+++ b/app/channels/iteration_channel.rb
@@ -1,12 +1,11 @@
 class IterationChannel < ApplicationCable::Channel
-  class UnauthorizedConnectionError < RuntimeError
-  end
-
   def subscribed
-    # Assert that the user owns this iteration
     iteration = Iteration.find_by!(uuid: params[:uuid])
 
-    raise UnauthorizedConnectionError unless iteration.viewable_by?(current_user)
+    unless iteration.viewable_by?(current_user)
+      reject
+      return
+    end
 
     # Don't use persisted objects for stream_for
     stream_for iteration.id

--- a/test/channels/iteration_channel_test.rb
+++ b/test/channels/iteration_channel_test.rb
@@ -1,15 +1,14 @@
 require "test_helper"
 
 class IterationChannelTest < ActionCable::Channel::TestCase
-  test "raises error for an unauthorized connection" do
+  test "rejects subscription for an unauthorized connection" do
     user = create :user
     iteration = create :iteration
     stub_connection(current_user: user)
 
-    assert_raises IterationChannel::UnauthorizedConnectionError do
-      subscribe uuid: iteration.uuid
-    end
+    subscribe uuid: iteration.uuid
 
+    assert subscription.rejected?
     assert_no_streams
   end
 end


### PR DESCRIPTION
## Summary
- Replace `raise UnauthorizedConnectionError` with ActionCable's built-in `reject` in `IterationChannel#subscribed`, preventing unhandled exceptions from hitting Sentry
- Remove the now-unused `UnauthorizedConnectionError` class
- Update test to verify subscription rejection instead of exception raising

## Test plan
- [x] `bundle exec rails test test/channels/iteration_channel_test.rb` passes
- [x] `bundle exec rubocop --except Metrics` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)