### PR TITLE
Fix removeChild DOM error in ActivityTicker during metric transitions

### DIFF
--- a/app/javascript/components/track/ActivityTicker.tsx
+++ b/app/javascript/components/track/ActivityTicker.tsx
@@ -7,14 +7,17 @@ export default function ActivityTicker({
   trackTitle,
   initialData,
 }: Elements.ActivityTickerProps) {
-  const { metric, animation } = Elements.useActivityTicker({
+  const { metric, metricKey, animation } = Elements.useActivityTicker({
     trackTitle,
     initialData,
   })
 
   if (!metric) return
   return (
-    <div className={assembleClassNames('flex items-start', animation)}>
+    <div
+      key={metricKey}
+      className={assembleClassNames('flex items-start', animation)}
+    >
       {metric.user || !metric.countryCode ? (
         <Elements.UserAvatar user={metric.user} />
       ) : (

--- a/app/javascript/components/track/activity-ticker/useActivityTicker.ts
+++ b/app/javascript/components/track/activity-ticker/useActivityTicker.ts
@@ -5,10 +5,12 @@ import { METRIC_TYPES, allowedMetricTypes } from './ActivityTicker.types'
 
 export function useActivityTicker({ initialData, trackTitle }): {
   metric: Metric
+  metricKey: number
   animation: 'animate-fadeIn' | 'animate-fadeOut'
 } {
   const [metric, setMetric] = useState<Metric>(initialData)
   const [isVisible, setIsVisible] = useState(true)
+  const [metricKey, setMetricKey] = useState(0)
 
   useEffect(() => {
     const connection = new MetricsChannel((metric) => {
@@ -20,6 +22,7 @@ export function useActivityTicker({ initialData, trackTitle }): {
 
       setIsVisible(false)
       setTimeout(() => {
+        setMetricKey((prev) => prev + 1)
         setMetric(metric)
         setIsVisible(true)
       }, 300)
@@ -27,5 +30,9 @@ export function useActivityTicker({ initialData, trackTitle }): {
     return () => connection.disconnect()
   }, [])
 
-  return { metric, animation: isVisible ? 'animate-fadeIn' : 'animate-fadeOut' }
+  return {
+    metric,
+    metricKey,
+    animation: isVisible ? 'animate-fadeIn' : 'animate-fadeOut',
+  }
 }


### PR DESCRIPTION
Closes #8379

## Summary
- Added a `metricKey` counter to `useActivityTicker` that increments each time a new metric arrives via WebSocket
- Applied `key={metricKey}` to the ActivityTicker content div, forcing React to fully unmount/remount rather than reconcile the DOM when metric data changes
- This prevents `NotFoundError: Failed to execute 'removeChild' on 'Node'` caused by React's reconciliation conflicting with conditional child components (`Handle`, `PublishedSolutionLink`, `Trans`) that change element types between metrics

## Test plan
- [x] `yarn test` — all 160 test suites pass (1550 tests)
- [ ] Verify activity ticker on track pages still animates smoothly between metrics
- [ ] Confirm Sentry error no longer occurs in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)