### PR TITLE
Guard against nil current_user in Action Cable channels

### DIFF
--- a/app/channels/submission/ai_help_records_channel.rb
+++ b/app/channels/submission/ai_help_records_channel.rb
@@ -1,5 +1,7 @@
 class Submission::AIHelpRecordsChannel < ApplicationCable::Channel
   def subscribed
+    return reject unless current_user
+
     submission = current_user.submissions.find_by!(uuid: params[:submission_uuid])
 
     # Don't use persisted objects for stream_for

--- a/app/channels/submission/test_runs_channel.rb
+++ b/app/channels/submission/test_runs_channel.rb
@@ -1,5 +1,7 @@
 class Submission::TestRunsChannel < ApplicationCable::Channel
   def subscribed
+    return reject unless current_user
+
     submission = current_user.submissions.find_by!(uuid: params[:submission_uuid])
 
     # Don't use persisted objects for stream_for


### PR DESCRIPTION
## Summary
- Reject subscriptions when `current_user` is nil in `Submission::AIHelpRecordsChannel` and `Submission::TestRunsChannel`
- Fixes `NoMethodError: undefined method 'submissions' for nil` on unauthenticated WebSocket connections
- Uses ActionCable's built-in `reject` method for clean subscription denial

Fixes https://thalamus-ai.sentry.io/share/issue/eed213ea634d4540b5bcb50633ac5368/

## Test plan
- [x] Rubocop passes on all channel files
- [ ] Verify unauthenticated WebSocket connections no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)