### PR TITLE
Guard against null document.body in showSiteFooter

### DIFF
--- a/app/javascript/utils/show-site-footer.ts
+++ b/app/javascript/utils/show-site-footer.ts
@@ -8,6 +8,12 @@ export function showSiteFooter(): void {
     return
   }
 
+  if (!document.body) {
+    retryCount++
+    setTimeout(showSiteFooter, 10)
+    return
+  }
+
   const elems = document.body.getElementsByClassName('c-react-component')
   for (const elem of elems) {
     // If this elem is hydrated, move onto the next one...


### PR DESCRIPTION
## Summary
- During Turbo navigation, `document.body` can momentarily be `null`, causing a crash on `getElementsByClassName`
- Added a null check that retries after a short delay, consistent with the existing retry pattern in this function

Closes #8658

## Test plan
- [ ] Verify site footer still appears correctly after normal page loads
- [ ] Verify no crash during rapid Turbo navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)