### PR TITLE
Memoize job lookup in ToolingJob::Cancel to fix race condition

### DIFF
--- a/app/commands/tooling_job/cancel.rb
+++ b/app/commands/tooling_job/cancel.rb
@@ -25,6 +25,7 @@ class ToolingJob::Cancel
     end
   end
 
+  memoize
   def job
     Exercism::ToolingJob.find_for_submission_uuid_and_type(submission_uuid, type)
   rescue StandardError

--- a/test/commands/tooling_job/cancel_test.rb
+++ b/test/commands/tooling_job/cancel_test.rb
@@ -60,4 +60,12 @@ class ToolingJob::CancelTest < ActiveSupport::TestCase
 
     assert submission.reload.representation_cancelled?
   end
+
+  test "gracefully handles missing job" do
+    submission = create :submission
+
+    ToolingJob::Cancel.(submission.uuid, :test_runner)
+
+    refute submission.reload.tests_cancelled?
+  end
 end


### PR DESCRIPTION
Closes #8397

## Summary
- The `job` method in `ToolingJob::Cancel` was not memoized, causing two separate Redis lookups — one for the guard check (`return unless job`) and one for `job.cancelled!`
- Between those two calls, another process could remove the job from Redis, making the second call return `nil` and raising `NoMethodError`
- Added `memoize` to the `job` method so the lookup happens once, matching the pattern used in `ToolingJob::Process` and throughout the codebase
- Added a test for the missing-job case

## Test plan
- [ ] Existing `ToolingJob::Cancel` tests continue to pass
- [ ] New test verifies graceful handling when no job exists in Redis
- [ ] Rubocop and Zeitwerk checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)