### PR TITLE
Filter non-actionable "Failed to load Stripe.js" errors from Sentry

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -138,7 +138,7 @@ if (process.env.SENTRY_DSN) {
           ex.value?.includes("read the 'sessionStorage' property from 'Window'")
       )
       if (isStorageAccessError) return null
-      
+
       // Drop non-actionable "Maximum call stack size exceeded" errors.
       // These come from browser extensions, third-party scripts, or users
       // with cached bundles (the root cause in app code was fixed in #8408).
@@ -150,6 +150,14 @@ if (process.env.SENTRY_DSN) {
           ex.value?.includes('Maximum call stack size exceeded')
       )
       if (isStackOverflowError) return null
+
+      // Drop non-actionable Stripe.js loading failures (ad blockers,
+      // privacy extensions, or network issues preventing the script from loading).
+      // Users already see a friendly fallback message in the UI.
+      const isStripeLoadError = event.exception?.values?.some((ex) =>
+        ex.value?.includes('Failed to load Stripe.js')
+      )
+      if (isStripeLoadError) return null
 
       const tag = document.querySelector<HTMLMetaElement>(
         'meta[name="user-id"]'


### PR DESCRIPTION
Closes #8620

## Summary
- Add a `beforeSend` filter in the Sentry configuration to drop "Failed to load Stripe.js" errors
- These errors are caused by ad blockers, privacy extensions, or network issues preventing the Stripe.js script from loading
- Users already see a friendly fallback message in the UI, so these errors are not actionable
- Follows the same pattern as the 12 other non-actionable error filters in the same function

## Test plan
- [x] `yarn test` passes (160 suites, 1551 tests)
- [x] Filter is consistent with existing patterns in `beforeSend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)