### PR TITLE
Add temporary pre-catalog Translatathon promo banner

### DIFF
--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -42,6 +42,8 @@ module ViewComponents
     def announcement_bar
       # return downtime_announcement_bar if user_signed_in?
 
+      return translatathon_announcement_bar if user_signed_in? && translatathon_banner
+
       return coding_fundamentals_announcement_bar unless user_signed_in?
       return front_end_fundamentals_announcement_bar if javascript_track? && current_user.seniority != :absolute_beginner
       return coding_fundamentals_announcement_bar if current_user.junior?
@@ -54,6 +56,23 @@ module ViewComponents
           tag.span("👋", class: 'emoji mr-6') +
             tag.span("Enjoying Exercism? We need your help to survive…") +
             tag.strong("Please donate if you can!")
+        end
+      end
+    end
+
+    memoize
+    def translatathon_banner
+      ViewComponents::TranslatathonBanner.(request.headers["Accept-Language"])
+    end
+
+    def translatathon_announcement_bar
+      banner = translatathon_banner
+      link_to(banner.url, class: "announcement-bar md:block hidden", target: "_blank", rel: "noopener", dir: banner.dir) do
+        tag.div(class: "lg-container") do
+          tag.span("🌍", class: 'emoji mr-6') +
+            tag.span(banner.pre) +
+            tag.strong(banner.link) +
+            tag.span(banner.post)
         end
       end
     end

--- a/app/helpers/view_components/site_header.rb
+++ b/app/helpers/view_components/site_header.rb
@@ -69,7 +69,9 @@ module ViewComponents
       banner = translatathon_banner
       link_to(banner.url, class: "announcement-bar md:block hidden", target: "_blank", rel: "noopener", dir: banner.dir) do
         tag.div(class: "lg-container") do
-          tag.span("🌍", class: 'emoji mr-6') +
+          # margin-inline-end (not mr-6) so the gap sits between the emoji and the
+          # text in both LTR and RTL banners.
+          tag.span("🌍", class: 'emoji', style: 'margin-inline-end:8px') +
             tag.span(banner.pre) +
             tag.strong(banner.link) +
             tag.span(banner.post)

--- a/app/helpers/view_components/translatathon_banner.rb
+++ b/app/helpers/view_components/translatathon_banner.rb
@@ -43,42 +43,42 @@ module ViewComponents
     # the program's own locale ids. Multi-variant languages have one entry per
     # variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); #program_locale maps a
     # browser tag to the right one. Each string is written in that language, with a
-    # translated phrase for the translation session; only "Jiki" stays as a proper
-    # noun.
+    # translated phrase for the translation session; only "Exercism" stays as a
+    # proper noun.
     COPY = {
-      "ar" => { pre: "هل تريد مساعدتنا في ترجمة Jiki إلى العربية؟ ", link: "انضمّ إلى جلسة الترجمة", post: "" },
-      "bn" => { pre: "Jiki-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ", link: "অনুবাদ সেশনে যোগ দিন", post: "" },
-      "ca" => { pre: "Vols ajudar-nos a traduir Jiki al català? ", link: "Uneix-te a la sessió de traducció", post: "" },
-      "de" => { pre: "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ", link: "Mach bei der Übersetzungssession mit", post: "" }, # rubocop:disable Layout/LineLength
-      "el" => { pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Jiki στα Ελληνικά; ", link: "Λάβε μέρος στη μεταφραστική συνεδρία", post: "" }, # rubocop:disable Layout/LineLength
-      "es-419" => { pre: "¿Quieres ayudarnos a traducir Jiki al español? ", link: "Únete a la sesión de traducción", post: "" },
-      "es-ES" => { pre: "¿Quieres ayudarnos a traducir Jiki al español? ", link: "Únete a la sesión de traducción", post: "" },
-      "fa" => { pre: "می‌خواهید در ترجمهٔ Jiki به فارسی به ما کمک کنید؟ ", link: "به نشست ترجمه بپیوندید", post: "" },
-      "fr" => { pre: "Vous voulez nous aider à traduire Jiki en français ? ", link: "Rejoignez la session de traduction", post: "" },
-      "hi" => { pre: "क्या आप Jiki का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ", link: "अनुवाद सत्र में शामिल हों", post: "" }, # rubocop:disable Layout/LineLength
-      "id" => { pre: "Ingin membantu kami menerjemahkan Jiki ke Bahasa Indonesia? ", link: "Ikuti sesi terjemahan", post: "" },
-      "it" => { pre: "Vuoi aiutarci a tradurre Jiki in italiano? ", link: "Partecipa alla sessione di traduzione", post: "" },
-      "ja" => { pre: "Jiki を日本語に翻訳するのを手伝いませんか？", link: "翻訳セッションに参加する", post: "" },
-      "ko" => { pre: "Jiki를 한국어로 번역하는 데 도움을 주시겠어요? ", link: "번역 세션에 참여하세요", post: "" },
-      "nl" => { pre: "Wil je ons helpen Jiki naar het Nederlands te vertalen? ", link: "Doe mee aan de vertaalsessie", post: "" },
-      "pl" => { pre: "Chcesz pomóc nam przetłumaczyć Jiki na polski? ", link: "Dołącz do sesji tłumaczeniowej", post: "" },
-      "pt-BR" => { pre: "Quer nos ajudar a traduzir o Jiki para o português? ", link: "Participe da sessão de tradução", post: "" },
-      "pt-pt" => { pre: "Quer ajudar-nos a traduzir o Jiki para português? ", link: "Junte-se à sessão de tradução", post: "" },
-      "ru" => { pre: "Хотите помочь нам перевести Jiki на русский? ", link: "Присоединяйтесь к сессии перевода", post: "" },
-      "sr" => { pre: "Желите да нам помогнете да преведемо Jiki на српски? ", link: "Придружите се преводилачкој сесији", post: "" },
-      "sw" => { pre: "Ungependa kutusaidia kutafsiri Jiki kwa Kiswahili? ", link: "Jiunge na kikao cha tafsiri", post: "" },
-      "tr" => { pre: "Jiki'yi Türkçeye çevirmemize yardım etmek ister misin? ", link: "Çeviri oturumuna katıl", post: "" },
-      "uk" => { pre: "Хочете допомогти нам перекласти Jiki українською? ", link: "Долучайтеся до сесії перекладу", post: "" },
-      "ur" => { pre: "کیا آپ Jiki کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ", link: "ترجمے کے سیشن میں شامل ہوں", post: "" }, # rubocop:disable Layout/LineLength
-      "vi" => { pre: "Bạn muốn giúp chúng tôi dịch Jiki sang Tiếng Việt? ", link: "Tham gia buổi dịch thuật", post: "" },
-      "zh-CN" => { pre: "想帮我们把 Jiki 翻译成中文吗？", link: "加入翻译活动", post: "" },
-      "zh-TW" => { pre: "想幫我們把 Jiki 翻譯成中文嗎？", link: "加入翻譯活動", post: "" }
+      "ar" => { pre: "هل تريد مساعدتنا في ترجمة Exercism إلى العربية؟ ", link: "انضمّ إلى جلسة الترجمة", post: "" },
+      "bn" => { pre: "Exercism-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ", link: "অনুবাদ সেশনে যোগ দিন", post: "" },
+      "ca" => { pre: "Vols ajudar-nos a traduir Exercism al català? ", link: "Uneix-te a la sessió de traducció", post: "" },
+      "de" => { pre: "Möchtest du uns helfen, Exercism ins Deutsche zu übersetzen? ", link: "Mach bei der Übersetzungssession mit", post: "" }, # rubocop:disable Layout/LineLength
+      "el" => { pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Exercism στα Ελληνικά; ", link: "Λάβε μέρος στη μεταφραστική συνεδρία", post: "" }, # rubocop:disable Layout/LineLength
+      "es-419" => { pre: "¿Quieres ayudarnos a traducir Exercism al español? ", link: "Únete a la sesión de traducción", post: "" },
+      "es-ES" => { pre: "¿Quieres ayudarnos a traducir Exercism al español? ", link: "Únete a la sesión de traducción", post: "" },
+      "fa" => { pre: "می‌خواهید در ترجمهٔ Exercism به فارسی به ما کمک کنید؟ ", link: "به نشست ترجمه بپیوندید", post: "" },
+      "fr" => { pre: "Vous voulez nous aider à traduire Exercism en français ? ", link: "Rejoignez la session de traduction", post: "" }, # rubocop:disable Layout/LineLength
+      "hi" => { pre: "क्या आप Exercism का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ", link: "अनुवाद सत्र में शामिल हों", post: "" }, # rubocop:disable Layout/LineLength
+      "id" => { pre: "Ingin membantu kami menerjemahkan Exercism ke Bahasa Indonesia? ", link: "Ikuti sesi terjemahan", post: "" },
+      "it" => { pre: "Vuoi aiutarci a tradurre Exercism in italiano? ", link: "Partecipa alla sessione di traduzione", post: "" },
+      "ja" => { pre: "Exercism を日本語に翻訳するのを手伝いませんか？", link: "翻訳セッションに参加する", post: "" },
+      "ko" => { pre: "Exercism을 한국어로 번역하는 데 도움을 주시겠어요? ", link: "번역 세션에 참여하세요", post: "" },
+      "nl" => { pre: "Wil je ons helpen Exercism naar het Nederlands te vertalen? ", link: "Doe mee aan de vertaalsessie", post: "" },
+      "pl" => { pre: "Chcesz pomóc nam przetłumaczyć Exercism na polski? ", link: "Dołącz do sesji tłumaczeniowej", post: "" },
+      "pt-BR" => { pre: "Quer nos ajudar a traduzir o Exercism para o português? ", link: "Participe da sessão de tradução", post: "" }, # rubocop:disable Layout/LineLength
+      "pt-pt" => { pre: "Quer ajudar-nos a traduzir o Exercism para português? ", link: "Junte-se à sessão de tradução", post: "" },
+      "ru" => { pre: "Хотите помочь нам перевести Exercism на русский? ", link: "Присоединяйтесь к сессии перевода", post: "" },
+      "sr" => { pre: "Желите да нам помогнете да преведемо Exercism на српски? ", link: "Придружите се преводилачкој сесији", post: "" }, # rubocop:disable Layout/LineLength
+      "sw" => { pre: "Ungependa kutusaidia kutafsiri Exercism kwa Kiswahili? ", link: "Jiunge na kikao cha tafsiri", post: "" },
+      "tr" => { pre: "Exercism'i Türkçeye çevirmemize yardım etmek ister misin? ", link: "Çeviri oturumuna katıl", post: "" },
+      "uk" => { pre: "Хочете допомогти нам перекласти Exercism українською? ", link: "Долучайтеся до сесії перекладу", post: "" },
+      "ur" => { pre: "کیا آپ Exercism کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ", link: "ترجمے کے سیشن میں شامل ہوں", post: "" }, # rubocop:disable Layout/LineLength
+      "vi" => { pre: "Bạn muốn giúp chúng tôi dịch Exercism sang Tiếng Việt? ", link: "Tham gia buổi dịch thuật", post: "" },
+      "zh-CN" => { pre: "想帮我们把 Exercism 翻译成中文吗？", link: "加入翻译活动", post: "" },
+      "zh-TW" => { pre: "想幫我們把 Exercism 翻譯成中文嗎？", link: "加入翻譯活動", post: "" }
     }.freeze
 
     # English display names for base language codes, used to fill in the English
-    # fallback banner ("Want to help us translate Jiki to <name>?"). Ruby has no
+    # fallback banner ("Want to help us translate Exercism to <name>?"). Ruby has no
     # Intl.DisplayNames, so we carry the names we care about. A code we can't name
-    # gets no banner (we never render "translate Jiki to xyz").
+    # gets no banner (we never render "translate Exercism to xyz").
     LANGUAGE_NAMES = {
       "af" => "Afrikaans", "am" => "Amharic", "ar" => "Arabic", "az" => "Azerbaijani",
       "be" => "Belarusian", "bg" => "Bulgarian", "bn" => "Bengali", "bs" => "Bosnian",
@@ -151,7 +151,7 @@ module ViewComponents
       return nil unless name
 
       Banner.new(
-        pre: "Want to help us translate Jiki to #{name}? ",
+        pre: "Want to help us translate Exercism to #{name}? ",
         link: "Join the Translatathon",
         post: "",
         url: TRANSLATATHON_URL,

--- a/app/helpers/view_components/translatathon_banner.rb
+++ b/app/helpers/view_components/translatathon_banner.rb
@@ -1,0 +1,203 @@
+module ViewComponents
+  # Temporary, pre-catalog promo copy for the Big Jiki & Exercism Translatathon.
+  #
+  # This is the server-side sibling of the Jiki front-end's TranslatathonBanner.
+  # The whole point is to reach speakers of languages we do NOT ship in the UI,
+  # so its copy can't come from an i18n catalog: it lives here. The site-header
+  # helper renders it as an announcement bar for signed-in users.
+  #
+  # It targets the first non-catalog language in the viewer's own preference list.
+  # On the front-end that list is `navigator.languages`; here it's the ordered
+  # `Accept-Language` request header (which encodes the same preference via q-values):
+  # - a language we run in the Translatathon program (COPY below) gets the whole
+  #   banner IN that language;
+  # - any other non-English language we can name gets the English banner with its
+  #   name filled in.
+  #
+  # The banner self-removes after the event (see END_TIME).
+  #
+  # NOTE: the translated strings below were drafted for the event and should be
+  # sanity-checked by native speakers / the Translatathon translators.
+  class TranslatathonBanner
+    # The resolved banner to render: pre/link/post are the sentence around the
+    # linked call-to-action, url is where it points, dir is "ltr" or "rtl".
+    Banner = Struct.new(:pre, :link, :post, :url, :dir, keyword_init: true)
+
+    # Where the call-to-action goes (opens in a new tab).
+    TRANSLATATHON_URL = "https://i18n.jiki.io".freeze
+
+    # The event weekend is 31 Jul - 2 Aug 2026; keep the banner up through 3 Aug.
+    # After this instant it never renders. Delete the whole class once the event
+    # is well past.
+    END_TIME = Time.utc(2026, 8, 4)
+
+    # Base languages we already ship in the UI: their speakers have nothing to
+    # translate to, so we never show them the banner. Exercism's UI is English,
+    # so English is the only catalog language.
+    CATALOG_LANGUAGES = Set.new(%w[en]).freeze
+
+    # Program languages that read right-to-left; the banner element gets dir="rtl".
+    RTL_TARGETS = Set.new(%w[ar fa ur]).freeze
+
+    # Fully-translated copy for each language in the Translatathon program, keyed by
+    # the program's own locale ids. Multi-variant languages have one entry per
+    # variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); #program_locale maps a
+    # browser tag to the right one. Each string is written in that language, with a
+    # translated phrase for the translation session; only "Jiki" stays as a proper
+    # noun.
+    COPY = {
+      "ar" => { pre: "هل تريد مساعدتنا في ترجمة Jiki إلى العربية؟ ", link: "انضمّ إلى جلسة الترجمة", post: "" },
+      "bn" => { pre: "Jiki-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ", link: "অনুবাদ সেশনে যোগ দিন", post: "" },
+      "ca" => { pre: "Vols ajudar-nos a traduir Jiki al català? ", link: "Uneix-te a la sessió de traducció", post: "" },
+      "de" => { pre: "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ", link: "Mach bei der Übersetzungssession mit", post: "" }, # rubocop:disable Layout/LineLength
+      "el" => { pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Jiki στα Ελληνικά; ", link: "Λάβε μέρος στη μεταφραστική συνεδρία", post: "" }, # rubocop:disable Layout/LineLength
+      "es-419" => { pre: "¿Quieres ayudarnos a traducir Jiki al español? ", link: "Únete a la sesión de traducción", post: "" },
+      "es-ES" => { pre: "¿Quieres ayudarnos a traducir Jiki al español? ", link: "Únete a la sesión de traducción", post: "" },
+      "fa" => { pre: "می‌خواهید در ترجمهٔ Jiki به فارسی به ما کمک کنید؟ ", link: "به نشست ترجمه بپیوندید", post: "" },
+      "fr" => { pre: "Vous voulez nous aider à traduire Jiki en français ? ", link: "Rejoignez la session de traduction", post: "" },
+      "hi" => { pre: "क्या आप Jiki का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ", link: "अनुवाद सत्र में शामिल हों", post: "" }, # rubocop:disable Layout/LineLength
+      "id" => { pre: "Ingin membantu kami menerjemahkan Jiki ke Bahasa Indonesia? ", link: "Ikuti sesi terjemahan", post: "" },
+      "it" => { pre: "Vuoi aiutarci a tradurre Jiki in italiano? ", link: "Partecipa alla sessione di traduzione", post: "" },
+      "ja" => { pre: "Jiki を日本語に翻訳するのを手伝いませんか？", link: "翻訳セッションに参加する", post: "" },
+      "ko" => { pre: "Jiki를 한국어로 번역하는 데 도움을 주시겠어요? ", link: "번역 세션에 참여하세요", post: "" },
+      "nl" => { pre: "Wil je ons helpen Jiki naar het Nederlands te vertalen? ", link: "Doe mee aan de vertaalsessie", post: "" },
+      "pl" => { pre: "Chcesz pomóc nam przetłumaczyć Jiki na polski? ", link: "Dołącz do sesji tłumaczeniowej", post: "" },
+      "pt-BR" => { pre: "Quer nos ajudar a traduzir o Jiki para o português? ", link: "Participe da sessão de tradução", post: "" },
+      "pt-pt" => { pre: "Quer ajudar-nos a traduzir o Jiki para português? ", link: "Junte-se à sessão de tradução", post: "" },
+      "ru" => { pre: "Хотите помочь нам перевести Jiki на русский? ", link: "Присоединяйтесь к сессии перевода", post: "" },
+      "sr" => { pre: "Желите да нам помогнете да преведемо Jiki на српски? ", link: "Придружите се преводилачкој сесији", post: "" },
+      "sw" => { pre: "Ungependa kutusaidia kutafsiri Jiki kwa Kiswahili? ", link: "Jiunge na kikao cha tafsiri", post: "" },
+      "tr" => { pre: "Jiki'yi Türkçeye çevirmemize yardım etmek ister misin? ", link: "Çeviri oturumuna katıl", post: "" },
+      "uk" => { pre: "Хочете допомогти нам перекласти Jiki українською? ", link: "Долучайтеся до сесії перекладу", post: "" },
+      "ur" => { pre: "کیا آپ Jiki کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ", link: "ترجمے کے سیشن میں شامل ہوں", post: "" }, # rubocop:disable Layout/LineLength
+      "vi" => { pre: "Bạn muốn giúp chúng tôi dịch Jiki sang Tiếng Việt? ", link: "Tham gia buổi dịch thuật", post: "" },
+      "zh-CN" => { pre: "想帮我们把 Jiki 翻译成中文吗？", link: "加入翻译活动", post: "" },
+      "zh-TW" => { pre: "想幫我們把 Jiki 翻譯成中文嗎？", link: "加入翻譯活動", post: "" }
+    }.freeze
+
+    # English display names for base language codes, used to fill in the English
+    # fallback banner ("Want to help us translate Jiki to <name>?"). Ruby has no
+    # Intl.DisplayNames, so we carry the names we care about. A code we can't name
+    # gets no banner (we never render "translate Jiki to xyz").
+    LANGUAGE_NAMES = {
+      "af" => "Afrikaans", "am" => "Amharic", "ar" => "Arabic", "az" => "Azerbaijani",
+      "be" => "Belarusian", "bg" => "Bulgarian", "bn" => "Bengali", "bs" => "Bosnian",
+      "ca" => "Catalan", "cs" => "Czech", "cy" => "Welsh", "da" => "Danish",
+      "de" => "German", "el" => "Greek", "es" => "Spanish", "et" => "Estonian",
+      "eu" => "Basque", "fa" => "Persian", "fi" => "Finnish", "fil" => "Filipino",
+      "fr" => "French", "ga" => "Irish", "gl" => "Galician", "gu" => "Gujarati",
+      "he" => "Hebrew", "hi" => "Hindi", "hr" => "Croatian", "ht" => "Haitian Creole",
+      "hy" => "Armenian", "id" => "Indonesian", "is" => "Icelandic", "it" => "Italian",
+      "ja" => "Japanese", "ka" => "Georgian", "kk" => "Kazakh", "km" => "Khmer",
+      "kn" => "Kannada", "ko" => "Korean", "lo" => "Lao", "lt" => "Lithuanian",
+      "lv" => "Latvian", "mk" => "Macedonian", "ml" => "Malayalam", "mn" => "Mongolian",
+      "mr" => "Marathi", "ms" => "Malay", "my" => "Burmese", "nb" => "Norwegian",
+      "ne" => "Nepali", "nl" => "Dutch", "nn" => "Norwegian", "no" => "Norwegian",
+      "pa" => "Punjabi", "pl" => "Polish", "pt" => "Portuguese", "ro" => "Romanian",
+      "ru" => "Russian", "si" => "Sinhala", "sk" => "Slovak", "sl" => "Slovenian",
+      "sq" => "Albanian", "sr" => "Serbian", "sv" => "Swedish", "sw" => "Swahili",
+      "ta" => "Tamil", "te" => "Telugu", "th" => "Thai", "tl" => "Filipino",
+      "tr" => "Turkish", "uk" => "Ukrainian", "ur" => "Urdu", "uz" => "Uzbek",
+      "vi" => "Vietnamese", "zh" => "Chinese", "zu" => "Zulu"
+    }.freeze
+
+    def self.call(...) = new(...).()
+
+    def initialize(accept_language_header, now: Time.current)
+      @accept_language_header = accept_language_header.to_s
+      @now = now
+    end
+
+    # Returns a Banner to render, or nil when nothing applies.
+    def call
+      return nil if now >= END_TIME
+
+      resolve(preferred_languages)
+    end
+
+    private
+    attr_reader :accept_language_header, :now
+
+    # Walk the viewer's language list in order, take the first language we don't
+    # already ship, and return either its in-program translated banner or the
+    # English fallback with its name filled in. The first non-catalog language
+    # decides: if we can't name it, we show nothing.
+    def resolve(languages)
+      languages.each do |tag|
+        base = tag.split("-").first&.downcase
+        next if base.nil? || CATALOG_LANGUAGES.include?(base)
+
+        key = program_locale(tag, base)
+        return program_banner(key, base) if key
+
+        return english_banner(base)
+      end
+      nil
+    end
+
+    def program_banner(key, base)
+      copy = COPY.fetch(key)
+      Banner.new(
+        pre: copy[:pre], link: copy[:link], post: copy[:post],
+        url: TRANSLATATHON_URL,
+        dir: RTL_TARGETS.include?(base) ? "rtl" : "ltr"
+      )
+    end
+
+    # The English fallback banner for a non-program language, with the language's
+    # English name filled in. Returns nil when we have no name for the code.
+    def english_banner(base)
+      name = LANGUAGE_NAMES[base]
+      return nil unless name
+
+      Banner.new(
+        pre: "Want to help us translate Jiki to #{name}? ",
+        link: "Join the Translatathon",
+        post: "",
+        url: TRANSLATATHON_URL,
+        dir: "ltr"
+      )
+    end
+
+    # Map a browser language tag to the program locale id whose copy we show, or
+    # nil if the language isn't in the program. Multi-variant languages collapse by
+    # region/script; every other program language is keyed by its bare base code.
+    def program_locale(tag, base)
+      case base
+      when "es"
+        region(tag) == "ES" ? "es-ES" : "es-419"
+      when "pt"
+        region(tag) == "PT" ? "pt-pt" : "pt-BR"
+      when "zh"
+        r = region(tag)
+        tag.match?(/hant/i) || %w[TW HK MO].include?(r) ? "zh-TW" : "zh-CN"
+      else
+        COPY.key?(base) ? base : nil
+      end
+    end
+
+    # The region subtag (first 2-alpha or 3-digit subtag), uppercased, or nil.
+    def region(tag)
+      tag.split("-").drop(1).find { |part| part.match?(/\A([A-Za-z]{2}|\d{3})\z/) }&.upcase
+    end
+
+    # The Accept-Language header parsed into an ordered list of language tags,
+    # highest q-value first (ties keep header order), dropping "*" and empties.
+    def preferred_languages
+      weighted = accept_language_header.split(",").filter_map.with_index do |part, index|
+        tag, *params = part.strip.split(";")
+        tag = tag.to_s.strip
+        next if tag.empty? || tag == "*"
+
+        quality = 1.0
+        params.each do |param|
+          key, value = param.split("=", 2)
+          quality = value.to_f if key.to_s.strip == "q"
+        end
+        [tag, quality, index]
+      end
+
+      weighted.sort_by { |_tag, quality, index| [-quality, index] }.map(&:first)
+    end
+  end
+end

--- a/test/helpers/view_components/translatathon_banner_test.rb
+++ b/test/helpers/view_components/translatathon_banner_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class ViewComponents::TranslatathonBannerTest < ActiveSupport::TestCase
+  # Before the event ends, so the banner is live.
+  BEFORE_END = Time.utc(2026, 8, 1)
+
+  def resolve(header, now: BEFORE_END)
+    ViewComponents::TranslatathonBanner.(header, now:)
+  end
+
+  test "returns nil for English speakers (catalog language)" do
+    assert_nil resolve("en-US,en;q=0.9")
+  end
+
+  test "returns nil for a blank header" do
+    assert_nil resolve("")
+    assert_nil resolve(nil)
+  end
+
+  test "returns nil once the event is over" do
+    assert_nil resolve("fr-FR", now: Time.utc(2026, 8, 4))
+    assert_nil resolve("fr-FR", now: Time.utc(2026, 9, 1))
+  end
+
+  test "shows the program banner in the target language" do
+    banner = resolve("fr-FR,fr;q=0.9,en;q=0.8")
+
+    assert_equal "Vous voulez nous aider à traduire Jiki en français ? ", banner.pre
+    assert_equal "Rejoignez la session de traduction", banner.link
+    assert_equal "https://i18n.jiki.io", banner.url
+    assert_equal "ltr", banner.dir
+  end
+
+  test "sets rtl for right-to-left program languages" do
+    assert_equal "rtl", resolve("ar").dir
+    assert_equal "rtl", resolve("fa-IR").dir
+    assert_equal "rtl", resolve("ur").dir
+  end
+
+  test "picks the first non-catalog language, skipping English" do
+    banner = resolve("en-GB,en;q=0.9,de;q=0.8")
+
+    assert_equal "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ", banner.pre
+  end
+
+  test "orders by q-value, not header order" do
+    # de has the higher quality despite appearing after fr.
+    banner = resolve("fr;q=0.5,de;q=0.9")
+
+    assert_equal "Mach bei der Übersetzungssession mit", banner.link
+  end
+
+  test "falls back to English copy with the language name for non-program languages" do
+    banner = resolve("sv-SE,sv;q=0.9")
+
+    assert_equal "Want to help us translate Jiki to Swedish? ", banner.pre
+    assert_equal "Join the Translatathon", banner.link
+    assert_equal "ltr", banner.dir
+  end
+
+  test "returns nil when the first non-catalog language has no name" do
+    assert_nil resolve("xx-YY")
+  end
+
+  test "maps Spanish variants to es-ES and es-419" do
+    assert_equal "es-ES", program_locale("es-ES", "es")
+    assert_equal "es-419", program_locale("es-MX", "es")
+    assert_equal "es-419", program_locale("es", "es")
+  end
+
+  test "maps Portuguese variants to pt-pt and pt-BR" do
+    assert_equal "pt-pt", program_locale("pt-PT", "pt")
+    assert_equal "pt-BR", program_locale("pt-BR", "pt")
+    assert_equal "pt-BR", program_locale("pt", "pt")
+  end
+
+  test "maps Chinese variants to zh-TW and zh-CN" do
+    assert_equal "zh-TW", program_locale("zh-TW", "zh")
+    assert_equal "zh-TW", program_locale("zh-HK", "zh")
+    assert_equal "zh-TW", program_locale("zh-Hant", "zh")
+    assert_equal "zh-CN", program_locale("zh-CN", "zh")
+    assert_equal "zh-CN", program_locale("zh", "zh")
+  end
+
+  private
+  def program_locale(tag, base)
+    ViewComponents::TranslatathonBanner.new("").send(:program_locale, tag, base)
+  end
+end

--- a/test/helpers/view_components/translatathon_banner_test.rb
+++ b/test/helpers/view_components/translatathon_banner_test.rb
@@ -25,7 +25,7 @@ class ViewComponents::TranslatathonBannerTest < ActiveSupport::TestCase
   test "shows the program banner in the target language" do
     banner = resolve("fr-FR,fr;q=0.9,en;q=0.8")
 
-    assert_equal "Vous voulez nous aider à traduire Jiki en français ? ", banner.pre
+    assert_equal "Vous voulez nous aider à traduire Exercism en français ? ", banner.pre
     assert_equal "Rejoignez la session de traduction", banner.link
     assert_equal "https://i18n.jiki.io", banner.url
     assert_equal "ltr", banner.dir
@@ -40,7 +40,7 @@ class ViewComponents::TranslatathonBannerTest < ActiveSupport::TestCase
   test "picks the first non-catalog language, skipping English" do
     banner = resolve("en-GB,en;q=0.9,de;q=0.8")
 
-    assert_equal "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ", banner.pre
+    assert_equal "Möchtest du uns helfen, Exercism ins Deutsche zu übersetzen? ", banner.pre
   end
 
   test "orders by q-value, not header order" do
@@ -53,7 +53,7 @@ class ViewComponents::TranslatathonBannerTest < ActiveSupport::TestCase
   test "falls back to English copy with the language name for non-program languages" do
     banner = resolve("sv-SE,sv;q=0.9")
 
-    assert_equal "Want to help us translate Jiki to Swedish? ", banner.pre
+    assert_equal "Want to help us translate Exercism to Swedish? ", banner.pre
     assert_equal "Join the Translatathon", banner.link
     assert_equal "ltr", banner.dir
   end


### PR DESCRIPTION
## What

A temporary announcement bar recruiting translators for the **Big Jiki & Exercism Translatathon**, shown to signed-in users whose browser's top language is one we don't ship the UI in.

This is the server-side sibling of the Jiki front-end's [`TranslatathonBanner`](https://github.com/jiki-education/front-end/pull/990). Same core logic, adapted to how this site does banners: it's a Ruby announcement bar in the site-header helper, not a React component.

## How it works

- **`ViewComponents::TranslatathonBanner`** resolves the ordered **`Accept-Language`** request header (the server-side equivalent of the front-end's `navigator.languages`, ordered by q-value).
- It takes the **first non-catalog language** in that list. English is the only catalog language on Exercism, so English speakers see nothing and fall through to the existing bars.
- A language in the **Translatathon program** gets the whole banner **in that language** (`COPY` map, RTL-aware for `ar`/`fa`/`ur`).
- Any other named non-English language gets the **English fallback** with its name filled in (e.g. "Want to help us translate Jiki to Swedish?"). Ruby has no `Intl.DisplayNames`, so names come from a `LANGUAGE_NAMES` map; a code we can't name shows nothing.
- **Self-removes after the event** (hardcoded `END_TIME` = 2026-08-04).
- The bar links to `https://i18n.jiki.io`, opening in a new tab.

## Mounting

Wired into `SiteHeader#announcement_bar`, following the existing announcement-bar pattern. It takes priority over the other bars for signed-in users when it applies. Signed-out users are never affected (and their header stays cached).

## Notes vs the front-end PR

- **No dismissal / no client-side rendering.** The announcement bar is server-rendered and non-dismissible by convention here, so the `localStorage` dismiss logic and full-screen-exercise suppression from the FE version are dropped.
- Temporary by design: delete `TranslatathonBanner`, its test, and the header hook after the event.

Unit-tested in `test/helpers/view_components/translatathon_banner_test.rb` (Accept-Language ordering, catalog exclusion, program/variant mapping, English fallback, end-date cutoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)