### PR TITLE
Extract issue number in /fix skill to support flexible formats

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -13,7 +13,7 @@ You are fixing a GitHub issue for the exercism/website repository.
 ## Issue details
 
 ```json
-!`gh issue view $ARGUMENTS --json number,title,body,labels,comments`
+!`gh issue view $(echo "$ARGUMENTS" | grep -oE '[0-9]+$') --json number,title,body,labels,comments`
 ```
 
 Issue number: !`echo "$ARGUMENTS" | grep -oE '[0-9]+$'`


### PR DESCRIPTION
## Summary
- The `/fix` skill passed `$ARGUMENTS` directly to `gh issue view`, which fails for formats like `exercism/website#8622`
- Now extracts the issue number first using the same `grep -oE '[0-9]+$'` pattern already used elsewhere in the skill
- Supports: `8622`, `exercism/website#8622`, `#8622`, and full GitHub URLs

## Test plan
- [ ] Run `/fix exercism/website#8622` — should fetch the issue successfully
- [ ] Run `/fix 8622` — should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)