### PR TITLE
Fix formatting in exercises.yml sign up prompt

### DIFF
--- a/config/locales/views/tracks/exercises.yml
+++ b/config/locales/views/tracks/exercises.yml
@@ -166,7 +166,7 @@ en:
           title: Ready to start %{exercise_title}?
           description_html:
             Sign up to Exercism to learn and master %{track_link} with
-            %{concept_link}%{exercise_link}, and real human mentoring,
+            %{concept_link}, %{exercise_link}, and real human mentoring,
             <strong>all for free.</strong>
           concept_plural:
             one: 1 concept


### PR DESCRIPTION
Corrected the formatting of the description_html string to properly include commas.

Previously was displaying as 

> ...master Gleam with **33 concepts122 exercises**, and real...

 now will display as

> ...master Gleam with **33 concepts**, **122 exercises**, and real...