### PR TITLE
Filter non-actionable network fetch errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -68,6 +68,15 @@ if (process.env.SENTRY_DSN) {
       )
       if (isFrameNotReadyError) return null
 
+      // Drop non-actionable network errors (connectivity loss, DNS failures, browser extensions blocking requests)
+      const isNetworkError = event.exception?.values?.some(
+        (ex) =>
+          ex.value?.includes(
+            'NetworkError when attempting to fetch resource'
+          ) || ex.value?.includes('Failed to fetch')
+      )
+      if (isNetworkError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8417
Closes #8388
Closes #8387

## Summary
- Add a new filter in the Sentry `beforeSend` hook to drop transient network fetch errors
- Filters Firefox's `NetworkError when attempting to fetch resource` and Chrome/Safari's `Failed to fetch`
- These errors are caused by connectivity loss, DNS failures, or browser extensions — not actionable application bugs
- Follows the same pattern as the existing filters for AbortError, dynamic import failures, Turnstile errors, and invalid origin errors

## Test plan
- [x] Verified the new filter follows the existing pattern in `react-bootloader.tsx`
- [x] JS tests pass (`yarn test` — 160 suites, 1550 tests passed)
- [x] Pre-commit hooks pass (prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)