### PR TITLE
Increase bootcamp code columns from TEXT to MEDIUMTEXT

### DIFF
--- a/db/migrate/20260209141203_increase_bootcamp_code_column_sizes.rb
+++ b/db/migrate/20260209141203_increase_bootcamp_code_column_sizes.rb
@@ -1,0 +1,9 @@
+class IncreaseBootcampCodeColumnSizes < ActiveRecord::Migration[7.1]
+  def change
+    return if Rails.env.production?
+
+    change_column :bootcamp_submissions, :code, :text, size: :medium
+    change_column :bootcamp_solutions, :code, :text, size: :medium
+    change_column :bootcamp_drawings, :code, :text, size: :medium
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_11_055432) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -106,7 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_11_055432) do
   create_table "bootcamp_drawings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "uuid", null: false
-    t.text "code", null: false
+    t.text "code", size: :medium, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
@@ -173,7 +173,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_11_055432) do
     t.bigint "user_id"
     t.bigint "exercise_id"
     t.string "uuid", null: false
-    t.text "code", null: false
+    t.text "code", size: :medium, null: false
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -190,7 +190,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_11_055432) do
     t.string "uuid", null: false
     t.bigint "solution_id"
     t.integer "status", limit: 2, null: false
-    t.text "code", null: false
+    t.text "code", size: :medium, null: false
     t.text "readonly_ranges", null: false
     t.text "test_results", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Closes #8483

## Summary
- Upgrades the `code` column from MySQL `TEXT` (~16K chars with utf8mb4) to `MEDIUMTEXT` (16MB) on three tables: `bootcamp_submissions`, `bootcamp_solutions`, and `bootcamp_drawings`
- Fixes `ActiveRecord::ValueTooLong` errors when users submit code that exceeds the TEXT limit
- Follows the existing pattern from `20210909203814_increase_submission_test_run_results_size.rb`

## Test plan
- [x] Migration runs successfully
- [x] `db/schema.rb` shows `size: :medium` on all three `code` columns
- [x] Existing `Bootcamp::Submission::Create` tests pass (5 tests, 11 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)