### PR TITLE
Add seniority mailshot audiences

### DIFF
--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -12,7 +12,9 @@ class Admin::MailshotsController < Admin::BaseController
   def show
     @send_count = User::Mailshot.where(mailshot: @mailshot).count
     @audiences = %w[
-      admins donors insiders jiki_waiting_list translators challenge#12in23 challenge#48in24
+      admins donors insiders jiki_waiting_list translators
+      absolute_beginners beginners juniors mids seniors
+      challenge#12in23 challenge#48in24
     ]
     @audiences += [100, 10, 3, 2, 1].map { |min| "reputation##{min}" }
     @audiences += [10, 30, 60, 90].map { |min| "recent##{min}" }

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -36,6 +36,11 @@ class Mailshot < ApplicationRecord
   def audience_for_insiders(_) = [User.insiders, ->(user) { user }]
   def audience_for_jiki_waiting_list(_) = [JikiSignup.includes(:user), ->(jiki_signup) { jiki_signup.user }]
   def audience_for_translators(_) = [User::Data.translators, ->(user_data) { user_data.user }]
+  def audience_for_absolute_beginners(_) = [User::Data.absolute_beginner_seniority, ->(user_data) { user_data.user }]
+  def audience_for_beginners(_) = [User::Data.beginner_seniority, ->(user_data) { user_data.user }]
+  def audience_for_juniors(_) = [User::Data.junior_seniority, ->(user_data) { user_data.user }]
+  def audience_for_mids(_) = [User::Data.mid_seniority, ->(user_data) { user_data.user }]
+  def audience_for_seniors(_) = [User::Data.senior_seniority, ->(user_data) { user_data.user }]
 
   def audience_for_reputation(min_rep)
     [

--- a/test/commands/mailshot/send_to_audience_segment_test.rb
+++ b/test/commands/mailshot/send_to_audience_segment_test.rb
@@ -88,6 +88,25 @@ class Mailshot::SendToAudienceSegmentTest < ActiveSupport::TestCase
     Mailshot::SendToAudienceSegment.(mailshot, :translators, nil, 10, 0)
   end
 
+  %i[absolute_beginner beginner junior mid senior].each do |seniority|
+    audience = "#{seniority}s".to_sym
+
+    test "schedules audience_for_#{audience}" do
+      mailshot = create :mailshot
+
+      good_user = create :user
+      good_user.data.update!(seniority:)
+
+      bad_user = create :user
+      bad_user.data.update!(seniority: seniority == :senior ? :beginner : :senior)
+
+      User::Mailshot::Send.expects(:call).with(good_user, mailshot)
+      User::Mailshot::Send.expects(:call).with(bad_user, mailshot).never
+
+      Mailshot::SendToAudienceSegment.(mailshot, audience, nil, 10, 0)
+    end
+  end
+
   test "schedules audience_for_challenge" do
     mailshot = create :mailshot
 


### PR DESCRIPTION
Adds mailshot audiences for each seniority level (absolute beginners, beginners, juniors, mids, seniors), following the same pattern as the recently-added `translators` audience.

## Changes
- `app/models/mailshot.rb` — `audience_for_absolute_beginners`, `beginners`, `juniors`, `mids`, `seniors`, each backed by the existing `seniority` enum scopes on `User::Data`.
- `app/controllers/admin/mailshots_controller.rb` — surfaces the five audiences in the admin dropdown.
- `test/commands/mailshot/send_to_audience_segment_test.rb` — parameterised test covering all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)