### PR TITLE
Guard against nil user in Mentor::Discussion#viewable_by?

### DIFF
--- a/app/models/mentor/discussion.rb
+++ b/app/models/mentor/discussion.rb
@@ -95,13 +95,13 @@ class Mentor::Discussion < ApplicationRecord
   def timed_out? = %i[student_timed_out mentor_timed_out].include?(status)
 
   def viewable_by?(user)
-    return true if user.admin?
+    return true if user&.admin?
 
     [mentor, student].include?(user)
   end
 
   def viewable_by_mentor?(user)
-    return true if user.admin?
+    return true if user&.admin?
 
     user == mentor
   end

--- a/test/models/mentor/discussion_test.rb
+++ b/test/models/mentor/discussion_test.rb
@@ -82,6 +82,12 @@ class Mentor::DiscussionTest < ActiveSupport::TestCase
     refute discussion.viewable_by?(user)
   end
 
+  test "#viewable_by? returns false if user is nil" do
+    discussion = create :mentor_discussion
+
+    refute discussion.viewable_by?(nil)
+  end
+
   test "finished?" do
     skip # TODO: Can this be deleted?
     discussion = create :mentor_discussion


### PR DESCRIPTION
Closes #8622

## Summary
- Use safe navigation operator (`&.`) in `Mentor::Discussion#viewable_by?` and `#viewable_by_mentor?` to prevent `NoMethodError` when `user` is `nil`
- This occurs when an unauthenticated user subscribes to `DiscussionPostListChannel` — the ActionCable connection allows nil `current_user`, which gets passed to `viewable_by?`
- Added test for nil user case

## Test plan
- [x] `bundle exec rails test test/models/mentor/discussion_test.rb` — all 19 tests pass
- [x] New test verifies `viewable_by?(nil)` returns `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)