### PR TITLE
Filter AbortError from Sentry to reduce noise

### DIFF
--- a/app/javascript/components/ErrorBoundary.tsx
+++ b/app/javascript/components/ErrorBoundary.tsx
@@ -32,6 +32,10 @@ const handleError = (error: Error) => {
     return
   }
 
+  if (error.name === 'AbortError') {
+    return
+  }
+
   Sentry.captureException(error)
 }
 

--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -41,6 +41,18 @@ if (process.env.SENTRY_DSN) {
       )
       if (isTurnstileError) return null
 
+      // Drop AbortErrors — expected when fetch requests are cancelled
+      // (e.g. user navigates away, component unmounts, React Query cancels stale requests)
+      const isAbortError = event.exception?.values?.some(
+        (ex) =>
+          ex.type === 'AbortError' ||
+          ex.value?.includes('AbortError') ||
+          ex.value?.includes('Fetch is aborted') ||
+          ex.value?.includes('The operation was aborted') ||
+          ex.value?.includes('signal is aborted without reason')
+      )
+      if (isAbortError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8378

## Summary
- Added AbortError filtering to the Sentry `beforeSend` hook in `react-bootloader.tsx` — this is a catch-all that drops AbortError events regardless of which code path generated them, matching across multiple browser-specific error message formats
- Added AbortError check to the `handleError` callback in `ErrorBoundary.tsx` — defense in depth, matching the existing pattern already used in the `useErrorHandler` hook

## Test plan
- [x] `yarn test` — all JS tests pass
- [x] `bundle exec rubocop --except Metrics` — clean
- [x] `bundle exec rails test:zeitwerk` — Zeitwerk happy
- [ ] After deploy, verify AbortError events stop appearing in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)