### PR TITLE
Guard against null document.body in react-bootloader

### DIFF
--- a/app/javascript/utils/react-bootloader.tsx
+++ b/app/javascript/utils/react-bootloader.tsx
@@ -435,6 +435,7 @@ export function renderComponents(
   if (!parentElement) {
     parentElement = document.body
   }
+  if (!parentElement) return
   // As getElementsByClassName returns a live collection, it is recommended to use Array.from
   // when iterating through it, otherwise the number of elements may change mid-loop.
   const elems = Array.from(
@@ -469,6 +470,7 @@ function renderTooltips(parentElement: HTMLElement, mappings: Mappings) {
   if (!parentElement) {
     parentElement = document.body
   }
+  if (!parentElement) return
   parentElement
     .querySelectorAll('[data-tooltip-type][data-endpoint]')
     .forEach((elem) => renderTooltip(mappings, elem as HTMLElement))


### PR DESCRIPTION
## Summary
- `renderComponents` and `renderTooltips` fall back to `document.body` when `parentElement` is null, but `document.body` itself can be null during Turbo navigation
- Added a second guard after the fallback to bail out safely instead of crashing

Closes #8657

## Test plan
- [ ] Verify React components still render correctly on page load
- [ ] Verify no crash during rapid Turbo navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)