### PR TITLE
Exclude PreqJobNotFinishedError from Sentry reporting

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -14,7 +14,7 @@ if Rails.env.production?
     config.environment = Rails.env
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.send_default_pii = false
-    config.excluded_exceptions += ['ActiveRecord::Deadlocked']
+    config.excluded_exceptions += ['ActiveRecord::Deadlocked', 'MandateJob::PreqJobNotFinishedError']
     config.before_send = SENTRY_ACTIVE_STORAGE_FILTER
   end
 end


### PR DESCRIPTION
Closes #8597

## Summary
- Added `MandateJob::PreqJobNotFinishedError` to Sentry's `excluded_exceptions` list
- This error is a normal, transient condition when a dependent job runs before its prerequisites complete — Sidekiq's default retry already handles it correctly
- Follows the existing pattern used for `ActiveRecord::Deadlocked`

## Test plan
- [ ] Verify no test regressions
- [ ] Confirm `PreqJobNotFinishedError` no longer appears in Sentry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)