### PR TITLE
Add OAuth provider for Jiki identity integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'humanize'
 
 # Authentication
 gem 'devise', '~> 4.7'
+gem 'doorkeeper', '~> 5.8'
 
 # Omniauth
 gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       faraday_middleware (~> 1.0)
       rack (>= 1.6)
     domain_name (0.6.20240107)
+    doorkeeper (5.9.1)
+      railties (>= 5)
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
@@ -680,6 +682,7 @@ DEPENDENCIES
   cssbundling-rails
   devise (~> 4.7)
   discourse_api
+  doorkeeper (~> 5.8)
   exercism-config (>= 0.130.0)
   factory_bot_rails
   friendly_id (~> 5.4.0)

--- a/app/commands/user/oauth_userinfo.rb
+++ b/app/commands/user/oauth_userinfo.rb
@@ -9,12 +9,21 @@ class User::OauthUserinfo
       handle: user.handle,
       name: user.name,
       email: user.email,
-      avatar_url: user.avatar_url,
+      avatar_url: absolute_avatar_url,
       membership_status:
     }
   end
 
   private
+  def absolute_avatar_url
+    url = user.avatar_url
+    return url if url.start_with?('http://', 'https://')
+
+    host = Rails.application.routes.default_url_options[:host].to_s
+    host = "https://#{host}" unless host.start_with?('http://', 'https://')
+    "#{host}#{url}"
+  end
+
   def membership_status
     return :lifetime_insider if user.data.insiders_status_active_lifetime?
     return :insider if user.data.insiders_status_active?

--- a/app/commands/user/oauth_userinfo.rb
+++ b/app/commands/user/oauth_userinfo.rb
@@ -1,0 +1,24 @@
+class User::OauthUserinfo
+  include Mandate
+
+  initialize_with :user
+
+  def call
+    {
+      id: user.id,
+      handle: user.handle,
+      name: user.name,
+      email: user.email,
+      avatar_url: user.avatar_url,
+      membership_status:
+    }
+  end
+
+  private
+  def membership_status
+    return :lifetime_insider if user.data.insiders_status_active_lifetime?
+    return :insider if user.data.insiders_status_active?
+
+    :normal
+  end
+end

--- a/app/controllers/api/oauth/userinfo_controller.rb
+++ b/app/controllers/api/oauth/userinfo_controller.rb
@@ -1,0 +1,19 @@
+module API
+  module Oauth
+    class UserinfoController < BaseController
+      skip_before_action :authenticate_user!, raise: false
+      skip_before_action :ensure_onboarded!, raise: false
+      skip_before_action :rate_limit_for_user!, raise: false
+      before_action :doorkeeper_authorize!
+
+      def show
+        render json: User::OauthUserinfo.(current_resource_owner)
+      end
+
+      private
+      def current_resource_owner
+        @current_resource_owner ||= User.find(doorkeeper_token.resource_owner_id)
+      end
+    end
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  orm :active_record
+
+  # Use Devise's current_user. If the user isn't signed in, bounce them to
+  # the normal Exercism sign-in flow with a return-to back to /oauth/authorize.
+  resource_owner_authenticator do
+    current_user || begin
+      store_location_for(:user, request.fullpath)
+      redirect_to(new_user_session_url)
+    end
+  end
+
+  # Restrict the Doorkeeper application admin UI to admins.
+  admin_authenticator do
+    current_user&.admin? || head(:forbidden)
+  end
+
+  # Jiki is a trusted first-party client — no consent screen.
+  skip_authorization do
+    true
+  end
+
+  # Identity-only OAuth: the access token is exchanged for a single
+  # /api/oauth/userinfo call and then discarded by the client. Keep it
+  # short-lived and don't issue refresh tokens.
+  access_token_expires_in 10.minutes
+  authorization_code_expires_in 5.minutes
+
+  # PKCE is required for all clients.
+  force_pkce
+
+  # Only support the Authorization Code flow.
+  grant_flows %w[authorization_code]
+
+  # We use one implicit scope: identity info via userinfo.
+  default_scopes :profile
+  optional_scopes
+
+  # The Authorization header is the only acceptable place for the token
+  # on the userinfo endpoint.
+  access_token_methods :from_bearer_authorization
+
+  # Reuse a valid token rather than minting a new one on each authorize.
+  reuse_access_token
+
+  base_controller 'ApplicationController'
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,155 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: "Name"
+        redirect_uri: "Redirect URI"
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: "cannot contain a fragment."
+              invalid_uri: "must be a valid URI."
+              unspecified_scheme: "must specify a scheme."
+              relative_uri: "must be an absolute URI."
+              secured_uri: "must be an HTTPS/SSL URI."
+              forbidden_uri: "is forbidden by the server."
+            scopes:
+              not_match_configured: "doesn't match those configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: "Are you sure?"
+      buttons:
+        edit: "Edit"
+        destroy: "Destroy"
+        submit: "Submit"
+        cancel: "Cancel"
+        authorize: "Authorize"
+      form:
+        error: "Whoops! Check your form for possible errors"
+      help:
+        confidential: "Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential."
+        redirect_uri: "Use one line per URI"
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require a redirect URI."
+        scopes: "Separate scopes with spaces. Leave blank to use the default scopes."
+      edit:
+        title: "Edit application"
+      index:
+        title: "Your applications"
+        new: "New Application"
+        name: "Name"
+        callback_url: "Callback URL"
+        confidential: "Confidential?"
+        actions: "Actions"
+        confidentiality:
+          "yes": "Yes"
+          "no": "No"
+      new:
+        title: "New Application"
+      show:
+        title: "Application: %{name}"
+        application_id: "UID:"
+        secret: "Secret:"
+        secret_hashed: "Secret hashed"
+        scopes: "Scopes:"
+        confidential: "Confidential:"
+        callback_urls: "Callback URLs:"
+        actions: "Actions"
+        not_defined: "Not defined"
+
+    authorizations:
+      buttons:
+        authorize: "Authorize"
+        deny: "Deny"
+      error:
+        title: "An error has occurred"
+      new:
+        title: "Authorization required"
+        prompt: "Authorize %{client_name} to use your account?"
+        able_to: "This application will be able to:"
+      show:
+        title: "Authorization code:"
+      form_post:
+        title: "Submit this form"
+
+    authorized_applications:
+      confirmations:
+        revoke: "Are you sure?"
+      buttons:
+        revoke: "Revoke"
+      index:
+        title: "Your authorized applications"
+        application: "Application"
+        created_at: "Created At"
+        date_format: "%Y-%m-%d %H:%M:%S"
+
+    pre_authorization:
+      status: "Pre-authorization"
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
+          missing_param: "Missing required parameter: %{value}."
+          request_not_authorized: "Request needs to be authorized. Required parameter for authorizing the request is missing or invalid."
+          invalid_code_challenge: "Code challenge is required."
+        invalid_redirect_uri: "The requested redirect URI is malformed or doesn't match the client redirect URI."
+        unauthorized_client: "The client is not authorized to perform this request using this method."
+        access_denied: "The resource owner or authorization server denied the request."
+        invalid_scope: "The requested scope is invalid, unknown, or malformed."
+        invalid_code_challenge_method:
+          zero: "The authorization server does not support PKCE as there are no accepted code_challenge_method values."
+          one: "The code_challenge_method must be %{challenge_methods}."
+          other: "The code_challenge_method must be one of %{challenge_methods}."
+        server_error: "The authorization server encountered an unexpected condition which prevented it from fulfilling the request."
+        temporarily_unavailable: "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
+
+        # Configuration error messages
+        credential_flow_not_configured: "Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured."
+        resource_owner_authenticator_not_configured: "Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured."
+        admin_authenticator_not_configured: "Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured."
+
+        # Access grant errors
+        unsupported_response_type: "The authorization server does not support this response type."
+        unsupported_response_mode: "The authorization server does not support this response mode."
+
+        # Access token errors
+        invalid_client: "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
+        invalid_grant: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+        unsupported_grant_type: "The authorization grant type is not supported by the authorization server."
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: "Application created."
+        destroy:
+          notice: "Application deleted."
+        update:
+          notice: "Application updated."
+      authorized_applications:
+        destroy:
+          notice: "Application revoked."
+
+    layouts:
+      admin:
+        title: "Doorkeeper"
+        nav:
+          oauth2_provider: "OAuth2 Provider"
+          applications: "Applications"
+          home: "Home"
+      application:
+        title: "OAuth authorization required"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ require 'sidekiq/web'
 require 'sidekiq-scheduler/web'
 
 Rails.application.routes.draw do
+  use_doorkeeper do
+    skip_controllers :applications, :authorized_applications
+  end
   mount ActionCable.server => '/cable'
   authenticate :user, ->(user) { user.admin? } do
     mount Sidekiq::Web => '/sidekiq'

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -288,6 +288,10 @@ namespace :api do
     end
 
     post "markdown/parse" => "markdown#parse", as: "parse_markdown"
+
+    namespace :oauth do
+      get :userinfo, to: 'userinfo#show'
+    end
   end
 end
 get "api/(*url)", to: 'api/errors#render_404'

--- a/db/migrate/20260531084553_create_doorkeeper_tables.rb
+++ b/db/migrate/20260531084553_create_doorkeeper_tables.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[7.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      # Remove `null: false` or use conditional constraint if you are planning to use public clients.
+      t.string  :secret,  null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :code_challenge
+      t.string   :code_challenge_method
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
+  end
+end

--- a/db/migrate/20260531084553_create_doorkeeper_tables.rb
+++ b/db/migrate/20260531084553_create_doorkeeper_tables.rb
@@ -2,6 +2,8 @@
 
 class CreateDoorkeeperTables < ActiveRecord::Migration[7.1]
   def change
+    return if Rails.env.production?
+
     create_table :oauth_applications do |t|
       t.string  :name,    null: false
       t.string  :uid,     null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,11 +39,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "add_uuid_to_code_tags_samples", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "name", null: false
@@ -75,15 +70,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
   end
 
-  create_table "bootcamp_chat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "solution_id", null: false
-    t.integer "author", null: false
-    t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["solution_id"], name: "index_bootcamp_chat_messages_on_solution_id"
-  end
-
   create_table "bootcamp_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.bigint "parent_id"
@@ -103,8 +89,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.string "uuid", null: false
     t.bigint "user_id", null: false
     t.boolean "active", default: false, null: false
-    t.text "description", null: false
     t.text "code", null: false
+    t.text "description", null: false
     t.text "tests", size: :long, null: false
     t.string "name", null: false
     t.integer "arity", null: false
@@ -147,7 +133,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.integer "level_idx", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "uuid"
     t.boolean "has_bonus_tasks", default: false, null: false
     t.boolean "blocks_project_progression", default: true, null: false
     t.boolean "blocks_level_progression", default: true, null: false
@@ -166,7 +151,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.datetime "updated_at", null: false
     t.string "youtube_id"
     t.string "labs_youtube_id"
-    t.integer "part", default: 1, null: false
   end
 
   create_table "bootcamp_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -177,7 +161,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.text "introduction_html", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "uuid"
   end
 
   create_table "bootcamp_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -297,27 +280,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
-  create_table "conversations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "course_slug", null: false
-    t.string "country_code_2"
-    t.datetime "paid_at"
-    t.string "checkout_session_id"
-    t.string "access_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "email_status", limit: 1, default: 0, null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
-  end
-
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -336,6 +298,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["track_id", "position"], name: "index_documents_on_track_id_and_position"
     t.index ["track_id"], name: "index_documents_on_track_id"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
+  end
+
+  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "course_slug", null: false
+    t.string "country_code_2"
+    t.datetime "paid_at"
+    t.string "checkout_session_id"
+    t.string "access_code"
+    t.integer "email_status", limit: 1, default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
   end
 
   create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -558,9 +536,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   end
 
   create_table "exercise_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "exercise_id", null: false
     t.string "tag", null: false
     t.boolean "filterable", default: true, null: false
+    t.bigint "exercise_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_id", "tag"], name: "index_exercise_tags_on_exercise_id_and_tag", unique: true
@@ -739,82 +717,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_jiki_signups_on_user_id", unique: true
-  end
-
-  create_table "localization_glossary_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "locale", null: false
-    t.string "term", null: false
-    t.string "translation", null: false
-    t.text "llm_instructions", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 1, null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_localization_glossary_entries_on_uuid", unique: true
-  end
-
-  create_table "localization_glossary_entry_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "type", null: false
-    t.integer "status", default: 0, null: false
-    t.string "uuid", null: false
-    t.bigint "glossary_entry_id"
-    t.bigint "proposer_id", null: false
-    t.bigint "reviewer_id"
-    t.string "term"
-    t.string "locale"
-    t.string "translation"
-    t.text "llm_instructions"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["glossary_entry_id"], name: "idx_on_glossary_entry_id_3c0b97fb4f"
-    t.index ["proposer_id"], name: "index_localization_glossary_entry_proposals_on_proposer_id"
-    t.index ["reviewer_id"], name: "index_localization_glossary_entry_proposals_on_reviewer_id"
-  end
-
-  create_table "localization_originals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.string "type", null: false
-    t.string "about_type"
-    t.bigint "about_id"
-    t.string "key", null: false
-    t.text "value", null: false
-    t.text "usage_details"
-    t.boolean "should_translate", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_localization_originals_on_key", unique: true
-    t.index ["type", "about_type", "about_id"], name: "idx_on_type_about_type_about_id_13bf9a28f1"
-    t.index ["type"], name: "index_localization_originals_on_type"
-    t.index ["uuid"], name: "index_localization_originals_on_uuid", unique: true
-  end
-
-  create_table "localization_translation_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.bigint "translation_id", null: false
-    t.bigint "proposer_id", null: false
-    t.bigint "reviewer_id"
-    t.integer "status", default: 0, null: false
-    t.boolean "modified_from_llm", null: false
-    t.text "value", null: false
-    t.text "llm_feedback"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["proposer_id"], name: "index_localization_translation_proposals_on_proposer_id"
-    t.index ["reviewer_id"], name: "index_localization_translation_proposals_on_reviewer_id"
-    t.index ["translation_id"], name: "index_localization_translation_proposals_on_translation_id"
-    t.index ["uuid"], name: "index_localization_translation_proposals_on_uuid", unique: true
-  end
-
-  create_table "localization_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.string "locale", null: false
-    t.string "key", null: false
-    t.text "value"
-    t.integer "status", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key", "locale"], name: "index_localization_translations_on_key_and_locale", unique: true
-    t.index ["uuid"], name: "index_localization_translations_on_uuid", unique: true
   end
 
   create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1213,10 +1115,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   end
 
   create_table "solution_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "tag", null: false
     t.bigint "solution_id", null: false
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
-    t.string "tag", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "track_id", null: false
@@ -1262,9 +1164,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
     t.bigint "published_exercise_representation_id"
+    t.bigint "exercise_approach_id"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_2"
+    t.index ["exercise_approach_id"], name: "index_solutions_on_exercise_approach_id"
     t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "id"], name: "mentor_selection_idx_3"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_solutions_on_exercise_id_and_git_important_files_hash"
     t.index ["exercise_id", "status", "num_stars", "updated_at"], name: "solutions_ex_stat_stars_upat"
@@ -1355,11 +1259,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
-  create_table "submission_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "submission_id", null: false
@@ -1401,7 +1300,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.integer "exercise_representer_version", limit: 2, default: 1, null: false
     t.bigint "approach_id"
     t.json "tags"
-    t.index "`exercise_id`, `approach_id`, (json_value(`tags`, _utf8mb4'$[0]' returning char(512) null on empty))", name: "index_submissions_exercise_approach_tags"
     t.index ["approach_id"], name: "index_submissions_on_approach_id"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_submissions_on_exercise_id_and_git_important_files_hash"
     t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
@@ -1672,11 +1570,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.boolean "email_about_events", default: true, null: false
     t.boolean "email_about_insiders", default: true, null: false
     t.boolean "email_on_acquired_trophy_notification", default: true, null: false
-    t.boolean "receive_onboarding_emails", default: true, null: false
     t.boolean "email_on_nudge_student_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_nudge_mentor_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_mentor_timed_out_discussion_notification", default: true, null: false
     t.boolean "email_on_student_timed_out_discussion_notification", default: true, null: false
+    t.boolean "receive_onboarding_emails", default: true, null: false
     t.index ["token"], name: "index_user_communication_preferences_on_token"
     t.index ["user_id"], name: "fk_rails_65642a5510"
   end
@@ -1740,11 +1638,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.bigint "user_id", null: false
     t.bigint "installation_id", null: false
     t.string "repo_full_name", null: false
-    t.boolean "enabled", default: true, null: false
-    t.boolean "sync_on_iteration_creation", default: true, null: false
-    t.boolean "sync_exercise_files", default: false, null: false
-    t.integer "processing_method", default: 1, null: false
-    t.string "main_branch_name", default: "main", null: false
+    t.boolean "enabled", null: false, default: true
+    t.boolean "sync_on_iteration_creation", null: false, default: true
+    t.boolean "sync_exercise_files", null: false
+    t.integer "processing_method", null: false, default: 1
+    t.string "main_branch_name", null: false, default: "main"
     t.string "commit_message_template", null: false
     t.string "path_template", null: false
     t.datetime "created_at", null: false
@@ -1948,7 +1846,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.string "video_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "context", default: "0", null: false
+    t.string "context"
     t.index ["context"], name: "index_user_watched_videos_on_context"
     t.index ["user_id", "video_provider", "video_id"], name: "user_watched_videos_uniq", unique: true
     t.index ["user_id"], name: "index_user_watched_videos_on_user_id"
@@ -1989,21 +1887,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["shadow_banned_by_id"], name: "fk_rails_5f0a1f5e10"
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
-  add_foreign_key "bootcamp_chat_messages", "bootcamp_solutions", column: "solution_id"
   add_foreign_key "bootcamp_concepts", "bootcamp_concepts", column: "parent_id"
   add_foreign_key "bootcamp_custom_functions", "users"
   add_foreign_key "bootcamp_drawings", "users"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_concepts", column: "concept_id"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_exercises", column: "exercise_id"
   add_foreign_key "bootcamp_submissions", "bootcamp_solutions", column: "solution_id"
-  add_foreign_key "bootcamp_user_projects", "bootcamp_projects", column: "project_id"
-  add_foreign_key "bootcamp_user_projects", "users"
   add_foreign_key "cohort_memberships", "cohorts"
   add_foreign_key "cohort_memberships", "users"
   add_foreign_key "cohorts", "tracks"
@@ -2054,13 +1948,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   add_foreign_key "github_team_members", "tracks"
   add_foreign_key "github_team_members", "users"
   add_foreign_key "jiki_signups", "users"
-  add_foreign_key "localization_glossary_entry_proposals", "localization_glossary_entries", column: "glossary_entry_id"
-  add_foreign_key "localization_glossary_entry_proposals", "users", column: "proposer_id"
-  add_foreign_key "localization_glossary_entry_proposals", "users", column: "reviewer_id"
-  add_foreign_key "localization_translation_proposals", "localization_translations", column: "translation_id"
-  add_foreign_key "localization_translation_proposals", "users", column: "proposer_id"
-  add_foreign_key "localization_translation_proposals", "users", column: "reviewer_id"
-  add_foreign_key "localization_translations", "localization_originals", column: "key", primary_key: "key"
   add_foreign_key "mentor_discussion_posts", "iterations"
   add_foreign_key "mentor_discussion_posts", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_discussion_posts", "users"
@@ -2093,6 +1980,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   add_foreign_key "solution_tags", "exercises"
   add_foreign_key "solution_tags", "solutions"
   add_foreign_key "solution_tags", "users"
+  add_foreign_key "solutions", "exercise_approaches"
   add_foreign_key "solutions", "exercise_representations", column: "published_exercise_representation_id"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
@@ -2127,7 +2015,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   add_foreign_key "user_bootcamp_data", "users"
   add_foreign_key "user_communication_preferences", "users"
   add_foreign_key "user_dismissed_introducers", "users"
-  add_foreign_key "user_github_solution_syncers", "users"
   add_foreign_key "user_mailshots", "mailshots"
   add_foreign_key "user_notifications", "exercises"
   add_foreign_key "user_notifications", "tracks"
@@ -2150,5 +2037,4 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   add_foreign_key "user_track_viewed_exercise_approaches", "users"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
-  add_foreign_key "users", "users", column: "shadow_banned_by_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "add_uuid_to_code_tags_samples", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "badges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -70,6 +75,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
   end
 
+  create_table "bootcamp_chat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "solution_id", null: false
+    t.integer "author", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["solution_id"], name: "index_bootcamp_chat_messages_on_solution_id"
+  end
+
   create_table "bootcamp_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.bigint "parent_id"
@@ -89,8 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.string "uuid", null: false
     t.bigint "user_id", null: false
     t.boolean "active", default: false, null: false
-    t.text "code", null: false
     t.text "description", null: false
+    t.text "code", null: false
     t.text "tests", size: :long, null: false
     t.string "name", null: false
     t.integer "arity", null: false
@@ -133,6 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "level_idx", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid"
     t.boolean "has_bonus_tasks", default: false, null: false
     t.boolean "blocks_project_progression", default: true, null: false
     t.boolean "blocks_level_progression", default: true, null: false
@@ -151,6 +166,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.datetime "updated_at", null: false
     t.string "youtube_id"
     t.string "labs_youtube_id"
+    t.integer "part", default: 1, null: false
   end
 
   create_table "bootcamp_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -161,6 +177,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.text "introduction_html", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid"
   end
 
   create_table "bootcamp_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -280,6 +297,27 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["watch_id", "exercise_id"], name: "index_community_videos_on_watch_id_and_exercise_id", unique: true
   end
 
+  create_table "conversations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "course_slug", null: false
+    t.string "country_code_2"
+    t.datetime "paid_at"
+    t.string "checkout_session_id"
+    t.string "access_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "email_status", limit: 1, default: 0, null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
+  end
+
   create_table "documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "track_id"
@@ -298,22 +336,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["track_id", "position"], name: "index_documents_on_track_id_and_position"
     t.index ["track_id"], name: "index_documents_on_track_id"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
-  end
-
-  create_table "course_enrollments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "course_slug", null: false
-    t.string "country_code_2"
-    t.datetime "paid_at"
-    t.string "checkout_session_id"
-    t.string "access_code"
-    t.integer "email_status", limit: 1, default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "uuid", null: false
-    t.index ["uuid"], name: "index_course_enrollments_on_uuid", unique: true
   end
 
   create_table "donations_payments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -536,9 +558,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   end
 
   create_table "exercise_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "exercise_id", null: false
     t.string "tag", null: false
     t.boolean "filterable", default: true, null: false
-    t.bigint "exercise_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_id", "tag"], name: "index_exercise_tags_on_exercise_id_and_tag", unique: true
@@ -719,6 +741,82 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["user_id"], name: "index_jiki_signups_on_user_id", unique: true
   end
 
+  create_table "localization_glossary_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "term", null: false
+    t.string "translation", null: false
+    t.text "llm_instructions", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 1, null: false
+    t.string "uuid", null: false
+    t.index ["uuid"], name: "index_localization_glossary_entries_on_uuid", unique: true
+  end
+
+  create_table "localization_glossary_entry_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "type", null: false
+    t.integer "status", default: 0, null: false
+    t.string "uuid", null: false
+    t.bigint "glossary_entry_id"
+    t.bigint "proposer_id", null: false
+    t.bigint "reviewer_id"
+    t.string "term"
+    t.string "locale"
+    t.string "translation"
+    t.text "llm_instructions"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["glossary_entry_id"], name: "idx_on_glossary_entry_id_3c0b97fb4f"
+    t.index ["proposer_id"], name: "index_localization_glossary_entry_proposals_on_proposer_id"
+    t.index ["reviewer_id"], name: "index_localization_glossary_entry_proposals_on_reviewer_id"
+  end
+
+  create_table "localization_originals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "type", null: false
+    t.string "about_type"
+    t.bigint "about_id"
+    t.string "key", null: false
+    t.text "value", null: false
+    t.text "usage_details"
+    t.boolean "should_translate", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_localization_originals_on_key", unique: true
+    t.index ["type", "about_type", "about_id"], name: "idx_on_type_about_type_about_id_13bf9a28f1"
+    t.index ["type"], name: "index_localization_originals_on_type"
+    t.index ["uuid"], name: "index_localization_originals_on_uuid", unique: true
+  end
+
+  create_table "localization_translation_proposals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.bigint "translation_id", null: false
+    t.bigint "proposer_id", null: false
+    t.bigint "reviewer_id"
+    t.integer "status", default: 0, null: false
+    t.boolean "modified_from_llm", null: false
+    t.text "value", null: false
+    t.text "llm_feedback"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proposer_id"], name: "index_localization_translation_proposals_on_proposer_id"
+    t.index ["reviewer_id"], name: "index_localization_translation_proposals_on_reviewer_id"
+    t.index ["translation_id"], name: "index_localization_translation_proposals_on_translation_id"
+    t.index ["uuid"], name: "index_localization_translation_proposals_on_uuid", unique: true
+  end
+
+  create_table "localization_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key", "locale"], name: "index_localization_translations_on_key_and_locale", unique: true
+    t.index ["uuid"], name: "index_localization_translations_on_uuid", unique: true
+  end
+
   create_table "mailshots", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.string "email_communication_preferences_key", null: false
@@ -890,6 +988,50 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["type", "track_id", "occurred_at"], name: "index_metrics_on_type_and_track_id_and_occurred_at"
     t.index ["uniqueness_key"], name: "index_metrics_on_uniqueness_key", unique: true
     t.index ["user_id"], name: "index_metrics_on_user_id"
+  end
+
+  create_table "oauth_access_grants", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "resource_owner_id", null: false
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "code_challenge"
+    t.string "code_challenge_method"
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "resource_owner_id"
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.string "scopes"
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "previous_refresh_token", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   create_table "partner_adverts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1071,10 +1213,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   end
 
   create_table "solution_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "tag", null: false
     t.bigint "solution_id", null: false
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
+    t.string "tag", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "track_id", null: false
@@ -1120,11 +1262,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "latest_iteration_head_tests_status", limit: 1, default: 0, null: false
     t.boolean "unlocked_help", default: false, null: false
     t.bigint "published_exercise_representation_id"
-    t.bigint "exercise_approach_id"
     t.index ["approved_by_id"], name: "fk_rails_4cc89d0b11"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_1"
     t.index ["created_at", "exercise_id"], name: "mentor_selection_idx_2"
-    t.index ["exercise_approach_id"], name: "index_solutions_on_exercise_approach_id"
     t.index ["exercise_id", "approved_by_id", "completed_at", "mentoring_requested_at", "id"], name: "mentor_selection_idx_3"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_solutions_on_exercise_id_and_git_important_files_hash"
     t.index ["exercise_id", "status", "num_stars", "updated_at"], name: "solutions_ex_stat_stars_upat"
@@ -1215,6 +1355,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["track_id"], name: "index_submission_representations_on_track_id"
   end
 
+  create_table "submission_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "submission_test_runs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.bigint "submission_id", null: false
@@ -1256,6 +1401,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.integer "exercise_representer_version", limit: 2, default: 1, null: false
     t.bigint "approach_id"
     t.json "tags"
+    t.index "`exercise_id`, `approach_id`, (json_value(`tags`, _utf8mb4'$[0]' returning char(512) null on empty))", name: "index_submissions_exercise_approach_tags"
     t.index ["approach_id"], name: "index_submissions_on_approach_id"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_submissions_on_exercise_id_and_git_important_files_hash"
     t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"
@@ -1526,11 +1672,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.boolean "email_about_events", default: true, null: false
     t.boolean "email_about_insiders", default: true, null: false
     t.boolean "email_on_acquired_trophy_notification", default: true, null: false
+    t.boolean "receive_onboarding_emails", default: true, null: false
     t.boolean "email_on_nudge_student_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_nudge_mentor_to_reply_in_discussion_notification", default: true, null: false
     t.boolean "email_on_mentor_timed_out_discussion_notification", default: true, null: false
     t.boolean "email_on_student_timed_out_discussion_notification", default: true, null: false
-    t.boolean "receive_onboarding_emails", default: true, null: false
     t.index ["token"], name: "index_user_communication_preferences_on_token"
     t.index ["user_id"], name: "fk_rails_65642a5510"
   end
@@ -1594,11 +1740,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.bigint "user_id", null: false
     t.bigint "installation_id", null: false
     t.string "repo_full_name", null: false
-    t.boolean "enabled", null: false, default: true
-    t.boolean "sync_on_iteration_creation", null: false, default: true
-    t.boolean "sync_exercise_files", null: false
-    t.integer "processing_method", null: false, default: 1
-    t.string "main_branch_name", null: false, default: "main"
+    t.boolean "enabled", default: true, null: false
+    t.boolean "sync_on_iteration_creation", default: true, null: false
+    t.boolean "sync_exercise_files", default: false, null: false
+    t.integer "processing_method", default: 1, null: false
+    t.string "main_branch_name", default: "main", null: false
     t.string "commit_message_template", null: false
     t.string "path_template", null: false
     t.datetime "created_at", null: false
@@ -1802,7 +1948,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.string "video_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "context"
+    t.string "context", default: "0", null: false
     t.index ["context"], name: "index_user_watched_videos_on_context"
     t.index ["user_id", "video_provider", "video_id"], name: "user_watched_videos_uniq", unique: true
     t.index ["user_id"], name: "index_user_watched_videos_on_user_id"
@@ -1843,17 +1989,21 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reputation"], name: "index_users_on_reputation"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["shadow_banned_by_id"], name: "fk_rails_5f0a1f5e10"
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users", column: "author_id"
+  add_foreign_key "bootcamp_chat_messages", "bootcamp_solutions", column: "solution_id"
   add_foreign_key "bootcamp_concepts", "bootcamp_concepts", column: "parent_id"
   add_foreign_key "bootcamp_custom_functions", "users"
   add_foreign_key "bootcamp_drawings", "users"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_concepts", column: "concept_id"
   add_foreign_key "bootcamp_exercise_concepts", "bootcamp_exercises", column: "exercise_id"
   add_foreign_key "bootcamp_submissions", "bootcamp_solutions", column: "solution_id"
+  add_foreign_key "bootcamp_user_projects", "bootcamp_projects", column: "project_id"
+  add_foreign_key "bootcamp_user_projects", "users"
   add_foreign_key "cohort_memberships", "cohorts"
   add_foreign_key "cohort_memberships", "users"
   add_foreign_key "cohorts", "tracks"
@@ -1904,6 +2054,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "github_team_members", "tracks"
   add_foreign_key "github_team_members", "users"
   add_foreign_key "jiki_signups", "users"
+  add_foreign_key "localization_glossary_entry_proposals", "localization_glossary_entries", column: "glossary_entry_id"
+  add_foreign_key "localization_glossary_entry_proposals", "users", column: "proposer_id"
+  add_foreign_key "localization_glossary_entry_proposals", "users", column: "reviewer_id"
+  add_foreign_key "localization_translation_proposals", "localization_translations", column: "translation_id"
+  add_foreign_key "localization_translation_proposals", "users", column: "proposer_id"
+  add_foreign_key "localization_translation_proposals", "users", column: "reviewer_id"
+  add_foreign_key "localization_translations", "localization_originals", column: "key", primary_key: "key"
   add_foreign_key "mentor_discussion_posts", "iterations"
   add_foreign_key "mentor_discussion_posts", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_discussion_posts", "users"
@@ -1917,6 +2074,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "mentor_testimonials", "mentor_discussions", column: "discussion_id"
   add_foreign_key "mentor_testimonials", "users", column: "mentor_id"
   add_foreign_key "mentor_testimonials", "users", column: "student_id"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "partner_adverts", "partners"
   add_foreign_key "partner_perks", "partners"
   add_foreign_key "problem_reports", "exercises"
@@ -1934,7 +2093,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "solution_tags", "exercises"
   add_foreign_key "solution_tags", "solutions"
   add_foreign_key "solution_tags", "users"
-  add_foreign_key "solutions", "exercise_approaches"
   add_foreign_key "solutions", "exercise_representations", column: "published_exercise_representation_id"
   add_foreign_key "solutions", "exercises"
   add_foreign_key "solutions", "iterations", column: "published_iteration_id"
@@ -1969,6 +2127,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "user_bootcamp_data", "users"
   add_foreign_key "user_communication_preferences", "users"
   add_foreign_key "user_dismissed_introducers", "users"
+  add_foreign_key "user_github_solution_syncers", "users"
   add_foreign_key "user_mailshots", "mailshots"
   add_foreign_key "user_notifications", "exercises"
   add_foreign_key "user_notifications", "tracks"
@@ -1991,4 +2150,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_000000) do
   add_foreign_key "user_track_viewed_exercise_approaches", "users"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
+  add_foreign_key "users", "users", column: "shadow_banned_by_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -543,6 +543,15 @@ kaido.perks.create!(
 
 Track::Trophies::Reseed.create!
 
+unless Doorkeeper::Application.exists?(name: "Jiki")
+  Doorkeeper::Application.create!(
+    name: "Jiki",
+    redirect_uri: "http://localhost:3061/auth/exercism/callback",
+    scopes: "profile",
+    confidential: true
+  )
+end
+
 Solution.published.each do |solution|
   next if solution.iterations.last.files.map(&:content).all?(&:empty?)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -546,7 +546,7 @@ Track::Trophies::Reseed.create!
 unless Doorkeeper::Application.exists?(name: "Jiki")
   Doorkeeper::Application.create!(
     name: "Jiki",
-    redirect_uri: "http://localhost:3061/auth/exercism/callback",
+    redirect_uri: "http://local.jiki.io:3061/auth/exercism/callback",
     scopes: "profile",
     confidential: true
   )

--- a/test/controllers/api/oauth/userinfo_controller_test.rb
+++ b/test/controllers/api/oauth/userinfo_controller_test.rb
@@ -1,0 +1,66 @@
+require_relative '../base_test_case'
+
+class API::Oauth::UserinfoControllerTest < API::BaseTestCase
+  test "returns 401 without a token" do
+    get api_oauth_userinfo_path, as: :json
+    assert_response :unauthorized
+  end
+
+  test "returns 401 with a bad token" do
+    get api_oauth_userinfo_path,
+      headers: { 'Authorization' => "Bearer not-a-real-token" }, as: :json
+    assert_response :unauthorized
+  end
+
+  test "returns the userinfo payload for a valid token" do
+    user = create(:user, handle: "alice", name: "Alice", email: "alice@example.com",
+      avatar_url: "https://example.com/a.png")
+    user.confirm
+
+    application = Doorkeeper::Application.create!(name: "Jiki",
+      redirect_uri: "https://example.com/cb", scopes: "profile")
+    token = Doorkeeper::AccessToken.create!(application:, resource_owner_id: user.id,
+      scopes: "profile", expires_in: 600)
+
+    get api_oauth_userinfo_path,
+      headers: { 'Authorization' => "Bearer #{token.token}" }, as: :json
+    assert_response :ok
+
+    assert_json_response(
+      id: user.id,
+      handle: "alice",
+      name: "Alice",
+      email: "alice@example.com",
+      avatar_url: user.avatar_url,
+      membership_status: "normal"
+    )
+  end
+
+  test "reports insider membership" do
+    user = create(:user)
+    user.data.update!(insiders_status: :active)
+    application = Doorkeeper::Application.create!(name: "Jiki",
+      redirect_uri: "https://example.com/cb", scopes: "profile")
+    token = Doorkeeper::AccessToken.create!(application:, resource_owner_id: user.id,
+      scopes: "profile", expires_in: 600)
+
+    get api_oauth_userinfo_path,
+      headers: { 'Authorization' => "Bearer #{token.token}" }, as: :json
+    assert_response :ok
+    assert_equal "insider", response.parsed_body["membership_status"]
+  end
+
+  test "reports lifetime_insider membership" do
+    user = create(:user)
+    user.data.update!(insiders_status: :active_lifetime)
+    application = Doorkeeper::Application.create!(name: "Jiki",
+      redirect_uri: "https://example.com/cb", scopes: "profile")
+    token = Doorkeeper::AccessToken.create!(application:, resource_owner_id: user.id,
+      scopes: "profile", expires_in: 600)
+
+    get api_oauth_userinfo_path,
+      headers: { 'Authorization' => "Bearer #{token.token}" }, as: :json
+    assert_response :ok
+    assert_equal "lifetime_insider", response.parsed_body["membership_status"]
+  end
+end

--- a/test/controllers/api/oauth/userinfo_controller_test.rb
+++ b/test/controllers/api/oauth/userinfo_controller_test.rb
@@ -31,7 +31,7 @@ class API::Oauth::UserinfoControllerTest < API::BaseTestCase
       handle: "alice",
       name: "Alice",
       email: "alice@example.com",
-      avatar_url: user.avatar_url,
+      avatar_url: "https://test.exercism.org#{user.avatar_url}",
       membership_status: "normal"
     )
   end


### PR DESCRIPTION
## Summary
- Adds [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) as an OAuth 2.0 provider so Jiki (a trusted first-party client) can authenticate users against Exercism.
- Mirrors Jiki's existing Google OAuth pattern: client exchanges code → access token → calls `/api/oauth/userinfo` once → discards the token.
- Exposes id, handle, name, email, avatar_url and membership_status (normal/insider/lifetime_insider) on the userinfo endpoint.

## Configuration
- `skip_authorization` is on — Jiki is first-party, no consent screen.
- PKCE is required (`force_pkce`).
- Access tokens expire after 10 minutes; no refresh tokens (identity-only use).
- Only the `authorization_code` grant flow is supported.
- Doorkeeper's applications/authorized_applications routes are skipped; admins can manage apps via the Rails console.

## Endpoints
| Route | Purpose |
| --- | --- |
| `GET /oauth/authorize` | User-facing authorization endpoint (auto-approves Jiki) |
| `POST /oauth/token` | Code → access token exchange |
| `POST /oauth/revoke` | Token revocation |
| `GET /api/oauth/userinfo` | Returns the user's identity payload |

## Test plan
- [ ] Run `bin/rails test test/controllers/api/oauth/userinfo_controller_test.rb`
- [ ] Re-seed db (`bin/rails db:seed`) and verify a Jiki `Doorkeeper::Application` row exists
- [ ] End-to-end test from Jiki API once that side is wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)