### PR TITLE
Retry Faraday::ConnectionFailed in ApplicationJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,6 +9,11 @@ class ApplicationJob < ActiveJob::Base
     Aws::Errors::MissingCredentialsError,
     wait: 10.seconds, attempts: 3
 
+  # Retry jobs that fail due to transient network connection errors
+  # (e.g. remote server closing connection, brief network interruptions)
+  retry_on Faraday::ConnectionFailed,
+    wait: 5.seconds, attempts: 5
+
   # Can be overriden to disable this
   def guard_against_deserialization_errors? = true
   rescue_from ActiveJob::DeserializationError do |exception|

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -19,6 +19,12 @@ class ApplicationJobTest < ActiveJob::TestCase
     end
   end
 
+  class TestFaradayConnectionFailedJob < ApplicationJob
+    def perform
+      raise Faraday::ConnectionFailed, "end of file reached"
+    end
+  end
+
   class TestDeserializationJob < ApplicationJob
     def perform
       # ActiveJob::DeserializationError uses $! so this needs
@@ -51,6 +57,12 @@ class ApplicationJobTest < ActiveJob::TestCase
   test "Aws::Errors missing credentials retries the job" do
     assert_enqueued_with(job: TestAwsMissingCredentialsJob) do
       TestAwsMissingCredentialsJob.perform_now
+    end
+  end
+
+  test "Faraday::ConnectionFailed retries the job" do
+    assert_enqueued_with(job: TestFaradayConnectionFailedJob) do
+      TestFaradayConnectionFailedJob.perform_now
     end
   end
 


### PR DESCRIPTION
Closes #8685

## Summary
- Add `retry_on Faraday::ConnectionFailed` to `ApplicationJob` with 5 attempts at 5-second intervals
- Handles transient network errors (e.g. remote server closing connections) that affect any async job making HTTP calls via Faraday (used by octokit, opensearch, coinbase, etc.)
- Follows existing pattern for `ActiveRecord::Deadlocked` and AWS credential error retries
- Not added to Sentry `excluded_exceptions` so persistent failures after all retries are still reported

## Test plan
- [x] Added test for `Faraday::ConnectionFailed` retry following existing test patterns
- [x] All `application_job_test.rb` tests pass (8 runs, 15 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)