### PR TITLE
Guard against empty frames array in useScrubber

### DIFF
--- a/app/javascript/components/bootcamp/JikiscriptExercisePage/Scrubber/useScrubber.ts
+++ b/app/javascript/components/bootcamp/JikiscriptExercisePage/Scrubber/useScrubber.ts
@@ -191,6 +191,8 @@ export function useScrubber({
       newTimelineTime?: number,
       pause: boolean = true
     ) => {
+      if (!lastFrame) return
+
       const isLastFrame = newFrame.timelineTime == lastFrame.timelineTime
       newTimelineTime = newTimelineTime || newFrame.timelineTime
 


### PR DESCRIPTION
## Summary
- When the `frames` array is empty, `lastFrame` (`frames[frames.length - 1]`) is `undefined`
- `moveToFrame` then crashes accessing `lastFrame.timelineTime`
- Added an early return when `lastFrame` is undefined

Closes #8681

## Test plan
- [ ] Verify bootcamp scrubber still works normally with frames present
- [ ] Confirm no crash when scrubber renders before frames are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)