### PR TITLE
Serve solution image data for browserless rendering

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -29,4 +29,12 @@ class ImagesController < ApplicationController
   def solution
     @solution = Solution.for!(params[:user_handle], params[:track_slug], params[:exercise_slug])
   end
+
+  # Feeds the image generator, which renders the share image without a browser
+  # and so needs the data rather than the page.
+  def solution_data
+    solution = Solution.for!(params[:user_handle], params[:track_slug], params[:exercise_slug])
+
+    render json: SerializeSolutionImage.(solution)
+  end
 end

--- a/app/serializers/serialize_highlightjs_theme.rb
+++ b/app/serializers/serialize_highlightjs_theme.rb
@@ -8,7 +8,7 @@
 class SerializeHighlightjsTheme
   include Mandate
 
-  CSS_PATH = Rails.root.join('app/css/highlighters/highlightjs-dark.css').freeze
+  CSS_PATH = Rails.root.join('app', 'css', 'highlighters', 'highlightjs-dark.css').freeze
   DEFAULT_SCOPE = 'default'.freeze
 
   # Any rule whose selectors mention .hljs, e.g.

--- a/app/serializers/serialize_highlightjs_theme.rb
+++ b/app/serializers/serialize_highlightjs_theme.rb
@@ -1,0 +1,60 @@
+# Extracts the highlight.js scope -> style mapping out of our own theme CSS.
+#
+# The image generator renders solution images without a browser, so it can't
+# rely on a stylesheet to colour the code. It needs the colours as data. Pulling
+# them out of the CSS rather than keeping a second hand-written copy means the
+# stylesheet stays the single source of truth - restyle the theme and the images
+# follow, instead of silently drifting.
+class SerializeHighlightjsTheme
+  include Mandate
+
+  CSS_PATH = Rails.root.join('app/css/highlighters/highlightjs-dark.css').freeze
+  DEFAULT_SCOPE = 'default'.freeze
+
+  # Any rule whose selectors mention .hljs, e.g.
+  # "& .hljs-doctag,\n& .hljs-keyword {\n color: #c678dd;\n}"
+  RULE = /([^{}]*\.hljs[^{}]*)\{([^{}]*)\}/m
+
+  # A selector we can map to a single highlight.js scope. Deliberately excludes
+  # compound and descendant selectors like ".hljs-title.class_" and
+  # ".hljs-class .hljs-title" - they're contextual, and a token only carries its
+  # own scope, so there's nothing to key them off. Skipping them leaves the
+  # plain scope's colour in place, which is the common case.
+  SIMPLE_SELECTOR = /\A\s*&\s*\.hljs([\w-]*)\s*\z/
+
+  COLOUR = /(?:\A|[;{\s])color:\s*(#\h{3,8})/
+  ITALIC = /font-style:\s*italic/
+  BOLD = /font-weight:\s*bold/
+
+  def call
+    stripped_css.scan(RULE).each_with_object({}) do |(selectors, body), styles|
+      style = style_for(body)
+      next if style.empty?
+
+      selectors.split(',').each do |selector|
+        suffix = selector[SIMPLE_SELECTOR, 1]
+        next if suffix.nil?
+
+        styles[scope_for(suffix)] = style
+      end
+    end
+  end
+
+  private
+  # Comments in the theme document the palette in hex, which would otherwise
+  # look like declarations to the scanner.
+  def stripped_css = CSS_PATH.read.gsub(%r{/\*.*?\*/}m, '')
+
+  def scope_for(suffix)
+    suffix = suffix.delete_prefix('-')
+    suffix.presence || DEFAULT_SCOPE
+  end
+
+  def style_for(body)
+    {
+      colour: body[COLOUR, 1],
+      italic: body.match?(ITALIC).presence,
+      bold: body.match?(BOLD).presence
+    }.compact
+  end
+end

--- a/app/serializers/serialize_solution_image.rb
+++ b/app/serializers/serialize_solution_image.rb
@@ -1,0 +1,39 @@
+# Everything the image generator needs to draw a solution's share image, in one
+# request.
+#
+# The generator used to get this by loading the HTML page in headless Chrome,
+# waiting for React to mount, and letting it fetch the files over XHR. Serving
+# the data directly means it can render without a browser at all.
+class SerializeSolutionImage
+  include Mandate
+
+  initialize_with :solution
+
+  def call
+    {
+      code: {
+        language: solution.track.highlightjs_language,
+        indent_size: solution.track.indent_size,
+        files:
+      },
+      footer: {
+        handle: solution.user.handle,
+        avatar_url: solution.user.avatar_url,
+        exercise_title: solution.exercise.title,
+        track_title: solution.track.title
+      },
+      highlight_theme: SerializeHighlightjsTheme.()
+    }
+  end
+
+  private
+  def iteration = @iteration ||= solution.latest_published_iteration
+
+  def files
+    return [] if iteration.blank?
+
+    iteration.files.map do |file|
+      { filename: file.filename, content: file.content }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,10 @@ Rails.application.routes.draw do
   resources :solution_tagger, only: [:index]
 
   resource :images, controller: "images" do
+    # Declared before the HTML route so the trailing segment isn't swallowed by
+    # :user_handle. A path segment rather than a .json format because handles
+    # are user-supplied and shouldn't have to be format-safe.
+    get "solutions/:track_slug/:exercise_slug/:user_handle/data", to: "images#solution_data"
     get "solutions/:track_slug/:exercise_slug/:user_handle", to: "images#solution"
     get "profiles/:user_handle", to: "images#profile"
   end

--- a/test/serializers/serialize_highlightjs_theme_test.rb
+++ b/test/serializers/serialize_highlightjs_theme_test.rb
@@ -53,7 +53,7 @@ class SerializeHighlightjsThemeTest < ActiveSupport::TestCase
 
     # The theme opens with a comment listing "base: #282c34" and friends. If
     # those leaked in we'd get scopes that highlight.js never emits.
-    assert theme.keys.all? { |scope| scope.match?(/\A[\w-]+\z/) }
+    assert(theme.keys.all? { |scope| scope.match?(/\A[\w-]+\z/) })
     refute theme.key?('base')
   end
 end

--- a/test/serializers/serialize_highlightjs_theme_test.rb
+++ b/test/serializers/serialize_highlightjs_theme_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class SerializeHighlightjsThemeTest < ActiveSupport::TestCase
+  test "extracts colours for the scopes highlight.js emits" do
+    theme = SerializeHighlightjsTheme.()
+
+    # A representative spread rather than the full set, so restyling the theme
+    # doesn't fail the suite for no reason.
+    %w[default comment keyword string number title literal].each do |scope|
+      assert theme.key?(scope), "expected a style for hljs-#{scope}"
+      assert_match(/\A#\h{3,8}\z/, theme[scope][:colour], "expected a hex colour for hljs-#{scope}")
+    end
+  end
+
+  test "reads scopes that share a rule with a compound or descendant selector" do
+    theme = SerializeHighlightjsTheme.()
+
+    # hljs-built_in is grouped with ".hljs-title.class_" and
+    # ".hljs-class .hljs-title". An earlier version required every selector in
+    # the group to be simple, so the whole rule - and built_in with it - was
+    # dropped.
+    assert_equal '#e6c07b', theme['built_in'][:colour]
+  end
+
+  test "skips contextual selectors that don't map to a single scope" do
+    theme = SerializeHighlightjsTheme.()
+
+    # "hljs-class" only ever appears as the ancestor in
+    # ".hljs-class .hljs-title". A token carries its own scope and no context,
+    # so there's nothing to match it on.
+    refute theme.key?('class')
+  end
+
+  test "carries font-style and font-weight where the theme sets them" do
+    theme = SerializeHighlightjsTheme.()
+
+    assert theme['comment'][:italic], "comments are italic in the theme"
+    assert theme['emphasis'][:italic], "emphasis is italic in the theme"
+    assert theme['strong'][:bold], "strong is bold in the theme"
+    refute theme['keyword'].key?(:bold), "keywords aren't bold in the theme"
+  end
+
+  test "shares one style across a grouped selector" do
+    theme = SerializeHighlightjsTheme.()
+
+    # "& .hljs-doctag, & .hljs-keyword, & .hljs-formula" is a single rule
+    assert_equal theme['doctag'], theme['keyword']
+    assert_equal theme['formula'], theme['keyword']
+  end
+
+  test "ignores the hex values in the palette comment" do
+    theme = SerializeHighlightjsTheme.()
+
+    # The theme opens with a comment listing "base: #282c34" and friends. If
+    # those leaked in we'd get scopes that highlight.js never emits.
+    assert theme.keys.all? { |scope| scope.match?(/\A[\w-]+\z/) }
+    refute theme.key?('base')
+  end
+end

--- a/test/serializers/serialize_solution_image_test.rb
+++ b/test/serializers/serialize_solution_image_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class SerializeSolutionImageTest < ActiveSupport::TestCase
+  test "serializes everything needed to draw the image" do
+    track = create :track, slug: 'ruby', title: 'Ruby'
+    exercise = create :practice_exercise, track:, title: 'Bob'
+    user = create :user, handle: 'ihid'
+    solution = create(:practice_solution, exercise:, user:)
+    submission = create(:submission, solution:)
+    iteration = create(:iteration, solution:, submission:)
+    create(:submission_file, submission:, filename: 'bob.rb', content: 'def hey; end')
+    solution.update(published_iteration: iteration, published_at: Time.current)
+
+    actual = SerializeSolutionImage.(solution)
+
+    assert_equal track.highlightjs_language, actual[:code][:language]
+    assert_equal track.indent_size, actual[:code][:indent_size]
+    assert_equal [{ filename: 'bob.rb', content: 'def hey; end' }], actual[:code][:files]
+    assert_equal 'ihid', actual[:footer][:handle]
+    assert_equal 'Bob', actual[:footer][:exercise_title]
+    assert_equal 'Ruby', actual[:footer][:track_title]
+    assert_equal user.avatar_url, actual[:footer][:avatar_url]
+  end
+
+  test "includes the theme so the generator can colour code without a stylesheet" do
+    solution = create :practice_solution
+
+    actual = SerializeSolutionImage.(solution)
+
+    assert_equal SerializeHighlightjsTheme.(), actual[:highlight_theme]
+  end
+
+  test "returns no files when nothing is published" do
+    solution = create :practice_solution
+
+    actual = SerializeSolutionImage.(solution)
+
+    assert_empty actual[:code][:files]
+  end
+end


### PR DESCRIPTION
Groundwork for taking headless Chrome out of the image generator. Paired with a PR on `exercism/image-generator`; **this one is inert until that ships** — it only adds an endpoint nothing calls yet.

## Why

`/images/solutions/...` exists solely to be screenshotted. The generator loads it in headless Chrome, waits for React to mount, and lets `SolutionView` fetch the files over XHR before it can photograph the result.

Chrome is there purely as a **JavaScript runtime**. That costs ~5.7s at 2000MB per image, and it's why four days of broken images happened when Cloudflare started challenging the Lambda's own callback — a browser fetching your public site looks exactly like a bot.

## What this adds

`GET /images/solutions/:track_slug/:exercise_slug/:user_handle/data` returning everything needed to draw the image in one request:

- the published iteration's files
- language + indent size
- footer bits (handle, avatar, exercise title, track title)
- the highlight.js theme as data

No page shell, no React, no follow-up XHR.

## The colours

This is the part worth reviewing. highlight.js emits scope classes (`hljs-keyword`) and `highlightjs-dark.css` colours them — useless to a renderer that can't load stylesheets.

Rather than hand-copy the palette into the generator and let the two drift, `SerializeHighlightjsTheme` **extracts it from the theme CSS** and ships it in the payload. Restyle the theme and the images follow. It captures **34 of 35** declared scopes.

The missing one is `hljs-class`, deliberately: it only ever appears as the ancestor in `.hljs-class .hljs-title`. A token carries its own scope and no ancestry, so there's nothing to match it on — the plain `title` colour stays, which is the common case.

Worth knowing about a bug I hit writing it: `hljs-built_in` shares a rule with `.hljs-title.class_` and `.hljs-class .hljs-title`. My first pattern required *every* selector in a group to be simple, so the whole rule was dropped and `built_in` silently lost its colour. There's a regression test for it.

## A route segment, not `.json`

`get ".../:user_handle/data"` rather than a format suffix, declared before the HTML route. Handles are user-supplied, and I didn't want a handle containing a dot to be parsed as a format.

## Testing

**The tests are unrun.** `bundle exec` fails in a worktree (the same problem `fix/worktree-deps` is about), so I couldn't run the suite or rubocop. What I did verify:

- Ruby syntax on every changed file
- The CSS parser executed standalone against the real `highlightjs-dark.css`, confirming 34/35 scopes, correct grouped-selector sharing, italic/bold extraction, and no leakage from the palette comment block

The serializer tests are written from the factory conventions in `test/serializers/` but have never executed — **please run them before merging**. `SerializeSolutionImage`'s use of `latest_published_iteration` and the `submission_file` factory are the parts I'd most expect to need adjusting.