### PR TITLE
Symlink node_modules and husky in worktrees

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -67,9 +67,15 @@ Only create the worktree **after the plan is approved**. The issue number has be
 
 ```bash
 git pull --ff-only origin main
-mkdir -p ../website-worktrees
-git worktree add ../website-worktrees/fix-<issue-number> -b fix/<issue-number>
-cd ../website-worktrees/fix-<issue-number>
+git worktree add worktrees/fix-<issue-number> -b fix/<issue-number>
+cd worktrees/fix-<issue-number>
+```
+
+After creating the worktree, symlink `node_modules` and husky from the main repo so that JS tooling (prettier, eslint, jest) and pre-commit hooks work without a full `yarn install`:
+
+```bash
+ln -s /Users/iHiD/Code/exercism/website/node_modules node_modules
+ln -s /Users/iHiD/Code/exercism/website/.husky/_ .husky/_
 ```
 
 **Important:** After creating the worktree, `cd` into it immediately. All subsequent work (file edits, bash commands, tests) happens inside the worktree. The main repo stays untouched on its current branch.
@@ -129,7 +135,7 @@ EOF
 
 ```bash
 cd /Users/iHiD/Code/exercism/website
-git worktree remove ../website-worktrees/fix-<issue-number>
+git worktree remove worktrees/fix-<issue-number>
 ```
 
 This removes the worktree directory and returns you to the main repo. The branch remains on the remote for the PR.

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /public/packs
 /public/packs-test
 /node_modules
+.husky/_
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity


### PR DESCRIPTION
## Summary
- Worktrees created by the `/fix` skill don't have `node_modules` or `.husky/_/husky.sh`, which breaks pre-commit hooks (prettier, eslint) and JS tests
- Add symlink commands to the `/fix` skill's Step 3 so `node_modules` and `.husky/_` are linked from the main repo after worktree creation
- Add `.husky/_` to `.gitignore` so the symlink doesn't show as an untracked file
- Update worktree paths from `../website-worktrees/` to `./worktrees/`

## Test plan
- [x] Created a worktree, added symlinks, and verified pre-commit hooks (prettier) ran successfully via the symlinked node_modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)