### PR TITLE
Filter non-actionable "invalid origin" errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -53,6 +53,12 @@ if (process.env.SENTRY_DSN) {
       )
       if (isAbortError) return null
 
+      // Drop non-actionable cross-origin postMessage errors (third-party iframes: Turnstile, YouTube, etc.)
+      const isInvalidOriginError = event.exception?.values?.some((ex) =>
+        ex.value?.includes('invalid origin')
+      )
+      if (isInvalidOriginError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8394

## Summary
- The "Error: invalid origin" is thrown by third-party iframe scripts (Cloudflare Turnstile, YouTube, Vimeo) during cross-origin postMessage communication — the string does not exist in our codebase
- Added a filter in Sentry's `beforeSend` handler to drop these non-actionable errors, following the same pattern already used for dynamic import and Turnstile errors

## Test plan
- [x] `yarn test` — 160 suites passed, 1550 tests passed
- [x] `bundle exec rubocop --except Metrics` — no offenses
- [x] `bundle exec rails test:zeitwerk` — Zeitwerk happy
- [ ] After deploy: confirm "invalid origin" errors stop appearing in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)