### PR TITLE
[FIX]: Feedback page not producing expected description

### DIFF
--- a/app/javascript/components/editor/FeedbackPanel/FeedbackPanelRequestMentoring.tsx
+++ b/app/javascript/components/editor/FeedbackPanel/FeedbackPanelRequestMentoring.tsx
@@ -60,7 +60,7 @@ export function RequestMentoring({
         </h4>
         <p className="text-p-base">
           <Trans
-            i18nKey="feedbackPanelRequestMentoring.feedbackPanelRequestMentoring.whyGetFeedbackDescription"
+            i18nKey="feedbackPanelRequestMentoring.feedbackPanelRequestMentoring.learningALanguage"
             ns="components/editor/FeedbackPanel"
             components={{ bold: <strong className="font-semibold" /> }}
           />


### PR DESCRIPTION
This issue was addressed in [Exercism Forum for i18n broke](http://forum.exercism.org/t/tell-us-all-the-things-that-i18n-broke/18884/46).

`Bug in every language > exercise > editor > feedback`. I just corrected the pointer to the data, which should be rendered.

Change made was: `whyGetFeedbackDescription` replaced this variable/key with the correct one which is `learningALanguage` which can be located at [/app/javascript/i18n/en/components-editor-FeedbackPanel.ts](https://github.com/exercism/website/blob/adeaff9bef05f1ed0d41b2ace6738af6ece20c00/app/javascript/i18n/en/components-editor-FeedbackPanel.ts#L12).

This was a minor fix so I don't mind if its not open to outside contributors. If it is open, I am glad to be of help.