### PR TITLE
Remove admin guard from perk click logging

### DIFF
--- a/app/commands/partner/log_perk_click.rb
+++ b/app/commands/partner/log_perk_click.rb
@@ -5,18 +5,10 @@ class Partner
     initialize_with :perk, :user, :clicked_at
 
     def call
-      return unless valid_click?
-
       Perk.where(id: perk.id).update_all('num_clicks = num_clicks + 1')
     end
 
     private
-    def valid_click?
-      return false if user&.admin?
-
-      true
-    end
-
     def doc
       {
         perk_id: perk.id,

--- a/test/commands/partner/log_perk_click_test.rb
+++ b/test/commands/partner/log_perk_click_test.rb
@@ -9,14 +9,4 @@ class Partner::LogPerkClickTest < ActiveSupport::TestCase
 
     assert_equal 1, perk.reload.num_clicks
   end
-
-  test "doesn't log for admin users" do
-    perk = create :perk
-    user = create :user, :admin
-    assert_equal 0, perk.num_clicks
-
-    Partner::LogPerkClick.(perk, user, nil)
-
-    assert_equal 0, perk.reload.num_clicks
-  end
 end


### PR DESCRIPTION
## Summary
- Drops the `user&.admin?` short-circuit in `Partner::LogPerkClick` so admin clicks are counted alongside everyone else's, mirroring the recent change to `LogAdvertClick`.

## Test plan
- [ ] Existing perk click test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)