### PR TITLE
Filter non-actionable removeChild DOM errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -77,6 +77,13 @@ if (process.env.SENTRY_DSN) {
       )
       if (isNetworkError) return null
 
+      // Drop non-actionable DOM removeChild errors (third-party scripts like reCAPTCHA
+      // trying to clean up nodes that React has already unmounted)
+      const isRemoveChildError = event.exception?.values?.some((ex) =>
+        ex.value?.includes("Failed to execute 'removeChild' on 'Node'")
+      )
+      if (isRemoveChildError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8451
Closes #8455

## Summary
- Adds a Sentry `beforeSend` filter to drop `NotFoundError: Failed to execute 'removeChild' on 'Node'` errors
- These errors are thrown by third-party scripts (reCAPTCHA, blob-loaded widgets) when they try to clean up DOM nodes that React has already unmounted during component teardown (e.g. closing a donation modal)
- Follows the identical pattern used by all existing Sentry error filters in this file

## Test plan
- [x] `yarn test` passes (160 suites, 1550 tests)
- [ ] Verify issues #8451 and #8455 stop receiving new Sentry events after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)