### PR TITLE
Guard against Hash-typed status in test results

### DIFF
--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -74,7 +74,7 @@ class Submission::TestRun < ApplicationRecord
     def to_h
       {
         name: test[:name].to_s,
-        status: Array(test[:status]).first.try(&:to_sym),
+        status: Array(test[:status]).first.try(:to_sym),
         test_code: test[:test_code],
         message: test[:message],
         message_html: Ansi::RenderHTML.(test[:message]),

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -241,6 +241,12 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_equal :pass, tr.test_results.first.to_h[:status]
   end
 
+  test "handles test result status as hash" do
+    tests = [{ 'name' => 'test1', 'status' => { 'value' => 'pass' } }]
+    tr = create(:submission_test_run, raw_results: { version: 2, status: 'pass', tests: tests })
+    assert_nil tr.test_results.first.to_h[:status]
+  end
+
   test "truncate message" do
     message = 'a' * 66_000
     test_run = create(:submission_test_run, raw_results: { message: })


### PR DESCRIPTION
Closes #8650
Closes #8651

## Summary
- Changed `.try(&:to_sym)` to `.try(:to_sym)` in `TestResult#to_h` (line 77 of `test_run.rb`)
- The block form of `try` (`&:to_sym`) bypasses the `respond_to?` check, so it crashes when `test[:status]` is a `HashWithIndifferentAccess` instead of a String
- The method-name form (`:to_sym`) properly checks `respond_to?` first and returns `nil` for unsupported types
- Added test for hash-typed status values

## Test plan
- [x] Existing tests pass (`bundle exec rails test test/models/submission/test_run_test.rb` — 18 tests, 58 assertions)
- [x] New test verifies hash-typed status returns `nil` instead of crashing
- [x] Existing array-status test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)