### PR TITLE
Cache the community page at the CDN for a day

### DIFF
--- a/app/controllers/community_controller.rb
+++ b/app/controllers/community_controller.rb
@@ -1,5 +1,6 @@
 class CommunityController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :cache_community!
 
   def show
     @supporter_avatar_urls = AVATAR_URLS
@@ -57,4 +58,11 @@ class CommunityController < ApplicationController
     "https://avatars1.githubusercontent.com/u/5337876?v=4",
     "https://avatars2.githubusercontent.com/u/286476"
   ].freeze
+
+  private
+  # Signed-out visitors get the same page as each other, and everything on it
+  # (forum threads, community stories, videos, contributors) tolerates a day
+  # of staleness. There is no purge path, so new stories and videos take up to
+  # a day to appear for them. cache_public_action! no-ops for signed-in users.
+  def cache_community! = cache_public_action!(edge_ttl: 1.day)
 end

--- a/test/controllers/community_controller_test.rb
+++ b/test/controllers/community_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class CommunityControllerTest < ActionDispatch::IntegrationTest
+  test "renders for signed-out users" do
+    Forum::RetrieveThreads.stubs(:call).returns([])
+
+    get community_path
+
+    assert_response :ok
+  end
+
+  test "renders for signed-in users" do
+    Forum::RetrieveThreads.stubs(:call).returns([])
+    sign_in!(create(:user))
+
+    get community_path
+
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
Follow-up to #9371 / #9372 / #9373, which took `CommunityController#show` from 2710ms p50 / 4999ms p95 to **215ms / 601ms**.

## Why caching rather than more tuning

With the Redis problem gone, the remaining time is spread thinly and there's no single dominant cost left. Slowest-bucket trace (392ms):

| | ms |
|---|---|
| `show.html.haml` self (untraced Ruby — HAML + JSON prop serialization) | 124 |
| DB inside the template, across 17 queries | ~100 |
| Rails `cache read` | 39 |
| `GET forum.exercism.org` (already cached) | 21 |
| `nav/tracks` (layout, not this page) | 21 |
| all four N+1s combined | ~26 |

Nothing there is a bug. So the lever is not rendering it at all for the visitors who don't need a fresh copy.

## The change

`before_action :cache_community!` → `cache_public_action!(edge_ttl: 1.day)`, same pattern as `SitemapsController`.

`cache_public_action!` already no-ops for signed-in users and for anyone carrying the `_exercism_user_id` cookie, so this only affects anonymous traffic. `Contributing::ContributorsController#index` — which renders the same contributors list — already uses the helper on its default 5–20 minute TTL.

## Tradeoff, explicitly

A day is a long TTL for a page with live-ish content. There is no purge path for this URL, so **new community stories and newly approved videos will take up to 24h to appear for signed-out visitors**, as will changes to the forum-threads block. Signed-in users always see current content. Flagged and chosen deliberately; if that's too long, the fix is either a shorter `edge_ttl` or wiring `Cloudflare::PurgeUrls` into `CommunityStory` and `CommunityVideo` approval.

## Tests

Added a smoke test covering signed-out and signed-in rendering — the page had **no test coverage at all**, which felt worth fixing before adding a callback to it.

I could not run it locally: Docker went down mid-session, so OpenSearch on :9200 is unreachable and `test_helper` can't boot for *any* test. I verified what I could without it — the callback is registered as a `:before`, the method is private, and its arity is correct — but the smoke test itself is unrun and needs CI to confirm.

Note the header can't be asserted in a controller test regardless: `cache_public_action!` returns early in the test env (`application_controller.rb:159`), which is why none of the existing users of it have header tests either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PThVRWeFZ2KHR6cwVFinX3