### PR TITLE
Don't report JSON::ParserError to Sentry in tooling job processors

### DIFF
--- a/app/commands/submission/analysis/process.rb
+++ b/app/commands/submission/analysis/process.rb
@@ -59,6 +59,8 @@ class Submission::Analysis::Process
 
     res = JSON.parse(tooling_job.execution_output['analysis.json'])
     res.is_a?(Hash) ? res.symbolize_keys : {}
+  rescue JSON::ParserError
+    {}
   rescue StandardError => e
     Sentry.capture_exception(e)
     {}
@@ -73,6 +75,8 @@ class Submission::Analysis::Process
 
     res = JSON.parse(tags_json)
     res.is_a?(Hash) ? res.symbolize_keys : {}
+  rescue JSON::ParserError
+    {}
   rescue StandardError => e
     Sentry.capture_exception(e)
     {}

--- a/app/commands/submission/representation/process.rb
+++ b/app/commands/submission/representation/process.rb
@@ -46,6 +46,8 @@ class Submission::Representation::Process
 
     res = JSON.parse(tooling_job.execution_output['mapping.json'])
     res.is_a?(Hash) ? res.symbolize_keys : {}
+  rescue JSON::ParserError
+    {}
   rescue StandardError => e
     Sentry.capture_exception(e)
     {}
@@ -60,6 +62,8 @@ class Submission::Representation::Process
 
     res = JSON.parse(representation_json)
     res.is_a?(Hash) ? res.symbolize_keys : {}
+  rescue JSON::ParserError
+    {}
   rescue StandardError => e
     Sentry.capture_exception(e)
     {}

--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -119,6 +119,8 @@ class Submission::TestRun::Process
 
     res = JSON.parse(results_json, allow_invalid_unicode: true)
     res.is_a?(Hash) ? res.symbolize_keys : {}
+  rescue JSON::ParserError
+    {}
   rescue StandardError => e
     Sentry.capture_exception(e)
     {}


### PR DESCRIPTION
Closes #8598

## Summary
- Add `rescue JSON::ParserError` clauses before the existing `rescue StandardError` in JSON-parsing methods across all three tooling job processors (test_run, analysis, representation)
- Malformed JSON from test runners (e.g. student stdout like "Hello, World!" mixed into `results.json`) is an expected condition that's already handled gracefully (returns `{}`, marks submission as exceptioned). These no longer create Sentry noise.
- Other unexpected `StandardError` exceptions continue to be reported to Sentry

## Test plan
- [x] Added test verifying `JSON::ParserError` does not call `Sentry.capture_exception`
- [x] All existing test_run process tests pass (19 runs, 0 failures)
- [x] All analysis process tests pass (9 runs, 0 failures)
- [x] All representation process tests pass (15 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)