### PR TITLE
Rescue Net::SMTPFatalError in ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,6 +7,7 @@ class ApplicationMailer < ActionMailer::Base
 
   rescue_from(Mail::Field::IncompleteParseError) {}
   rescue_from(Net::SMTPSyntaxError) {}
+  rescue_from(Net::SMTPFatalError) {}
 
   def user_email_with_name(user)
     name = user.name.presence || user.handle

--- a/test/mailers/mailer_rescues_test.rb
+++ b/test/mailers/mailer_rescues_test.rb
@@ -20,4 +20,15 @@ class MailerRescuesTest < ActionMailer::TestCase
 
     NotificationsMailer.with(notification:).joined_exercism.deliver_now
   end
+
+  test "rescues Net::SMTPFatalError" do
+    user = create :user
+    notification = create(:joined_exercism_notification, user:)
+
+    Mail::Message.any_instance.stubs(:deliver).raises(
+      Net::SMTPFatalError.new("554 Transaction failed: Invalid domain name: '2010'.")
+    )
+
+    NotificationsMailer.with(notification:).joined_exercism.deliver_now
+  end
 end


### PR DESCRIPTION
Closes #8695

## Summary
- Add `rescue_from(Net::SMTPFatalError) {}` to `ApplicationMailer`, matching the existing pattern for `Net::SMTPSyntaxError`
- Emails sent to users with invalid domain names (e.g. `user@2010`) cause the SMTP server to return `554 Transaction failed: Invalid domain name`, which was unhandled and crashed `ActionMailer::MailDeliveryJob`

## Test plan
- [x] Added test in `test/mailers/mailer_rescues_test.rb` following the existing `Net::SMTPSyntaxError` test pattern
- [x] All 3 mailer rescue tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)