### PR TITLE
Render 429 error page for Turbo frame requests

### DIFF
--- a/app/controllers/concerns/user_rate_limit_concern.rb
+++ b/app/controllers/concerns/user_rate_limit_concern.rb
@@ -12,13 +12,13 @@ module UserRateLimitConcern
     count = Rails.cache.increment(key, 1, expires_in: within)
     return unless count && count > max
 
-    if request.xhr? || controller_path.starts_with?("api/")
+    if (request.xhr? && !turbo_frame_request?) || controller_path.starts_with?("api/")
       head :too_many_requests
     else
       @status_code = 429
       @error_title = "You've gone too fast!"
       @errror_message = ""
-      render template: "errors/too_many_requests"
+      render template: "errors/too_many_requests", status: :too_many_requests
     end
   end
 end


### PR DESCRIPTION
Closes #8450

## Summary
- Turbo frame requests are XHR, so the rate limit concern was returning `head :too_many_requests` (empty body) for them
- Turbo then couldn't find `<turbo-frame id="tf-main">` in the empty response and threw an error (the Sentry issue)
- More importantly, the user saw nothing — a silent failure with no explanation
- Now Turbo frame requests fall through to render the styled 429 error page inside the `turbo_frame` layout, giving users a proper "too many requests" message
- Also adds the missing `status: :too_many_requests` to the render call (was defaulting to 200)

## Test plan
- [x] Controller tests pass (0 failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)