### PR TITLE
Filter non-actionable "frame window is not ready" Sentry errors

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -59,6 +59,13 @@ if (process.env.SENTRY_DSN) {
       )
       if (isInvalidOriginError) return null
 
+      // Drop non-actionable iframe readiness errors (third-party scripts or browser internals
+      // accessing iframe.contentWindow before the frame is ready)
+      const isFrameNotReadyError = event.exception?.values?.some((ex) =>
+        ex.value?.includes('frame window is not ready')
+      )
+      if (isFrameNotReadyError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8384

## Summary
- Add a Sentry `beforeSend` filter to drop "frame window is not ready" errors
- The error originates from third-party scripts or browser internals accessing `iframe.contentWindow` before the frame is loaded — the exact string does not exist in our source code or any dependency
- Follows the identical pattern used for the existing non-actionable error filters (dynamic imports, Turnstile, AbortError, invalid origin)

## Test plan
- [x] Verified the error string is not in source code or node_modules (not actionable)
- [x] Filter follows existing pattern in `beforeSend`
- [x] `yarn test` passes (160 suites, 1550 tests)
- [ ] Post-deploy: monitor Sentry for absence of new "frame window is not ready" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)