### PR TITLE
Guard against Array message/output in test results

### DIFF
--- a/app/models/submission/test_run.rb
+++ b/app/models/submission/test_run.rb
@@ -76,11 +76,11 @@ class Submission::TestRun < ApplicationRecord
         name: test[:name].to_s,
         status: Array(test[:status]).first.try(:to_sym),
         test_code: test[:test_code],
-        message: test[:message],
-        message_html: Ansi::RenderHTML.(test[:message]),
+        message: Array(test[:message]).first,
+        message_html: Ansi::RenderHTML.(Array(test[:message]).first),
         expected: test[:expected],
-        output: test[:output],
-        output_html: Ansi::RenderHTML.(test[:output]),
+        output: Array(test[:output]).first,
+        output_html: Ansi::RenderHTML.(Array(test[:output]).first),
         task_id: test[:task_id]&.to_i
       }
     end

--- a/test/models/submission/test_run_test.rb
+++ b/test/models/submission/test_run_test.rb
@@ -247,6 +247,22 @@ class Submission::TestRunTest < ActiveSupport::TestCase
     assert_nil tr.test_results.first.to_h[:status]
   end
 
+  test "handles test result message as array" do
+    tests = [{ 'name' => 'test1', 'status' => 'fail', 'message' => ['Expected 1 but got 2'] }]
+    tr = create(:submission_test_run, raw_results: { version: 2, status: 'fail', tests: tests })
+    result = tr.test_results.first.to_h
+    assert_equal 'Expected 1 but got 2', result[:message]
+    assert_equal 'Expected 1 but got 2', result[:message_html]
+  end
+
+  test "handles test result output as array" do
+    tests = [{ 'name' => 'test1', 'status' => 'fail', 'output' => ['some output'] }]
+    tr = create(:submission_test_run, raw_results: { version: 2, status: 'fail', tests: tests })
+    result = tr.test_results.first.to_h
+    assert_equal 'some output', result[:output]
+    assert_equal 'some output', result[:output_html]
+  end
+
   test "truncate message" do
     message = 'a' * 66_000
     test_run = create(:submission_test_run, raw_results: { message: })


### PR DESCRIPTION
Closes #8653
Closes #8654

## Summary
- Tooling runners can return `message` and `output` as Arrays (e.g., `["Expected 1 but got 2"]`) inside individual test result objects
- Applied `Array().first` to safely unwrap these fields in `TestResult#to_h`, matching the existing pattern for `status` and `version`
- Both the raw values and their `_html` variants (via `Ansi::RenderHTML`) are now protected

## Test plan
- [x] Added test for Array `message` in test results — verifies both `message` and `message_html` are unwrapped
- [x] Added test for Array `output` in test results — verifies both `output` and `output_html` are unwrapped
- [x] All 20 tests in `test/models/submission/test_run_test.rb` pass (62 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)