### PR TITLE
Replace stale Jiki waiting list copy

### DIFF
--- a/app/javascript/i18n/en/components-modals-seniority-survey-modal.ts
+++ b/app/javascript/i18n/en/components-modals-seniority-survey-modal.ts
@@ -7,10 +7,9 @@ export default {
     "In a few weeks, you'll go from zero to making these...",
   'bootcampAd.punchline':
     "The platform for anyone that wants to get really good at coding. It's incredibly effective. It's fun. <strong>And it's free!</strong>",
-  'bootcampAd.learnMore': 'Join the Waiting List',
+  'bootcampAd.learnMore': 'Check out Jiki',
   'bootcampAd.close': 'Close',
-  'bootcampAd.offer':
-    '(The first 1,000 to join the waiting list get Premium for free!)',
+  'bootcampAd.offer': "(Did we mention it's free?)",
   'bootcampAd.videoIntro': 'Watch the Course Intro 👇',
   'bootcampAd.feature.video': '<strong>Video</strong> tutorials',
   'bootcampAd.feature.fun': '<strong>Fun</strong> projects',

--- a/app/javascript/i18n/en/components-modals-track-welcome-modal-LHS.ts
+++ b/app/javascript/i18n/en/components-modals-track-welcome-modal-LHS.ts
@@ -6,7 +6,7 @@ export default {
   'bootcampRecommendation.codingJourney':
     "If you're just starting out on your coding journey, our new platfrom <strong>Jiki</strong> might be a better fit for you.",
   'bootcampRecommendation.selfPaced':
-    "It launches in January 2026 and you can sign up for the waiting list now! And best of all, <strong>it's free!</strong>",
-  'bootcampRecommendation.cta.checkOutCourse': 'Join the Waiting List',
+    "It's available now and best of all, <strong>it's free!</strong>",
+  'bootcampRecommendation.cta.checkOutCourse': 'Check out Jiki',
   'bootcampRecommendation.cta.continueAnyway': 'Continue anyway',
 }


### PR DESCRIPTION
## Summary
- Jiki has launched, so the modal/ad copy referring to a waiting list, a January 2026 launch, or a "first 1,000 get Premium" promo is no longer accurate.
- Replaces those strings in the track welcome modal and the seniority survey modal ad with present-tense CTAs ("Check out Jiki" / "available now").

## Test plan
- [ ] Open a track as a beginner user and confirm the track-welcome bootcamp recommendation reads correctly.
- [ ] Trigger the seniority survey modal bootcamp ad and confirm the new copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)