### PR TITLE
Add git -C rule to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ rm -rf .built-assets/              # Clear asset cache if needed
 - Always use Bearer token authentication for API
 - Delegate business logic to commands, keep controllers thin
 
+## Git Usage
+
+- **Do not use `git -C <path>`**. Instead, `cd` to the correct directory before running git commands. This avoids issues with worktrees and ensures hooks run in the right context.
+
 ## Critical Warnings
 
 **Never cancel long-running operations:**


### PR DESCRIPTION
## Summary
- Adds a rule to CLAUDE.md instructing AI agents to `cd` to the correct directory instead of using `git -C <path>`, which avoids issues with worktrees and ensures hooks run in the right context.

## Test plan
- [x] Verified the rule is clear and placed in a logical section

🤖 Generated with [Claude Code](https://claude.com/claude-code)