### PR TITLE
Filter student code errors from Sentry and fix async error handling

### DIFF
--- a/app/javascript/components/bootcamp/JikiscriptExercisePage/CodeMirror/useEditorHandler.tsx
+++ b/app/javascript/components/bootcamp/JikiscriptExercisePage/CodeMirror/useEditorHandler.tsx
@@ -91,15 +91,13 @@ export function useEditorHandler({
     }
   }
 
-  const handleRunCode = () => {
+  const handleRunCode = async () => {
     if (editorHandler.current) {
       const value = editorHandler.current.getValue()
 
       setLatestValueSnapshot(value)
       try {
-        //const time = performance.now()
-        runCode(value, editorViewRef.current)
-        //console.log('Duration', performance.now() - time)
+        await runCode(value, editorViewRef.current)
       } catch (e: unknown) {
         if (
           process.env.NODE_ENV === 'development' ||

--- a/app/javascript/components/bootcamp/JikiscriptExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
+++ b/app/javascript/components/bootcamp/JikiscriptExercisePage/hooks/useConstructRunCode/useConstructRunCode.ts
@@ -125,7 +125,6 @@ export function useConstructRunCode({
           }
         }
       )
-      // try {
       testResults = await generateAndRunTestSuite(
         {
           studentCode,
@@ -143,20 +142,6 @@ export function useConstructRunCode({
         editorView,
         language
       )
-      // console.log("Thinks I've run", testResults.tests.length)
-      // } catch (error) {
-      //   console.log(error)
-      //   const compError = error as CompilationError
-      //   if (
-      //     compError.hasOwnProperty('type') &&
-      //     compError.type == 'CompilationError'
-      //   ) {
-      //     handleCompilationError(compError.error, editorView)
-      //     return
-      //   }
-      //   console.log(compError)
-      // }
-      console.log('No error')
 
       const bonusTestResults = await generateAndRunTestSuite(
         {

--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -104,6 +104,16 @@ if (process.env.SENTRY_DSN) {
       )
       if (isNonErrorRejection) return null
 
+      // Drop errors from student code running in blob URLs (bootcamp JS
+      // exercises execute student solutions via dynamically created blob:
+      // modules — errors from those are expected, not application bugs)
+      const isStudentCodeError = event.exception?.values?.some((ex) =>
+        ex.stacktrace?.frames?.some((frame) =>
+          frame.filename?.startsWith('blob:')
+        )
+      )
+      if (isStudentCodeError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8471

## Summary
- **Sentry filter**: Add `beforeSend` filter to drop errors with stack frames from `blob:` URLs — these are student JS exercise solutions running in the bootcamp test runner, not application bugs
- **Async fix**: `handleRunCode` called the async `runCode()` without `await`, so the existing try-catch (which shows the "Oops! Something went very wrong" error UI) never fired for async errors. Added `async`/`await` so the existing error handling works as intended
- **Cleanup**: Removed stale commented-out try-catch and debug `console.log` from `useConstructRunCode.ts`

## Test plan
- [x] `yarn test` passes (160 suites, 1550 tests)
- [ ] Verify student code errors no longer appear in Sentry
- [ ] Verify the "Oops!" error UI shows when a test runner error occurs in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)