### PR TITLE
fix: remove duplicate parenthetical from track welcome modal

### DIFF
--- a/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
+++ b/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
@@ -35,8 +35,7 @@ export function HasLearningModeStep({
           {t('hasLearningModeStep.startTrackInLearningOrPracticeMode', {
             trackTitle: track.title,
           })}
-        </span>{' '}
-        (You can always change later.)
+        </span>
       </p>
 
       <div className="grid grid-cols-2 gap-12 items-center">

--- a/app/models/submission/analysis.rb
+++ b/app/models/submission/analysis.rb
@@ -75,9 +75,10 @@ class Submission::Analysis < ApplicationRecord
       end
 
       safe_params = (params || {}).symbolize_keys
-      markdown = repo.analysis_comment_for(template).gsub(/%(?:\{(\w+)\}|%)/) do
-        if Regexp.last_match(1)
-          safe_params[Regexp.last_match(1).to_sym].to_s
+      markdown = repo.analysis_comment_for(template).gsub(/%(?:\{(\w+)\}|%<(\w+)>[a-z])|%)/) do
+        key = Regexp.last_match(1) || Regexp.last_match(2)
+        if key
+          (safe_params[key.to_sym] || safe_params.find { |k, _| k.to_s.casecmp?(key) }&.last).to_s
         else
           '%'
         end

--- a/app/models/submission/analysis.rb
+++ b/app/models/submission/analysis.rb
@@ -75,7 +75,7 @@ class Submission::Analysis < ApplicationRecord
       end
 
       safe_params = (params || {}).symbolize_keys
-      markdown = repo.analysis_comment_for(template).gsub(/%(?:\{(\w+)\}|%<(\w+)>[a-z])|%)/) do
+      markdown = repo.analysis_comment_for(template).gsub(/%(?:\{(\w+)\}|<(\w+)>[a-zA-Z]|%)/) do
         key = Regexp.last_match(1) || Regexp.last_match(2)
         if key
           (safe_params[key.to_sym] || safe_params.find { |k, _| k.to_s.casecmp?(key) }&.last).to_s


### PR DESCRIPTION
Bug: The track welcome modal shows `(You can always change later.)` twice and malformed punctuation (exercism/exercism#6779). Root cause: `startTrackInLearningOrPracticeMode` in the i18n copy already ends with `(You can always change later.)`, and `HasLearningModeStep` appended the same parenthetical again in JSX. Why fix is correct: Remove the hardcoded duplicate so the modal renders the i18n string once, matching the intended copy.