### PR TITLE
Guard against undefined currentIteration in SolutionView

### DIFF
--- a/app/javascript/components/common/SolutionView.tsx
+++ b/app/javascript/components/common/SolutionView.tsx
@@ -36,7 +36,7 @@ export default function SolutionView({
   indentSize,
   outOfDate,
   links,
-}: Props): JSX.Element {
+}: Props): JSX.Element | null {
   const publishedIterations = iterations.filter((iteration) =>
     publishedIterationIdxs.includes(iteration.idx)
   )
@@ -50,10 +50,14 @@ export default function SolutionView({
     isFetching,
   } = usePaginatedRequestQuery<{
     files: File[]
-  }>([currentIteration.links.files], {
-    endpoint: currentIteration.links.files,
-    options: {},
+  }>([currentIteration?.links.files ?? 'noop'], {
+    endpoint: currentIteration?.links.files,
+    options: { enabled: !!currentIteration },
   })
+
+  if (!currentIteration) {
+    return null
+  }
 
   return (
     <div

--- a/test/javascript/components/common/SolutionView.test.tsx
+++ b/test/javascript/components/common/SolutionView.test.tsx
@@ -32,3 +32,15 @@ test('does not render out of date notice', async () => {
 
   expect(screen.queryByText('Outdated')).not.toBeInTheDocument()
 })
+
+test('renders nothing when publishedIterations is empty', async () => {
+  const { container } = render(
+    <SolutionView
+      {...buildProps()}
+      iterations={[createIteration({ idx: 1 })]}
+      publishedIterationIdxs={[99]}
+    />
+  )
+
+  expect(container.innerHTML).toBe('')
+})


### PR DESCRIPTION
Closes #8599

## Summary
- When `publishedIterations` is empty (no iterations match `publishedIterationIdxs`), `currentIteration` is `undefined` and accessing `.links.files` throws a TypeError
- Added optional chaining (`?.`) and `enabled: !!currentIteration` to the query hook so it doesn't crash or fire when there's no iteration
- Added `if (!currentIteration) return null` guard after hooks to gracefully render nothing
- Added test verifying the component renders nothing when no published iterations match

## Test plan
- [x] Existing tests pass (`yarn test test/javascript/components/common/SolutionView.test.tsx`)
- [x] New test confirms component returns null when `publishedIterationIdxs` don't match any iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)