### PR TITLE
Retry transient AWS credential errors in all jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,6 +3,12 @@ class ApplicationJob < ActiveJob::Base
   # (excluded via Sentry config's excluded_exceptions)
   retry_on ActiveRecord::Deadlocked
 
+  # Retry jobs that fail due to transient AWS credential errors
+  # (e.g. during credential rotation or ECS task role refresh)
+  retry_on Aws::Sigv4::Errors::MissingCredentialsError,
+    Aws::Errors::MissingCredentialsError,
+    wait: 10.seconds, attempts: 3
+
   # Can be overriden to disable this
   def guard_against_deserialization_errors? = true
   rescue_from ActiveJob::DeserializationError do |exception|

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -7,6 +7,18 @@ class ApplicationJobTest < ActiveJob::TestCase
     end
   end
 
+  class TestAwsSigv4MissingCredentialsJob < ApplicationJob
+    def perform
+      raise Aws::Sigv4::Errors::MissingCredentialsError
+    end
+  end
+
+  class TestAwsMissingCredentialsJob < ApplicationJob
+    def perform
+      raise Aws::Errors::MissingCredentialsError, "credentials not set"
+    end
+  end
+
   class TestDeserializationJob < ApplicationJob
     def perform
       # ActiveJob::DeserializationError uses $! so this needs
@@ -27,6 +39,18 @@ class ApplicationJobTest < ActiveJob::TestCase
   test "deadlock retries the job" do
     assert_enqueued_with(job: TestDeadlockedJob) do
       TestDeadlockedJob.perform_now
+    end
+  end
+
+  test "Aws::Sigv4 missing credentials retries the job" do
+    assert_enqueued_with(job: TestAwsSigv4MissingCredentialsJob) do
+      TestAwsSigv4MissingCredentialsJob.perform_now
+    end
+  end
+
+  test "Aws::Errors missing credentials retries the job" do
+    assert_enqueued_with(job: TestAwsMissingCredentialsJob) do
+      TestAwsMissingCredentialsJob.perform_now
     end
   end
 


### PR DESCRIPTION
Closes #8630
Closes #8636

## Summary
- Added `retry_on` for `Aws::Sigv4::Errors::MissingCredentialsError` and `Aws::Errors::MissingCredentialsError` to `ApplicationJob`
- Jobs hitting transient credential errors (e.g. during credential rotation or ECS task role refresh) now retry up to 3 times with 10s wait
- Persistent failures still raise after retries exhaust, so Sentry captures genuine issues
- This complements the existing in-method retry in `Submission::File#raw_content` (PR #8469) by covering all other S3 code paths (e.g. `put_object`, Active Storage)

## Test plan
- [x] Added tests for both `Aws::Sigv4::Errors::MissingCredentialsError` and `Aws::Errors::MissingCredentialsError` retry behavior
- [x] All 7 `application_job_test.rb` tests pass (including 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)