### PR TITLE
Handle invalid URIs in markdown link rendering

### DIFF
--- a/app/commands/markdown/render_html.rb
+++ b/app/commands/markdown/render_html.rb
@@ -74,7 +74,11 @@ class Markdown::RenderHTML
       # TODO: re-enable once we figure out how to do custom scrubbing
       # return vimeo_link(node) if vimeo_link?(node)
 
-      uri = Addressable::URI.parse(node.url)
+      uri = begin
+        Addressable::URI.parse(node.url)
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
 
       out('<a href="', link_href(uri), '"')
       out(' title="', escape_html(node.title), '"') if node.title.present?
@@ -83,7 +87,7 @@ class Markdown::RenderHTML
         out(' rel="noreferrer', nofollow_links ? ' nofollow' : '', '"')
       else
         out(' rel="nofollow"') if nofollow_links
-        out(' data-turbo="false"') if uri.fragment.present?
+        out(' data-turbo="false"') if uri&.fragment.present?
       end
       out(link_tooltip_attributes(node))
       out('>', :children, '</a>')
@@ -108,6 +112,7 @@ class Markdown::RenderHTML
     end
 
     def external_url?(uri)
+      return false if uri.nil?
       return false if uri.scheme.nil?
       return true unless %w[https http].include?(uri.scheme)
       return false if %w[exercism.io exercism.lol local.exercism.io exercism.org local.exercism.io].include?(uri.host)

--- a/test/commands/markdown/parse_test.rb
+++ b/test/commands/markdown/parse_test.rb
@@ -339,6 +339,11 @@ Done')
     assert_equal expected, Markdown::Parse.("[exercise:julia/two-fer](+https://exercism.org/tracks/julia/exercises/two-fer)")
   end
 
+  test "handles invalid URI without crashing" do
+    expected = %(<p><a>link</a></p>\n)
+    assert_equal expected, Markdown::Parse.("[link](https://)")
+  end
+
   test "render vimeo video without link" do
     expected = %(<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/595885125?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="X Exercism_ Tutorial Your first mentoring session 1.m4v"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>\n) # rubocop:disable Layout/LineLength
     assert_equal expected, Markdown::Parse.("[video:vimeo/595885125]()")


### PR DESCRIPTION
Closes #8600

## Summary
- Rescue `Addressable::URI::InvalidURIError` when parsing link URLs in the markdown renderer, so malformed URIs like bare `https://` don't crash the rendering pipeline
- Add nil guard to `external_url?` and safe navigation for `uri.fragment` to handle the nil URI case
- Add regression test for invalid URI handling

## Test plan
- [x] New test `handles invalid URI without crashing` passes
- [x] All 135 existing markdown parse tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)