### PR TITLE
Defer EFS cleanup out of the tooling job request

### DIFF
--- a/app/commands/tooling_job/process.rb
+++ b/app/commands/tooling_job/process.rb
@@ -4,7 +4,10 @@ class ToolingJob::Process
   initialize_with :id
 
   def call
-    ToolingJob::DeleteFromEFS.(job.efs_dir)
+    # This is deferred because it's cleanup rather than part of processing -
+    # nothing below reads from EFS. It's an rm_rf over NFS, so every file is a
+    # network round trip, and there's no reason for the request to wait for it.
+    ToolingJob::DeleteFromEFS.defer(job.efs_dir)
 
     send("process_#{job.type}_job!")
     job.processed!


### PR DESCRIPTION
`SPI::ToolingJobsController#update` spends most of its time outside the database: 181ms of self time against 288ms total, with every DB node in the Skylight trace under 5ms.

Part of that was Redis client construction, fixed by the pooling bump in 1524768f2, which took P50 from 334ms to 224ms. The rest is this: an `rm_rf` against an EFS mount, run synchronously in the request. Recursive delete over NFS is a network round trip per file, and Skylight has no probe for it, so it shows up as unexplained self time.

Nothing in the request needs the directory gone. It holds the input files uploaded by `ToolingJob::Create`, the delete already runs before processing starts, and none of `Submission::TestRun/Representation/Analysis::Process` reads from EFS. It's cleanup, so defer it.

The other caller, `Iteration::CountLinesOfCode`, keeps its synchronous delete: it runs in the background already, and its `ensure` block wants the directory gone before the job ends.

## Note

I couldn't run the test suite locally (OpenSearch isn't up in my environment), so this is relying on CI.

One tradeoff worth a second opinion: cleanup now depends on Sidekiq. If the queue backs up or a job fails permanently, EFS directories leak, and nothing else sweeps them. Given this endpoint runs ~1,000 requests per 30 minutes, that's worth being deliberate about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158PLXyrQHQDafC7K2MRmXg