### PR TITLE
Guard against undefined storedTheme in useTheme hook

### DIFF
--- a/app/javascript/components/settings/theme-preference-form/useTheme.tsx
+++ b/app/javascript/components/settings/theme-preference-form/useTheme.tsx
@@ -33,11 +33,11 @@ export function useTheme(
     theme: defaultThemePreference,
     time: Date.now(),
   })
-  const [theme, setTheme] = useState<string>(storedTheme.theme || '')
+  const [theme, setTheme] = useState<string>(storedTheme?.theme || '')
   const debouncedTheme = useDebounce(theme, 500)
 
   useEffect(() => {
-    if (hasFiveMinElapsed(storedTheme.time)) {
+    if (!storedTheme?.time || hasFiveMinElapsed(storedTheme.time)) {
       setStoredTheme({ theme: defaultThemePreference, time: Date.now() })
     }
   }, [])


### PR DESCRIPTION
Closes #8399

## Summary
- Added optional chaining (`?.`) when accessing `storedTheme.theme` and `storedTheme.time` in `useTheme` hook
- The `useLocalStorage` hook can return `null`/non-object values when localStorage contains corrupted or legacy-format data (e.g. `JSON.parse("null")` succeeds but returns `null`), causing `TypeError: Cannot read properties of undefined (reading 'theme')`
- When `storedTheme` has no valid `time`, we now treat it as expired and reset to the server-provided default, which also repairs the corrupted localStorage entry

## Test plan
- [x] `yarn test` — all 160 test suites pass
- [ ] Manual: set `localStorage.setItem('theme-preference', 'null')` in dev tools then reload — ThemeToggleButton should render without crashing
- [ ] Manual: clear `localStorage.removeItem('theme-preference')` and reload — should use default theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)