### PR TITLE
Handle Array version in test run raw_results

### DIFF
--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -13,7 +13,7 @@ class Submission::TestRun < ApplicationRecord
   delegate :solution, to: :submission
 
   before_create do
-    self.version = raw_results[:version].to_i
+    self.version = Array(raw_results[:version]).first.to_i
     self.message = raw_results[:message] unless self.message
     self.output = raw_results[:output] unless self.output
     self.status = raw_results.fetch(:status, :error) unless self.status

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -230,6 +230,11 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal submission.track, test_run.track
   end
 
+  test "handles version as array" do
+    tr = create(:submission_test_run, raw_results: { version: [3], status: :pass })
+    assert_equal 3, tr.version
+  end
+
   test "truncate message" do
     message = 'a' * 66_000
     test_run = create(:submission_test_run, raw_results: { message: })


### PR DESCRIPTION
Closes #8611

## Summary
- Fixed `NoMethodError: undefined method 'to_i' for an instance of Array` in `Submission::TestRun` `before_create` callback
- When tooling runners return `version` as an array (e.g., `[3]`) instead of a scalar, `raw_results[:version].to_i` raises an error
- Changed to `Array(raw_results[:version]).first.to_i` which safely handles both scalar and array values

## Test plan
- [x] Added test case for array version in `test/models/submission/test_run_test.rb`
- [x] All 16 existing test_run model tests pass
- [x] Rubocop and Brakeman pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)