### PR TITLE
Handle Redis cluster errors in Metrics increment methods

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -17,6 +17,10 @@ module Metrics
 
       define_method "increment_num_#{key}!" do
         Exercism.redis_cache_client.incr(redis_key)
+      rescue Redis::Cluster::InitialSetupError, RedisClient::Cluster::InitialSetupError
+        # Redis connectivity issues are transient. These counters
+        # are periodically recalculated from the database, so
+        # a missed increment is harmless.
       end
 
       define_method "set_num_#{key}!" do


### PR DESCRIPTION
Closes #8433

## Summary
- Rescue `Redis::Cluster::InitialSetupError` and `RedisClient::Cluster::InitialSetupError` in the `Metrics` module's `increment_num_*!` methods
- These counters are periodically recalculated from the database via `set_num_*!`, so a missed increment during a transient Redis connectivity issue is harmless
- Follows the same approach as the existing guard in `ToolingJob::Create`, but silently rescues instead of retrying since these run inside `after_create` callbacks

## Test plan
- [x] Existing `Metric::Create` tests pass (8 tests, 24 assertions)
- [x] Rubocop passes via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)