### PR TITLE
Rescue URI::InvalidURIError in bootcamp image_proxy

### DIFF
--- a/app/controllers/bootcamp/dashboard_controller.rb
+++ b/app/controllers/bootcamp/dashboard_controller.rb
@@ -33,6 +33,8 @@ class Bootcamp::DashboardController < Bootcamp::BaseController
       expires_in 1.year, public: true
 
       send_data image.read, type: image.content_type, disposition: 'inline'
+    rescue URI::InvalidURIError
+      head :bad_request
     rescue OpenURI::HTTPError
       head :not_found
     end

--- a/test/controllers/bootcamp/dashboard_controller_test.rb
+++ b/test/controllers/bootcamp/dashboard_controller_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class Bootcamp::DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "image_proxy returns bad_request for invalid URI characters" do
+    user = create(:user, :with_bootcamp_data, bootcamp_attendee: true)
+    sign_in!(user)
+
+    get bootcamp_image_proxy_path(filename: "check-circle", format: "svg>")
+    assert_response :bad_request
+  end
+end


### PR DESCRIPTION
Closes #8677

## Summary
- The `image_proxy` action constructs a URL from `params[:filename]` and `params[:format]`. When the format contains invalid URI characters (e.g., a trailing `>`), `URI.open` raises `URI::InvalidURIError` which was not rescued, causing a 500 error.
- Added a `rescue URI::InvalidURIError` clause that returns `400 Bad Request` for malformed URIs.
- Added a controller test covering this case.

## Test plan
- [x] New test passes: `bundle exec rails test test/controllers/bootcamp/dashboard_controller_test.rb`
- [x] Pre-commit hooks pass (rubocop, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)