### PR TITLE
Throttle unauthenticated crawling of expensive endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -21,9 +21,60 @@ class Rack::Attack::Request
     auth_header = env['HTTP_AUTHORIZATION']
     auth_header&.match(/^Bearer\s+(.+)$/)&.captures&.first
   end
+
+  # In production we sit behind Cloudflare and then an ALB, which means the
+  # X-Forwarded-For chain can resolve to a Cloudflare PoP address rather than
+  # the real client. Throttling on that would throttle everyone behind the PoP.
+  # CF-Connecting-IP is always set by Cloudflare and is always the true client IP.
+  # It's only absent in local/test, where we fall back to req.ip.
+  def client_ip
+    env['HTTP_CF_CONNECTING_IP'].presence || ip
+  end
+
+  # Rack::Attack is middleware, so Devise's user_signed_in? isn't available.
+  # The _exercism_user_id cookie is set for every signed-in user (see
+  # ApplicationController#set_user_id_cookie) and is the same signal our
+  # Cloudflare cache rules use to bypass the cache for logged-in users.
+  def signed_in?
+    cookies['_exercism_user_id'].present?
+  end
 end
 
 Rack::Attack.throttled_response_retry_after_header = true
+
+# Exempt verified search engine crawlers from all throttling.
+#
+# The X-Search-Engine header is set by a Cloudflare transform rule, which sets
+# it to "false" by default and only to "true" for requests Cloudflare has
+# verified as Googlebot/bingbot/DuckDuckBot/Applebot. We deliberately do no
+# user-agent matching here - the header is the entire mechanism, because only
+# Cloudflare can actually verify a bot.
+#
+# The header is trustworthy because:
+# - The ALB security group only accepts traffic on 443 from Cloudflare's IP
+#   ranges, so requests cannot reach us without passing through Cloudflare.
+# - The transform rule *always* sets the header (to "false" when unverified),
+#   so a client-supplied value can never survive to the origin.
+Rack::Attack.safelist("verified search engines") do |req|
+  req.env['HTTP_X_SEARCH_ENGINE'] == 'true'
+end
+
+# YandexBot (and friends) hammer two endpoints hard enough to be ~40% of the
+# traffic reaching origin. Cap unauthenticated crawling of them per-IP per-day.
+CRAWLED_EXERCISE_PATH = %r{\A/tracks/[^/]+/exercises/[^/]+(/|\z)}
+Rack::Attack.throttle("Unauthenticated crawling of expensive endpoints", limit: 500, period: 1.day) do |req|
+  next unless req.get?
+  next if req.signed_in?
+
+  # Only resolve the route for the API endpoint (and only once we know the path
+  # is in the right namespace) - recognize_path is expensive and blows up on
+  # paths mounted outside the router, such as /sidekiq.
+  matches = req.path.match?(CRAWLED_EXERCISE_PATH) ||
+            (req.path.starts_with?('/api/v2/solutions') && req.routed_to == 'api/solutions/submission_files#index')
+  next unless matches
+
+  "unauthenticated-crawl|#{req.client_ip}"
+end
 
 api_non_get_limit_proc = proc do |req|
   next 4 if req.post? && req.routed_to == 'api/iterations#create'

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -42,13 +42,15 @@ end
 
 Rack::Attack.throttled_response_retry_after_header = true
 
-# Exempt verified search engine crawlers from all throttling.
+# Exempt verified search engine crawlers from all throttling, so that indexing
+# is never collateral damage of a limit aimed at everything else.
 #
-# The X-Search-Engine header is set by a Cloudflare transform rule, which sets
-# it to "false" by default and only to "true" for requests Cloudflare has
-# verified as Googlebot/bingbot/DuckDuckBot/Applebot. We deliberately do no
-# user-agent matching here - the header is the entire mechanism, because only
-# Cloudflare can actually verify a bot.
+# The X-Search-Engine header is set by a Cloudflare transform rule, which
+# decides which crawlers we want to exempt. We deliberately do no user-agent
+# matching here: a user agent is just a header and anyone can claim to be a
+# search engine, so only Cloudflare - which verifies crawlers by IP ownership
+# and reverse DNS - can answer this. Changing which engines are exempt is a
+# change to that rule, not to this file.
 #
 # The header is trustworthy because:
 # - The ALB security group only accepts traffic on 443 from Cloudflare's IP
@@ -59,8 +61,11 @@ Rack::Attack.safelist("verified search engines") do |req|
   req.env['HTTP_X_SEARCH_ENGINE'] == 'true'
 end
 
-# YandexBot (and friends) hammer two endpoints hard enough to be ~40% of the
-# traffic reaching origin. Cap unauthenticated crawling of them per-IP per-day.
+# These two endpoints are cheap to request and expensive to serve, and are
+# enumerable: there is one URL per exercise and one per submission, so anything
+# walking the site systematically can pull an unbounded number of them. Cap
+# unauthenticated access per-IP per-day. The limit is far above what any
+# person browsing the site would reach.
 CRAWLED_EXERCISE_PATH = %r{\A/tracks/[^/]+/exercises/[^/]+(/|\z)}
 Rack::Attack.throttle("Unauthenticated crawling of expensive endpoints", limit: 500, period: 1.day) do |req|
   next unless req.get?

--- a/test/initializers/rack_attack_test.rb
+++ b/test/initializers/rack_attack_test.rb
@@ -174,6 +174,112 @@ class RackAttackTest < Webhooks::BaseTestCase
     end
   end
 
+  test "unauthenticated exercise page requests under the limit are not throttled" do
+    create :practice_exercise
+    ip = "1.2.3.4"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 499)
+
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers(ip)
+      assert_response :ok
+    end
+  end
+
+  test "unauthenticated exercise page requests over the limit are throttled" do
+    create :practice_exercise
+    ip = "1.2.3.5"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers(ip)
+      assert_response :too_many_requests
+    end
+  end
+
+  test "unauthenticated submission files requests over the limit are throttled" do
+    solution = create :practice_solution
+    submission = create(:submission, solution:)
+    ip = "1.2.3.6"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get api_solution_submission_files_path(solution.uuid, submission.uuid), headers: crawler_headers(ip)
+      assert_response :too_many_requests
+    end
+  end
+
+  test "authenticated requests are not throttled by the crawl throttle" do
+    create :practice_exercise
+    ip = "1.2.3.7"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers(ip).merge('HTTP_COOKIE' => '_exercism_user_id=123')
+      assert_response :ok
+    end
+  end
+
+  test "verified search engines are safelisted from the crawl throttle" do
+    create :practice_exercise
+    ip = "1.2.3.8"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers(ip).merge('HTTP_X_SEARCH_ENGINE' => 'true')
+      assert_response :ok
+    end
+  end
+
+  test "unverified search engine header does not bypass the crawl throttle" do
+    create :practice_exercise
+    ip = "1.2.3.9"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers(ip).merge('HTTP_X_SEARCH_ENGINE' => 'false')
+      assert_response :too_many_requests
+    end
+  end
+
+  test "other paths are unaffected by the crawl throttle" do
+    create :track
+    ip = "1.2.3.10"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get tracks_path, headers: crawler_headers(ip)
+      assert_response :ok
+    end
+  end
+
+  test "the crawl throttle is keyed on CF-Connecting-IP, not the connecting address" do
+    create :practice_exercise
+
+    freeze_time do
+      fill_crawl_throttle("1.2.3.11", 500)
+
+      # A different real client behind the same Cloudflare PoP is unaffected
+      get "/tracks/ruby/exercises/bob", headers: crawler_headers("1.2.3.12")
+      assert_response :ok
+    end
+  end
+
+  def crawler_headers(ip)
+    { 'HTTP_CF_CONNECTING_IP' => ip }
+  end
+
+  def fill_crawl_throttle(ip, count)
+    key = "Unauthenticated crawling of expensive endpoints:unauthenticated-crawl|#{ip}"
+    count.times { Rack::Attack.cache.count(key, 1.day) }
+  end
+
   def setup_user(user = nil)
     @current_user = user || create(:user)
     @current_user.confirm


### PR DESCRIPTION
## Context

We're being crawled extremely hard by YandexBot: ~1M requests/day from ~60 IPs, which is roughly **40% of all traffic reaching origin**. Two endpoints take the bulk of it:

- `/tracks/{track}/exercises/{exercise}` and everything below it — 3.63M requests/week
- `/api/v2/solutions/{solution_uuid}/submissions/{submission_uuid}/files` — 2.65M requests/week

## What this does

Adds a per-IP daily cap of **500 requests** on **unauthenticated GETs** to those two endpoints only. At 500/day across ~60 Yandex IPs that takes them from ~1M/day to ~30k/day.

The three conditions are all required: GET, path matches one of the two endpoints, and no `_exercism_user_id` cookie. Rack::Attack is middleware so `user_signed_in?` isn't available — the `_exercism_user_id` cookie is the same logged-in signal our Cloudflare cache rules key their bypass on, so it stays consistent with the edge.

The exercise pages are matched with a path regex (they fan out into a dozen nested controllers, so route resolution buys nothing). The API endpoint is matched with `routed_to`, gated behind a cheap path prefix check first — `recognize_path` is expensive, and it raises on paths mounted outside the router such as `/sidekiq`.

### Keyed on CF-Connecting-IP, not `req.ip`

Behind Cloudflare + the ALB, the `X-Forwarded-For` chain can resolve to a **Cloudflare PoP address** rather than the real client. Throttling on that would throttle every user behind that PoP. There's no `trusted_proxies` config in this repo, so `req.ip` is not safe to key on. This throttle uses `CF-Connecting-IP`, which Cloudflare always sets to the true client IP, falling back to `req.ip` only when the header is absent (local/test only).

The existing throttles have the same latent issue via `Rack::Attack::Request#throttle_key`. **This PR deliberately does not touch them** — that's a separate change with its own blast radius. A new helper is added instead.

## ⚠️ Deploy-ordering note — read this

There's also a `safelist` that exempts verified search engines, keyed on the request header `X-Search-Engine` being exactly `"true"`. That header is set by **a Cloudflare transform rule that has not landed yet** (it's being written separately). It sets the header to `"false"` by default and `"true"` only for Cloudflare-verified Googlebot/bingbot/DuckDuckBot/Applebot.

**Until that transform rule is live, the safelist is inert and verified search engine bots WILL be throttled by this change.** Googlebot in particular could hit the 500/day cap on exercise pages. Land the Cloudflare transform rule before (or at the same time as) deploying this.

The header is trustworthy once the rule exists because the ALB security group only accepts 443 from Cloudflare IP ranges, so nothing reaches origin without passing through Cloudflare, and the transform rule *always* sets the header — a client-supplied value can never survive to us. There is deliberately no user-agent matching in Ruby; only Cloudflare can actually verify a bot.

## Tests

Added to `test/initializers/rack_attack_test.rb`, following the existing patterns there. Counters are pre-seeded via `Rack::Attack.cache.count` rather than firing 500 real requests, so the tests stay fast.

- under the limit passes; over the limit returns 429
- the submission files endpoint is throttled
- authenticated requests (cookie present) are not throttled
- `X-Search-Engine: true` bypasses the throttle; `"false"` does not
- other paths (e.g. `/tracks`) are unaffected
- a different `CF-Connecting-IP` is unaffected by another IP's exhausted quota

All 17 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGr9woFrDZjnneiK1XQbG3
