### PR TITLE
Test actual localStorage operations in safeLocalStorage

### DIFF
--- a/app/javascript/utils/safe-local-storage.ts
+++ b/app/javascript/utils/safe-local-storage.ts
@@ -2,12 +2,18 @@
  * Safely access window.localStorage.
  *
  * In some browsers (Safari private browsing, restricted iframes, strict cookie
- * settings) even reading window.localStorage throws a SecurityError.  This
- * helper returns null when access is denied so callers can degrade gracefully.
+ * settings) even reading window.localStorage throws a SecurityError.  Some
+ * browsers allow reading the property but throw on actual storage operations.
+ * This helper tests a real write/remove cycle and returns null when access is
+ * denied so callers can degrade gracefully.
  */
 export function safeLocalStorage(): Storage | null {
   try {
-    return window.localStorage
+    const storage = window.localStorage
+    const testKey = '__exercism_storage_test__'
+    storage.setItem(testKey, 'test')
+    storage.removeItem(testKey)
+    return storage
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- Some browsers (Safari private browsing, restricted iframes) return a `Storage` object from `window.localStorage` but throw `SecurityError` on any actual operation (`setItem`, `getItem`)
- `safeLocalStorage()` was only catching errors from reading the property, so downstream code (`createSyncStoragePersister`) received a broken Storage object and crashed
- Now performs a real write/remove cycle to verify the storage is actually usable

Closes #8697

## Test plan
- [ ] Verify React Query offline cache persistence still works in normal browsers
- [ ] Confirm no crash in Safari private browsing or other restricted storage environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)