### PR TITLE
Handle RestClient::Forbidden in GitHub Solution Syncer token generation

### DIFF
--- a/app/commands/user/github_solution_syncer/create.rb
+++ b/app/commands/user/github_solution_syncer/create.rb
@@ -12,6 +12,8 @@ class User::GithubSolutionSyncer::Create
       installation_id:,
       repo_full_name: repo.full_name
     )
+  rescue User::GithubSolutionSyncer::GithubApp::InstallationNotFoundError
+    raise GithubSolutionSyncerCreationError, "GitHub App installation not found or no longer accessible"
   rescue Octokit::Unauthorized
     raise GithubSolutionSyncerCreationError, "GitHub authorization failed"
   rescue Octokit::Error => e

--- a/app/commands/user/github_solution_syncer/github_app.rb
+++ b/app/commands/user/github_solution_syncer/github_app.rb
@@ -31,7 +31,7 @@ module User::GithubSolutionSyncer::GithubApp
     )
 
     JSON.parse(response.body)["token"]
-  rescue RestClient::NotFound
-    raise InstallationNotFoundError, "GitHub App installation #{installation_id} not found"
+  rescue RestClient::NotFound, RestClient::Forbidden
+    raise InstallationNotFoundError, "GitHub App installation #{installation_id} not found or not accessible"
   end
 end

--- a/test/commands/user/github_solution_syncer/create_test.rb
+++ b/test/commands/user/github_solution_syncer/create_test.rb
@@ -72,6 +72,19 @@ class User::GithubSolutionSyncer
       end
     end
 
+    test "raises GithubSolutionSyncerCreationError when installation is not found or forbidden" do
+      user = create(:user)
+      installation_id = 123_456
+
+      GithubApp.stubs(:generate_installation_token!).raises(
+        GithubApp::InstallationNotFoundError, "GitHub App installation #{installation_id} not found or not accessible"
+      )
+
+      assert_raises GithubSolutionSyncerCreationError do
+        User::GithubSolutionSyncer::Create.(user, installation_id)
+      end
+    end
+
     test "replaces existing syncer" do
       user = create(:user)
       old_syncer = create(

--- a/test/commands/user/github_solution_syncer/github_app_test.rb
+++ b/test/commands/user/github_solution_syncer/github_app_test.rb
@@ -27,4 +27,16 @@ class User::GithubSolutionSyncer::GithubAppTest < ActiveSupport::TestCase
       User::GithubSolutionSyncer::GithubApp.generate_installation_token!(installation_id)
     end
   end
+
+  test "raises InstallationNotFoundError on 403" do
+    installation_id = 123_456
+
+    User::GithubSolutionSyncer::GithubApp.stubs(:generate_jwt).returns("fake.jwt.token")
+    stub_request(:post, "https://api.github.com/app/installations/#{installation_id}/access_tokens").
+      to_return(status: 403, body: { message: "Forbidden" }.to_json)
+
+    assert_raises(User::GithubSolutionSyncer::GithubApp::InstallationNotFoundError) do
+      User::GithubSolutionSyncer::GithubApp.generate_installation_token!(installation_id)
+    end
+  end
 end


### PR DESCRIPTION
Closes #8642

## Summary
- `GithubApp.generate_installation_token!` now catches `RestClient::Forbidden` (403) alongside the existing `RestClient::NotFound` (404), raising `InstallationNotFoundError` for both
- `Create` command catches `InstallationNotFoundError` and wraps it in a `GithubSolutionSyncerCreationError` so the callback controller can show a user-friendly error message instead of a 500
- Added tests for both the 403 handling in `GithubApp` and the error wrapping in `Create`

## Test plan
- [x] Existing tests pass (9 runs, 14 assertions, 0 failures)
- [x] New test: 403 response raises `InstallationNotFoundError`
- [x] New test: `InstallationNotFoundError` from token generation is wrapped in `GithubSolutionSyncerCreationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)