### PR TITLE
Optimise bootcamp member and sitemap solution queries

### DIFF
--- a/app/commands/user/jiki/retrieve_bootcamp_member_ids.rb
+++ b/app/commands/user/jiki/retrieve_bootcamp_member_ids.rb
@@ -7,9 +7,8 @@ class User::Jiki::RetrieveBootcampMemberIds
 
   private
   def from_data
-    User.joins(:data).
-      where('user_data.bootcamp_attendee = TRUE OR user_data.bootcamp_mentor = TRUE').
-      pluck(:id)
+    User::Data.where(bootcamp_attendee: true).pluck(:user_id) +
+      User::Data.where(bootcamp_mentor: true).pluck(:user_id)
   end
 
   def from_bootcamp_data

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -95,10 +95,14 @@ class SitemapsController < ApplicationController
       pages << [track_exercise_url(track, exercise), exercise.updated_at, :monthly, 0.75]
       pages << [track_exercise_solutions_url(track, exercise), Time.zone.today, :daily, 0.7]
 
-      exercise.solutions.published.where('num_stars > 0').order(num_stars: :desc).limit(100).includes(:track, :exercise,
-        :user).each do |solution|
-        priority = 0.5 + [0.1, solution.num_stars / 100.0].min
-        pages << [Exercism::Routes.published_solution_url(solution), solution.updated_at, :monthly, priority]
+      # We already have the track and exercise in hand, so build the URL directly
+      # rather than going via published_solution_url, which would reload both per solution.
+      exercise.solutions.published.where('num_stars > 0').
+        order(num_stars: :desc).limit(100).
+        joins(:user).pluck(:num_stars, :updated_at, 'users.handle').each do |num_stars, updated_at, handle|
+        priority = 0.5 + [0.1, num_stars / 100.0].min
+        url = Exercism::Routes.track_exercise_solution_url(track.slug, exercise.slug, handle)
+        pages << [url, updated_at, :monthly, priority]
       end
 
       if exercise.has_approaches? # rubocop:disable Style/Next

--- a/db/migrate/20260812153931_add_bootcamp_indexes_to_user_data.rb
+++ b/db/migrate/20260812153931_add_bootcamp_indexes_to_user_data.rb
@@ -1,0 +1,8 @@
+class AddBootcampIndexesToUserData < ActiveRecord::Migration[7.0]
+  def change
+    return if Rails.env.production?
+
+    add_index :user_data, %i[bootcamp_attendee user_id], name: "index_user_data__bootcamp_attendees"
+    add_index :user_data, %i[bootcamp_mentor user_id], name: "index_user_data__bootcamp_mentors"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_12_153931) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1612,6 +1612,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_31_084553) do
     t.boolean "bootcamp_mentor", default: false, null: false
     t.string "locale"
     t.text "translator_locales"
+    t.index ["bootcamp_attendee", "user_id"], name: "index_user_data__bootcamp_attendees"
+    t.index ["bootcamp_mentor", "user_id"], name: "index_user_data__bootcamp_mentors"
     t.index ["discord_uid"], name: "index_user_data_on_discord_uid", unique: true
     t.index ["first_donated_at", "show_on_supporters_page", "user_id"], name: "index_user_data__supporters-page"
     t.index ["first_donated_at"], name: "index_user_data_on_first_donated_at"


### PR DESCRIPTION
Two unrelated query optimisations found via Skylight. They're independent, so happy to split if you'd prefer.

## 1. `RetrieveBootcampMemberIds` — 14s full table scan

`from_data` was scanning all ~2.8m rows of `user_data` to return a handful of ids.

Neither `bootcamp_attendee` nor `bootcamp_mentor` had an index, and the `OR` would have prevented single-index use even if one existed (MySQL needs both columns indexed for an index_merge union).

- Adds a covering index per column, `(flag, user_id)`. Since both flags are `false` for nearly every row, the `= TRUE` range is tiny and the lookup is index-only, never touching the table.
- Splits the `OR` into two lookups so each uses its own index.
- Drops the `users` join, which filtered nothing. `user_data` is `dependent: :destroy` (`app/models/user.rb:26`), so rows can't outlive their user.

`call` already does `.uniq` over the combined result, so the return value is unchanged.

## 2. `SitemapsController#track` — 1.5s, 800 allocations

The per-exercise solutions query had `includes(:track, :exercise, :user)`, but `track` and `exercise` are already loop variables at that point. It was firing two redundant preload queries per exercise and hydrating ~400 objects to read three values.

Now plucks the three values it needs and builds the URL directly rather than via `published_solution_url` (which would go back to `solution.track` / `solution.exercise`).

- Preload queries: 3 per exercise → 1
- Objects allocated: ~400 per exercise → 0

The query itself was already well served by the existing `solutions_ex_stat_stars_upat` index on `(exercise_id, status, num_stars, updated_at)`, so no index change here.

## Testing

**Not verified by tests.** The suite can't run locally right now (OpenSearch refusing on :9200), and there are no existing sitemap tests. Confirmed syntax and rubocop only (no new offences; the `track` method was already over the metrics limits).

Worth someone hitting `/sitemaps/track/:id` and diffing the XML against main before merging, since the pluck ordering and URL-building swap are easy to get subtly wrong.

## Note

Rebuilding `db/schema.rb` via `db:migrate` pulled in a lot of unrelated drift from my local DB (`localization_*` tables, `solution_assistant_conversations`, a dropped `solutions.exercise_approach_id`, and others). I reverted that and hand-wrote the two index lines, so this diff is minimal, but it suggests `main`'s `schema.rb` may be out of sync with what's actually deployed. Might be worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THPfH3VL6jqnWZSLLvAo8i