### PR TITLE
Filter Safari's dynamic import error variant from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -27,8 +27,10 @@ if (process.env.SENTRY_DSN) {
     sendDefaultPii: false,
     beforeSend: (event) => {
       // Drop non-actionable dynamic import failures (network issues, stale chunks)
-      const isDynamicImportError = event.exception?.values?.some((ex) =>
-        ex.value?.includes('Failed to fetch dynamically imported module')
+      const isDynamicImportError = event.exception?.values?.some(
+        (ex) =>
+          ex.value?.includes('Failed to fetch dynamically imported module') ||
+          ex.value?.includes('Importing a module script failed')
       )
       if (isDynamicImportError) return null
 


### PR DESCRIPTION
Closes #8383

## Summary
- Extends the Sentry `beforeSend` filter to also catch Safari/WebKit's `"Importing a module script failed"` error message
- PR #8349 already filters Chrome/Firefox's `"Failed to fetch dynamically imported module"` but Safari uses different wording for the same transient error
- Both are non-actionable (flaky connections, ad blockers, deploys invalidating cached chunk names)

## Test plan
- [x] `yarn test` passes (160 suites, 1550 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)