### PR TITLE
Filter Safari 'Load failed' network errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -79,12 +79,15 @@ if (process.env.SENTRY_DSN) {
       )
       if (isFrameNotReadyError) return null
 
-      // Drop non-actionable network errors (connectivity loss, DNS failures, browser extensions blocking requests)
+      // Drop non-actionable network errors (connectivity loss, DNS failures, browser extensions blocking requests).
+      // Messages vary by browser: Chrome="Failed to fetch", Firefox="NetworkError…", Safari="Load failed"
       const isNetworkError = event.exception?.values?.some(
         (ex) =>
           ex.value?.includes(
             'NetworkError when attempting to fetch resource'
-          ) || ex.value?.includes('Failed to fetch')
+          ) ||
+          ex.value?.includes('Failed to fetch') ||
+          ex.value?.includes('Load failed')
       )
       if (isNetworkError) return null
 


### PR DESCRIPTION
Closes #8584

## Summary
- Safari/WebKit reports network fetch failures as "Load failed" (a `TypeError`), which is the equivalent of Chrome's "Failed to fetch" and Firefox's "NetworkError when attempting to fetch resource"
- The existing Sentry `beforeSend` filter already drops the Chrome and Firefox variants but was missing Safari's message
- Added `"Load failed"` to the network error filter so these non-actionable errors are no longer reported

## Test plan
- [x] `yarn test` — all 1550 JS tests pass
- [x] Pre-commit hooks pass (prettier)
- [x] Verified the change is a minimal addition to the existing filter pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)