### PR TITLE
Cache the count of available exercises

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -84,6 +84,24 @@ class Exercise < ApplicationRecord
     joins(:track).find_by('tracks.slug': track_slug, slug: exercise_slug)
   end
 
+  NUM_AVAILABLE_EXERCISES_CACHE_KEY = 'num_available_exercises'.freeze
+  def self.num_available
+    @num_available ||= Rails.cache.fetch(NUM_AVAILABLE_EXERCISES_CACHE_KEY, expires_in: 1.day) do
+      Exercise.available.count
+    end
+  end
+
+  def self.reset_num_available!
+    Rails.cache.delete(NUM_AVAILABLE_EXERCISES_CACHE_KEY)
+    @num_available = nil
+  end
+
+  # NOTE: this uses Exercise (not self.class) as exercises are STI,
+  # and the count/cache always lives on the base class.
+  after_save_commit do
+    Exercise.reset_num_available!
+  end
+
   delegate :files_for_editor, :exemplar_files, :introduction, :instructions, :source, :source_url,
     :approaches_introduction, :approaches_introduction_exists?,
     :approaches_introduction_edit_url, to: :git

--- a/app/views/devise/shared/_information.html.haml
+++ b/app/views/devise/shared/_information.html.haml
@@ -317,7 +317,7 @@
     %p
       Level up your programming skills with
       = succeed(',') do
-        %strong #{Exercise.available.count} exercises across #{Track.num_active} languages
+        %strong #{Exercise.num_available} exercises across #{Track.num_active} languages
       and insightful discussion with our dedicated team of welcoming mentors.
     %p
       %strong Exercism is 100% free forever.

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -46,7 +46,7 @@
           .section-header.mb-24.sm:mb-32
             = graphical_icon :exercises, hex: true
             %h2.text-h2
-              = t('.exercises_section.title_html', count: number_with_delimiter(Exercise.available.count)).html_safe
+              = t('.exercises_section.title_html', count: number_with_delimiter(Exercise.num_available)).html_safe
             %hr.c-divider
             %p.text-p-xlarge
               = t('.exercises_section.subtitle')

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -1,6 +1,25 @@
 require 'test_helper'
 
 class ExerciseTest < ActiveSupport::TestCase
+  test "num_available caches count and is reset when an exercise is saved" do
+    Exercise.reset_num_available!
+
+    create :practice_exercise, status: :active
+    create :practice_exercise, status: :wip
+
+    assert_equal 1, Exercise.num_available
+
+    # Cached, so a change that skips callbacks doesn't change the value
+    Exercise.where(status: :wip).update_all(status: :active)
+    assert_equal 1, Exercise.num_available
+
+    # Saving an exercise busts the cache
+    create :practice_exercise, status: :beta
+    assert_equal 3, Exercise.num_available
+  ensure
+    Exercise.reset_num_available!
+  end
+
   test "to_slug" do
     exercise = create :concept_exercise
     assert_equal exercise.slug, exercise.to_param


### PR DESCRIPTION
Part of a small series of fixes for the highest-execution statements in production `performance_schema`.

## The problem

`Exercise.available.count` was the single most-executed statement we have:

- **6.3M executions**
- **8,825 rows examined per call**, an unindexed full table scan
- **55.5 billion rows examined in total**
- `SUM_NO_INDEX_USED` equal to the execution count, so **not one execution used an index**

It has two callers, and both are hot anonymous paths:

- the homepage exercises section, our largest origin traffic consumer at roughly **181k requests/day**
- the Devise information partial, rendered on every sign-in, sign-up and password page

Neither needs a live number. It is marketing copy.

## The fix

Adds `Exercise.num_available`, cached for 1 day and busted in an `after_save_commit`, so adding an exercise or flipping one to active is reflected immediately. This mirrors the existing `Track.num_active` pattern in `app/models/track.rb` rather than inventing a new mechanism, and the two are already rendered side by side in the Devise partial.

The callback deliberately calls `Exercise.reset_num_available!` rather than `self.class...`: exercises are STI, and the count and its cache always belong to the base class.

## Trade-off

Bulk updates that skip callbacks (`update_all` and friends) will not bust the cache, so the number can be up to a day stale after one. That is acceptable for this value.

## Testing

`test/models/exercise_test.rb` passes: 24 runs, 53 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkFBXyo1T71CgY8W1qSeFF