### PR TITLE
Guard against blank/short OIDs in lookup_commit

### DIFF
--- a/app/jobs/update_tracks_build_status_job.rb
+++ b/app/jobs/update_tracks_build_status_job.rb
@@ -7,7 +7,7 @@ class UpdateTracksBuildStatusJob < ApplicationJob
     tracks.find_each do |track|
       Track::UpdateBuildStatus.(track)
     rescue StandardError => e
-      Sentry.capture_exception(e)
+      Sentry.capture_exception(e, extra: { track_slug: track.slug, synced_to_git_sha: track.synced_to_git_sha })
     end
   end
 

--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -57,11 +57,13 @@ module Git
     def lookup_commit(sha, update_on_failure: true)
       return head_commit if sha == "HEAD"
 
+      raise MissingCommitError, sha if sha.blank?
+
       lookup(sha).tap do |object|
         raise 'wrong-type' if object.type != :commit
       end
     rescue Rugged::OdbError, Rugged::InvalidError
-      raise MissingCommitError unless update_on_failure
+      raise MissingCommitError, sha unless update_on_failure
 
       fetch!
       lookup_commit(sha, update_on_failure: false)

--- a/test/models/git/repository_test.rb
+++ b/test/models/git/repository_test.rb
@@ -14,6 +14,22 @@ module Git
       end
     end
 
+    test "lookup_commit_for_blank_sha_raises_without_fetch" do
+      repository = ::Git::Repository.new(repo_url: TestHelpers.git_repo_url("track"))
+      repository.expects(:fetch!).never
+      assert_raises Git::MissingCommitError do
+        repository.lookup_commit("")
+      end
+    end
+
+    test "lookup_commit_for_nil_sha_raises_without_fetch" do
+      repository = ::Git::Repository.new(repo_url: TestHelpers.git_repo_url("track"))
+      repository.expects(:fetch!).never
+      assert_raises Git::MissingCommitError do
+        repository.lookup_commit(nil)
+      end
+    end
+
     test "lookup_commit_for_head" do
       repository = ::Git::Repository.new(repo_url: TestHelpers.git_repo_url("track"))
       assert_equal repository.head_commit, repository.lookup_commit("HEAD")


### PR DESCRIPTION
Closes #8626

## Summary
- Add early guard in `Git::Repository#lookup_commit` to raise `MissingCommitError` immediately for blank SHAs, avoiding a pointless `fetch!` call
- Include the SHA value in all `MissingCommitError` messages so the malformed value is visible in error reports
- Add track context (`track_slug`, `synced_to_git_sha`) to Sentry reports in `UpdateTracksBuildStatusJob` so the offending track can be identified and the data fixed upstream

## Test plan
- [x] New tests verify blank and nil SHAs raise `MissingCommitError` without calling `fetch!`
- [x] Existing `lookup_commit` tests continue to pass
- [x] Full `test/models/git/repository_test.rb` passes (10 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)