### PR TITLE
Clean up Twine2 Story global event handlers on unmount

### DIFF
--- a/app/javascript/components/common/CLIWalkthrough.tsx
+++ b/app/javascript/components/common/CLIWalkthrough.tsx
@@ -24,6 +24,8 @@ export default ({ html }: { html: string }): JSX.Element => {
 
     return () => {
       $(window).off('shown.sm.passage', scrollToTop)
+      $(window).off('popstate')
+      $(window).off('hashchange')
     }
   }, [])
 


### PR DESCRIPTION
Closes #8374

## Summary
- `Story.start()` registers `popstate` and `hashchange` handlers on `$(window)`, but these were never cleaned up when the CLIWalkthrough component unmounted
- Stale handlers could fire on a destroyed Story instance where `this.history` is undefined, causing the `TypeError: can't access property "length", this.history is undefined` reported in Sentry
- Added cleanup of both `popstate` and `hashchange` handlers in the useEffect cleanup function

## Test plan
- [x] `yarn test` — 1550 passed
- [x] `bundle exec rubocop --except Metrics` — no offenses
- [x] `bundle exec rails test:zeitwerk` — Zeitwerk is happy

🤖 Generated with [Claude Code](https://claude.com/claude-code)