### PR TITLE
Speed up account resetting

### DIFF
--- a/app/commands/user/reset_account.rb
+++ b/app/commands/user/reset_account.rb
@@ -4,6 +4,13 @@ class User::ResetAccount
   initialize_with :user
 
   def call
+    # Do this before anything else. reset_associations! would delete these
+    # anyway, but UserTrack::Reset destroys its tokens one-by-one, and each
+    # destroy fires an after_commit that recalculates the user's reputation.
+    # Clearing them upfront (without callbacks) makes that a no-op. The
+    # reputation is explicitly zeroed below.
+    user.reputation_tokens.delete_all
+
     reset_tracks!
     reset_mentoring!
     reset_associations!
@@ -39,8 +46,10 @@ class User::ResetAccount
       UserTrack::Destroy.(user_track)
     end
 
-    user.viewed_community_solutions.destroy_all
-    user.viewed_exercise_approaches.destroy_all
+    # These models have no destroy callbacks or dependents, so deleting them
+    # in one statement rather than row-by-row is safe.
+    user.viewed_community_solutions.delete_all
+    user.viewed_exercise_approaches.delete_all
   end
 
   def reset_mentoring!

--- a/app/commands/user_track/reset.rb
+++ b/app/commands/user_track/reset.rb
@@ -13,8 +13,12 @@ class UserTrack::Reset
     user.solution_mentor_requests.joins(:solution).
       where(student: user, solution: user_track.solutions.select(:id), status: %i[pending cancelled]).
       destroy_all
-    user_track.viewed_community_solutions.destroy_all
-    user_track.viewed_exercise_approaches.destroy_all
+    # These models have no destroy callbacks or dependents, so deleting them
+    # in one statement rather than row-by-row is safe.
+    # The associations have no dependent strategy (they're scoped by track), so
+    # the strategy is passed explicitly to delete the rows rather than nullify.
+    user_track.viewed_community_solutions.delete_all(:delete_all)
+    user_track.viewed_exercise_approaches.delete_all(:delete_all)
     user_track.solutions.update_all(%{
       user_id = #{User::GHOST_USER_ID},
       unique_key = UUID(),

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -17,7 +17,9 @@ class SettingsController < ApplicationController
   end
 
   def reset_account
-    User::ResetAccount.(current_user) if params[:handle] == current_user.handle
+    # This takes seconds for a large account, and nothing in the response
+    # depends on it having finished, so run it in the background.
+    User::ResetAccount.defer(current_user) if params[:handle] == current_user.handle
 
     render json: {
       links: {

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -11,4 +11,28 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to integrations_settings_path
     assert_nil user.reload.discord_uid
   end
+
+  test "reset_account resets in the background" do
+    user = create :user, bio: "Some bio"
+
+    sign_in!(user)
+    perform_enqueued_jobs do
+      patch reset_account_settings_path, params: { handle: user.handle }, as: :json
+    end
+
+    assert_response :ok
+    assert_nil user.reload.bio
+  end
+
+  test "reset_account does nothing with the wrong handle" do
+    user = create :user, bio: "Some bio"
+
+    sign_in!(user)
+    perform_enqueued_jobs do
+      patch reset_account_settings_path, params: { handle: "someone-else" }, as: :json
+    end
+
+    assert_response :ok
+    assert_equal "Some bio", user.reload.bio
+  end
 end


### PR DESCRIPTION
Looked into [`SettingsController#reset_account` in Skylight](https://www.skylight.io/app/applications/VNpB7GqXZDpQ/recent/6h/endpoints/SettingsController%23reset_account?responseType=json): 3.4s p50 / 9.2s p95, essentially all of it `User::ResetAccount` running inline in the request.

### Reputation tokens were being destroyed one at a time

`UserTrack::Reset` calls `destroy_all` on the track's `PublishedSolutionToken`s. Every destroy fires the `after_commit` in `User::ReputationToken`, which opens a transaction, sums all the user's tokens, updates `users.reputation`, updates `user_tracks.reputation`, and busts a Redis key. Skylight showed this as ~64 DELETEs each with an accompanying SELECT, UPDATE and TRANSACTION, around 400ms.

All of that is thrown away: `reset_associations!` deletes every reputation token anyway, and `user.update(reputation: 0)` overwrites the result. So they're now cleared up front (without callbacks) and the per-track `destroy_all` finds nothing. `UserTrack::Reset` is unchanged for standalone use, where the recalculation does matter.

### `destroy_all` on callback-free models

`UserTrack::ViewedCommunitySolution` and `ViewedExerciseApproach` have no destroy callbacks and no dependents, but were being deleted row-by-row (73 DELETEs in the trace). Now one statement each.

### Deferred the reset

The above still leaves a couple of seconds of unavoidable work (`DELETE user_activities` alone was 592ms, the `UPDATE solutions ... UUID()` rewrite 336ms), and it grows with account size, so a big account would keep creeping towards a timeout. Nothing in the response depends on the reset having finished (the body is just a link to the homepage, which the modal redirects to), so it now runs via `.defer`.

The one behavioural change is that a user can land on the homepage while the reset is still in flight and briefly see stale data. `User::DestroyAccount` is unaffected: it still calls `User::ResetAccount` synchronously before destroying the user.

### Tests

Added controller tests covering both the reset and the wrong-handle no-op. Existing `User::ResetAccount`, `User::DestroyAccount` and `UserTrack::Reset` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq136Skg3EsPyqUjEyypeo