### PR TITLE
Filter non-actionable Non-Error promise rejection errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -97,6 +97,13 @@ if (process.env.SENTRY_DSN) {
       })
       if (isObfuscatedExtensionError) return null
 
+      // Drop non-actionable promise rejections with non-Error values
+      // (no stack trace, arbitrary strings from third-party code or browser extensions)
+      const isNonErrorRejection = event.exception?.values?.some((ex) =>
+        ex.value?.includes('Non-Error promise rejection captured with value:')
+      )
+      if (isNonErrorRejection) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8454

## Summary
- Add a filter in the Sentry `beforeSend` callback to drop `Non-Error promise rejection captured with value:` errors
- These are unhandled promise rejections where a non-Error value (e.g. a plain string) was rejected, producing no stack trace and no actionable information
- Follows the same pattern as all existing Sentry error filters in `react-bootloader.tsx`

## Test plan
- [x] Verified the filter string matches the exact Sentry SDK synthetic message format
- [x] Confirmed the filter follows the established pattern of all other filters in `beforeSend`
- [x] `yarn test` passes (160/160 suites, 1550/1550 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)