### PR TITLE
Add shadow banning to hide users from mentoring

### DIFF
--- a/app/commands/mentor/discussion/retrieve.rb
+++ b/app/commands/mentor/discussion/retrieve.rb
@@ -55,6 +55,12 @@ class Mentor::Discussion::Retrieve
     @discussions = Mentor::Discussion.
       includes(solution: [:user, { exercise: :track }]).
       where(mentor:)
+
+    # Don't show shadow-banned students' discussions
+    shadow_banned_user_ids = User.where.not(shadow_banned_at: nil).select(:id)
+    @discussions = @discussions.where.not(
+      solution_id: Solution.where(user_id: shadow_banned_user_ids).select(:id)
+    )
   end
 
   def filter_status!

--- a/app/commands/mentor/discussion/retrieve.rb
+++ b/app/commands/mentor/discussion/retrieve.rb
@@ -33,6 +33,7 @@ class Mentor::Discussion::Retrieve
 
   def call
     setup!
+    filter_shadow_banned!
     filter_status!
     filter_track!
     filter_student!
@@ -55,12 +56,10 @@ class Mentor::Discussion::Retrieve
     @discussions = Mentor::Discussion.
       includes(solution: [:user, { exercise: :track }]).
       where(mentor:)
+  end
 
-    # Don't show shadow-banned students' discussions
-    shadow_banned_user_ids = User.where.not(shadow_banned_at: nil).select(:id)
-    @discussions = @discussions.where.not(
-      solution_id: Solution.where(user_id: shadow_banned_user_ids).select(:id)
-    )
+  def filter_shadow_banned!
+    @discussions = @discussions.joins(:solution).where.not(solutions: { user_id: User.shadow_banned.select(:id) })
   end
 
   def filter_status!

--- a/app/commands/mentor/request/retrieve.rb
+++ b/app/commands/mentor/request/retrieve.rb
@@ -64,7 +64,7 @@ class Mentor::Request::Retrieve
     )
 
     # Don't show shadow-banned students' requests
-    @requests = @requests.where.not(student_id: User.where.not(shadow_banned_at: nil).select(:id))
+    @requests = @requests.where.not(student_id: User.shadow_banned.select(:id))
 
     if exercise_slug.present?
       filter_exercises!

--- a/app/commands/mentor/request/retrieve.rb
+++ b/app/commands/mentor/request/retrieve.rb
@@ -46,6 +46,9 @@ class Mentor::Request::Retrieve
     @requests = Mentor::Request.
       pending.
       unlocked_for(mentor)
+
+    # Shadow-banned mentors see empty queues
+    @requests = @requests.none if mentor&.shadow_banned?
   end
 
   def filter!
@@ -59,6 +62,9 @@ class Mentor::Request::Retrieve
         where('blocked_by_mentor = ? OR blocked_by_student = ?', true, true).
         select(:student_id)
     )
+
+    # Don't show shadow-banned students' requests
+    @requests = @requests.where.not(student_id: User.where.not(shadow_banned_at: nil).select(:id))
 
     if exercise_slug.present?
       filter_exercises!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,6 +82,12 @@ class ApplicationController < ActionController::Base
     redirect_to maintaining_root_path
   end
 
+  def ensure_moderator!
+    return if current_user&.moderator?
+
+    redirect_to root_path
+  end
+
   def ensure_iHiD! # rubocop:disable Naming/MethodName
     return true if Rails.env.development?
     return true if current_user&.id == User::IHID_USER_ID

--- a/app/controllers/moderation/base_controller.rb
+++ b/app/controllers/moderation/base_controller.rb
@@ -1,0 +1,5 @@
+class Moderation::BaseController < ApplicationController
+  before_action :ensure_moderator!
+
+  layout "admin"
+end

--- a/app/controllers/moderation/shadow_banned_users_controller.rb
+++ b/app/controllers/moderation/shadow_banned_users_controller.rb
@@ -1,0 +1,28 @@
+class Moderation::ShadowBannedUsersController < Moderation::BaseController
+  def index
+    @users = User.includes(:shadow_banned_by).where.not(shadow_banned_at: nil).order(shadow_banned_at: :desc)
+  end
+
+  def create
+    handle = params[:handle]&.strip
+    user = User.find_by(handle: handle)
+
+    if user.nil?
+      flash[:alert] = "Could not find user with handle '#{handle}'"
+    elsif user.shadow_banned?
+      flash[:alert] = "#{user.handle} is already shadow banned"
+    else
+      user.update!(shadow_banned_at: Time.current, shadow_banned_by_id: current_user.id)
+      flash[:notice] = "#{user.handle} has been shadow banned from mentoring"
+    end
+
+    redirect_to moderation_shadow_banned_users_path
+  end
+
+  def destroy
+    user = User.find_by!(handle: params[:id])
+    user.update!(shadow_banned_at: nil, shadow_banned_by_id: nil)
+    flash[:notice] = "Shadow ban removed for #{user.handle}"
+    redirect_to moderation_shadow_banned_users_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -344,9 +344,12 @@ class User < ApplicationRecord
   def profile? = profile.present?
   def may_create_profile? = reputation >= User::Profile::MIN_REPUTATION
 
+  belongs_to :shadow_banned_by, class_name: "User", optional: true
+
   def confirmed? = super && !disabled? && !blocked?
   def disabled? = !!disabled_at
   def blocked? = User::BlockDomain.blocked?(user: self)
+  def shadow_banned? = !!shadow_banned_at
 
   def github_auth? = uid.present?
   def captcha_required? = !github_auth? && Time.current - created_at < 2.days

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,6 +147,7 @@ class User < ApplicationRecord
 
   scope :with_data, -> { joins(:data) }
   scope :insiders, -> { with_data.where(user_data: { insiders_status: %i[active active_lifetime] }) }
+  scope :shadow_banned, -> { where.not(shadow_banned_at: nil) }
 
   # TODO: Validate presence of name
   validates :handle, uniqueness: { case_sensitive: false }, handle_format: true, length: { maximum: 190 }

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -4,6 +4,7 @@ module User::Roles
   def staff? = roles.include?(:staff) || admin?
   def maintainer? = roles.include?(:maintainer) || staff?
   def supermentor? = roles.include?(:supermentor) || staff?
+  def moderator? = roles.include?(:moderator) || staff?
   def mentor? = became_mentor_at.present? || staff?
   def roles = super.to_a.map(&:to_sym).to_set
 end

--- a/app/views/moderation/shadow_banned_users/index.html.haml
+++ b/app/views/moderation/shadow_banned_users/index.html.haml
@@ -1,0 +1,31 @@
+.c-admin-table
+  .lg-container
+    %h1.text-h1.mb-8 Shadow Banned Users
+
+    - if flash[:notice]
+      .mb-12.text-p-base.font-bold.text-darkSuccessGreen= flash[:notice]
+    - if flash[:alert]
+      .mb-12.text-p-base.font-bold.text-red= flash[:alert]
+
+    = form_with(url: moderation_shadow_banned_users_path, method: :post, class: "flex items-end gap-8 mb-16") do |form|
+      .flex.flex-col
+        = form.label :handle, "User handle", class: 'text-h6 mb-4'
+        = form.text_field :handle, required: true
+      %div
+        = form.submit "Shadow Ban", class: 'btn btn-primary btn-base'
+
+    %table.mb-8{ style: "border-collapse: collapse; width: 100%; background: white;" }
+      %tr
+        %th{ style: "border: 1px solid #ddd; padding: 8px 12px; text-align: left;" } Handle
+        %th{ style: "border: 1px solid #ddd; padding: 8px 12px; text-align: left;" } Email
+        %th{ style: "border: 1px solid #ddd; padding: 8px 12px; text-align: left;" } Banned at
+        %th{ style: "border: 1px solid #ddd; padding: 8px 12px; text-align: left;" } Banned by
+        %th{ style: "border: 1px solid #ddd; padding: 8px 12px; text-align: left;" } Actions
+      - @users.each do |user|
+        %tr
+          %td{ style: "border: 1px solid #ddd; padding: 8px 12px;" }= user.handle
+          %td{ style: "border: 1px solid #ddd; padding: 8px 12px;" }= user.email
+          %td{ style: "border: 1px solid #ddd; padding: 8px 12px;" }= user.shadow_banned_at.strftime("%Y-%m-%d %H:%M")
+          %td{ style: "border: 1px solid #ddd; padding: 8px 12px;" }= user.shadow_banned_by&.handle || "Unknown"
+          %td{ style: "border: 1px solid #ddd; padding: 8px 12px;" }
+            = button_to "Remove", moderation_shadow_banned_user_path(user), method: :delete, class: 'btn btn-primary btn-base'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,14 @@ Rails.application.routes.draw do
     resource :workflow_run_updates, only: [:create]
   end
 
+  # ########## #
+  # Moderation #
+  # ########## #
+  namespace :moderation do
+    root to: redirect('/moderation/shadow_banned_users')
+    resources :shadow_banned_users, only: %i[index create destroy]
+  end
+
   # ##### #
   # Admin #
   # ##### #

--- a/db/migrate/20260318000000_add_shadow_banned_to_users.rb
+++ b/db/migrate/20260318000000_add_shadow_banned_to_users.rb
@@ -1,0 +1,9 @@
+class AddShadowBannedToUsers < ActiveRecord::Migration[7.0]
+  def change
+    return if Rails.env.production?
+
+    add_column :users, :shadow_banned_at, :datetime, null: true
+    add_column :users, :shadow_banned_by_id, :bigint, null: true
+    add_foreign_key :users, :users, column: :shadow_banned_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,11 +37,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
-  create_table "add_uuid_to_code_tags_samples", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -75,15 +70,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
   end
 
-  create_table "bootcamp_chat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "solution_id", null: false
-    t.integer "author", null: false
-    t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["solution_id"], name: "index_bootcamp_chat_messages_on_solution_id"
-  end
-
   create_table "bootcamp_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.bigint "parent_id"
@@ -103,8 +89,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.string "uuid", null: false
     t.bigint "user_id", null: false
     t.boolean "active", default: false, null: false
-    t.text "description", null: false
     t.text "code", null: false
+    t.text "description", null: false
     t.text "tests", size: :long, null: false
     t.string "name", null: false
     t.integer "arity", null: false
@@ -147,7 +133,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "level_idx", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "uuid"
     t.boolean "has_bonus_tasks", default: false, null: false
     t.boolean "blocks_project_progression", default: true, null: false
     t.boolean "blocks_level_progression", default: true, null: false
@@ -166,7 +151,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.datetime "updated_at", null: false
     t.string "youtube_id"
     t.string "labs_youtube_id"
-    t.integer "part", default: 1, null: false
   end
 
   create_table "bootcamp_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -177,7 +161,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.text "introduction_html", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "uuid"
   end
 
   create_table "bootcamp_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -297,27 +280,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
-  create_table "conversations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "course_slug", null: false
-    t.string "country_code_2"
-    t.datetime "paid_at"
-    t.string "checkout_session_id"
-    t.string "access_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "email_status", limit: 1, default: 0, null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
-  end
-
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -336,6 +298,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["track_id", "position"], name: "index_documents_on_track_id_and_position"
     t.index ["track_id"], name: "index_documents_on_track_id"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
+  end
+
+  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "course_slug", null: false
+    t.string "country_code_2"
+    t.datetime "paid_at"
+    t.string "checkout_session_id"
+    t.string "access_code"
+    t.integer "email_status", limit: 1, default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
   end
 
   create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -558,9 +536,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   end
 
   create_table "exercise_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "exercise_id", null: false
     t.string "tag", null: false
     t.boolean "filterable", default: true, null: false
+    t.bigint "exercise_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_id", "tag"], name: "index_exercise_tags_on_exercise_id_and_tag", unique: true
@@ -739,82 +717,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_jiki_signups_on_user_id", unique: true
-  end
-
-  create_table "localization_glossary_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "locale", null: false
-    t.string "term", null: false
-    t.string "translation", null: false
-    t.text "llm_instructions", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 1, null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_localization_glossary_entries_on_uuid", unique: true
-  end
-
-  create_table "localization_glossary_entry_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "type", null: false
-    t.integer "status", default: 0, null: false
-    t.string "uuid", null: false
-    t.bigint "glossary_entry_id"
-    t.bigint "proposer_id", null: false
-    t.bigint "reviewer_id"
-    t.string "term"
-    t.string "locale"
-    t.string "translation"
-    t.text "llm_instructions"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["glossary_entry_id"], name: "idx_on_glossary_entry_id_3c0b97fb4f"
-    t.index ["proposer_id"], name: "index_localization_glossary_entry_proposals_on_proposer_id"
-    t.index ["reviewer_id"], name: "index_localization_glossary_entry_proposals_on_reviewer_id"
-  end
-
-  create_table "localization_originals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.string "type", null: false
-    t.string "about_type"
-    t.bigint "about_id"
-    t.string "key", null: false
-    t.text "value", null: false
-    t.text "usage_details"
-    t.boolean "should_translate", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_localization_originals_on_key", unique: true
-    t.index ["type", "about_type", "about_id"], name: "idx_on_type_about_type_about_id_13bf9a28f1"
-    t.index ["type"], name: "index_localization_originals_on_type"
-    t.index ["uuid"], name: "index_localization_originals_on_uuid", unique: true
-  end
-
-  create_table "localization_translation_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.bigint "translation_id", null: false
-    t.bigint "proposer_id", null: false
-    t.bigint "reviewer_id"
-    t.integer "status", default: 0, null: false
-    t.boolean "modified_from_llm", null: false
-    t.text "value", null: false
-    t.text "llm_feedback"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["proposer_id"], name: "index_localization_translation_proposals_on_proposer_id"
-    t.index ["reviewer_id"], name: "index_localization_translation_proposals_on_reviewer_id"
-    t.index ["translation_id"], name: "index_localization_translation_proposals_on_translation_id"
-    t.index ["uuid"], name: "index_localization_translation_proposals_on_uuid", unique: true
-  end
-
-  create_table "localization_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.string "locale", null: false
-    t.string "key", null: false
-    t.text "value"
-    t.integer "status", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key", "locale"], name: "index_localization_translations_on_key_and_locale", unique: true
-    t.index ["uuid"], name: "index_localization_translations_on_uuid", unique: true
   end
 
   create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1169,10 +1071,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   end
 
   create_table "solution_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "tag", null: false
     t.bigint "solution_id", null: false
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
-    t.string "tag", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "track_id", null: false
@@ -1218,9 +1120,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
     t.bigint "published_exercise_representation_id"
+    t.bigint "exercise_approach_id"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_2"
+    t.index ["exercise_approach_id"], name: "index_solutions_on_exercise_approach_id"
     t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "id"], name: "mentor_selection_idx_3"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_solutions_on_exercise_id_and_git_important_files_hash"
     t.index ["exercise_id", "status", "num_stars", "updated_at"], name: "solutions_ex_stat_stars_upat"
@@ -1311,11 +1215,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
-  create_table "submission_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "submission_id", null: false
@@ -1357,7 +1256,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "exercise_representer_version", limit: 2, default: 1, null: false
     t.bigint "approach_id"
     t.json "tags"
-    t.index "`exercise_id`, `approach_id`, (json_value(`tags`, _utf8mb4'$[0]' returning char(512) null on empty))", name: "index_submissions_exercise_approach_tags"
     t.index ["approach_id"], name: "index_submissions_on_approach_id"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_submissions_on_exercise_id_and_git_important_files_hash"
     t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
@@ -1628,11 +1526,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.boolean "email_about_events", default: true, null: false
     t.boolean "email_about_insiders", default: true, null: false
     t.boolean "email_on_acquired_trophy_notification", default: true, null: false
-    t.boolean "receive_onboarding_emails", default: true, null: false
     t.boolean "email_on_nudge_student_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_nudge_mentor_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_mentor_timed_out_discussion_notification", default: true, null: false
     t.boolean "email_on_student_timed_out_discussion_notification", default: true, null: false
+    t.boolean "receive_onboarding_emails", default: true, null: false
     t.index ["token"], name: "index_user_communication_preferences_on_token"
     t.index ["user_id"], name: "fk_rails_65642a5510"
   end
@@ -1696,11 +1594,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.bigint "user_id", null: false
     t.bigint "installation_id", null: false
     t.string "repo_full_name", null: false
-    t.boolean "enabled", default: true, null: false
-    t.boolean "sync_on_iteration_creation", default: true, null: false
-    t.boolean "sync_exercise_files", default: false, null: false
-    t.integer "processing_method", default: 1, null: false
-    t.string "main_branch_name", default: "main", null: false
+    t.boolean "enabled", null: false, default: true
+    t.boolean "sync_on_iteration_creation", null: false, default: true
+    t.boolean "sync_exercise_files", null: false
+    t.integer "processing_method", null: false, default: 1
+    t.string "main_branch_name", null: false, default: "main"
     t.string "commit_message_template", null: false
     t.string "path_template", null: false
     t.datetime "created_at", null: false
@@ -1904,7 +1802,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.string "video_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "context", default: "0", null: false
+    t.string "context"
     t.index ["context"], name: "index_user_watched_videos_on_context"
     t.index ["user_id", "video_provider", "video_id"], name: "user_watched_videos_uniq", unique: true
     t.index ["user_id"], name: "index_user_watched_videos_on_user_id"
@@ -1945,21 +1843,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["shadow_banned_by_id"], name: "fk_rails_5f0a1f5e10"
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
-  add_foreign_key "bootcamp_chat_messages", "bootcamp_solutions", column: "solution_id"
   add_foreign_key "bootcamp_concepts", "bootcamp_concepts", column: "parent_id"
   add_foreign_key "bootcamp_custom_functions", "users"
   add_foreign_key "bootcamp_drawings", "users"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_concepts", column: "concept_id"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_exercises", column: "exercise_id"
   add_foreign_key "bootcamp_submissions", "bootcamp_solutions", column: "solution_id"
-  add_foreign_key "bootcamp_user_projects", "bootcamp_projects", column: "project_id"
-  add_foreign_key "bootcamp_user_projects", "users"
   add_foreign_key "cohort_memberships", "cohorts"
   add_foreign_key "cohort_memberships", "users"
   add_foreign_key "cohorts", "tracks"
@@ -2010,13 +1904,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "github_team_members", "tracks"
   add_foreign_key "github_team_members", "users"
   add_foreign_key "jiki_signups", "users"
-  add_foreign_key "localization_glossary_entry_proposals", "localization_glossary_entries", column: "glossary_entry_id"
-  add_foreign_key "localization_glossary_entry_proposals", "users", column: "proposer_id"
-  add_foreign_key "localization_glossary_entry_proposals", "users", column: "reviewer_id"
-  add_foreign_key "localization_translation_proposals", "localization_translations", column: "translation_id"
-  add_foreign_key "localization_translation_proposals", "users", column: "proposer_id"
-  add_foreign_key "localization_translation_proposals", "users", column: "reviewer_id"
-  add_foreign_key "localization_translations", "localization_originals", column: "key", primary_key: "key"
   add_foreign_key "mentor_discussion_posts", "iterations"
   add_foreign_key "mentor_discussion_posts", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_discussion_posts", "users"
@@ -2047,6 +1934,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "solution_tags", "exercises"
   add_foreign_key "solution_tags", "solutions"
   add_foreign_key "solution_tags", "users"
+  add_foreign_key "solutions", "exercise_approaches"
   add_foreign_key "solutions", "exercise_representations", column: "published_exercise_representation_id"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
@@ -2081,7 +1969,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "user_bootcamp_data", "users"
   add_foreign_key "user_communication_preferences", "users"
   add_foreign_key "user_dismissed_introducers", "users"
-  add_foreign_key "user_github_solution_syncers", "users"
   add_foreign_key "user_mailshots", "mailshots"
   add_foreign_key "user_notifications", "exercises"
   add_foreign_key "user_notifications", "tracks"
@@ -2104,5 +1991,4 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "user_track_viewed_exercise_approaches", "users"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
-  add_foreign_key "users", "users", column: "shadow_banned_by_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "add_uuid_to_code_tags_samples", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -70,6 +75,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
   end
 
+  create_table "bootcamp_chat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.integer "author", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["solution_id"], name: "index_bootcamp_chat_messages_on_solution_id"
+  end
+
   create_table "bootcamp_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.bigint "parent_id"
@@ -89,8 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.string "uuid", null: false
     t.bigint "user_id", null: false
     t.boolean "active", default: false, null: false
-    t.text "code", null: false
     t.text "description", null: false
+    t.text "code", null: false
     t.text "tests", size: :long, null: false
     t.string "name", null: false
     t.integer "arity", null: false
@@ -133,6 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.integer "level_idx", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid"
     t.boolean "has_bonus_tasks", default: false, null: false
     t.boolean "blocks_project_progression", default: true, null: false
     t.boolean "blocks_level_progression", default: true, null: false
@@ -151,6 +166,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.datetime "updated_at", null: false
     t.string "youtube_id"
     t.string "labs_youtube_id"
+    t.integer "part", default: 1, null: false
   end
 
   create_table "bootcamp_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -161,6 +177,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.text "introduction_html", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid"
   end
 
   create_table "bootcamp_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -280,6 +297,27 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
+  create_table "conversations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "course_slug", null: false
+    t.string "country_code_2"
+    t.datetime "paid_at"
+    t.string "checkout_session_id"
+    t.string "access_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "email_status", limit: 1, default: 0, null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
+  end
+
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -298,22 +336,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.index ["track_id", "position"], name: "index_documents_on_track_id_and_position"
     t.index ["track_id"], name: "index_documents_on_track_id"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
-  end
-
-  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "course_slug", null: false
-    t.string "country_code_2"
-    t.datetime "paid_at"
-    t.string "checkout_session_id"
-    t.string "access_code"
-    t.integer "email_status", limit: 1, default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
   end
 
   create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -536,9 +558,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   end
 
   create_table "exercise_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "exercise_id", null: false
     t.string "tag", null: false
     t.boolean "filterable", default: true, null: false
-    t.bigint "exercise_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_id", "tag"], name: "index_exercise_tags_on_exercise_id_and_tag", unique: true
@@ -717,6 +739,82 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_jiki_signups_on_user_id", unique: true
+  end
+
+  create_table "localization_glossary_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "term", null: false
+    t.string "translation", null: false
+    t.text "llm_instructions", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 1, null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_localization_glossary_entries_on_uuid", unique: true
+  end
+
+  create_table "localization_glossary_entry_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "type", null: false
+    t.integer "status", default: 0, null: false
+    t.string "uuid", null: false
+    t.bigint "glossary_entry_id"
+    t.bigint "proposer_id", null: false
+    t.bigint "reviewer_id"
+    t.string "term"
+    t.string "locale"
+    t.string "translation"
+    t.text "llm_instructions"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["glossary_entry_id"], name: "idx_on_glossary_entry_id_3c0b97fb4f"
+    t.index ["proposer_id"], name: "index_localization_glossary_entry_proposals_on_proposer_id"
+    t.index ["reviewer_id"], name: "index_localization_glossary_entry_proposals_on_reviewer_id"
+  end
+
+  create_table "localization_originals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "type", null: false
+    t.string "about_type"
+    t.bigint "about_id"
+    t.string "key", null: false
+    t.text "value", null: false
+    t.text "usage_details"
+    t.boolean "should_translate", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_localization_originals_on_key", unique: true
+    t.index ["type", "about_type", "about_id"], name: "idx_on_type_about_type_about_id_13bf9a28f1"
+    t.index ["type"], name: "index_localization_originals_on_type"
+    t.index ["uuid"], name: "index_localization_originals_on_uuid", unique: true
+  end
+
+  create_table "localization_translation_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.bigint "translation_id", null: false
+    t.bigint "proposer_id", null: false
+    t.bigint "reviewer_id"
+    t.integer "status", default: 0, null: false
+    t.boolean "modified_from_llm", null: false
+    t.text "value", null: false
+    t.text "llm_feedback"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proposer_id"], name: "index_localization_translation_proposals_on_proposer_id"
+    t.index ["reviewer_id"], name: "index_localization_translation_proposals_on_reviewer_id"
+    t.index ["translation_id"], name: "index_localization_translation_proposals_on_translation_id"
+    t.index ["uuid"], name: "index_localization_translation_proposals_on_uuid", unique: true
+  end
+
+  create_table "localization_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key", "locale"], name: "index_localization_translations_on_key_and_locale", unique: true
+    t.index ["uuid"], name: "index_localization_translations_on_uuid", unique: true
   end
 
   create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1071,10 +1169,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   end
 
   create_table "solution_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "tag", null: false
     t.bigint "solution_id", null: false
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
+    t.string "tag", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "track_id", null: false
@@ -1120,11 +1218,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
     t.bigint "published_exercise_representation_id"
-    t.bigint "exercise_approach_id"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_2"
-    t.index ["exercise_approach_id"], name: "index_solutions_on_exercise_approach_id"
     t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "id"], name: "mentor_selection_idx_3"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_solutions_on_exercise_id_and_git_important_files_hash"
     t.index ["exercise_id", "status", "num_stars", "updated_at"], name: "solutions_ex_stat_stars_upat"
@@ -1215,6 +1311,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
+  create_table "submission_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "submission_id", null: false
@@ -1256,6 +1357,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.integer "exercise_representer_version", limit: 2, default: 1, null: false
     t.bigint "approach_id"
     t.json "tags"
+    t.index "`exercise_id`, `approach_id`, (json_value(`tags`, _utf8mb4'$[0]' returning char(512) null on empty))", name: "index_submissions_exercise_approach_tags"
     t.index ["approach_id"], name: "index_submissions_on_approach_id"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_submissions_on_exercise_id_and_git_important_files_hash"
     t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
@@ -1526,11 +1628,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.boolean "email_about_events", default: true, null: false
     t.boolean "email_about_insiders", default: true, null: false
     t.boolean "email_on_acquired_trophy_notification", default: true, null: false
+    t.boolean "receive_onboarding_emails", default: true, null: false
     t.boolean "email_on_nudge_student_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_nudge_mentor_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_mentor_timed_out_discussion_notification", default: true, null: false
     t.boolean "email_on_student_timed_out_discussion_notification", default: true, null: false
-    t.boolean "receive_onboarding_emails", default: true, null: false
     t.index ["token"], name: "index_user_communication_preferences_on_token"
     t.index ["user_id"], name: "fk_rails_65642a5510"
   end
@@ -1594,11 +1696,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.bigint "user_id", null: false
     t.bigint "installation_id", null: false
     t.string "repo_full_name", null: false
-    t.boolean "enabled", null: false, default: true
-    t.boolean "sync_on_iteration_creation", null: false, default: true
-    t.boolean "sync_exercise_files", null: false
-    t.integer "processing_method", null: false, default: 1
-    t.string "main_branch_name", null: false, default: "main"
+    t.boolean "enabled", default: true, null: false
+    t.boolean "sync_on_iteration_creation", default: true, null: false
+    t.boolean "sync_exercise_files", default: false, null: false
+    t.integer "processing_method", default: 1, null: false
+    t.string "main_branch_name", default: "main", null: false
     t.string "commit_message_template", null: false
     t.string "path_template", null: false
     t.datetime "created_at", null: false
@@ -1802,7 +1904,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.string "video_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "context"
+    t.string "context", default: "0", null: false
     t.index ["context"], name: "index_user_watched_videos_on_context"
     t.index ["user_id", "video_provider", "video_id"], name: "user_watched_videos_uniq", unique: true
     t.index ["user_id"], name: "index_user_watched_videos_on_user_id"
@@ -1834,6 +1936,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.datetime "disabled_at"
     t.integer "flair", limit: 1
     t.integer "version", limit: 2, default: 0, null: false
+    t.datetime "shadow_banned_at"
+    t.bigint "shadow_banned_by_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -1841,17 +1945,21 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["shadow_banned_by_id"], name: "fk_rails_5f0a1f5e10"
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
+  add_foreign_key "bootcamp_chat_messages", "bootcamp_solutions", column: "solution_id"
   add_foreign_key "bootcamp_concepts", "bootcamp_concepts", column: "parent_id"
   add_foreign_key "bootcamp_custom_functions", "users"
   add_foreign_key "bootcamp_drawings", "users"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_concepts", column: "concept_id"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_exercises", column: "exercise_id"
   add_foreign_key "bootcamp_submissions", "bootcamp_solutions", column: "solution_id"
+  add_foreign_key "bootcamp_user_projects", "bootcamp_projects", column: "project_id"
+  add_foreign_key "bootcamp_user_projects", "users"
   add_foreign_key "cohort_memberships", "cohorts"
   add_foreign_key "cohort_memberships", "users"
   add_foreign_key "cohorts", "tracks"
@@ -1902,6 +2010,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   add_foreign_key "github_team_members", "tracks"
   add_foreign_key "github_team_members", "users"
   add_foreign_key "jiki_signups", "users"
+  add_foreign_key "localization_glossary_entry_proposals", "localization_glossary_entries", column: "glossary_entry_id"
+  add_foreign_key "localization_glossary_entry_proposals", "users", column: "proposer_id"
+  add_foreign_key "localization_glossary_entry_proposals", "users", column: "reviewer_id"
+  add_foreign_key "localization_translation_proposals", "localization_translations", column: "translation_id"
+  add_foreign_key "localization_translation_proposals", "users", column: "proposer_id"
+  add_foreign_key "localization_translation_proposals", "users", column: "reviewer_id"
+  add_foreign_key "localization_translations", "localization_originals", column: "key", primary_key: "key"
   add_foreign_key "mentor_discussion_posts", "iterations"
   add_foreign_key "mentor_discussion_posts", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_discussion_posts", "users"
@@ -1932,7 +2047,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   add_foreign_key "solution_tags", "exercises"
   add_foreign_key "solution_tags", "solutions"
   add_foreign_key "solution_tags", "users"
-  add_foreign_key "solutions", "exercise_approaches"
   add_foreign_key "solutions", "exercise_representations", column: "published_exercise_representation_id"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
@@ -1967,6 +2081,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   add_foreign_key "user_bootcamp_data", "users"
   add_foreign_key "user_communication_preferences", "users"
   add_foreign_key "user_dismissed_introducers", "users"
+  add_foreign_key "user_github_solution_syncers", "users"
   add_foreign_key "user_mailshots", "mailshots"
   add_foreign_key "user_notifications", "exercises"
   add_foreign_key "user_notifications", "tracks"
@@ -1989,4 +2104,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_09_141203) do
   add_foreign_key "user_track_viewed_exercise_approaches", "users"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
+  add_foreign_key "users", "users", column: "shadow_banned_by_id"
 end

--- a/test/commands/mentor/discussion/retrieve_test.rb
+++ b/test/commands/mentor/discussion/retrieve_test.rb
@@ -187,4 +187,16 @@ class Mentor::Discussion::RetrieveTest < ActiveSupport::TestCase
       Mentor::Discussion::Retrieve.(user, status)
     end
   end
+
+  test "does not retrieve shadow-banned students' discussions" do
+    mentor = create :user
+
+    normal_discussion = create :mentor_discussion, :awaiting_mentor, mentor: mentor
+
+    shadow_banned_discussion = create :mentor_discussion, :awaiting_mentor, mentor: mentor
+    shadow_banned_student = shadow_banned_discussion.solution.user
+    shadow_banned_student.update!(shadow_banned_at: Time.current)
+
+    assert_equal [normal_discussion], Mentor::Discussion::Retrieve.(mentor, :awaiting_mentor, page: 1)
+  end
 end

--- a/test/commands/mentor/request/retrieve_test.rb
+++ b/test/commands/mentor/request/retrieve_test.rb
@@ -173,4 +173,33 @@ class Mentor::Request::RetrieveTest < ActiveSupport::TestCase
     assert requests.is_a?(ActiveRecord::Relation)
     refute_respond_to requests, :current_page
   end
+
+  test "does not retrieve shadow-banned students' requests" do
+    mentored_track = create :track
+    mentor = create :user
+    create :user_track_mentorship, user: mentor, track: mentored_track
+
+    normal_student = create :user
+    banned_student = create :user, shadow_banned_at: Time.current
+
+    normal_solution = create :concept_solution, track: mentored_track, user: normal_student
+    banned_solution = create :concept_solution, track: mentored_track, user: banned_student
+
+    normal_request = create :mentor_request, solution: normal_solution
+    create :mentor_request, solution: banned_solution
+
+    assert_equal [normal_request], Mentor::Request::Retrieve.(mentor:)
+  end
+
+  test "shadow-banned mentor sees empty queue" do
+    mentored_track = create :track
+    mentor = create :user, shadow_banned_at: Time.current
+    create :user_track_mentorship, user: mentor, track: mentored_track
+
+    student = create :user
+    solution = create :concept_solution, track: mentored_track, user: student
+    create :mentor_request, solution: solution
+
+    assert_empty Mentor::Request::Retrieve.(mentor:)
+  end
 end

--- a/test/controllers/moderation/shadow_banned_users_controller_test.rb
+++ b/test/controllers/moderation/shadow_banned_users_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Moderation::ShadowBannedUsersControllerTest < ActionDispatch::IntegrationTest
+  test "index redirects if not signed in" do
+    get moderation_shadow_banned_users_url
+
+    assert_response :redirect
+  end
+
+  test "index redirects if not moderator" do
+    sign_in!
+
+    get moderation_shadow_banned_users_url
+
+    assert_response :redirect
+  end
+
+  test "index succeeds for moderator" do
+    user = create(:user, :staff)
+
+    sign_in!(user)
+
+    get moderation_shadow_banned_users_url
+
+    assert_response :success
+  end
+
+  test "create shadow bans a user" do
+    moderator = create(:user, :staff)
+    student = create :user
+
+    sign_in!(moderator)
+
+    post moderation_shadow_banned_users_url, params: { handle: student.handle }
+
+    student.reload
+    assert student.shadow_banned?
+    assert_equal moderator.id, student.shadow_banned_by_id
+    assert_redirected_to moderation_shadow_banned_users_url
+  end
+
+  test "create handles unknown handle" do
+    moderator = create(:user, :staff)
+    sign_in!(moderator)
+
+    post moderation_shadow_banned_users_url, params: { handle: "nonexistent" }
+
+    assert_redirected_to moderation_shadow_banned_users_url
+  end
+
+  test "destroy removes shadow ban" do
+    moderator = create(:user, :staff)
+    student = create :user, shadow_banned_at: Time.current, shadow_banned_by_id: moderator.id
+
+    sign_in!(moderator)
+
+    delete moderation_shadow_banned_user_url(student)
+
+    student.reload
+    refute student.shadow_banned?
+    assert_nil student.shadow_banned_by_id
+    assert_redirected_to moderation_shadow_banned_users_url
+  end
+end


### PR DESCRIPTION
## Summary
- Add `shadow_banned_at` and `shadow_banned_by_id` columns to users table
- Shadow-banned students' mentoring requests are hidden from all mentors
- Shadow-banned students' mentoring discussions are hidden from all mentors
- Shadow-banned mentors see an empty request queue
- New `/moderation/shadow_banned_users` UI for moderators to add/remove shadow bans
- Tracks who applied each ban and when

## Test plan
- [x] `bin/rails test test/commands/mentor/request/retrieve_test.rb` — shadow-banned students filtered out, shadow-banned mentors see empty queue
- [x] `bin/rails test test/commands/mentor/discussion/retrieve_test.rb` — shadow-banned students' discussions filtered out
- [x] `bin/rails test test/controllers/moderation/shadow_banned_users_controller_test.rb` — access control, create/destroy actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)