### PR TITLE
Guard against undefined value in CodeMirror component

### DIFF
--- a/app/javascript/components/misc/CodeMirror.tsx
+++ b/app/javascript/components/misc/CodeMirror.tsx
@@ -51,6 +51,10 @@ export default function CodeMirror({
   const [textarea, setTextarea] = useState<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
 
+  if (value === undefined || value === null) {
+    return <div className="editor" />
+  }
+
   const setValue = (text: string) => {
     if (!viewRef.current) {
       return


### PR DESCRIPTION
## Summary
- When `value` is `undefined` or `null`, the CodeMirror component crashes trying to read `.length` on it during `EditorState.create`
- Added an early return that renders an empty editor div when value is missing

Closes #8692

## Test plan
- [ ] Verify CodeMirror editor still renders normally when `value` is a valid string
- [ ] Confirm no crash when a component passes `undefined` as the value prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)