### PR TITLE
Fix typo and update launch date in Jiki waiting list section

### DIFF
--- a/app/views/jiki/index.html.haml
+++ b/app/views/jiki/index.html.haml
@@ -439,7 +439,7 @@
       Join the
       %strong.font-semibold Waiting List
     %p.intro.text-balance
-      We're be opening up the course starting in February 2026.
+      We'll be opening up the course starting in March 2026.
       The first 1,000 signups get
       %strong.font-semibold free Premium access
       for the year!


### PR DESCRIPTION
## Summary
- Fixes typo in waiting list section: "We're be" → "We'll be"
- Updates launch date from February to March 2026 (missed in #8843)

## Test plan
- [ ] Verify the Jiki landing page renders correctly with the updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)