### PR TITLE
Speed up user_track summary generation

### DIFF
--- a/app/commands/user_track/generate_summary_data.rb
+++ b/app/commands/user_track/generate_summary_data.rb
@@ -64,32 +64,51 @@ class UserTrack::GenerateSummaryData
     end
   end
 
+  # This deliberately plucks rather than instantiating ActiveRecord objects.
+  # A large track has 130+ exercises with several hundred rows across the
+  # concept join tables, and instantiating all of that costs far more time
+  # than the queries themselves - especially as we only want a few scalars
+  # off each row.
   def generate_exercises_data!
-    exercises = (
-      user_track.concept_exercises.includes(:taught_concepts, :prerequisites).to_a +
-      user_track.practice_exercises.includes(:practiced_concepts, :prerequisites).to_a
-    ).freeze
+    exercises = pluck_exercises(user_track.concept_exercises) +
+                pluck_exercises(user_track.practice_exercises)
 
-    @exercises_data = exercises.each_with_object({}) do |exercise, data|
-      prerequisite_concept_slugs = exercise.prerequisites.pluck(:slug)
-      practiced_concepts = exercise.practice_exercise? ? exercise.practiced_concepts.pluck(:slug) : []
+    exercise_ids = exercises.map(&:first)
+    prerequisites = concept_slugs_by_exercise_id(Exercise::Prerequisite, exercise_ids)
+    practiced = concept_slugs_by_exercise_id(Exercise::PracticedConcept, exercise_ids)
+    taught = concept_slugs_by_exercise_id(Exercise::TaughtConcept, exercise_ids)
 
-      solution_data = solutions_data[exercise.slug]
+    @exercises_data = exercises.each_with_object({}) do |(id, slug, type, position), data|
+      solution_data = solutions_data[slug]
+      concept_exercise = type == ConceptExercise.to_s
 
       exercise_data = {
-        id: exercise.id,
-        slug: exercise.slug,
-        type: exercise.git_type.to_sym,
-        position: exercise.position,
-        tutorial: exercise.tutorial?,
-        prerequisite_concept_slugs:,
-        practiced_concepts:,
+        id:,
+        slug:,
+        type: type.sub("Exercise", "").downcase.to_sym,
+        position:,
+        tutorial: slug == Exercise::TUTORIAL_SLUG,
+        prerequisite_concept_slugs: prerequisites[id],
+        practiced_concepts: concept_exercise ? [] : practiced[id],
         has_solution: !!solution_data,
         completed_at: solution_data&.fetch(:completed_at) || nil
       }
-      exercise_data[:taught_concepts] = exercise.taught_concepts.pluck(:slug) if exercise.concept_exercise?
-      data[exercise.slug] = exercise_data
+      exercise_data[:taught_concepts] = taught[id] if concept_exercise
+      data[slug] = exercise_data
     end
+  end
+
+  def pluck_exercises(exercises)
+    exercises.except(:includes).pluck(:id, :slug, :type, :position)
+  end
+
+  def concept_slugs_by_exercise_id(klass, exercise_ids)
+    klass.joins(:concept).
+      where(exercise_id: exercise_ids).
+      pluck(:exercise_id, :'track_concepts.slug').
+      each_with_object(Hash.new { |data, exercise_id| data[exercise_id] = [] }) do |(exercise_id, slug), data|
+        data[exercise_id] << slug
+      end
   end
 
   def calculate_unlocking!
@@ -118,14 +137,16 @@ class UserTrack::GenerateSummaryData
   def solutions_data
     return {} if user_track.external?
 
-    solutions = user_track.solutions.includes(:exercise)
-    solutions.each_with_object({}) do |solution, data|
-      data[solution.exercise.slug] = {
-        slug: solution.exercise.slug,
-        status: solution.status,
-        completed_at: solution.completed_at&.to_i
-      }
-    end
+    # As with the exercises, this plucks to avoid instantiating a Solution and
+    # an Exercise for each of the user's solutions on the track.
+    user_track.solutions.pluck(:'exercises.slug', :status, :completed_at).
+      each_with_object({}) do |(slug, status, completed_at), data|
+        data[slug] = {
+          slug:,
+          status: status.to_sym,
+          completed_at: completed_at&.to_i
+        }
+      end
   end
 
   def exercise_is_unlocked?(exercise_data, tutorial_pending)

--- a/app/commands/user_track/monitor_changes.rb
+++ b/app/commands/user_track/monitor_changes.rb
@@ -43,9 +43,11 @@ class UserTrack::MonitorChanges
     concept_progressions.reject! { |cp| cp[:to] == cp[:from] }
 
     # Inject the concept into each result, and remove id
+    # The track is included on each of these as callers serialize them into
+    # links, which needs the track's slug.
     progressed_concepts = Concept.where(
       id: concept_progressions.map { |c| c[:id] }
-    ).index_by(&:id)
+    ).includes(:track).index_by(&:id)
 
     concept_progressions.map do |cp|
       cp[:concept] = progressed_concepts[cp[:id]]
@@ -54,8 +56,8 @@ class UserTrack::MonitorChanges
 
     # And finally return it all as a neat hash
     {
-      unlocked_exercises: Exercise.where(id: unlocked_exercise_ids),
-      unlocked_concepts: Concept.where(id: unlocked_concept_ids),
+      unlocked_exercises: Exercise.where(id: unlocked_exercise_ids).includes(:track),
+      unlocked_concepts: Concept.where(id: unlocked_concept_ids).includes(:track),
       concept_progressions:
     }
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -2,6 +2,8 @@ class Exercise < ApplicationRecord
   extend FriendlyId
   extend Mandate::Memoize
 
+  TUTORIAL_SLUG = "hello-world".freeze
+
   friendly_id :slug, use: [:history]
 
   enum status: {
@@ -128,7 +130,7 @@ class Exercise < ApplicationRecord
   def concept_exercise? = is_a?(ConceptExercise)
   def practice_exercise? = is_a?(PracticeExercise)
   def approaches? = approaches.exists?
-  def tutorial? = slug == "hello-world"
+  def tutorial? = slug == TUTORIAL_SLUG
   def has_test_runner? = super && track.has_test_runner?
 
   memoize

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -4,6 +4,14 @@ class UserTrack < ApplicationRecord
 
   MIN_REP_TO_TRAIN_ML = 50
 
+  # The summary cache key includes a digest of the generator, so that a change
+  # to how summaries are built invalidates every cached summary. The file can't
+  # change within the lifetime of a process, so we only read it once rather than
+  # on every summary lookup.
+  SUMMARY_GENERATOR_DIGEST = Digest::SHA1.hexdigest(
+    File.read(Rails.root.join('app', 'commands', 'user_track', 'generate_summary_data.rb'))
+  ).freeze
+
   serialize :summary_data, coder: JSON
 
   belongs_to :user
@@ -215,7 +223,7 @@ class UserTrack < ApplicationRecord
   def summary
     return @summary if @summary
 
-    digest = Digest::SHA1.hexdigest(File.read(Rails.root.join('app', 'commands', 'user_track', 'generate_summary_data.rb')))
+    digest = SUMMARY_GENERATOR_DIGEST
     track_updated_at = association(:track).loaded? ? track.updated_at : Track.where(id: track_id).pick(:updated_at)
     expected_key = "#{track_updated_at.to_f}:#{last_touched_at.to_f}:#{digest}"
 


### PR DESCRIPTION
`API::SolutionsController#complete` spends roughly half its time in Ruby rather than in the database (241ms of self-time out of a 489ms trace). Profiling on production narrowed the bulk of that to `UserTrack::GenerateSummaryData#generate_exercises_data!`: **85ms for a 131-exercise track, of which only 14.6ms was SQL**.

The cost was ActiveRecord instantiation, not the queries. We built 131 `Exercise` objects, several hundred join-table rows, a `Solution` and an `Exercise` per solution, and the `Concept`s behind all of it, purely to read a handful of scalars off each one.

So pluck the columns we actually want instead, and group the concept slugs by exercise id in Ruby. The query count is unchanged.

This is on the hot path for every completion: `Solution` touches `user_track.last_touched_at`, which invalidates the summary and forces a full regeneration inside the same request.

### Measured against production data

Run on bastion, patching the new implementation in alongside the old so both ran against the same real `user_track`s:

| Track | Before | After | |
|---|---|---|---|
| ruby | 71.4ms | 31.8ms | 55% |
| rust | 51.8ms | 24.1ms | 53% |
| elixir | 123.2ms | 41.2ms | 67% |
| python | 107.3ms | 37.5ms | 65% |
| javascript | 84.0ms | 36.4ms | 57% |

Output was byte-identical to the current implementation on every track tested, which is the part I'd most want a reviewer to weigh — it exercises real data shapes the fixtures don't.

### Also in here

- **Cache the summary generator's digest in a constant.** It was doing a `File.read` plus a SHA1 (~1ms measured) on *every* summary lookup, to digest a file that cannot change within the lifetime of a process.
- **Eager load the tracks in `UserTrack::MonitorChanges`.** Callers serialize these into links, which needs the track slug, so this was an N+1 — Skylight reports it at 39 queries on average and 136 at worst. Bullet caught it once the instantiation change stopped masking it.

### Still open

This doesn't account for all of the Ruby self-time, and I deliberately haven't guessed at the rest. `SerializeTrack` and `UserTrack::Summary` are both cheap on inspection; anything remaining is un-instrumented Ruby that Skylight can't see into, which would want a sampling profiler (`stackprof` isn't currently in the Gemfile). Better to ship this and re-read Skylight once it's deployed.

### Testing

`test/controllers/api/solutions_controller_test.rb` + `test/commands/solution/` — 297 runs, 0 failures.
`test/models/user_track_test.rb` + `test/commands/user_track/` — 100 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdqdKybgsK8DofsVAsAQDS