### PR TITLE
Rescue all Net::SMTPSyntaxError variants in ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,7 +6,7 @@ class ApplicationMailer < ActionMailer::Base
   helper :email
 
   rescue_from(Mail::Field::IncompleteParseError) {}
-  rescue_from("Net::SMTPSyntaxError: 501 5.5.2 RCPT TO syntax error") {}
+  rescue_from(Net::SMTPSyntaxError) {}
 
   def user_email_with_name(user)
     name = user.name.presence || user.handle

--- a/test/mailers/mailer_rescues_test.rb
+++ b/test/mailers/mailer_rescues_test.rb
@@ -8,4 +8,16 @@ class MailerRescuesTest < ActionMailer::TestCase
 
     NotificationsMailer.with(notification:).joined_exercism.deliver_now
   end
+
+  test "rescues Net::SMTPSyntaxError" do
+    user = create :user
+    notification = create(:joined_exercism_notification, user:)
+
+    # Stub deliver to raise the SMTP error that Sentry reported
+    Mail::Message.any_instance.stubs(:deliver).raises(
+      Net::SMTPSyntaxError.new("501 Invalid RCPT TO address provided")
+    )
+
+    NotificationsMailer.with(notification:).joined_exercism.deliver_now
+  end
 end


### PR DESCRIPTION
Closes #8403

## Summary
- Broadened `rescue_from` in `ApplicationMailer` from matching a specific error message string (`"Net::SMTPSyntaxError: 501 5.5.2 RCPT TO syntax error"`) to rescuing the exception class `Net::SMTPSyntaxError`
- This handles all SMTP syntax error message variants, including the `"501 Invalid RCPT TO address provided"` reported by Sentry
- Added test for `Net::SMTPSyntaxError` rescue behavior

## Test plan
- [x] Mailer rescue tests pass (`bundle exec rails test test/mailers/mailer_rescues_test.rb`)
- [x] All mailer tests pass (`bundle exec rails test test/mailers/`)
- [x] Rubocop passes with no offenses
- [x] Zeitwerk eager loading passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)