### PR TITLE
Make the partner advert deterministic so advert pages can be edge-cached

### DIFF
--- a/app/helpers/view_components/partner/advert.rb
+++ b/app/helpers/view_components/partner/advert.rb
@@ -21,8 +21,12 @@ module ViewComponents
       @advert ||= ::Partner::Advert.for_track(track)
     end
 
+    # Deliberately does not check request.is_crawler?. That check keyed the
+    # rendered HTML to the User-Agent, which Cloudflare does not include in its
+    # cache key, so whichever client happened to warm the cache decided whether
+    # everyone else saw an advert. Nothing bills us for a render either: clicks
+    # are what count, and Partner::AdvertsController still ignores crawlers.
     def show_advert?
-      return false if request.is_crawler?
       return true if preview
       return false unless advert
       return false if current_user&.hide_website_adverts?

--- a/app/models/partner/advert.rb
+++ b/app/models/partner/advert.rb
@@ -7,7 +7,20 @@ class Partner::Advert < ApplicationRecord
 
   serialize :track_slugs, coder: JSON
 
+  # The chosen advert is cached for a day. The selection below is random, which
+  # makes every render of a page containing an advert unique and therefore
+  # impossible to cache at the CDN. Caching the decision costs us nothing now
+  # that there is effectively a single active advert, and it lets the track and
+  # exercise pages that render it be given a long edge TTL.
   def self.for_track(track)
+    id = Rails.cache.fetch("partner/advert/for_track/#{track.slug}", expires_in: 1.day) do
+      select_for_track(track)&.id
+    end
+
+    find_by(id:)
+  end
+
+  def self.select_for_track(track)
     candidates = active.to_a.sort_by! { rand }
 
     # Sort through ones without slugs first, then ones with them.
@@ -25,6 +38,18 @@ class Partner::Advert < ApplicationRecord
 
     nil
   end
+  private_class_method :select_for_track
+
+  # Without this, an advert that is retired or goes out of budget would carry on
+  # being served for up to a day. Adverts change rarely, so clearing every
+  # track's key on any change is cheaper than versioning the key on read.
+  def self.clear_for_track_cache!
+    Track.pluck(:slug).each do |slug|
+      Rails.cache.delete("partner/advert/for_track/#{slug}")
+    end
+  end
+
+  after_commit { self.class.clear_for_track_cache! }
 
   before_create do
     self.uuid = SecureRandom.compact_uuid

--- a/test/models/partner/advert_test.rb
+++ b/test/models/partner/advert_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class Partner::AdvertTest < ActiveSupport::TestCase
+  test "for_track returns an advert without track slugs" do
+    track = create :track
+    advert = create :advert, status: :active
+
+    assert_equal advert, Partner::Advert.for_track(track)
+  end
+
+  test "for_track prefers an advert that names the track" do
+    track = create :track, slug: "ruby"
+    create :advert, status: :active
+    targeted = create :advert, status: :active, track_slugs: ["ruby"]
+
+    assert_equal targeted, Partner::Advert.for_track(track)
+  end
+
+  test "for_track ignores an advert that names a different track" do
+    track = create :track, slug: "ruby"
+    generic = create :advert, status: :active
+    create :advert, status: :active, track_slugs: ["python"]
+
+    assert_equal generic, Partner::Advert.for_track(track)
+  end
+
+  test "for_track returns nil when there are no active adverts" do
+    track = create :track
+    create :advert, status: :pending
+
+    assert_nil Partner::Advert.for_track(track)
+  end
+
+  test "for_track caches its decision" do
+    track = create :track
+    advert = create :advert, status: :active
+
+    assert_equal advert, Partner::Advert.for_track(track)
+    assert_equal advert.id, Rails.cache.read("partner/advert/for_track/#{track.slug}")
+  end
+
+  test "for_track caches the absence of an advert" do
+    track = create :track
+
+    assert_nil Partner::Advert.for_track(track)
+    assert Rails.cache.exist?("partner/advert/for_track/#{track.slug}")
+  end
+
+  test "for_track caches per track" do
+    ruby = create :track, slug: "ruby"
+    python = create :track, slug: "python", title: "Python"
+    generic = create :advert, status: :active
+    targeted = create :advert, status: :active, track_slugs: ["python"]
+
+    assert_equal generic, Partner::Advert.for_track(ruby)
+    assert_equal targeted, Partner::Advert.for_track(python)
+  end
+
+  test "saving an advert clears the cached decision" do
+    track = create :track
+    advert = create :advert, status: :active
+
+    assert_equal advert, Partner::Advert.for_track(track)
+
+    advert.retired!
+
+    assert_nil Rails.cache.read("partner/advert/for_track/#{track.slug}")
+    assert_nil Partner::Advert.for_track(track)
+  end
+
+  test "clear_for_track_cache! clears every track's key" do
+    ruby = create :track, slug: "ruby"
+    python = create :track, slug: "python", title: "Python"
+    create :advert, status: :active
+
+    Partner::Advert.for_track(ruby)
+    Partner::Advert.for_track(python)
+
+    Partner::Advert.clear_for_track_cache!
+
+    assert_nil Rails.cache.read("partner/advert/for_track/ruby")
+    assert_nil Rails.cache.read("partner/advert/for_track/python")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -171,6 +171,11 @@ class ActiveSupport::TestCase
     reset_redis!
     reset_rack_attack!
 
+    # The test cache store is an in-memory one that outlives each test, so
+    # anything cached in one test leaks into the next. Nothing rolls it back
+    # the way the transactional fixtures roll back the database.
+    Rails.cache.clear
+
     # We do it like this (rather than stub/unstub) so that we
     # can have this method globally without disabling mocha's
     # protections against unstubbing unecessary methods.


### PR DESCRIPTION
Groundwork for giving `/tracks/:t/exercises/:e` (~98k origin reqs) and `/tracks/:t/concepts/:c` (~15k) a long Cloudflare edge TTL. Both render a partner advert, and the advert was the only thing making those pages uncacheable.

## The problem

Two separate sources of non-determinism in the rendered HTML:

1. `Partner::Advert.for_track` sorted the active adverts with `sort_by! { rand }`. Every render was potentially a different advert, so caching a page froze one arbitrary roll of the dice per URL for the whole TTL.
2. `show_advert?` returned false for `request.is_crawler?`, a User-Agent check. Cloudflare does not include the User-Agent in its cache key, so whichever client warmed the cache decided whether *everyone* saw an advert. A crawler warming it meant humans got none.

## The changes

**Cache the selection per track for a day.** Now that there is effectively a single active advert, the rotation the randomness bought us is worth nothing. Saving any advert clears every track's key, so an advert that is retired or goes out of budget stops being served immediately rather than lingering for up to a day. Adverts change rarely, so clearing ~70 keys on write is cheaper than versioning the key on every read.

**Drop the crawler check on render.** Nothing bills us for a render: `num_impressions` is never incremented anywhere, and clicks are logged in `Partner::AdvertsController`, which keeps its own `is_crawler?` guard and is not cached. So the only behavioural change is that crawlers now see advert markup, and the HTML no longer varies by client.

**Clear `Rails.cache` between tests.** The test store is an in-memory one that outlives each test, so without this the new cache leaks between tests in a way nothing rolls back. This is a latent hazard for every other `Rails.cache.fetch` in the app too, of which there are several.

## Follow-up, not in this PR

Applying `cache_public_action!(edge_ttl:)` to the exercise and concept show actions. That lands with the rest of the 1-day-plus caching work in a separate PR, which deliberately leaves these two actions alone. It should merge after this one.

## Testing

New `test/models/partner/advert_test.rb` covers the selection logic (which had no tests at all), the caching, and the cache clearing. `test/models` and `test/helpers` pass in full: 1461 runs, 0 failures. The 8 errors in that run are pre-existing `Aws::S3::Errors::NoSuchBucket` failures from LocalStack buckets not being provisioned in worktrees, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMk8fyX9gpLAXUaUwViyfu