### PR TITLE
Validate donation amount to prevent Stripe overflow error

### DIFF
--- a/app/controllers/api/payments/payment_intents_controller.rb
+++ b/app/controllers/api/payments/payment_intents_controller.rb
@@ -1,7 +1,14 @@
 class API::Payments::PaymentIntentsController < API::BaseController
   before_action :authenticate_user!
 
+  MAX_AMOUNT_IN_CENTS = 99_999_999
+
   def create
+    amount_in_cents = params[:amount_in_cents].to_i
+    unless amount_in_cents.between?(1, MAX_AMOUNT_IN_CENTS)
+      return render json: { error: "Amount must be between 1 and #{MAX_AMOUNT_IN_CENTS} cents" }, status: :ok
+    end
+
     payment_intent = ::Payments::Stripe::PaymentIntent::Create.(
       current_user || params[:email],
       params[:type],

--- a/app/javascript/components/donations/donation-form/CustomAmountInput.tsx
+++ b/app/javascript/components/donations/donation-form/CustomAmountInput.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react'
 import currency from 'currency.js'
 
+const MAX_AMOUNT = '999999.99'
+
 export const CustomAmountInput = ({
   onChange,
   selected,
@@ -8,6 +10,7 @@ export const CustomAmountInput = ({
   defaultValue,
   value,
   min = '0',
+  max = MAX_AMOUNT,
   className = '',
   onBlur,
 }: {
@@ -18,6 +21,7 @@ export const CustomAmountInput = ({
   defaultValue?: currency
   value?: currency | string
   min?: string
+  max?: string
   className?: string
 }): JSX.Element => {
   const handleCustomAmountChange = useCallback(
@@ -34,9 +38,14 @@ export const CustomAmountInput = ({
         return
       }
 
+      if (parseFloat(e.target.value) > parseFloat(max)) {
+        onChange(currency(NaN))
+        return
+      }
+
       onChange(currency(e.target.value))
     },
-    [onChange]
+    [onChange, max]
   )
 
   const classNames = [
@@ -51,6 +60,7 @@ export const CustomAmountInput = ({
       <input
         type="number"
         min={min}
+        max={max}
         step="0.01"
         onBlur={onBlur}
         placeholder={placeholder}

--- a/test/controllers/api/payments/payment_intents_controller_test.rb
+++ b/test/controllers/api/payments/payment_intents_controller_test.rb
@@ -35,6 +35,36 @@ class API::Payments::PaymentIntentsControllerTest < API::BaseTestCase
     )
   end
 
+  test "rejects amount over maximum" do
+    setup_user
+    post api_payments_payment_intents_path(
+      type: 'payment', amount_in_cents: 100_000_000
+    ), headers: @headers, as: :json
+
+    assert_response :ok
+    assert_includes JSON.parse(response.body)["error"], "Amount must be between"
+  end
+
+  test "rejects zero amount" do
+    setup_user
+    post api_payments_payment_intents_path(
+      type: 'payment', amount_in_cents: 0
+    ), headers: @headers, as: :json
+
+    assert_response :ok
+    assert_includes JSON.parse(response.body)["error"], "Amount must be between"
+  end
+
+  test "rejects negative amount" do
+    setup_user
+    post api_payments_payment_intents_path(
+      type: 'payment', amount_in_cents: -100
+    ), headers: @headers, as: :json
+
+    assert_response :ok
+    assert_includes JSON.parse(response.body)["error"], "Amount must be between"
+  end
+
   test "returns an error if raised" do
     error = "oh dear!!"
     ::Payments::Stripe::PaymentIntent::Create.expects(:call).raises(Stripe::InvalidRequestError.new(error, nil))


### PR DESCRIPTION
Closes #8484

## Summary
- **Client-side**: Added max amount validation (`$999,999.99`) to `CustomAmountInput` — both as an HTML `max` attribute and a JavaScript check in the change handler. Values exceeding the max are treated as NaN, which all parent components already handle gracefully by falling back to defaults.
- **Server-side**: Added amount range validation (1–99,999,999 cents) in `PaymentIntentsController#create` before calling the Stripe API, returning an error in the existing format.
- Added controller tests for over-max, zero, and negative amounts.

The root cause was that extremely large custom amounts (e.g. `10000000000000000000`) get multiplied by 100 via `currency.js` `intValue`, producing `1e+21` in JavaScript scientific notation, which Stripe Elements rejects.

## Test plan
- [x] `bundle exec rails test test/controllers/api/payments/payment_intents_controller_test.rb` — 8 tests, 0 failures
- [x] Pre-commit hooks pass (rubocop, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)