### PR TITLE
Handle network errors in useSubmissionsList test run fetch

### DIFF
--- a/app/javascript/components/editor/useSubmissionsList.ts
+++ b/app/javascript/components/editor/useSubmissionsList.ts
@@ -154,11 +154,15 @@ export const useSubmissionsList = (
       method: 'GET',
     })
 
-    fetch.then((json) => {
-      const testRun = typecheck<TestRun>(json, 'testRun')
+    fetch
+      .then((json) => {
+        const testRun = typecheck<TestRun>(json, 'testRun')
 
-      set(current.uuid, { ...current, testRun: testRun })
-    })
+        set(current.uuid, { ...current, testRun: testRun })
+      })
+      .catch(() => {
+        remove(current.uuid)
+      })
   }, [set])
 
   return { current, create, set, remove }


### PR DESCRIPTION
Closes #8465
Closes #8467

## Summary
- Add `.catch()` handler to the test run fetch in `useSubmissionsList` that removes the submission from the list on network failure, resetting the UI to a clean state instead of leaving it stuck in a loading/pending state
- The Sentry `beforeSend` filter already drops `"Failed to fetch"` errors (commit 741e5e749), so no new Sentry filtering is needed
- #8465 (`request-query.ts`) needs no code change — React Query already handles fetch errors via its built-in retry/error state

cc @dem4ron

## Test plan
- [x] `yarn test` passes (160/160 suites, 1550/1550 tests)
- [ ] Verify in browser: when a network error occurs during test run fetch, the editor resets to a clean state rather than showing a stuck loading indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)