### PR TITLE
Only dehydrate successful queries to prevent unhandled rejections

### DIFF
--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -249,8 +249,13 @@ if (typeof window !== 'undefined') {
       shouldDehydrateQuery: (query) => {
         const [key] = query.queryKey
         // only persist notifications and reputation in localStorage cache
-        return [NOTIFICATIONS_CACHE_KEY, REPUTATION_CACHE_KEY].includes(
-          key as string
+        // also check status to avoid dehydrating pending queries whose
+        // promises can reject with an unhandled "redacted" error
+        return (
+          query.state.status === 'success' &&
+          [NOTIFICATIONS_CACHE_KEY, REPUTATION_CACHE_KEY].includes(
+            key as string
+          )
         )
       },
     },


### PR DESCRIPTION
Closes #8605

## Summary
- The custom `shouldDehydrateQuery` callback in `persistQueryClient` was overriding TanStack Query's default status check, allowing queries in any state (including `pending`) to be dehydrated
- When a pending query's promise later rejected (e.g. due to a network error), TanStack Query's dehydration catch handler would create an unhandled `Error("redacted")`, which Sentry captured
- Added `query.state.status === 'success'` check to the callback, matching the library's default `defaultShouldDehydrateQuery` behavior while keeping the existing key-based filtering

## Test plan
- [x] Verified JS tests pass (infrastructure failures unrelated to change)
- [ ] Verify notifications and reputation data still persist to localStorage after successful fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)