### PR TITLE
Fix time-bomb in journey overview system test

### DIFF
--- a/test/system/flows/journey/overview_test.rb
+++ b/test/system/flows/journey/overview_test.rb
@@ -5,39 +5,42 @@ module Flows
   module Journey
     class OverviewTest < ApplicationSystemTestCase
       include CapybaraHelpers
-      include ActiveSupport::Testing::TimeHelpers
 
       test "user sees track learning details" do
         Time.zone = "UTC"
-        travel_to Time.zone.local(2024, 6, 26) do
-          user = create :user
-          track = create :track
-          create :user_track, user:, track:, created_at: Time.zone.local(2016, 12, 25)
+        # The joined date and the "N years ago" text are both rendered client-side
+        # by dayjs against the real browser clock, so travel_to (which only affects
+        # the test process) can't pin them. Anchor the join date relative to now so
+        # it stays exactly 9 years ago, permanently. Midday avoids any timezone
+        # boundary flipping the displayed date.
+        started_at = 9.years.ago.change(hour: 12)
 
-          exercise = create(:concept_exercise, track:)
-          solution = create(:concept_solution, exercise:, user:)
-          create :mentor_discussion, student: user, solution:, status: :finished
+        user = create :user
+        track = create :track
+        create :user_track, user:, track:, created_at: started_at
 
-          exercise = create(:concept_exercise, track:)
-          solution = create(:concept_solution, exercise:, user:)
-          create :mentor_discussion, student: user, solution:, status: :awaiting_student
+        exercise = create(:concept_exercise, track:)
+        solution = create(:concept_solution, exercise:, user:)
+        create :mentor_discussion, student: user, solution:, status: :finished
 
-          exercise = create(:concept_exercise, track:)
-          solution = create(:concept_solution, exercise:, user:)
-          create :mentor_request, student: user, solution:, status: :pending
+        exercise = create(:concept_exercise, track:)
+        solution = create(:concept_solution, exercise:, user:)
+        create :mentor_discussion, student: user, solution:, status: :awaiting_student
 
-          use_capybara_host do
-            sign_in!(user)
-            visit journey_url
+        exercise = create(:concept_exercise, track:)
+        solution = create(:concept_solution, exercise:, user:)
+        create :mentor_request, student: user, solution:, status: :pending
 
-            sleep 60
-            assert_text "25 Dec 2016"
-            assert_text "When you joined the Ruby Track"
-            assert_text "1 Mentoring session completed"
-            assert_text "You have 1 discussion in progress and 1 solution in the queue."
+        use_capybara_host do
+          sign_in!(user)
+          visit journey_url
 
-            assert_text "You started working through the Ruby Track 9 years ago."
-          end
+          assert_text started_at.strftime("%d %b %Y")
+          assert_text "When you joined the Ruby Track"
+          assert_text "1 Mentoring session completed"
+          assert_text "You have 1 discussion in progress and 1 solution in the queue."
+
+          assert_text "You started working through the Ruby Track 9 years ago."
         end
       end
 


### PR DESCRIPTION
## Problem

`Flows::Journey::OverviewTest#test_user_sees_track_learning_details` started failing:

```
expected to find text "You started working through the Ruby Track 9 years ago."
in "... You started working through the Ruby Track 10 years ago. ..."
```

## Cause

The test hard-coded the track join date to **Dec 2016** and wrapped everything in `travel_to Time.zone.local(2024, 6, 26)` to try to pin "now".

But both the joined date and the "N years ago" text are rendered **client-side by dayjs against the real browser clock** (`TrackSummary.tsx` → `fromNow(track.startedAt)` / `timeFormat(...)`). `travel_to` only affects the Ruby test process, **not** the Capybara app-server/browser — so the relative time was always computed against real wall-clock time. As real time advanced past the 9-year mark, dayjs now rounds 2016→today to "10 years ago", and the assertion broke. It's a latent time-bomb, unrelated to any code change.

## Fix

- Anchor the join date to `9.years.ago` (at midday, to avoid any timezone boundary flipping the displayed date) so the gap is **permanently exactly nine years**.
- Assert the displayed date dynamically (`started_at.strftime("%d %b %Y")`) instead of a literal.
- Drop the ineffective `travel_to` block and its now-unused `TimeHelpers` include.
- Remove a stray **`sleep 60`** — Capybara's `assert_text` already waits for async content, so a blind 60-second sleep was pure wasted CI time.

## Testing

Couldn't run the system suite locally (ChromeDriver here is pinned to Chrome 138 vs local Chrome 150 — environment only). The change is deterministic and CI will exercise it. Logic verified against `TrackSummary.tsx` / `utils/time` (dayjs `fromNow` rounds `9.years.ago` to "9 years ago" and stays there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)