### PR TITLE
Truncate GitHub issue titles to prevent ValueTooLong error

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -67,12 +67,12 @@ Only create the worktree **after the plan is approved**. The issue number has be
 
 ```bash
 git pull --ff-only origin main
-mkdir -p ../website-worktrees
-git worktree add ../website-worktrees/fix-<issue-number> -b fix/<issue-number>
-cd ../website-worktrees/fix-<issue-number>
+mkdir -p worktrees
+git worktree add worktrees/fix-<issue-number> -b fix/<issue-number>
+cd worktrees/fix-<issue-number>
 ```
 
-**Important:** After creating the worktree, `cd` into it immediately. All subsequent work (file edits, bash commands, tests) happens inside the worktree. The main repo stays untouched on its current branch.
+**CRITICAL:** You MUST `cd` into the worktree immediately after creating it. All subsequent work — file reads, edits, bash commands, tests — MUST happen from inside the worktree directory using `cd worktrees/fix-<issue-number> && <command>` on every Bash call. Do NOT use absolute paths to the worktree from the main repo. The main repo stays untouched on its current branch.
 
 ### Step 4: Implement the fix
 
@@ -128,10 +128,9 @@ EOF
 ### Step 8: Clean up worktree
 
 ```bash
-cd /Users/iHiD/Code/exercism/website
-git worktree remove ../website-worktrees/fix-<issue-number>
+git worktree remove worktrees/fix-<issue-number>
 ```
 
-This removes the worktree directory and returns you to the main repo. The branch remains on the remote for the PR.
+This removes the worktree directory. The branch remains on the remote for the PR.
 
 Report the PR URL to the user.

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ vendor/bundle/
 
 # Claude local settings
 .claude/settings.local.json
+
+# Git worktrees
+worktrees/

--- a/app/commands/github/issue/create_or_update.rb
+++ b/app/commands/github/issue/create_or_update.rb
@@ -6,7 +6,7 @@ class Github::Issue::CreateOrUpdate
   def call
     issue = ::Github::Issue.create_or_find_by!(node_id:) do |i|
       i.number = attributes[:number]
-      i.title = attributes[:title]
+      i.title = title
       i.status = status
       i.repo = attributes[:repo]
       i.opened_at = attributes[:opened_at]
@@ -17,7 +17,7 @@ class Github::Issue::CreateOrUpdate
 
     issue.update!(
       number: attributes[:number],
-      title: attributes[:title],
+      title:,
       status:,
       repo: attributes[:repo],
       opened_at: attributes[:opened_at],
@@ -35,6 +35,7 @@ class Github::Issue::CreateOrUpdate
     end
   end
 
+  def title = attributes[:title].to_s.truncate(255)
   def status = attributes[:state].downcase.to_sym
 
   def log_metric!(issue)

--- a/test/commands/github/issue/create_or_update_test.rb
+++ b/test/commands/github/issue/create_or_update_test.rb
@@ -67,6 +67,23 @@ class Github::Issue::CreateOrUpdateTest < ActiveSupport::TestCase
     assert_nil issue.opened_by_username
   end
 
+  test "truncates title longer than 255 characters" do
+    long_title = "a" * 300
+
+    issue = Github::Issue::CreateOrUpdate.(
+      "MDU6SXNzdWU3MjM2MjUwMTI=",
+      number: 999,
+      title: long_title,
+      state: "OPEN",
+      repo: "exercism/ruby",
+      labels: [],
+      opened_at: Time.parse("2020-10-17T02:39:37Z").utc,
+      opened_by_username: "SleeplessByte"
+    )
+
+    assert_equal 255, issue.title.length
+  end
+
   test "update issue if data has changed" do
     issue = create :github_issue
 


### PR DESCRIPTION
Closes #8370

## Summary
- The `github_issues.title` column is `VARCHAR(255)` but GitHub issue titles can exceed that length, causing `ActiveRecord::ValueTooLong` errors in `Github::Issue::CreateOrUpdate`
- Added `title` helper method that truncates to 255 characters before saving
- Also updated `/fix` skill to use local `worktrees/` directory instead of `../website-worktrees/` and added `worktrees/` to `.gitignore`

## Test plan
- [x] Added test verifying a 300-character title is truncated to 255
- [x] All 11 existing tests in `create_or_update_test.rb` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)