### PR TITLE
Strip non-serializable promise fields from React Query cache

### DIFF
--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -222,6 +222,15 @@ if (typeof window !== 'undefined') {
   const persister = createSyncStoragePersister({
     storage: window.localStorage,
     key: 'REACT_QUERY_OFFLINE_CACHE',
+    // Strip non-serializable `promise` fields from dehydrated query state.
+    // When a query is pending during dehydration, its state includes a real
+    // Promise which JSON.stringify silently mangles into a non-thenable value.
+    // On hydration, React Query's tryResolveSync calls .then() on it, causing
+    // "TypeError: t.then is not a function" (Sentry EXERCISM-JS-3 / #8587).
+    serialize: (data) =>
+      JSON.stringify(data, (key, value) =>
+        key === 'promise' ? undefined : value
+      ),
   })
 
   // use query client by pulling it out of the provider with useQueryClient hook


### PR DESCRIPTION
Closes #8587

## Summary
- The `persistQueryClient` persister uses `JSON.stringify` to serialize the React Query cache to localStorage. When a query is in `pending` status during dehydration, its state includes a real `Promise` object in the `promise` field. `JSON.stringify` silently mangles this into a non-thenable value (e.g. `{}`).
- On the next page load, `hydrate()` iterates the restored queries and calls `tryResolveSync(promise)`, which invokes `.then()` on the mangled value, causing **`TypeError: t.then is not a function`** (Sentry EXERCISM-JS-3).
- Fix: use a custom JSON replacer in the serializer that strips `promise` keys before they reach localStorage. Promise objects can never survive JSON serialization, so this is always safe.

## Test plan
- [x] `yarn test` passes (160 suites, 1550 tests)
- [ ] After deployment, verify the Sentry error "t.then is not a function" stops appearing
- [ ] Users who had corrupted localStorage data will get a clean cache on next dehydration cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)