### PR TITLE
Handle RuntimeError from git commands in GitHub Solution Syncer

### DIFF
--- a/app/commands/user/github_solution_syncer/sync_everything.rb
+++ b/app/commands/user/github_solution_syncer/sync_everything.rb
@@ -21,6 +21,8 @@ class User::GithubSolutionSyncer
       # noop - the integration no longer has permission to access the repo
     rescue Octokit::ServerError
       requeue_job!(30.seconds)
+    rescue RuntimeError
+      # noop - git command may have failed due to transient issues or repo unavailability
     end
 
     def sync_everything(branch_name, token = nil)

--- a/app/commands/user/github_solution_syncer/sync_track.rb
+++ b/app/commands/user/github_solution_syncer/sync_track.rb
@@ -21,6 +21,8 @@ class User::GithubSolutionSyncer
       # noop - the integration no longer has permission to access the repo
     rescue Octokit::ServerError
       requeue_job!(30.seconds)
+    rescue RuntimeError
+      # noop - git command may have failed due to transient issues or repo unavailability
     end
 
     private

--- a/test/commands/user/github_solution_syncer/sync_everything_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_everything_test.rb
@@ -22,6 +22,16 @@ class User::GithubSolutionSyncer
       User::GithubSolutionSyncer::SyncEverything.(user)
     end
 
+    test "noops when git command fails" do
+      user = create(:user)
+      create(:user_github_solution_syncer, user:)
+
+      CreatePullRequest.stubs(:call).raises(RuntimeError, "Command failed with exit 1: git")
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncEverything.(user)
+    end
+
     test "requeues on server error" do
       user = create(:user)
       create(:user_github_solution_syncer, user:)

--- a/test/commands/user/github_solution_syncer/sync_track_test.rb
+++ b/test/commands/user/github_solution_syncer/sync_track_test.rb
@@ -26,6 +26,18 @@ class User::GithubSolutionSyncer
       User::GithubSolutionSyncer::SyncTrack.(user_track)
     end
 
+    test "noops when git command fails" do
+      user = create(:user)
+      track = create(:track, slug: "ruby")
+      user_track = create(:user_track, user:, track:)
+      create(:user_github_solution_syncer, user:)
+
+      CreatePullRequest.stubs(:call).raises(RuntimeError, "Command failed with exit 1: git")
+
+      # Should not raise
+      User::GithubSolutionSyncer::SyncTrack.(user_track)
+    end
+
     test "requeues on server error" do
       user = create(:user)
       track = create(:track, slug: "ruby")


### PR DESCRIPTION
Closes #8665

## Summary
- `LocalGitRepo` shells out to git via `system(..., exception: true)`, which raises `RuntimeError` when a git command exits non-zero (e.g., clone fails due to network issues or repo unavailability)
- `SyncTrack` and `SyncEverything` already rescue `InstallationNotFoundError`, `Octokit::Forbidden`, and `Octokit::ServerError`, but not `RuntimeError` from git failures
- Added `rescue RuntimeError` to both callers, matching the existing noop pattern
- Added tests for both cases

## Test plan
- [x] Ran `sync_track_test.rb` and `sync_everything_test.rb` — all 8 tests pass
- [x] Pre-commit hooks (rubocop, prettier) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)