### PR TITLE
Delete the approaches introduction "Last updated" date

### DIFF
--- a/app/controllers/tracks/dig_deeper_controller.rb
+++ b/app/controllers/tracks/dig_deeper_controller.rb
@@ -40,7 +40,6 @@ class Tracks::DigDeeperController < ApplicationController
       users: introduction_users,
       num_authors: @exercise.approach_introduction_authors.count,
       num_contributors: @exercise.approach_introduction_contributors.count,
-      updated_at: @exercise.approaches_introduction_last_modified_at,
       links: {
         edit: @exercise.approaches_introduction_edit_url
       }

--- a/app/javascript/components/track/dig-deeper-components/DiggingDeeper.tsx
+++ b/app/javascript/components/track/dig-deeper-components/DiggingDeeper.tsx
@@ -1,7 +1,6 @@
 // i18n-key-prefix: diggingDeeper
 // i18n-namespace: components/track/dig-deeper-components
 import React from 'react'
-import dayjs from 'dayjs'
 import { GraphicalIcon, Icon } from '@/components/common'
 import Credits from '@/components/common/Credits'
 import { User } from '@/components/types'
@@ -16,7 +15,6 @@ export type ApproachIntroduction = {
   }
   numAuthors: number
   numContributors: number
-  updatedAt: string
 }
 
 export function DiggingDeeper({
@@ -65,13 +63,6 @@ function DiggingDeeperFooter({
           className="text-textColor1 font-semibold leading-150"
           users={introduction.users}
         />
-        {introduction.updatedAt && (
-          <div className="pl-24 ml-24 border-l-1 border-borderLight2 font-medium hidden sm:block">
-            {t('diggingDeeper.lastUpdated', {
-              date: dayjs(introduction.updatedAt).format('D MMM YYYY'),
-            })}
-          </div>
-        )}
       </div>
       <a
         href={introduction.links.edit}

--- a/app/javascript/i18n/en/components-track-dig-deeper-components.ts
+++ b/app/javascript/i18n/en/components-track-dig-deeper-components.ts
@@ -13,7 +13,6 @@ export default {
   'diggingDeeper.digDeeper': 'Dig deeper',
   'diggingDeeper.author': 'author',
   'diggingDeeper.contributor': 'contributor',
-  'diggingDeeper.lastUpdated': 'Last updated {{date}}',
   'diggingDeeper.editViaGitHub': 'Edit via GitHub',
   'diggingDeeper.linkOpensInNewTab': 'The link opens in a new window or tab',
 }

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -83,7 +83,7 @@ class Exercise < ApplicationRecord
   end
 
   delegate :files_for_editor, :exemplar_files, :introduction, :instructions, :source, :source_url,
-    :approaches_introduction, :approaches_introduction_last_modified_at, :approaches_introduction_exists?,
+    :approaches_introduction, :approaches_introduction_exists?,
     :approaches_introduction_edit_url, to: :git
   delegate :dir, :no_important_files_changed?, to: :git, prefix: true
   delegate :content, :edit_url, to: :mentoring_notes, prefix: :mentoring_notes

--- a/app/models/git/exercise.rb
+++ b/app/models/git/exercise.rb
@@ -5,8 +5,7 @@ module Git
     extend Git::HasGitFilepath
 
     delegate :head_sha, :lookup_commit, :head_commit, to: :repo
-    delegate :introduction, :introduction_last_modified_at, :introduction_exists?, :introduction_edit_url, to: :approaches,
-      prefix: true
+    delegate :introduction, :introduction_exists?, :introduction_edit_url, to: :approaches, prefix: true
 
     git_filepath :instructions, file: ".docs/instructions.md", append_file: ".docs/instructions.append.md"
     git_filepath :introduction, file: ".docs/introduction.md", append_file: ".docs/introduction.append.md"

--- a/app/models/git/exercise/approaches.rb
+++ b/app/models/git/exercise/approaches.rb
@@ -29,13 +29,6 @@ class Git::Exercise::Approaches
   memoize
   def config_introduction = config[:introduction].to_h
 
-  memoize
-  def introduction_last_modified_at
-    return unless introduction_exists?
-
-    repo.file_last_modified_at(introduction_absolute_filepath)
-  end
-
   def introduction_edit_url
     url = introduction_exists? ? EDIT_GITHUB_URL : NEW_GITHUB_URL
 

--- a/app/models/git/repository.rb
+++ b/app/models/git/repository.rb
@@ -75,16 +75,6 @@ module Git
       false
     end
 
-    def file_last_modified_at(path)
-      walker = Rugged::Walker.new(rugged_repo)
-      walker.sorting(Rugged::SORT_DATE)
-      walker.push(head_commit.oid)
-      last_commit = walker.find do |commit|
-        commit.parents.size == 1 && commit.diff(paths: [path]).size.positive?
-      end
-      last_commit.time
-    end
-
     def find_file_oid(commit, path)
       entry = commit.tree.path(path)
       raise "Not a blob" if entry[:type] != :blob

--- a/test/models/git/exercise/approaches_test.rb
+++ b/test/models/git/exercise/approaches_test.rb
@@ -83,20 +83,6 @@ class Git::Exercise::ApproachesTest < ActiveSupport::TestCase
     assert_equal expected_filepaths, approaches.absolute_filepaths
   end
 
-  test "introduction_last_modified_at with approaches introduction" do
-    approaches = Git::Exercise::Approaches.new("bob", "practice", "HEAD",
-      repo_url: TestHelpers.git_repo_url("track"))
-
-    assert_equal Time.zone.utc_to_local(Time.utc(2023, 8, 31, 10, 27, 9)), approaches.introduction_last_modified_at
-  end
-
-  test "introduction_last_modified_at without approaches introduction" do
-    approaches = Git::Exercise::Approaches.new(:leap, "practice", "HEAD",
-      repo_url: TestHelpers.git_repo_url("track"))
-
-    assert_nil approaches.introduction_last_modified_at
-  end
-
   test "introduction_authors" do
     approaches = Git::Exercise::Approaches.new("bob", "practice", "HEAD",
       repo_url: TestHelpers.git_repo_url("track"))


### PR DESCRIPTION
## The problem

`Tracks::DigDeeperController#show` is one of the slowest endpoints on the site: **p50 2845ms, p95 9798ms** for the `html` variant, and **p50 2030ms, p95 7914ms** for `html+turbo-frame`.

The Skylight trace is oddly clean, because almost none of the time is visible:

```
[#35] Tracks::DigDeeperController#show ··· 3044ms (self: 2903ms)
  ...30 children, 28 of them < 5ms...
  [#61 view] layouts/application.html.haml ··· 108ms (4%)
```

~95% of the request is uninstrumented Ruby inside the action.

## The cause

`Git::Repository#file_last_modified_at` walks the track repo's history back from HEAD, computing a **full tree diff per commit**, until it finds one touching the path:

```ruby
walker.push(head_commit.oid)
last_commit = walker.find do |commit|
  commit.parents.size == 1 && commit.diff(paths: [path]).size.positive?
end
```

On a track repo with thousands of commits and an intro that hasn't been edited in a while, that's thousands of tree diffs per page view. It's Rugged/C work, so Skylight attributes it to controller self time and shows nothing.

## What it was actually rendering

Following it through `ReactComponents::Track::DigDeeper` → `DiggingDeeper.tsx`, the entire output was one line of footer text:

```tsx
{introduction.updatedAt && (
  <div className="pl-24 ml-24 ... hidden sm:block">
    {t('diggingDeeper.lastUpdated', { date: dayjs(introduction.updatedAt).format('D MMM YYYY') })}
  </div>
)}
```

**"Last updated 31 Aug 2023"**, at day precision, next to the author credits, and `hidden sm:block` so mobile users never saw it at all while still paying for it.

Seconds of commit-walking per request for that isn't a trade worth making, so this deletes it rather than caching it.

## The change

- Drops `updated_at` from `DigDeeperController#introduction`
- Removes the footer block, the `updatedAt` field on `ApproachIntroduction`, the now-unused `dayjs` import, and the `diggingDeeper.lastUpdated` i18n key
- Removes `Git::Exercise::Approaches#introduction_last_modified_at` and its delegates on `Git::Exercise` / `Exercise`
- Removes `Git::Repository#file_last_modified_at` itself, which had no other caller anywhere in the app

Net: 45 lines deleted, 2 added.

## Not in this PR

Spotted while tracing, worth separate PRs:
- `SitemapsController#track` — `solutions` N+1 at **93 reps avg, 168 max**, p95 12197ms. Worst p95 in the app.
- `CommunityController#show` — 2759ms of uninstrumented Ruby in `community/show.html.haml`. Same blind-spot signature, different cause; needs its own dig.
- The `user_profiles` / `solutions` N+1s in the approaches render here (~66-81ms per query). Small next to 2.9s, but a visible fraction of what's left once this lands.
- Adding `Skylight.instrument` around `Git::Repository`'s read methods, so the next one of these is a trace read rather than a code read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNK7GscbkmQbkMzXQDJvsB