### PR TITLE
Handle non-ASCII email addresses in VerifyEmail

### DIFF
--- a/app/commands/user/verify_email.rb
+++ b/app/commands/user/verify_email.rb
@@ -11,6 +11,8 @@ class User::VerifyEmail
 
   private
   def email_status
+    return :invalid unless user.email.ascii_only?
+
     case check_email_status!
     when 'valid'
       :verified

--- a/test/commands/user/verify_email_test.rb
+++ b/test/commands/user/verify_email_test.rb
@@ -31,6 +31,15 @@ class User::VerifyEmailTest < ActiveSupport::TestCase
     end
   end
 
+  test "marks email with non-ASCII characters as invalid" do
+    user = create :user, email: "user@\u2666gmail.com"
+    user.update(email_status: :unverified)
+
+    User::VerifyEmail.(user)
+
+    assert_equal :invalid, user.email_status
+  end
+
   %i[verified invalid].each do |email_status|
     test "does not verify email when current email status is #{email_status}" do
       created_at = Time.current - 2.days


### PR DESCRIPTION
Closes #8404

## Summary
- Emails with non-ASCII characters (e.g., `bigaillonjm@♦gmail.com`) caused a `URI::InvalidURIError` when `User::VerifyEmail` interpolated them into the SparkPost API URL
- Added an `ascii_only?` check that marks non-ASCII emails as `:invalid` immediately, skipping the API call entirely
- Non-ASCII characters aren't valid in email addresses per RFC 5321, so this is the correct classification

## Test plan
- [x] Added test for non-ASCII email being marked as invalid
- [x] All existing VerifyEmail tests pass (8/8)
- [x] Rubocop clean
- [x] Zeitwerk happy

🤖 Generated with [Claude Code](https://claude.com/claude-code)