### PR TITLE
Auto-close Sentry issues, exclude ops-handler from auto-close

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pause:
-    if: github.repository_owner == 'exercism' && github.actor != 'sentry[bot]'
+    if: github.repository_owner == 'exercism' && github.actor != 'ops-handler[bot]'
     uses: exercism/github-actions/.github/workflows/community-contributions.yml@main
     with:
       forum_category: support


### PR DESCRIPTION
## Summary
- The community contributions workflow was excluding `sentry[bot]` from auto-close, but should exclude `ops-handler[bot]` instead
- Sentry issues should be auto-closed (they're noise); ops-handler issues should stay open (they're actionable)
- See #8571 for an example of an ops-handler issue that was incorrectly auto-closed

## Test plan
- Verify ops-handler[bot] issues are no longer auto-closed by the workflow
- Verify sentry[bot] issues are now auto-closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)