### PR TITLE
Simplify User::Notification::MarkRelevantAsRead to a single UPDATE

### DIFF
--- a/app/commands/user/notification/mark_relevant_as_read.rb
+++ b/app/commands/user/notification/mark_relevant_as_read.rb
@@ -4,13 +4,8 @@ class User::Notification::MarkRelevantAsRead
   initialize_with :user, :path
 
   def call
-    ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
-      ids = user.notifications.pending_or_unread.where(path:).pluck(:id)
-
-      return unless ids.present?
-
-      User::Notification.where(id: ids).update_all(status: :read, read_at: Time.current)
-    end
-    NotificationsChannel.broadcast_changed!(user)
+    num_changed = user.notifications.pending_or_unread.where(path:).
+      update_all(status: :read, read_at: Time.current)
+    NotificationsChannel.broadcast_changed!(user) if num_changed.positive?
   end
 end


### PR DESCRIPTION
Replaces the pluck + conditional `update_all` + explicit transaction with a single statement, using `update_all`'s return value (the number of affected rows).

```ruby
def call
  num_changed = user.notifications.pending_or_unread.where(path:).
    update_all(status: :read, read_at: Time.current)
  NotificationsChannel.broadcast_changed!(user) if num_changed.positive?
end
```

### Why

This runs as an `around_action` in `ApplicationController#mark_notifications_as_read!` on **every signed-in navigational GET**, inside a `Concurrent::Promises.future` (so it also checks out a second pooled DB connection per request).

Measured on production, the query examines **1 row in 0.0386 ms** (`EXPLAIN ANALYZE`, index range scan on `index_user_notifications_on_user_id_and_status`) and returns nothing the overwhelming majority of the time — users average ~3.2 notifications each. So the query is not the cost. **The cost is that we open and commit a transaction on every signed-in page view to do nothing.**

Commits are the unit that drives write I/O on this Aurora cluster: measured `write IOPS = 12.0 + 7.49 × commits/s`, against a total of ~11.4 commits/s. Removing a commit from the most-travelled signed-in code path is worth more than it looks.

### Behaviour

Unchanged. Two things worth noting:

- **The isolation level is no longer set.** `Exercism::READ_COMMITTED` was there for the multi-statement transaction (pluck-then-update); a single autocommitted `UPDATE` doesn't need it, and nothing else depended on the block being a transaction.
- **The broadcast is now guarded by `num_changed.positive?`.** This is not actually a change: the old code's `return unless ids.present?` inside the transaction block returned from `call` and skipped the broadcast too. Same behaviour, expressed without the early return. (This mirrors `User::Notification::MarkAllAsRead`, which already used the `update_all` return value.)

It's also marginally safer — it removes the TOCTOU window between the `pluck` and the `UPDATE`.

### Testing

`test/commands/user/notification/mark_relevant_as_read_test.rb` passes unchanged (3 runs, 0 failures) — including the existing `does not broadcast if none were changed` test, which confirms the guard preserves the old behaviour. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGr9woFrDZjnneiK1XQbG3
