### PR TITLE
Guard against undefined files in Editor filesEqual

### DIFF
--- a/app/javascript/components/Editor.tsx
+++ b/app/javascript/components/Editor.tsx
@@ -61,6 +61,7 @@ export type TabIndex =
   | 'chat-gpt'
 
 const filesEqual = (files: File[], other: File[]) => {
+  if (!files || !other) return false
   if (files.length !== other.length) {
     return false
   }

--- a/app/javascript/utils/use-storage.ts
+++ b/app/javascript/utils/use-storage.ts
@@ -15,7 +15,7 @@ export function useLocalStorage<T>(
     try {
       const item = JSON.parse(localStorage.getItem(key) || '') as T
 
-      return item
+      return item ?? initialValue
     } catch (error) {
       return initialValue
     }


### PR DESCRIPTION
Closes #8638

## Summary
- Add null guard in `filesEqual` to prevent TypeError when either argument is `undefined`/`null`
- Fix `useLocalStorage` to use nullish coalescing (`??`) so that `JSON.parse("null")` falls back to `initialValue` instead of returning `null`

The root cause is that `useLocalStorage` can return `null` when localStorage contains a parseable null value. This propagates through `useSaveFiles` into the `filesEqual` function, which then crashes accessing `.length` on `undefined`.

## Test plan
- [x] `yarn test` passes (160 suites, 1551 tests)
- [x] Verified `filesEqual` returns `false` when either argument is nullish (safe default: treats files as changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)