### PR TITLE
Add translators mailshot audience

### DIFF
--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -12,7 +12,7 @@ class Admin::MailshotsController < Admin::BaseController
   def show
     @send_count = User::Mailshot.where(mailshot: @mailshot).count
     @audiences = %w[
-      admins donors insiders jiki_waiting_list challenge#12in23 challenge#48in24
+      admins donors insiders jiki_waiting_list translators challenge#12in23 challenge#48in24
     ]
     @audiences += [100, 10, 3, 2, 1].map { |min| "reputation##{min}" }
     @audiences += [10, 30, 60, 90].map { |min| "recent##{min}" }

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -35,6 +35,7 @@ class Mailshot < ApplicationRecord
   def audience_for_donors(_) = [User::Data.donors, ->(user_data) { user_data.user }]
   def audience_for_insiders(_) = [User.insiders, ->(user) { user }]
   def audience_for_jiki_waiting_list(_) = [JikiSignup.includes(:user), ->(jiki_signup) { jiki_signup.user }]
+  def audience_for_translators(_) = [User::Data.translators, ->(user_data) { user_data.user }]
 
   def audience_for_reputation(min_rep)
     [

--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -4,6 +4,7 @@ class User::Data < ApplicationRecord
 
   scope :donors, -> { where.not(first_donated_at: nil) }
   scope :public_supporter, -> { donors.where(show_on_supporters_page: true) }
+  scope :translators, -> { where.not(translator_locales: [nil, "", "[]", "{}"]) }
 
   belongs_to :user
 

--- a/test/commands/mailshot/send_to_audience_segment_test.rb
+++ b/test/commands/mailshot/send_to_audience_segment_test.rb
@@ -74,6 +74,20 @@ class Mailshot::SendToAudienceSegmentTest < ActiveSupport::TestCase
     Mailshot::SendToAudienceSegment.(mailshot, :jiki_waiting_list, nil, 10, 0)
   end
 
+  test "schedules audience_for_translators" do
+    mailshot = create :mailshot
+
+    good_user = create :user
+    good_user.update!(translator_locales: ["nl"])
+
+    bad_user = create :user
+
+    User::Mailshot::Send.expects(:call).with(good_user, mailshot)
+    User::Mailshot::Send.expects(:call).with(bad_user, mailshot).never
+
+    Mailshot::SendToAudienceSegment.(mailshot, :translators, nil, 10, 0)
+  end
+
   test "schedules audience_for_challenge" do
     mailshot = create :mailshot
 


### PR DESCRIPTION
Adds a `translators` mailshot audience so a mailshot can be sent to everyone who has set `translator_locales` (i.e. active translators).

## Changes
- New `User::Data.translators` scope filtering to records with a non-empty `translator_locales`.
- `Mailshot#audience_for_translators` returning that relation.
- Surfaces `translators` in the admin audience dropdown.
- Test covering the new audience segment.

Follows the same pattern as the recently added `jiki_waiting_list` audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)