### PR TITLE
Fix UrlGenerationError for invalid course slugs

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -129,7 +129,7 @@ class CoursesController < ApplicationController
   def use_course!
     @bundle = Courses::BundleCodingFrontEnd.instance
     @course = Courses::Course.course_for_slug(params[:id])
-    redirect_to action: :coding_fundamentals unless @course
+    redirect_to jiki_url unless @course
   end
 
   def use_enrollment!


### PR DESCRIPTION
Closes #8592

## Summary
- When visiting `/courses/<invalid-slug>` (e.g., `/courses/learn-vue-js`), the `use_course!` callback tried to redirect to a non-existent `:coding_fundamentals` action, causing an `ActionController::UrlGenerationError`
- Changed the redirect to use `jiki_url`, which is consistent with all other redirects in the `CoursesController`

## Test plan
- [x] Verified the fix matches the redirect pattern used elsewhere in the controller (lines 17, 22, 126)
- [ ] Visit `/courses/learn-vue-js` — should redirect to Jiki instead of raising an error
- [ ] Visit a valid course slug — should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)