### PR TITLE
Stop fingerprinting source map files so Sentry can resolve stack traces

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -42,11 +42,16 @@ class Propshaft::Asset
   def digested_path
     return logical_path if digested_by_esbuild?
     return logical_path if already_digested?
+    return logical_path if source_map?
 
     logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
   end
 
   def digested_by_esbuild?
     logical_path.to_s =~ /-([0-9A-Z]{8})\.js/
+  end
+
+  def source_map?
+    logical_path.to_s.end_with?('.map')
   end
 end


### PR DESCRIPTION
Closes #8631

## Summary
- Propshaft was adding a content hash to entry point `.map` files (e.g., `application.js.map` → `application.js-{hash}.map`), but the `sourceMappingURL` comment in the JS files references the un-fingerprinted name
- This mismatch prevented Sentry from fetching source maps, leaving all production JS errors with minified/unreadable stack traces (like "Error: ud")
- Source maps are only fetched by dev tools and error trackers — never by browsers during normal navigation — so cache-busting is irrelevant for them
- The existing `digested_by_esbuild?` check (added in 6c8725f to prevent double-hashing code-split chunks) was not designed with source maps in mind

## Test plan
- [x] Verified `application.js.map` now passes through as `application.js.map` (not `application.js-{hash}.map`)
- [x] Verified `core.js.map`, `internal.js.map`, `landing.js.map` all pass through un-fingerprinted
- [x] Verified `.js` and `.css` files still get Propshaft fingerprinting as before
- [x] Verified code-split chunk `.map` files still work (already passed through via `digested_by_esbuild?`)
- [ ] Post-deploy: confirm `https://assets.exercism.org/assets/application.js.map` returns 200
- [ ] Post-deploy: confirm Sentry errors show resolved stack traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)