### PR TITLE
Guard against blank results.json before JSON parsing

### DIFF
--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -114,7 +114,10 @@ class Submission::TestRun::Process
   def results
     return {} if tooling_job.execution_output.nil?
 
-    res = JSON.parse(tooling_job.execution_output['results.json'], allow_invalid_unicode: true)
+    results_json = tooling_job.execution_output['results.json']
+    return {} if results_json.blank?
+
+    res = JSON.parse(results_json, allow_invalid_unicode: true)
     res.is_a?(Hash) ? res.symbolize_keys : {}
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/test/commands/submission/test_run/process_test.rb
+++ b/test/commands/submission/test_run/process_test.rb
@@ -52,6 +52,21 @@ class Submission::TestRun::ProcessTest < ActiveSupport::TestCase
     assert submission.reload.tests_exceptioned?
   end
 
+  test "handle empty results.json in execution output" do
+    submission = create :submission
+    job = create_tooling_job!(
+      submission,
+      :test_runner,
+      execution_status: 200,
+      execution_output: { "results.json" => "" },
+      source: { 'exercise_git_sha' => submission.git_sha }
+    )
+
+    Submission::TestRun::Process.(job)
+
+    assert submission.reload.tests_exceptioned?
+  end
+
   test "handle tests pass" do
     submission = create :submission
     results = { 'status' => 'pass', 'message' => "", 'tests' => [] }


### PR DESCRIPTION
Closes #8375

## Summary
- When a tooling job's `execution_output` exists but `results.json` is an empty string, `JSON.parse` raises `JSON::ParserError: Empty input` which gets reported to Sentry as noise
- Added a `.blank?` guard to return `{}` early before parsing, matching the existing pattern in `Analysis::Process#tags_data` and `Representation::Process#metadata`
- Added test covering the empty `results.json` scenario

## Test plan
- [x] New test `handle empty results.json in execution output` passes
- [x] All existing `Submission::TestRun::ProcessTest` tests pass (17/17)
- [x] Rubocop clean
- [x] Zeitwerk happy
- [x] JS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)