### PR TITLE
Handle unhandled promise rejection in submitCode calls

### DIFF
--- a/app/javascript/components/bootcamp/CSSExercisePage/LHS/ControlButtons.tsx
+++ b/app/javascript/components/bootcamp/CSSExercisePage/LHS/ControlButtons.tsx
@@ -99,6 +99,8 @@ export function ControlButtons({
       },
       customFunctions: [],
       readonlyRanges: { html: htmlReadonlyRanges, css: cssReadonlyRanges },
+    }).catch(() => {
+      // Submission is fire-and-forget; server errors are non-critical
     })
   }, [
     exercise,

--- a/app/javascript/components/bootcamp/FrontendExercisePage/LHS/LHS.tsx
+++ b/app/javascript/components/bootcamp/FrontendExercisePage/LHS/LHS.tsx
@@ -113,6 +113,8 @@ export function LHS() {
         css: cssReadonlyRanges,
         js: jsReadonlyRanges,
       },
+    }).catch(() => {
+      // Submission is fire-and-forget; server errors are non-critical
     })
 
     const result = parseJS(jsView.state.doc.toString())

--- a/app/javascript/components/bootcamp/JikiscriptExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
+++ b/app/javascript/components/bootcamp/JikiscriptExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
@@ -237,6 +237,8 @@ export function useConstructRunCode({
           editorView,
           readOnlyRangesStateField
         ),
+      }).catch(() => {
+        // Submission is fire-and-forget; server errors are non-critical
       })
     },
     [


### PR DESCRIPTION
Closes #8453

## Summary
- The `submitCode` function throws `new Error('Failed to submit code')` when the HTTP response is not OK, but all three call sites (JikiscriptExercisePage, CSSExercisePage, FrontendExercisePage) invoke it fire-and-forget without `await` or `.catch()`, causing unhandled promise rejections reported to Sentry
- Added `.catch()` handlers to all three `submitCode` call sites since these submissions are intentionally fire-and-forget background saves — users already see test results from client-side execution

## Test plan
- [x] `yarn test` passes (160/160 suites, 1550/1550 tests)
- [x] Verified all three call sites have `.catch()` handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)