### PR TITLE
Bust landing page etag cache

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,7 @@ class PagesController < ApplicationController
     return redirect_to dashboard_path if user_signed_in?
 
     @num_tracks = Track.num_active
-    return unless stale?(etag: @num_tracks)
+    return unless stale?(etag: [@num_tracks, 1])
 
     @tracks = Track.active.order(num_students: :desc).limit(12).to_a
 


### PR DESCRIPTION
Adds a version component to the landing page etag so previously cached responses are invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCkfS91ZjSLcGmbDehDAeH