### PR TITLE
Raise specific errors after upstream retries exhausted

### DIFF
--- a/app/commands/iteration/count_lines_of_code.rb
+++ b/app/commands/iteration/count_lines_of_code.rb
@@ -6,6 +6,7 @@ class Iteration::CountLinesOfCode
   initialize_with :iteration, retries_count: 0
 
   MAX_RETRIES = 3
+  LocCounterTemporarilyUnavailable = Class.new(StandardError)
 
   def call
     # Sometimes the iteration might be deleted
@@ -37,7 +38,8 @@ class Iteration::CountLinesOfCode
     iteration.update_column(:num_loc, num_loc)
     Solution::UpdateNumLoc.(iteration.solution)
   rescue RestClient::BadGateway, RestClient::ServiceUnavailable, RestClient::GatewayTimeout
-    raise if retries_count >= MAX_RETRIES
+    # This error is manually ignored on Sentry unless it escalates
+    raise LocCounterTemporarilyUnavailable if retries_count >= MAX_RETRIES
 
     self.class.defer(iteration, retries_count: retries_count + 1, wait: rand(30..90))
   ensure

--- a/test/commands/iteration/count_lines_of_code_test.rb
+++ b/test/commands/iteration/count_lines_of_code_test.rb
@@ -118,7 +118,7 @@ class Iteration::CountLinesOfCodeTest < ActiveJob::TestCase
 
     RestClient.stubs(:post).raises(RestClient::BadGateway)
 
-    assert_raises RestClient::BadGateway do
+    assert_raises Iteration::CountLinesOfCode::LocCounterTemporarilyUnavailable do
       Iteration::CountLinesOfCode.(iteration, retries_count: 3)
     end
   end

--- a/test/commands/iteration/generate_snippet_test.rb
+++ b/test/commands/iteration/generate_snippet_test.rb
@@ -115,7 +115,7 @@ class Iteration::GenerateSnippetTest < ActiveJob::TestCase
 
     RestClient.stubs(:post).raises(RestClient::BadGateway)
 
-    assert_raises RestClient::BadGateway do
+    assert_raises Iteration::GenerateSnippet::SnippetGeneratorTemporarilyUnavailable do
       Iteration::GenerateSnippet.(iteration, retries_count: 3)
     end
   end


### PR DESCRIPTION
Closes #8588

## Summary
- Added `SnippetGeneratorTemporarilyUnavailable` error to `Iteration::GenerateSnippet` and `LocCounterTemporarilyUnavailable` error to `Iteration::CountLinesOfCode`
- After exhausting 3 retries on 502/503/504 responses, these named errors are raised instead of the raw `RestClient` exceptions
- This gives each failure a distinct identity in Sentry so they can be manually ignored unless they escalate

## Test plan
- [x] Updated existing "raises after max retries exhausted" tests to expect the new error classes
- [x] All 20 tests pass for both commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)