### PR TITLE
Guard against empty files array in FileEditorCodeMirror

### DIFF
--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -41,7 +41,11 @@ export function FileEditorCodeMirror({
   settings: EditorSettings
   files: File[]
   readonly: boolean
-}): JSX.Element {
+}): JSX.Element | null {
+  if (!defaultFiles || defaultFiles.length === 0) {
+    return null
+  }
+
   const [files, setFiles] = useState(defaultFiles)
   const [tab, setTab] = useState(files[0].filename)
   const containerRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Closes #8419

## Summary
- Add early return guard in `FileEditorCodeMirror` when `files` prop is empty or undefined
- Prevents `TypeError: Cannot read properties of undefined (reading '0')` when accessing `files[0].filename`
- This can occur when localStorage returns an empty array for saved editor files
- Follows existing defensive pattern used in `FilePanel` and `IterationFiles` components

## Test plan
- [x] All 65 Editor-related JS tests pass (19 test suites)
- [x] Pre-commit hooks pass (prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)