### PR TITLE
Upgrade @codemirror/legacy-modes to fix indent TypeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@codemirror/lang-python": "^6.1.5",
     "@codemirror/lang-rust": "^6.0.1",
     "@codemirror/lang-yaml": "^6.1.1",
-    "@codemirror/legacy-modes": "^6.4.0",
+    "@codemirror/legacy-modes": "^6.5.2",
     "@codemirror/state": "^6.5.0",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
     "@lezer/lr" "^1.0.0"
     style-mod "^4.0.0"
 
-"@codemirror/legacy-modes@^6.4.0":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/legacy-modes/-/legacy-modes-6.4.2.tgz#723a55aae21304d4c112575943d3467c9040d217"
-  integrity sha512-HsvWu08gOIIk303eZQCal4H4t65O/qp1V4ul4zVa3MHK5FJ0gz3qz3O55FIkm+aQUcshUOjBx38t2hPiJwW5/g==
+"@codemirror/legacy-modes@^6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz#7e2976c79007cd3fa9ed8a1d690892184a7f5ecf"
+  integrity sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==
   dependencies:
     "@codemirror/language" "^6.0.0"
 


### PR DESCRIPTION
Closes #8586

## Summary
- Upgrades `@codemirror/legacy-modes` from 6.4.2 to 6.5.2
- Fixes a typo bug in the library's `simple-mode.js` indent function where `meta.doneIndentState` was referenced instead of `meta.dontIndentStates`, causing `TypeError: Cannot read properties of undefined (reading 'indexOf')` when indenting code
- Affected tracks: wasm, rust, and factor (any legacy mode using `dontIndentStates`)

## Test plan
- [x] Verified `simple-mode.js` line 115 now correctly references `meta.dontIndentStates`
- [x] `yarn test` passes (1550 passed, 29 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)