### PR TITLE
Handle UserTrackNotFoundError in API exercises start

### DIFF
--- a/app/controllers/api/exercises_controller.rb
+++ b/app/controllers/api/exercises_controller.rb
@@ -16,6 +16,10 @@ class API::ExercisesController < API::BaseController
         exercise: Exercism::Routes.edit_track_exercise_url(@track, @exercise)
       }
     }
+  rescue UserTrackNotFoundError
+    render_403(:track_not_joined)
+  rescue ExerciseLockedError
+    render_403(:exercise_locked)
   end
 
   private

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -8,6 +8,7 @@ en:
       not_maintainer: "You do not have maintainer permissions"
       duplicate_submission: "No files you submitted have changed since your last submission"
       duplicate_video: "The video has already been submitted by someone else"
+      exercise_locked: "This exercise is locked"
       exercise_not_found: "The exercise you specified could not be found"
       invalid_auth_token: "The auth token provided is invalid"
       invalid_mentor_student_relationship: "There is not a valid relationship between you and this student"

--- a/test/controllers/api/exercises_controller_test.rb
+++ b/test/controllers/api/exercises_controller_test.rb
@@ -99,6 +99,66 @@ module API
       assert_equal expected, response.body
     end
 
+    #########
+    # START #
+    #########
+    test "start should return 403 when user has not joined track" do
+      setup_user
+      track = create :track
+      exercise = create(:practice_exercise, track:)
+
+      patch start_api_track_exercise_path(track, exercise),
+        headers: @headers, as: :json
+
+      assert_response :forbidden
+      expected = {
+        error: {
+          type: "track_not_joined",
+          message: I18n.t("api.errors.track_not_joined")
+        }
+      }
+      assert_equal expected, response.parsed_body.deep_symbolize_keys
+    end
+
+    test "start should return 403 when exercise is locked" do
+      setup_user
+      track = create :track
+      create(:user_track, user: @current_user, track:)
+      exercise = create(:practice_exercise, track:)
+      UserTrack.any_instance.stubs(:exercise_unlocked?).with(exercise).returns(false)
+
+      patch start_api_track_exercise_path(track, exercise),
+        headers: @headers, as: :json
+
+      assert_response :forbidden
+      expected = {
+        error: {
+          type: "exercise_locked",
+          message: I18n.t("api.errors.exercise_locked")
+        }
+      }
+      assert_equal expected, response.parsed_body.deep_symbolize_keys
+    end
+
+    test "start should create solution and return exercise link" do
+      setup_user
+      track = create :track
+      create(:user_track, user: @current_user, track:)
+      exercise = create(:practice_exercise, track:)
+      UserTrack.any_instance.stubs(:exercise_unlocked?).with(exercise).returns(true)
+
+      patch start_api_track_exercise_path(track, exercise),
+        headers: @headers, as: :json
+
+      assert_response :ok
+      expected = {
+        links: {
+          exercise: Exercism::Routes.edit_track_exercise_url(track, exercise)
+        }
+      }
+      assert_equal expected.to_json, response.body
+    end
+
     test "index should search when not logged in" do
       track = create :track
       exercise = create :concept_exercise, track:, title: "Bob"


### PR DESCRIPTION
Closes #8663

## Summary
- Rescue `UserTrackNotFoundError` in `API::ExercisesController#start` and return a 403 with `track_not_joined` error, matching the pattern used in `API::V1::SolutionsController` and `API::SolutionsController`
- Also rescue `ExerciseLockedError` from the same code path and return a 403 with `exercise_locked` error
- Add i18n key for the new `exercise_locked` error type
- Add test coverage for the `start` action (track not joined, exercise locked, happy path)

## Test plan
- [x] `bundle exec rails test test/controllers/api/exercises_controller_test.rb` — 8 tests pass
- [x] `bundle exec rails test test/commands/solution/create_test.rb` — 7 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)