### PR TITLE
Cache sitemaps at the CDN for a day

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,5 +1,6 @@
 class SitemapsController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :cache_sitemap!, except: [:robots_txt]
 
   around_action do |_, action|
     ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
@@ -122,6 +123,12 @@ class SitemapsController < ApplicationController
   end
 
   private
+  # Sitemaps are crawler-only and exist to be re-read roughly daily, so
+  # a day of staleness costs nothing and keeps the expensive per-track
+  # queries off the origin almost entirely. There is no purge path: these
+  # simply expire.
+  def cache_sitemap! = cache_public_action!(edge_ttl: 1.day)
+
   def pages_to_xml(pages)
     builder = Nokogiri::XML::Builder.new do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do


### PR DESCRIPTION
Skylight shows `SitemapsController#track` (xml) at **889ms P50 / 12.9s P95**, with **80% of the time in a single N+1**: one top-solutions query per active exercise, averaging 93 reps and peaking at 168 over a 6h window.

Sitemaps exist to be re-read by crawlers roughly daily, so a day of staleness costs nothing, and caching at the edge keeps that query work off the origin almost entirely.

This reuses the `edge_ttl` parameter added for community solution pages in #9351, emitting `max-age=1, public, s-maxage=<~1 day>` (jittered). `robots_txt` is excluded. There is no purge path here, unlike solution pages: these simply expire.

The N+1 itself is worth fixing separately, since it still sets the cost of a cache miss. The likely fix is dropping the `joins(:user)` so the query stays inside the covering `solutions_ex_stat_stars_upat` index and batching the handle lookup once per track; that is being benchmarked against production data before proposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJuVxZuxcQVnsEnKJMtbdB