### PR TITLE
Don't let route resolution 500 requests from middleware

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,11 +3,20 @@ require 'http_authentication_token'
 class Rack::Attack::Request
   extend Mandate::Memoize
 
+  # Resolving a route from middleware is best-effort. recognize_path raises
+  # RoutingError for anything the router doesn't know, but it can also raise
+  # other things: paths mounted outside the router (/sidekiq) blow up with
+  # NoMethodError because Warden isn't in the env yet, and route constraints
+  # are arbitrary code that can fail in arbitrary ways.
+  #
+  # Every caller treats nil as "no route", so rescuing broadly is the safe
+  # behaviour. The alternative is a throttle definition raising inside
+  # middleware, which 500s the request before it ever reaches the app.
   memoize
   def routed_to
     route = Rails.application.routes.recognize_path(path, { method: request_method })
     "#{route[:controller]}##{route[:action]}"
-  rescue ActionController::RoutingError
+  rescue StandardError
     nil
   end
 
@@ -71,9 +80,9 @@ Rack::Attack.throttle("Unauthenticated crawling of expensive endpoints", limit: 
   next unless req.get?
   next if req.signed_in?
 
-  # Only resolve the route for the API endpoint (and only once we know the path
-  # is in the right namespace) - recognize_path is expensive and blows up on
-  # paths mounted outside the router, such as /sidekiq.
+  # Only resolve the route for the API endpoint, and only once we know the
+  # path is in the right namespace: recognize_path walks the whole route set,
+  # which is far too expensive to pay on every unauthenticated GET.
   matches = req.path.match?(CRAWLED_EXERCISE_PATH) ||
             (req.path.starts_with?('/api/v2/solutions') && req.routed_to == 'api/solutions/submission_files#index')
   next unless matches

--- a/test/initializers/rack_attack_test.rb
+++ b/test/initializers/rack_attack_test.rb
@@ -164,6 +164,19 @@ class RackAttackTest < Webhooks::BaseTestCase
     end
   end
 
+  test "routed_to returns nil rather than raising when the route cannot be resolved" do
+    # recognize_path raises RoutingError for unknown paths, but it can also
+    # raise other things - NoMethodError for paths mounted outside the router,
+    # or anything at all from a route constraint. None of them should escape
+    # into the middleware stack and 500 the request.
+    [ActionController::RoutingError, NoMethodError, RuntimeError].each do |error_class|
+      Rails.application.routes.stubs(:recognize_path).raises(error_class, "boom")
+
+      request = Rack::Attack::Request.new(Rack::MockRequest.env_for("/anything"))
+      assert_nil request.routed_to
+    end
+  end
+
   test "sidekiq is not blocked" do
     user = create :user, :admin
     setup_user(user)


### PR DESCRIPTION
## Why

`Rack::Attack::Request#routed_to` rescued only `ActionController::RoutingError`, but `recognize_path` can raise other things:

- `/sidekiq` raises `NoMethodError: undefined method 'authenticate!' for nil` — Warden isn't in the env yet when Rack::Attack runs, and the Sidekiq mount's constraint reaches for it.
- Route constraints in general are arbitrary code, and can fail in arbitrary ways.

Anything that escapes takes the request down with a 500, from inside a throttle definition — which should never be able to break a request it isn't even throttling.

The existing throttles only avoided this because they all `next if req.path.starts_with?('/sidekiq')` before ever calling `routed_to`. That's a guard every future throttle would have to remember, for a reason that isn't obvious from reading it.

## What

Rescue `StandardError` and return `nil`. Every caller already treats `nil` as "no route", so failing open is both correct and the least surprising behaviour.

Also updates a comment in the crawl throttle that claimed `routed_to` "blows up on paths mounted outside the router" — no longer true, and the prefix gate there is now purely about not paying `recognize_path` on every unauthenticated GET.

## Testing

Added a test asserting `routed_to` returns `nil` for `RoutingError`, `NoMethodError` and `RuntimeError`. Verified it fails against the old rescue (`NoMethodError: boom` escapes) and passes with the new one. Full file: 18 runs, 304 assertions, 0 failures.

Follow-up to #9356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGr9woFrDZjnneiK1XQbG3