### PR TITLE
Guard against undefined metric.user in impact map

### DIFF
--- a/app/javascript/components/impact/map.tsx
+++ b/app/javascript/components/impact/map.tsx
@@ -59,6 +59,8 @@ const MetricPointUserWithTooltip = ({
   metric: Metric
   text: string
 }): JSX.Element => {
+  if (!metric.user) return <></>
+
   const avatarRef = useRef(null)
   const content = (
     <div


### PR DESCRIPTION
## Summary
- `MetricPointUserWithTooltip` accesses `metric.user.handle` and `metric.user.avatarUrl`, but `user` is optional on the `Metric` type
- Added an early return when user data is missing to prevent the crash

Closes #8656

## Test plan
- [ ] Verify impact map still renders metric points with user data correctly
- [ ] Confirm no crash when a metric arrives via WebSocket without user data

🤖 Generated with [Claude Code](https://claude.com/claude-code)