### PR TITLE
Guard against nil generic_exercise in GenericExercisesController

### DIFF
--- a/app/controllers/generic_exercises_controller.rb
+++ b/app/controllers/generic_exercises_controller.rb
@@ -49,6 +49,7 @@ class GenericExercisesController < ApplicationController
     end
 
     @ps_data = @exercise.generic_exercise
+    render_404 unless @ps_data
   rescue ActiveRecord::RecordNotFound
     render_404
   end


### PR DESCRIPTION
Closes #8668

## Summary
- When an exercise exists but has no corresponding `GenericExercise` record, `@ps_data` is set to `nil` by the `use_exercise!` before_action
- The view then crashes at line 1 calling `.title` on `nil`
- Added a `render_404 unless @ps_data` guard, matching the existing pattern for missing exercises
- Protects both the `show` and `approaches` actions since they both use the same before_action

## Test plan
- [x] Verified the fix by code inspection — single-line guard clause following the existing 404 pattern
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)