### PR TITLE
Guard against empty file selection in avatar image crop

### DIFF
--- a/app/javascript/components/profile/avatar-selector/use-image-crop.ts
+++ b/app/javascript/components/profile/avatar-selector/use-image-crop.ts
@@ -86,6 +86,9 @@ export const useImageCrop = () => {
   })
 
   const handleAttach = useCallback((e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
     const fileReader = new FileReader()
 
     fileReader.onloadend = () => {
@@ -97,7 +100,7 @@ export const useImageCrop = () => {
       })
     }
 
-    fileReader.readAsDataURL(e.target.files[0])
+    fileReader.readAsDataURL(file)
   }, [])
 
   return { state, dispatch, handleAttach }


### PR DESCRIPTION
## Summary
- When a user opens the file dialog then cancels, `e.target.files[0]` is `undefined`
- `readAsDataURL` then throws because it expects a `Blob`
- Added a null check to bail out early when no file is selected

Closes #8655

## Test plan
- [ ] Open avatar upload dialog, select a file — should work as before
- [ ] Open avatar upload dialog, click cancel — should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)