### PR TITLE
Fix the image data 404 test

### DIFF
--- a/test/controllers/spi/solution_image_data_controller_test.rb
+++ b/test/controllers/spi/solution_image_data_controller_test.rb
@@ -33,9 +33,12 @@ class SPI::SolutionImageDataControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test "404s for a solution that doesn't exist" do
-    get "/spi/solution_image_data/nope/nope/nope"
-
-    assert_response :not_found
+  test "raises for a solution that doesn't exist" do
+    # SPI::BaseController has no rescue_from, so Solution.for! propagates -
+    # Rails turns that into a 404 in production. The generator only needs a
+    # non-200 so it fails and logs rather than caching a broken image.
+    assert_raises ActiveRecord::RecordNotFound do
+      get "/spi/solution_image_data/nope/nope/nope"
+    end
   end
 end


### PR DESCRIPTION
Fixes the red `ruby-tests` shard on main. My fault, from #9354.

## What broke

`SPI::BaseController` has no `rescue_from ActiveRecord::RecordNotFound` — unlike `ImagesController`, which does. So `Solution.for!` propagates the exception instead of rendering a 404.

Rails converts that to a 404 in production, so **the endpoint behaves correctly**. But in the test environment the exception surfaces, and my test asserted `assert_response :not_found`. It errored rather than failed:

```
374 runs, 813 assertions, 0 failures, 1 errors, 5 skips
bin/rails test test/controllers/spi/solution_image_data_controller_test.rb:36
```

## The fix

Assert the raise instead, which is what the rest of the controller tests do for controllers without a `rescue_from` — `api/user_tracks_controller_test.rb`, `tracks/mentor_discussions_controller_test.rb`, `api/bootcamp/custom_functions_controller_test.rb` all use `assert_raises ActiveRecord::RecordNotFound`. Mine was the odd one out.

**No production behaviour changes.** The generator only needs a non-200 so it fails and logs rather than caching a broken image, and a 404 does that.

## Why it slipped through

I wrote that test without running it — `bundle exec` doesn't work in a git worktree (the `fix/worktree-deps` problem), so I'd only syntax-checked and flagged it as unverified on the PR. The two tests that mattered passed; this one asserted behaviour I'd assumed rather than checked.