### PR TITLE
fix: remove duplicated 'You can always change later.' in welcome modal

### DIFF
--- a/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
+++ b/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
@@ -35,8 +35,7 @@ export function HasLearningModeStep({
           {t('hasLearningModeStep.startTrackInLearningOrPracticeMode', {
             trackTitle: track.title,
           })}
-        </span>{' '}
-        (You can always change later.)
+        </span>
       </p>
 
       <div className="grid grid-cols-2 gap-12 items-center">


### PR DESCRIPTION
Removes the hardcoded "(You can always change later.)" that was appended after the translated `startTrackInLearningOrPracticeMode` string, which already includes that phrase. The modal text was showing the sentence twice.

Closes #6779