### PR TITLE
Serve image data over SPI so the generator can use the internal ALB

### DIFF
--- a/app/controllers/spi/solution_image_data_controller.rb
+++ b/app/controllers/spi/solution_image_data_controller.rb
@@ -1,4 +1,11 @@
 module SPI
+  # Feeds the image generator, which draws a solution's share image without a
+  # browser and so needs the data rather than the page.
+  #
+  # Being on SPI means the generator reaches this over the internal ALB. Fetching
+  # the equivalent from the public site instead meant the lambda had to be
+  # allowlisted by source IP in Cloudflare - the coupling that left every image
+  # timing out for four days once bot mitigation was turned on.
   class SolutionImageDataController < BaseController
     def show
       solution = Solution.for!(
@@ -7,20 +14,7 @@ module SPI
         params[:exercise_slug]
       )
 
-      exercise = solution.exercise
-      track = exercise.track
-      file = solution.latest_published_iteration_submission.files.first
-      snippet = solution.snippet.presence || file.content[0, 10]
-      render json: {
-        solution: {
-          snippet:,
-          extension: File.extname(file.filename),
-          language: track.highlightjs_language,
-          track_icon_url: track.icon_url,
-          exercise_icon_url: exercise.icon_url,
-          user_avatar_url: solution.user.avatar_url
-        }
-      }
+      render json: SerializeSolutionImage.(solution)
     end
   end
 end

--- a/test/controllers/spi/solution_image_data_controller_test.rb
+++ b/test/controllers/spi/solution_image_data_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class SPI::SolutionImageDataControllerTest < ActionDispatch::IntegrationTest
+  test "returns the data needed to draw the image" do
+    track = create :track, slug: 'ruby', title: 'Ruby'
+    exercise = create :practice_exercise, track:, slug: 'bob', title: 'Bob'
+    user = create :user, handle: 'ihid'
+    solution = create(:practice_solution, exercise:, user:)
+    submission = create(:submission, solution:)
+    iteration = create(:iteration, solution:, submission:)
+    create(:submission_file, submission:, filename: 'bob.rb', content: 'def hey; end')
+    solution.update(published_iteration: iteration, published_at: Time.current)
+
+    get "/spi/solution_image_data/ruby/bob/ihid"
+
+    assert_response :ok
+    actual = JSON.parse(response.body, symbolize_names: true)
+    assert_equal [{ filename: 'bob.rb', content: 'def hey; end' }], actual[:code][:files]
+    assert_equal 'ihid', actual[:footer][:handle]
+    assert_equal 'Bob', actual[:footer][:exercise_title]
+    assert_equal 'Ruby', actual[:footer][:track_title]
+    # Without this the generator has no way to colour the code - it can't load
+    # the stylesheet that normally does it.
+    assert actual[:highlight_theme][:keyword][:colour].present?
+  end
+
+  test "is reachable without authentication" do
+    # The generator calls this over the internal ALB with no session.
+    solution = create :practice_solution
+
+    get "/spi/solution_image_data/#{solution.track.slug}/#{solution.exercise.slug}/#{solution.user.handle}"
+
+    assert_response :ok
+  end
+
+  test "404s for a solution that doesn't exist" do
+    get "/spi/solution_image_data/nope/nope/nope"
+
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
Pairs with **exercism/image-generator#14**. **Merge and deploy this first** — the generator PR points at this endpoint.

## Why

The generator currently fetches its payload from `exercism.org/images/.../data`. That's a round trip **out through Cloudflare** and back, which means the lambda has to be allowlisted by source IP to reach our own site.

That coupling is exactly what broke image generation for four days: bot mitigation was turned on, the lambda's requests got challenged, and every render hung until timeout. Adding `ip.src eq 13.40.244.182` fixed it, but it left a tripwire — the next time those rules are tightened, or the NAT gateway is recreated and the EIP changes, it breaks again with no obvious cause.

## What changes

`/spi` is already internal-only: the public ALB fixed-responds `/spi/*`, and the internal ALB forwards it to Rails (priority 90 → `webservers-spi`). So the payload just moves there. **No terraform or ALB change needed** — the routing already exists.

Result: the request never leaves the VPC. No Cloudflare, no internet round trip, no NAT data charges, nothing to allowlist.

## Reusing #5747's endpoint

`SPI::SolutionImageDataController` already existed, added in #5747 ("Add endpoint for solution image generator", Aug 2023). It's been dead since the day it was created:

- Nothing in this repo or the generator references it — the only mention is its own route
- It was built for a **Ruby/vips** generator that never got past a stub (`body: 'hello'`)
- Six months later, generator #6 replaced the whole approach with puppeteer screenshots, which reads HTML rather than a payload

So the name is right, the route is right, and no consumer can break. I've reshaped it to return what the renderer actually needs rather than adding a second near-identically-named endpoint beside it.

The old shape (`snippet`, `extension`, icon URLs) is gone. If you know of an external consumer I can't see from the codebase, say so and I'll add alongside instead.

## Note on sequencing

The public `images#solution_data` route **stays for now**. Production is currently serving satori-rendered images through it, so it can't be removed until the generator has switched over and deployed. Worth a follow-up PR to delete it — it's a public endpoint exposing full solution file contents as JSON, which is fine (the same content is already public via the HTML page) but pointless once nothing calls it.

## Testing

Adds the controller test this endpoint never had — payload shape, no-auth access, and a 404 for an unknown solution. Includes an assertion that `highlight_theme` is populated, since without it the generator has no way to colour code (it can't load the stylesheet that normally does that).

**Unrun locally** — `bundle exec` doesn't work in a git worktree (the `fix/worktree-deps` problem), so I've only syntax-checked. The equivalent serializer tests passed in CI on #9348, and this reuses `SerializeSolutionImage` unchanged, so I'd expect green.