### PR TITLE
Guard against nil lookups in User.for! and Solution#starred_by?

### DIFF
--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -127,6 +127,11 @@ class Solution < ApplicationRecord
   end
 
   def starred_by?(user)
+    # The community solutions pages are overwhelmingly viewed by
+    # anonymous users. Guarding here avoids millions of pointless
+    # queries for a star with a NULL user_id, which can never exist.
+    return false if user.nil?
+
     stars.exists?(user:)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,6 +203,12 @@ class User < ApplicationRecord
     return param if param.is_a?(User)
     return find_by!(id: param) if param.is_a?(Numeric)
 
+    # A nil param (e.g. a signed-out user being passed to UserTrack.for)
+    # can never match a row, as handle is never NULL. Raising here gives
+    # the same result as the query below without the database round-trip,
+    # which is worth many millions of queries a day.
+    raise ActiveRecord::RecordNotFound if param.nil?
+
     find_by!(handle: param)
   end
 

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -621,6 +621,22 @@ class SolutionTest < ActiveSupport::TestCase
     assert_equal 1, solution.num_stars
   end
 
+  test "starred_by?" do
+    solution = create :concept_solution
+    user = create :user
+
+    refute solution.starred_by?(user)
+    create(:solution_star, solution:, user:)
+    assert solution.starred_by?(user)
+  end
+
+  test "starred_by? is false for nil user" do
+    solution = create :concept_solution
+    create(:solution_star, solution:)
+
+    refute solution.starred_by?(nil)
+  end
+
   test "out_of_date" do
     exercise = create :concept_exercise
     solution = create(:concept_solution, exercise:)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -16,6 +16,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user, User.for!(user.handle)
   end
 
+  test "#for! with nil raises" do
+    create :user # Sanity
+
+    assert_raises ActiveRecord::RecordNotFound do
+      User.for!(nil)
+    end
+  end
+
   test "creates data" do
     user = create :user
     assert user.data


### PR DESCRIPTION
Part of a small series of fixes for the highest-execution statements in production `performance_schema`.

Two of the top statements are queries whose `WHERE` clause can never match a row, because they compare a `NOT NULL` column against `NULL`. Both are reached by passing `nil` for a signed-out user.

## `User.for!`

**32.6M executions** of `SELECT users.* WHERE handle IS NULL LIMIT 1`, examining **zero rows** every single time.

`User.for!` returns early for a `User` and for a `Numeric`, then falls through to `find_by!(handle: param)`. With a `nil` param that becomes `find_by!(handle: nil)`, and `users.handle` is `NOT NULL`, so it always raises `RecordNotFound` after a pointless round-trip.

Nothing surfaced this because the caller, `UserTrack.for!`, swallows the `RecordNotFound`. The volume comes from `use_track!` being a `before_action` on most public pages, combined with `Current#user_track_for` being unable to memoize a block that raises, so it repeats within a single request as well as across them.

Raising directly for `nil` gives every caller exactly the same result, without touching the database.

## `Solution#starred_by?`

**18.2M executions** of `SELECT 1 FROM solution_stars WHERE solution_id = ? AND user_id IS NULL`.

This is anonymous visitors on community solution pages asking whether they have starred a solution. `solution_stars.user_id` is a required foreign key, so `NULL` can never match. Returning `false` for a `nil` user is the same answer, for free.

## Behaviour

Neither change alters anything for a real user. Also adds coverage for `starred_by?`, which had none.

## Testing

`test/models/user_test.rb` and `test/models/solution_test.rb`: 110 runs, 265 assertions, 0 failures.

There is **one pre-existing, unrelated error** in `solution_test.rb:188` (`files_for_editor`), caused by a missing LocalStack S3 bucket in the local environment rather than by anything in this branch. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkFBXyo1T71CgY8W1qSeFF