### PR TITLE
Prevent stack overflow from repeated Google Translate monkey-patching

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -160,7 +160,12 @@ export function initReact(mappings: Mappings): void {
   }
 }
 
+let googleTranslatePatched = false
+
 function onGoogleTranslateDetected(): void {
+  if (googleTranslatePatched) return
+  googleTranslatePatched = true
+
   // See: https://github.com/facebook/react/issues/11538#issuecomment-417504600
   if (typeof Node === 'function' && Node.prototype) {
     const originalRemoveChild: (child: Node) => Node =


### PR DESCRIPTION
Closes #8401

## Summary
- The `onGoogleTranslateDetected()` function in `react-bootloader.tsx` monkey-patches `Node.prototype.removeChild` and `insertBefore` to work around a React/Google Translate bug
- A `MutationObserver` calls this function on every class attribute change on `<html>`, but each call wraps the **already-wrapped** method, creating an ever-deeper closure chain
- After enough mutations, any `removeChild`/`insertBefore` call overflows the call stack (`RangeError: Maximum call stack size exceeded`)
- Fix: add a guard flag so the patching only runs once — subsequent observer callbacks return immediately

## Test plan
- [x] `yarn test` — all 1550 JS tests pass
- [x] `bundle exec rubocop --except Metrics` — no offenses
- [x] `bundle exec rails test:zeitwerk` — autoloader check passes
- [ ] Monitor Sentry for the `RangeError: Maximum call stack size exceeded` error after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)