### PR TITLE
Handle Git::MissingCommitError in exercise retrieval commands

### DIFF
--- a/app/commands/track/retrieve_foregone_practice_exercises.rb
+++ b/app/commands/track/retrieve_foregone_practice_exercises.rb
@@ -3,5 +3,9 @@ class Track::RetrieveForegonePracticeExercises
 
   initialize_with :track
 
-  def call = GenericExercise.where(slug: track.git.foregone_exercises)
+  def call
+    GenericExercise.where(slug: track.git.foregone_exercises)
+  rescue Git::MissingCommitError
+    GenericExercise.none
+  end
 end

--- a/app/commands/track/retrieve_unimplemented_practice_exercises.rb
+++ b/app/commands/track/retrieve_unimplemented_practice_exercises.rb
@@ -9,5 +9,10 @@ class Track::RetrieveUnimplementedPracticeExercises
 
   private
   def implemented_exercise_slugs = track.practice_exercises.pluck(:slug)
-  def foregone_exercise_slugs = track.git.foregone_exercises
+
+  def foregone_exercise_slugs
+    track.git.foregone_exercises
+  rescue Git::MissingCommitError
+    []
+  end
 end

--- a/test/commands/track/retrieve_foregone_practice_exercises_test.rb
+++ b/test/commands/track/retrieve_foregone_practice_exercises_test.rb
@@ -12,4 +12,12 @@ class Track::RetrieveForegonePracticeExercisesTest < ActiveSupport::TestCase
 
     assert_equal %w[alphametics zipper], foregone_exercise_slugs.sort
   end
+
+  test "returns empty when git commit is missing" do
+    track = create :track
+
+    Git::Track.any_instance.stubs(:foregone_exercises).raises(Git::MissingCommitError)
+
+    assert_empty Track::RetrieveForegonePracticeExercises.(track)
+  end
 end

--- a/test/commands/track/retrieve_unimplemented_practice_exercises_test.rb
+++ b/test/commands/track/retrieve_unimplemented_practice_exercises_test.rb
@@ -42,4 +42,16 @@ class Track::RetrieveUnimplementedPracticeExercisesTest < ActiveSupport::TestCas
 
     assert_equal %w[bob forth], unimplemented_exercise_slugs.sort
   end
+
+  test "includes foregone exercises when git commit is missing" do
+    track = create :track
+    create(:generic_exercise, slug: 'alphametics')
+    create(:generic_exercise, slug: 'anagram')
+
+    Git::Track.any_instance.stubs(:foregone_exercises).raises(Git::MissingCommitError)
+
+    unimplemented_exercise_slugs = Track::RetrieveUnimplementedPracticeExercises.(track).map(&:slug)
+
+    assert_equal %w[alphametics anagram], unimplemented_exercise_slugs.sort
+  end
 end


### PR DESCRIPTION
Closes #8659

## Summary
- Rescue `Git::MissingCommitError` in `Track::RetrieveForegonePracticeExercises`, returning `GenericExercise.none` so the build status update can still complete
- Rescue `Git::MissingCommitError` in `Track::RetrieveUnimplementedPracticeExercises#foregone_exercise_slugs`, returning `[]` so foregone exercises are not excluded (slightly overstated unimplemented list, self-correcting once the track syncs)
- Follows the existing pattern used in `Git::Sync` and `Git::Exercise::CheckForTestableChangesBetweenVersions`

## Test plan
- [x] Added test for `RetrieveForegonePracticeExercises` returning empty when commit is missing
- [x] Added test for `RetrieveUnimplementedPracticeExercises` including foregone exercises when commit is missing
- [x] All 6 tests pass in both test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)