### PR TITLE
Remove duplicate parenthetical from track welcome modal

### DIFF
--- a/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
+++ b/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
@@ -35,8 +35,7 @@ export function HasLearningModeStep({
           {t('hasLearningModeStep.startTrackInLearningOrPracticeMode', {
             trackTitle: track.title,
           })}
-        </span>{' '}
-        (You can always change later.)
+        </span>
       </p>
 
       <div className="grid grid-cols-2 gap-12 items-center">


### PR DESCRIPTION
## Bug
The track welcome modal shows `(You can always change later.)` twice and malformed punctuation (exercism/exercism#6779).

## Root cause
`startTrackInLearningOrPracticeMode` in the i18n copy already ends with `(You can always change later.)`, and `HasLearningModeStep` appended the same parenthetical again in JSX.

## Why this fix is correct
Remove the hardcoded duplicate so the modal renders the i18n string once, matching the intended copy.

Fixes exercism/exercism#6779

Made with [Cursor](https://cursor.com)