### PR TITLE
Reuse a single Redis client in CalculateContextualData

### DIFF
--- a/app/commands/user/reputation_token/calculate_contextual_data.rb
+++ b/app/commands/user/reputation_token/calculate_contextual_data.rb
@@ -99,8 +99,15 @@ class User::ReputationToken::CalculateContextualData
   Data = Struct.new(:activity, :reputation)
   private_constant :Data
 
+  # This is memoized deliberately. In production Exercism.redis_cache_client
+  # returns a *new* Redis::Cluster every call, and each one does full cluster
+  # topology discovery (CLUSTER NODES + a connection to every node) on its
+  # first command - ~38ms measured against production. with_cache runs twice
+  # per user, so the contributors list was paying that 40 times per render.
+  memoize
+  def redis = Exercism.redis_cache_client
+
   def with_cache(user_id, key)
-    redis = Exercism.redis_cache_client
     user_key = User::ReputationToken.cache_hash_for(user_id)
     value_key = ["contextual/#{key}", period, track_id, category].join("|")
 


### PR DESCRIPTION
## Problem

`CommunityController#show` sits at 2.7s p50 / 5.0s p95 in Skylight, with ~4s of *self* time in `community/show.html.haml` and only ~105ms of traced children. Every SQL query on the page is cheap — the whole assembler does ~5ms of SQL.

The time is in Redis, which Skylight can't see (no Redis probe enabled).

`Exercism.redis_cache_client` is not memoized, and in production it returns a **new** `Redis::Cluster` every call:

```ruby
def self.redis_cache_client = redis_client(config.cache_redis_url)

def self.redis_client(url)
  ...
  Redis::Cluster.new(nodes: [url])
end
```

Each instance builds its own `Router` on first command ([redis-cluster-client `cluster.rb:145`](https://github.com/redis-rb/redis-cluster-client/blob/master/lib/redis_client/cluster.rb)), which means full topology discovery: connect to the seed node, `CLUSTER NODES`, then open a connection to every node in the cluster.

`with_cache` calls it once per user per key. The contributors list serialises 20 users × 2 keys = **40 cluster clients per render**, all thrown away afterwards.

## Evidence (measured on production)

Cold (new client each time) vs warm (one reused client):

```
cold: 45.0ms   warm: 34.9ms   <- first call builds the router
cold: 37.1ms   warm:  1.6ms
cold: 43.6ms   warm:  1.7ms
cold: 35.0ms   warm:  1.5ms
cold: 32.0ms   warm:  1.5ms
```

The production query log for one `AssembleContributors` call shows the smoking gun — a 1.5 second gap containing **no queries at all**:

```
21:21:24.563  User::Profile Load (0.9ms)   <- Search finishes
                                           <- 1.50s of silence
21:21:26.063  User Load (1.2ms)            <- serializer starts
```

1500ms ÷ 40 = 37.5ms per call, matching the cold number exactly. No queries in the gap means all 40 keys were cache *hits*, so it is pure client-construction overhead.

## Result

`AssembleContributors` on production, before and after memoizing:

| | before | after |
|---|---|---|
| run 1 | 1520ms | 160ms |
| run 2 | 1545ms | 96ms |
| run 3 | 1664ms | 101ms |

~15×. The silent gap collapses from 1500ms to ~78ms for the same 40 hgets.

This also stops us leaking 40 sets of cluster connections per request.

## Follow-ups

Two separate PRs:

1. Memoizing `redis_client` in `exercism-config` itself, which fixes this everywhere (`Metrics` builds 2-3 clients per call) rather than just here. This PR gets the win without waiting on a gem release.
2. Pipelining the 40 `hget`s into a single round trip, taking the remaining ~100ms down further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PThVRWeFZ2KHR6cwVFinX3