### PR TITLE
Handle Cloudflare Turnstile errors gracefully

### DIFF
--- a/app/helpers/view_components/captcha.rb
+++ b/app/helpers/view_components/captcha.rb
@@ -7,6 +7,7 @@ module ViewComponents
           data: {
             sitekey: Exercism.secrets.turnstile_site_key,
             callback: "turnstileEnableSubmitButton",
+            error_callback: "turnstileHandleError",
             size: "flexible",
             theme: "light"
           }
@@ -20,6 +21,13 @@ module ViewComponents
                 const form = turnstileElement.closest('form');
                 const submitButton = form.querySelector('button[type="submit"]');
                 submitButton.disabled = false;
+              }
+
+              /* Handle Turnstile errors gracefully to prevent uncaught exceptions reaching Sentry.
+                 Returning true tells Turnstile we handled the error, suppressing its default error throw. */
+              window.turnstileHandleError = (errorCode) => {
+                console.warn('Cloudflare Turnstile error:', errorCode);
+                return true;
               }
             JS
           end

--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -32,6 +32,15 @@ if (process.env.SENTRY_DSN) {
       )
       if (isDynamicImportError) return null
 
+      // Drop non-actionable Cloudflare Turnstile widget errors (browser extensions, privacy settings, etc.)
+      const isTurnstileError = event.exception?.values?.some(
+        (ex) =>
+          ex.type?.includes('TurnstileError') ||
+          ex.value?.includes('TurnstileError') ||
+          ex.value?.includes('[Cloudflare Turnstile]')
+      )
+      if (isTurnstileError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8376

## Summary
- Add `data-error-callback` to the Turnstile widget in `captcha.rb` so errors are caught by a handler that logs to `console.warn` and returns `true` (telling Turnstile the error was handled, suppressing uncaught throws)
- Add a Turnstile error filter in Sentry's `beforeSend` callback in `react-bootloader.tsx` to drop any TurnstileError events that slip through (e.g., errors during script loading before the callback is registered)

## Test plan
- [x] `bundle exec rubocop --except Metrics` passes
- [x] `yarn test` passes (1550 tests)
- [x] `bundle exec rails test:zeitwerk` passes
- [ ] Monitor Sentry after deploy to confirm TurnstileError reports drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)