### PR TITLE
Fix the inert duplicate pre-check when creating notifications

### DIFF
--- a/app/commands/user/notification/create.rb
+++ b/app/commands/user/notification/create.rb
@@ -20,7 +20,11 @@ class User::Notification::Create
     # Don't attempt to create a notification when there already is one
     # This optimizes for scripts that create notifications but where
     # the notification has usually already been created
-    existing_notification = user.notifications.find_by(uniqueness_key: notification.uniqueness_key)
+    # The uniqueness_key is only assigned in a before_create hook, so we
+    # generate it manually here. Using notification.uniqueness_key on an
+    # unsaved record queries for NULL and therefore never matches.
+    uniqueness_key = notification.generate_uniqueness_key!
+    existing_notification = user.notifications.find_by(uniqueness_key:)
     return existing_notification if existing_notification.present?
 
     begin
@@ -34,7 +38,7 @@ class User::Notification::Create
       # If the notification is already created, then don't
       # blow up. This could happen for multiple reasons and
       # it's not necessarily an error.
-      user.notifications.find_by(uniqueness_key: notification.uniqueness_key)
+      user.notifications.find_by(uniqueness_key:)
     end
   end
 end

--- a/app/commands/user/notification/create_email_only.rb
+++ b/app/commands/user/notification/create_email_only.rb
@@ -16,6 +16,16 @@ class User::Notification::CreateEmailOnly
       params:
     )
 
+    # Don't attempt to create a notification when there already is one.
+    # This optimizes for scripts that create notifications but where
+    # the notification has usually already been created, and avoids
+    # the DB work of an insert that's guaranteed to fail and roll back.
+    # The uniqueness_key is only assigned in a before_create hook, so
+    # we generate it manually here to check against.
+    uniqueness_key = notification.generate_uniqueness_key!
+    existing_notification = user.notifications.find_by(uniqueness_key:)
+    return existing_notification if existing_notification.present?
+
     begin
       notification.save!
       notification.tap do
@@ -25,7 +35,7 @@ class User::Notification::CreateEmailOnly
       # If the notification is already created, then don't
       # blow up. This could happen for multiple reasons and
       # it's not necessarily an error.
-      user.notifications.find_by(uniqueness_key: notification.uniqueness_key)
+      user.notifications.find_by(uniqueness_key:)
     end
   end
 end

--- a/test/commands/user/notification/create_email_only_test.rb
+++ b/test/commands/user/notification/create_email_only_test.rb
@@ -35,5 +35,22 @@ class User::Notifications::CreateEmailOnlyTest < ActiveSupport::TestCase
     n_1 = User::Notification::CreateEmailOnly.(user, type, **params)
     n_2 = User::Notification::CreateEmailOnly.(user, type, **params)
     assert_equal n_1, n_2
+    assert_equal 1, User::Notification.count
+  end
+
+  test "duplicate is caught before hitting the database" do
+    user = create :user
+    type = :mentor_started_discussion
+    discussion = create(:mentor_discussion)
+    params = { discussion: }
+
+    n_1 = User::Notification::CreateEmailOnly.(user, type, **params)
+
+    # The second call should short-circuit on the pre-check, so neither
+    # the insert nor the email should happen again.
+    User::Notification::SendEmail.expects(:call).never
+    User::Notification.any_instance.expects(:save!).never
+
+    assert_equal n_1, User::Notification::CreateEmailOnly.(user, type, **params)
   end
 end


### PR DESCRIPTION
Part of a small series of fixes for the highest-execution statements in production `performance_schema`.

## The problem

`User::Notification::Create` has a pre-check that is meant to return an existing notification rather than attempting an insert that is guaranteed to fail. It has never worked.

The check read `notification.uniqueness_key` on an **unsaved** record, but that column is only assigned in the `before_create` hook in `IsParamaterisedSti`. On an unsaved record it is always `nil`, so the query went out as `uniqueness_key IS NULL` against a `NOT NULL` column and could never match.

That is **30.4M executions** of a statement that returns nothing by construction.

With the guard inert, every duplicate fell through to `save!`, hit the unique index, raised `RecordNotUnique` and rolled back. Those rollbacks are a share of **46.7M `ROLLBACK`s at 3.7ms each**. A rollback is far more expensive than the `SELECT` that was supposed to prevent it, so the code was paying for the guard and getting none of its benefit.

`User::Notification::CreateEmailOnly` had **no pre-check at all**, so every duplicate there went straight to insert-and-rollback.

## The fix

Both paths now compute the key up front via `generate_uniqueness_key!`, the same method the `before_create` hook uses, and check against that. The saved record ends up with an identical key, so nothing changes about what is written.

## The rescue is deliberately retained

The `RecordNotUnique` rescue stays in both commands, and that is intentional rather than an oversight.

The pre-check is an optimisation for the common case, not a guarantee: two concurrent callers can both pass it before either commits. The rescue remains the correctness backstop for that race. It now just reuses the key computed above instead of re-reading it off the record.

## Testing

`test/commands/user/notification/`: 31 runs, 74 assertions, 0 failures. Adds a test asserting the second call short-circuits on the pre-check, so neither the insert nor the email happens again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkFBXyo1T71CgY8W1qSeFF