### PR TITLE
Enforce two-phase workflow in /fix skill

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -18,15 +18,21 @@ You are fixing a GitHub issue for the exercism/website repository.
 
 Issue number: !`echo "$ARGUMENTS" | grep -oE '[0-9]+$'`
 
-## Critical: Protect existing work
+## Critical: Two phase.
 
-**Before doing anything else**, check the current git state:
+Your work is split into two phases.
+
+The first phase is purely planning. You must **NOT** make any changes to git state (switching branches, creating branches etc). You should presume that other work is SIMULTANEOUSLY happening WHILE you are planning.
+
+Once the plan has been **APPROVED** by the user you should check the current git state:
 
 - Run `git status` to check for uncommitted changes and the current branch.
 - If there are **uncommitted or staged changes**, STOP and ask the user how to proceed. Do NOT checkout another branch, stash, or discard anything.
 - If you are **not on main**, STOP and ask the user how to proceed. Do NOT switch branches or reset.
 
 Never destroy or discard existing work.
+
+If the plan has been approved, and you are on a clean main branch, continue with your work.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Updates the `/fix` Claude Code skill to enforce a two-phase workflow
- **Planning phase**: must not touch git state (no branch creation/switching), since other work may be happening simultaneously
- **Implementation phase**: only begins after the plan is approved and the working tree is confirmed clean on main
- Previously the skill checked git state upfront before any planning happened, which could interfere with in-progress work

## Test plan
- [x] Reviewed the diff — changes are limited to `.claude/skills/fix/SKILL.md`
- [x] Skill instructions are clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)