### PR TITLE
Filter non-actionable stack overflow errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -128,6 +128,18 @@ if (process.env.SENTRY_DSN) {
       )
       if (isStudentCodeError) return null
 
+      // Drop non-actionable "Maximum call stack size exceeded" errors.
+      // These come from browser extensions, third-party scripts, or users
+      // with cached bundles (the root cause in app code was fixed in #8408).
+      // Stack traces for these are truncated by browsers and not useful in
+      // minified production bundles.
+      const isStackOverflowError = event.exception?.values?.some(
+        (ex) =>
+          ex.type === 'RangeError' &&
+          ex.value?.includes('Maximum call stack size exceeded')
+      )
+      if (isStackOverflowError) return null
+
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'
       )


### PR DESCRIPTION
Closes #8591

## Summary
- Add a `beforeSend` filter for `RangeError: Maximum call stack size exceeded` errors in the Sentry JS configuration
- These errors have non-actionable stack traces (`undefined:31`) and come from browser extensions, third-party scripts, or users with cached bundles
- The root cause in app code (repeated Google Translate monkey-patching) was already fixed in #8408
- Follows the same pattern as the 10 existing Sentry noise filters in `react-bootloader.tsx`

## Test plan
- [x] `yarn test` passes (160 suites, 1550 tests)
- [x] Filter matches the established pattern used by existing filters (checks both `ex.type` and `ex.value`)
- [x] Pre-commit hooks pass (prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)