### PR TITLE
Scrub invalid UTF-8 from test run results before parsing

### DIFF
--- a/app/commands/submission/test_run/process.rb
+++ b/app/commands/submission/test_run/process.rb
@@ -114,10 +114,10 @@ class Submission::TestRun::Process
   def results
     return {} if tooling_job.execution_output.nil?
 
-    results_json = tooling_job.execution_output['results.json']
-    return {} if results_json&.scrub.blank?
+    results_json = tooling_job.execution_output['results.json']&.scrub
+    return {} if results_json.blank?
 
-    res = JSON.parse(results_json, allow_invalid_unicode: true)
+    res = JSON.parse(results_json)
     res.is_a?(Hash) ? res.symbolize_keys : {}
   rescue JSON::ParserError
     {}


### PR DESCRIPTION
## Summary
- `results_json` was only scrubbed for the `blank?` check, but the original unscrubbed string was passed to `JSON.parse`
- Invalid UTF-8 bytes survived into the database via the parsed hash, crashing on deserialization with `ArgumentError: invalid byte sequence in UTF-8`
- Now scrubs upfront so all downstream consumers (including ActiveRecord's JSON serializer) get clean UTF-8 data
- `allow_invalid_unicode: true` is no longer needed since the string is already scrubbed

Closes #8680

## Test plan
- [ ] Run existing test suite for `Submission::TestRun::Process`
- [ ] Verify test runs with valid JSON still process normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)