### PR TITLE
Handle Octokit::UnprocessableEntity in GitHub solution syncer PR creation

### DIFF
--- a/app/commands/user/github_solution_syncer/create_pull_request.rb
+++ b/app/commands/user/github_solution_syncer/create_pull_request.rb
@@ -23,9 +23,9 @@ class User::GithubSolutionSyncer
         pr_title,
         pr_message
       )
-    rescue Octokit::NotFound, Octokit::Forbidden
-      # Repo may have been deleted/renamed, or the integration
-      # no longer has permission — nothing to sync to
+    rescue Octokit::NotFound, Octokit::Forbidden, Octokit::UnprocessableEntity
+      # Repo may have been deleted/renamed, the integration no longer
+      # has permission, or there are no commits between branches
       nil
     end
 

--- a/test/commands/user/github_solution_syncer/create_pull_request_test.rb
+++ b/test/commands/user/github_solution_syncer/create_pull_request_test.rb
@@ -70,5 +70,33 @@ class User::GithubSolutionSyncer
       result = User::GithubSolutionSyncer::CreatePullRequest.(syncer, "title", "body", &block)
       assert_nil result
     end
+
+    test "returns nil when PR validation fails" do
+      syncer = create :user_github_solution_syncer
+
+      hex_8 = SecureRandom.hex(8)
+      SecureRandom.expects(:hex).with(8).returns(hex_8)
+
+      token = "fake-token-#{SecureRandom.uuid}"
+      GithubApp.expects(:generate_installation_token!).with(syncer.installation_id).returns(token)
+
+      client = mock
+      Octokit::Client.expects(:new).with(access_token: token).returns(client).at_least_once
+
+      base_branch = "main"
+      base_sha = "base-commit-sha"
+      new_branch = "exercism-sync/#{hex_8}"
+      client.expects(:repository).with(syncer.repo_full_name).returns(mock(default_branch: base_branch))
+      client.expects(:branch).with(syncer.repo_full_name, base_branch).returns(mock(commit: mock(sha: base_sha)))
+      client.expects(:create_ref).with(syncer.repo_full_name, "heads/#{new_branch}", base_sha)
+
+      block = ->(_, _) {}
+      block.expects(:call).with(new_branch, token).returns(true)
+
+      client.expects(:create_pull_request).raises(Octokit::UnprocessableEntity)
+
+      result = User::GithubSolutionSyncer::CreatePullRequest.(syncer, "title", "body", &block)
+      assert_nil result
+    end
   end
 end


### PR DESCRIPTION
Closes #8596

## Summary
- Add `Octokit::UnprocessableEntity` to the rescue clause in `User::GithubSolutionSyncer::CreatePullRequest`
- When GitHub returns a 422 "No commits between branches" error during PR creation, the syncer now silently handles it instead of raising to Sentry
- This is consistent with the existing handling of `Octokit::NotFound` and `Octokit::Forbidden`

## Test plan
- [x] Added test for `Octokit::UnprocessableEntity` being raised during `create_pull_request`
- [x] All 4 `CreatePullRequestTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)