### PR TITLE
Move OAuth userinfo route out of /api/v2 namespace

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -288,10 +288,10 @@ namespace :api do
     end
 
     post "markdown/parse" => "markdown#parse", as: "parse_markdown"
+  end
 
-    namespace :oauth do
-      get :userinfo, to: 'userinfo#show'
-    end
+  namespace :oauth do
+    get :userinfo, to: 'userinfo#show'
   end
 end
 get "api/(*url)", to: 'api/errors#render_404'


### PR DESCRIPTION
## Summary
The userinfo endpoint was nested under \`scope :v2\`, putting it at \`/api/v2/oauth/userinfo\`. Jiki (and the docs we wrote) expected \`/api/oauth/userinfo\`. Requests to the unversioned URL fell through to \`api/errors#render_404\` — which inherits \`API::BaseController\`'s auth filter and rejected the Doorkeeper token with \`invalid_auth_token\`, masking the routing miss.

Moves the route up one level so it lives at \`/api/oauth/userinfo\` (identity payload isn't versioned).

This change was briefly pushed to main as \`fdcfc4702\` and reverted in \`2c4bdbbea\` so it can go through PR review.

## Test plan
- [ ] \`bin/rails test test/controllers/api/oauth/userinfo_controller_test.rb\` (passes locally)
- [ ] Run the full Jiki → Exercism OAuth flow locally and confirm userinfo returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)