### PR TITLE
Drop the public solution image data route

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -29,12 +29,4 @@ class ImagesController < ApplicationController
   def solution
     @solution = Solution.for!(params[:user_handle], params[:track_slug], params[:exercise_slug])
   end
-
-  # Feeds the image generator, which renders the share image without a browser
-  # and so needs the data rather than the page.
-  def solution_data
-    solution = Solution.for!(params[:user_handle], params[:track_slug], params[:exercise_slug])
-
-    render json: SerializeSolutionImage.(solution)
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,10 +122,6 @@ Rails.application.routes.draw do
   resources :solution_tagger, only: [:index]
 
   resource :images, controller: "images" do
-    # Declared before the HTML route so the trailing segment isn't swallowed by
-    # :user_handle. A path segment rather than a .json format because handles
-    # are user-supplied and shouldn't have to be format-safe.
-    get "solutions/:track_slug/:exercise_slug/:user_handle/data", to: "images#solution_data"
     get "solutions/:track_slug/:exercise_slug/:user_handle", to: "images#solution"
     get "profiles/:user_handle", to: "images#profile"
   end


### PR DESCRIPTION
Cleanup after exercism/image-generator#14. Nothing calls this any more.

The generator fetched its payload from `/images/solutions/.../data` for about a day. It now reads the same payload from `/spi/solution_image_data/...` over the internal ALB, so the public route is dead.

Worth removing rather than leaving: it's an unauthenticated public endpoint serving a solution's full file contents as JSON. That's not a leak — the same content is already public on the HTML page it was extracted from — but there's no reason to keep a second, undocumented way to get it.

`SerializeSolutionImage` stays; the SPI controller uses it, and its tests are unchanged.

**Safe to merge now** — the generator switched over and deployed earlier, and has been serving from the SPI endpoint since (~13k invocations/day, zero errors).