### PR TITLE
Fix invalid hook call in handleSyncEverything

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,6 +657,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x64-mingw32
   x86_64-linux
 

--- a/app/javascript/components/settings/github-syncer/sections/ConnectedSection/JustConnectedModal.tsx
+++ b/app/javascript/components/settings/github-syncer/sections/ConnectedSection/JustConnectedModal.tsx
@@ -2,19 +2,16 @@ import React from 'react'
 import Modal from '@/components/modals/Modal'
 import { GitHubSyncerContext } from '../../GitHubSyncerForm'
 import { Icon } from '@/components/common'
-import { fetchWithParams, handleJsonErrorResponse } from '../../fetchWithParams'
-import toast from 'react-hot-toast'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
+import { useSyncEverything } from '../../useSyncEverything'
 
 export function JustConnectedModal(): JSX.Element {
   const { t } = useAppTranslation(
     'components/settings/github-syncer/sections/ConnectedSection'
   )
-  const { t: tSync } = useAppTranslation(
-    'components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx'
-  )
   const { links } = React.useContext(GitHubSyncerContext)
   const [isModalOpen, setIsModalOpen] = React.useState(false)
+  const syncEverything = useSyncEverything(links.syncEverything)
 
   React.useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search)
@@ -31,34 +28,9 @@ export function JustConnectedModal(): JSX.Element {
   }, [])
 
   const handleSync = React.useCallback(() => {
-    fetchWithParams({
-      url: links.syncEverything,
-    })
-      .then(async (response) => {
-        if (response.ok) {
-          toast.success(
-            tSync(
-              'yourBackupForAllTracksHasBeenQueuedAndShouldBeCompletedWithinAFewMinutes'
-            ),
-            { duration: 5000 }
-          )
-        } else {
-          await handleJsonErrorResponse(
-            response,
-            tSync('errorQueuingBackupForAllTracks')
-          )
-        }
-      })
-      .catch((error) => {
-        console.error('Error:', error)
-        toast.error(
-          tSync(
-            'somethingWentWrongWhileQueuingTheBackupForAllTracksPleaseTryAgain'
-          )
-        )
-      })
+    syncEverything()
     handleRemoveParam()
-  }, [links.syncEverything, tSync, handleRemoveParam])
+  }, [syncEverything, handleRemoveParam])
 
   const handleCloseModal = React.useCallback(() => {
     handleRemoveParam()

--- a/app/javascript/components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx
+++ b/app/javascript/components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx
@@ -6,6 +6,7 @@ import { fetchWithParams, handleJsonErrorResponse } from '../../fetchWithParams'
 import { StaticTooltip } from '@/components/bootcamp/JikiscriptExercisePage/Scrubber/ScrubberTooltipInformation'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { Trans } from 'react-i18next'
+import { useSyncEverything } from '../../useSyncEverything'
 
 type Track = {
   title: string
@@ -52,32 +53,7 @@ export function ManualSyncSection() {
     [links.syncTrack, t]
   )
 
-  const handleSyncEverything = useCallback(() => {
-    fetchWithParams({
-      url: links.syncEverything,
-    })
-      .then(async (response) => {
-        if (response.ok) {
-          toast.success(
-            t(
-              'yourBackupForAllTracksHasBeenQueuedAndShouldBeCompletedWithinAFewMinutes'
-            ),
-            { duration: 5000 }
-          )
-        } else {
-          await handleJsonErrorResponse(
-            response,
-            t('errorQueuingBackupForAllTracks')
-          )
-        }
-      })
-      .catch((error) => {
-        console.error('Error:', error)
-        toast.error(
-          t('somethingWentWrongWhileQueuingTheBackupForAllTracksPleaseTryAgain')
-        )
-      })
-  }, [links.syncEverything, t])
+  const handleSyncEverything = useSyncEverything(links.syncEverything)
 
   return (
     <section

--- a/app/javascript/components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx
+++ b/app/javascript/components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx
@@ -52,6 +52,33 @@ export function ManualSyncSection() {
     [links.syncTrack, t]
   )
 
+  const handleSyncEverything = useCallback(() => {
+    fetchWithParams({
+      url: links.syncEverything,
+    })
+      .then(async (response) => {
+        if (response.ok) {
+          toast.success(
+            t(
+              'yourBackupForAllTracksHasBeenQueuedAndShouldBeCompletedWithinAFewMinutes'
+            ),
+            { duration: 5000 }
+          )
+        } else {
+          await handleJsonErrorResponse(
+            response,
+            t('errorQueuingBackupForAllTracks')
+          )
+        }
+      })
+      .catch((error) => {
+        console.error('Error:', error)
+        toast.error(
+          t('somethingWentWrongWhileQueuingTheBackupForAllTracksPleaseTryAgain')
+        )
+      })
+  }, [links.syncEverything, t])
+
   return (
     <section
       style={{
@@ -119,11 +146,7 @@ export function ManualSyncSection() {
       <div className="group relative">
         <button
           disabled={!isSyncingEnabled}
-          onClick={() =>
-            handleSyncEverything({
-              syncEverythingEndpoint: links.syncEverything,
-            })
-          }
+          onClick={handleSyncEverything}
           className="btn btn-primary relative group"
         >
           {t('backupEverythingLabel')}
@@ -138,38 +161,4 @@ export function ManualSyncSection() {
       </div>
     </section>
   )
-}
-
-export function handleSyncEverything({
-  syncEverythingEndpoint,
-}: {
-  syncEverythingEndpoint: string
-}) {
-  const { t } = useAppTranslation(
-    'components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx'
-  )
-  fetchWithParams({
-    url: syncEverythingEndpoint,
-  })
-    .then(async (response) => {
-      if (response.ok) {
-        toast.success(
-          t(
-            'yourBackupForAllTracksHasBeenQueuedAndShouldBeCompletedWithinAFewMinutes'
-          ),
-          { duration: 5000 }
-        )
-      } else {
-        await handleJsonErrorResponse(
-          response,
-          t('errorQueuingBackupForAllTracks')
-        )
-      }
-    })
-    .catch((error) => {
-      console.error('Error:', error)
-      toast.error(
-        t('somethingWentWrongWhileQueuingTheBackupForAllTracksPleaseTryAgain')
-      )
-    })
 }

--- a/app/javascript/components/settings/github-syncer/useSyncEverything.tsx
+++ b/app/javascript/components/settings/github-syncer/useSyncEverything.tsx
@@ -1,0 +1,37 @@
+import { useCallback } from 'react'
+import toast from 'react-hot-toast'
+import { fetchWithParams, handleJsonErrorResponse } from './fetchWithParams'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+
+export function useSyncEverything(syncEverythingEndpoint: string) {
+  const { t } = useAppTranslation(
+    'components/settings/github-syncer/sections/ConnectedSection/ManualSyncSection.tsx'
+  )
+
+  return useCallback(() => {
+    fetchWithParams({
+      url: syncEverythingEndpoint,
+    })
+      .then(async (response) => {
+        if (response.ok) {
+          toast.success(
+            t(
+              'yourBackupForAllTracksHasBeenQueuedAndShouldBeCompletedWithinAFewMinutes'
+            ),
+            { duration: 5000 }
+          )
+        } else {
+          await handleJsonErrorResponse(
+            response,
+            t('errorQueuingBackupForAllTracks')
+          )
+        }
+      })
+      .catch((error) => {
+        console.error('Error:', error)
+        toast.error(
+          t('somethingWentWrongWhileQueuingTheBackupForAllTracksPleaseTryAgain')
+        )
+      })
+  }, [syncEverythingEndpoint, t])
+}


### PR DESCRIPTION
Closes #8452

## Summary
- The `handleSyncEverything` function was a standalone exported function that called `useAppTranslation()` (a React hook), violating the Rules of Hooks — it was invoked from `onClick` handlers, outside the component render cycle
- Moved the sync-everything logic into `useCallback` hooks inside `ManualSyncSection` and `JustConnectedModal`, matching the pattern already used by `handleSyncSingleTrack`
- Removed the standalone exported function that was the source of the error

## Test plan
- [x] `yarn test` passes (160/160 suites, 1550/1550 tests)
- [ ] Manual: navigate to Settings > GitHub Syncer when connected, click "Backup Everything" — should show success/error toast without React hook errors
- [ ] Manual: verify the JustConnectedModal sync button also works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)