### PR TITLE
Update Jiki launch date from February to March 2026

### DIFF
--- a/app/views/jiki/index.html.haml
+++ b/app/views/jiki/index.html.haml
@@ -42,6 +42,11 @@
           %strong 40+
           languages
 
+    .video-container
+      <script src="https://cdn.jsdelivr.net/npm/@mux/mux-player"></script>
+      <mux-player playback-id="v2kO7cS7n8IhguzE013jOmPHmkXrrIwFNcM5qgz1P17c" poster="https://assets.exercism.org/images/thumbnails/jiki-waiting.png" metadata-video-title="Waiting Page 1" accent-color="#7c3aed" style="width: 100%; aspect-ratio: 16/9;"></mux-player>
+
+
   = render "scrolling_testimonials"
 
 %section.welcome
@@ -531,7 +536,7 @@
     .faq
       %h4 When will Jiki launch?
       %p
-        Jiki is launching in February 2026. We'll be letting people in gradually throughout February and March as we add more languages.
+        Jiki is launching in March 2026. We'll be letting people in gradually throughout March and April as we add more languages.
 
     .faq
       %h4 I already signed up to the Bootcamp - is this different?


### PR DESCRIPTION
## Summary
- Update Jiki launch date from February 2026 to March 2026
- Shift the gradual rollout window from "February and March" to "March and April"
- Add video container to the Jiki landing page

## Test plan
- [ ] Verify the Jiki landing page displays the updated launch date
- [ ] Verify the video player renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)