### PR TITLE
Stop auto-closing Sentry issues

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pause:
-    if: github.repository_owner == 'exercism' # Stops this job from running on forks
+    if: github.repository_owner == 'exercism' && github.actor != 'sentry[bot]'
     uses: exercism/github-actions/.github/workflows/community-contributions.yml@main
     with:
       forum_category: support


### PR DESCRIPTION
## Summary
- The community contributions workflow auto-closes issues from non-org-members
- `sentry[bot]` isn't an org member, so Sentry-created issues (e.g. #8358) were being immediately closed
- Skip the workflow when `github.actor` is `sentry[bot]`

## Test plan
- [ ] Verify next Sentry-created issue stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)