### PR TITLE
Guard against Array status in test results

### DIFF
--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -74,7 +74,7 @@ class Submission::TestRun < ApplicationRecord
     def to_h
       {
         name: test[:name].to_s,
-        status: test[:status].try(&:to_sym),
+        status: Array(test[:status]).first.try(&:to_sym),
         test_code: test[:test_code],
         message: test[:message],
         message_html: Ansi::RenderHTML.(test[:message]),

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -235,6 +235,12 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal 3, tr.version
   end
 
+  test "handles test result status as array" do
+    tests = [{ 'name' => 'test1', 'status' => ['pass'] }]
+    tr = create(:submission_test_run, raw_results: { version: 2, status: 'pass', tests: tests })
+    assert_equal :pass, tr.test_results.first.to_h[:status]
+  end
+
   test "truncate message" do
     message = 'a' * 66_000
     test_run = create(:submission_test_run, raw_results: { message: })


### PR DESCRIPTION
Closes #8634
Closes #8635

## Summary
- Tooling runners can return `status` as an Array (e.g., `["pass"]`) inside individual test result objects, causing `NoMethodError: undefined method 'to_sym' for an instance of Array` when serializing
- Applied `Array().first` unwrap on `test[:status]` in `TestResult#to_h`, matching the existing pattern used for the `version` field (PR #8618)
- Added test for array status in test results

## Test plan
- [x] `bundle exec rails test test/models/submission/test_run_test.rb` — 17 tests, 0 failures
- [x] New test verifies `['pass']` is correctly unwrapped to `:pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)