### PR TITLE
Sanitize title in GitHub issue search to prevent UnprocessableEntity

### DIFF
--- a/app/commands/github/issue/open.rb
+++ b/app/commands/github/issue/open.rb
@@ -35,6 +35,11 @@ class Github::Issue::Open
   memoize
   def issue
     author = Exercism.config.github_bot_username
-    Exercism.octokit_client.search_issues("\"#{title}\" is:issue in:title repo:#{repo} author:#{author}")[:items]&.first
+    sanitized_title = title.gsub(/[{}]/, '')
+    Exercism.octokit_client.search_issues(
+      "\"#{sanitized_title}\" is:issue in:title repo:#{repo} author:#{author}"
+    )[:items]&.first
+  rescue Octokit::UnprocessableEntity
+    nil
   end
 end

--- a/test/commands/github/issue/open_test.rb
+++ b/test/commands/github/issue/open_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class Github::Issue::OpenTest < ActiveSupport::TestCase
+  setup do
+    Exercism.config.stubs(:github_bot_username).returns('exercism-bot')
+  end
+
+  test "opens issue when issue was not yet created" do
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22Test%20title%22%20is:issue%20in:title%20repo:exercism/ruby-analyzer%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 0,
+          incomplete_results: false,
+          items: []
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby-analyzer/issues").
+      with do |request|
+        json = JSON.parse(request.body)
+        json["title"] == "Test title" &&
+          json["body"] == "Test body"
+      end.
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "Test title", "Test body")
+  end
+
+  test "re-opens issue when issue was closed" do
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22Test%20title%22%20is:issue%20in:title%20repo:exercism/ruby-analyzer%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 1,
+          incomplete_results: false,
+          items: [{
+            number: 42,
+            state: "closed"
+          }]
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    stub_request(:patch, "https://api.github.com/repos/exercism/ruby-analyzer/issues/42").
+      with(body: { state: "open" }.to_json).
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "Test title", "Test body")
+  end
+
+  test "does nothing when issue already open" do
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22Test%20title%22%20is:issue%20in:title%20repo:exercism/ruby-analyzer%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 1,
+          incomplete_results: false,
+          items: [{
+            number: 42,
+            state: "open"
+          }]
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "Test title", "Test body")
+
+    # If the GitHub API would have been called to create/reopen, we would not have gotten to this point
+  end
+
+  test "sanitizes curly braces from title in search query" do
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=%22keymentoring_request_url%20not%20found%22%20is:issue%20in:title%20repo:exercism/ruby-analyzer%20author:exercism-bot"). # rubocop:disable Layout/LineLength
+      to_return(
+        status: 200,
+        body: {
+          total_count: 0,
+          incomplete_results: false,
+          items: []
+        }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby-analyzer/issues").
+      with do |request|
+        json = JSON.parse(request.body)
+        json["title"] == "key{mentoring_request_url} not found"
+      end.
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "key{mentoring_request_url} not found", "backtrace")
+  end
+
+  test "creates issue when search returns UnprocessableEntity" do
+    stub_request(:get, %r{api\.github\.com/search/issues}).
+      to_return(status: 422, body: "", headers: {})
+
+    stub_request(:post, "https://api.github.com/repos/exercism/ruby-analyzer/issues").
+      to_return(status: 200, body: "", headers: {}).
+      times(1)
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "key{mentoring_request_url} not found", "backtrace")
+  end
+
+  test "does nothing in development environment" do
+    # Unstub github_bot_username since it won't be called (early return)
+    Exercism.config.unstub(:github_bot_username)
+    Rails.env.stubs(:development?).returns(true)
+
+    Github::Issue::Open.("exercism/ruby-analyzer", "Test title", "Test body")
+
+    # No API calls should be made - if they were, WebMock would raise
+  end
+end


### PR DESCRIPTION
Closes #8367

## Summary
- Strip `{}` characters from the title when constructing GitHub search queries in `Github::Issue::Open`, preventing `Octokit::UnprocessableEntity` errors caused by special characters in error messages (e.g., `KeyError: key{mentoring_request_url} not found`)
- Rescue `Octokit::UnprocessableEntity` in the search method as a fallback, treating search failures as "no existing issue found" so a new issue gets created
- The original unsanitized title is preserved for the created GitHub issue

## Test plan
- [x] Added tests for `Github::Issue::Open` covering: create, reopen, no-op, curly brace sanitization, UnprocessableEntity fallback, development environment skip
- [x] All 6 new tests pass
- [x] All 60 related tests pass (github/issue commands + submission analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)