### PR TITLE
Bump exercism-config to 0.132.0 for pooled Redis clients

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'kaminari'
 gem 'oj', '~> 3.14.0'
 
 # Setup dependencies
-gem 'exercism-config', '>= 0.131.0'
+gem 'exercism-config', '>= 0.132.0'
 # gem 'exercism-config', path: '../config'
 
 # Model-level dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     et-orbi (1.2.11)
       tzinfo
     event_stream_parser (1.0.0)
-    exercism-config (0.131.0)
+    exercism-config (0.132.0)
       aws-sdk-dynamodb (~> 1.0)
       aws-sdk-secretsmanager (~> 1.0)
       mandate
@@ -683,7 +683,7 @@ DEPENDENCIES
   devise (~> 4.7)
   discourse_api
   doorkeeper (~> 5.8)
-  exercism-config (>= 0.131.0)
+  exercism-config (>= 0.132.0)
   factory_bot_rails
   friendly_id (~> 5.4.0)
   geocoder (~> 1.8)


### PR DESCRIPTION
Picks up [exercism/config#83](https://github.com/exercism/config/pull/83), released as 0.132.0.

## What it fixes

Every call to `Exercism.redis_cache_client` / `.redis_tooling_client` / `.redis_git_cache_client` used to build a **new** `Redis::Cluster`, each of which did full topology discovery (`CLUSTER NODES`, then a connection to every node) on its first command, and then threw the connection away.

Measured on production:

```
cold: 45.0ms   warm: 34.9ms   <- first call builds the router
cold: 37.1ms   warm:  1.6ms
cold: 43.6ms   warm:  1.7ms
cold: 35.0ms   warm:  1.5ms
cold: 32.0ms   warm:  1.5ms
```

Per #83, this was ~96% of our ElastiCache ECPU bill and 73M new connections/week on `tooling-jobs-serverless`.

On this side it's why `CommunityController#show` sits at 2.7s p50 / 5.0s p95 — `CalculateContextualData` calls `redis_cache_client` twice per user, so the 20-strong contributors list built 40 cluster clients per render. Skylight has no Redis probe, so it showed up only as ~4s of unattributable self time in `community/show.html.haml`, with a 1.5s gap in the query log containing no queries at all.

## No call site changes needed

`ConnectionPool::Wrapper` checks a connection out per method call, so `Exercism.redis_cache_client.get(...)` still does the right thing.

## Verified locally against the pooled gem

```
is a Wrapper:  true
pool size:     5
same object:   true      # memoized across calls
tooling distinct: true   # separate pool per client type
roundtrip works:  true
pipelined works:  [nil, nil]
```

`pipelined` matters because #9372 adds the first pipelining call site in the codebase, and #83 notes that `Wrapper` doesn't guarantee a *sequence* of commands lands on one connection. I checked: `Wrapper#method_missing` forwards the block and runs the whole call inside a single `with`, so a pipeline executes on one checked-out connection. Safe. A sequence of separate calls still wouldn't be.

## Lockfile

Updated with `--conservative` so only `exercism-config` moves. An unconstrained update also dragged in aws-sdk-core, aws-partitions and zeitwerk, which don't belong here.

## Related

- #9371 — memoizes the client in `CalculateContextualData`. Now redundant given this bump; worth closing unless you want it as belt-and-braces.
- #9372 — pipelines the 40 round-trips into 2. Still worth it: this PR fixes the per-call *cost*, that one fixes the per-call *count*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PThVRWeFZ2KHR6cwVFinX3