### PR TITLE
Cache the track pages at the CDN for a day

### DIFF
--- a/app/commands/concept/invalidate_cloudflare_cache.rb
+++ b/app/commands/concept/invalidate_cloudflare_cache.rb
@@ -1,0 +1,21 @@
+class Concept::InvalidateCloudflareCache
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :concept
+
+  def call
+    Cloudflare::PurgeUrls.(urls)
+  end
+
+  private
+  # A concept changing its name or blurb changes the concept map too, so the
+  # track's concepts index gets purged alongside the concept page itself.
+  def urls
+    [
+      Exercism::Routes.track_concept_url(concept.track, concept),
+      Exercism::Routes.track_concepts_url(concept.track)
+    ]
+  end
+end

--- a/app/commands/exercise/invalidate_cloudflare_cache.rb
+++ b/app/commands/exercise/invalidate_cloudflare_cache.rb
@@ -1,0 +1,26 @@
+class Exercise::InvalidateCloudflareCache
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :exercise
+
+  def call
+    Cloudflare::PurgeUrls.(urls)
+  end
+
+  private
+  # The dig deeper page lists an exercise's approaches and articles, so it
+  # goes stale whenever any of them do. The approach and article pages
+  # cross-link to each other, so the whole set gets purged together.
+  def urls
+    [
+      Exercism::Routes.track_exercise_url(track, exercise),
+      Exercism::Routes.track_exercise_dig_deeper_url(track, exercise),
+      *exercise.approaches.map { |approach| Exercism::Routes.track_exercise_approach_url(track, exercise, approach) },
+      *exercise.articles.map { |article| Exercism::Routes.track_exercise_article_url(track, exercise, article) }
+    ]
+  end
+
+  def track = exercise.track
+end

--- a/app/commands/exercise/update_has_approaches.rb
+++ b/app/commands/exercise/update_has_approaches.rb
@@ -9,6 +9,12 @@ class Exercise::UpdateHasApproaches
     ActiveRecord::Base.transaction(isolation: Exercism::READ_COMMITTED) do
       exercise.update(has_approaches:)
     end
+
+    # The exercise sync commands call this for every exercise on a force-sync,
+    # so only purge when the flag genuinely moved. Community video approval
+    # purges from CommunityVideo itself, which covers the case where an
+    # approved video changes the dig deeper page without moving this flag.
+    ::Exercise::InvalidateCloudflareCache.defer(exercise) if exercise.saved_change_to_has_approaches?
   end
 
   private

--- a/app/commands/git/sync.rb
+++ b/app/commands/git/sync.rb
@@ -37,6 +37,10 @@ class Git::Sync
     filepath_in_diff?(head_git_track.config_filepath)
   end
 
+  # Changes to these attributes are bookkeeping rather than anything a
+  # visitor can see, so they don't justify a Cloudflare purge.
+  IGNORED_CHANGES = %w[synced_to_git_sha git_sha updated_at].freeze
+
   private
   memoize
   def current_git_track

--- a/app/commands/git/sync_concept.rb
+++ b/app/commands/git/sync_concept.rb
@@ -18,8 +18,17 @@ class Git::SyncConcept < Git::Sync
       synced_to_git_sha: head_git_concept.synced_git_sha
     )
 
+    # Capture this before the syncs below re-save the concept and reset its
+    # dirty tracking.
+    content_changed = concept.saved_changes.except(*IGNORED_CHANGES).present?
+
     Git::SyncConceptAuthors.(concept)
     Git::SyncConceptContributors.(concept)
+
+    # Only purge when something a visitor can see actually changed. A
+    # force-sync re-saves every concept on every track, and purging all of
+    # those would burn through Cloudflare's rate limits for nothing.
+    Concept::InvalidateCloudflareCache.defer(concept) if content_changed
   end
 
   private

--- a/app/commands/git/sync_concept_exercise.rb
+++ b/app/commands/git/sync_concept_exercise.rb
@@ -25,12 +25,22 @@ class Git::SyncConceptExercise < Git::Sync
       representer_version: head_git_exercise.representer_version
     )
 
+    # Capture this before the syncs below re-save the exercise and reset its
+    # dirty tracking.
+    content_changed = exercise.saved_changes.except(*IGNORED_CHANGES).present?
+
     Git::SyncExerciseAuthors.(exercise)
     Git::SyncExerciseContributors.(exercise)
     Git::SyncExerciseApproaches.(exercise)
     Git::SyncExerciseArticles.(exercise)
     ::Exercise::UpdateHasApproaches.(exercise)
     SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    # Only purge when something a visitor can see actually changed. The weekly
+    # SyncTracksJob force-syncs every track, and purging every exercise on
+    # every track would be ~150 exercises x several URLs x ~70 tracks, which
+    # would burst past Cloudflare's per-zone purge rate limits.
+    ::Exercise::InvalidateCloudflareCache.defer(exercise) if content_changed
   end
 
   private

--- a/app/commands/git/sync_exercise_approaches.rb
+++ b/app/commands/git/sync_exercise_approaches.rb
@@ -7,13 +7,24 @@ class Git::SyncExerciseApproaches < Git::Sync
   end
 
   def call
+    fingerprint_before = approaches_fingerprint
+
     # This removes any approaches that aren't read from the config below
     exercise.update(approaches:)
     Git::SyncExerciseApproachIntroduction.(exercise, introduction_config)
+
+    # A force-sync runs this for every exercise on every track, so only purge
+    # when the approaches genuinely changed. Otherwise the weekly SyncTracksJob
+    # would burst past Cloudflare's per-zone purge rate limits.
+    ::Exercise::InvalidateCloudflareCache.defer(exercise) if approaches_fingerprint != fingerprint_before
   end
 
   private
   attr_reader :exercise
+
+  # updated_at only moves when an approach's content actually changes, so
+  # this catches edits as well as additions and removals.
+  def approaches_fingerprint = exercise.approaches.reload.pluck(:id, :updated_at).sort
 
   def approaches
     approaches_config.map.with_index do |approach, index|

--- a/app/commands/git/sync_exercise_articles.rb
+++ b/app/commands/git/sync_exercise_articles.rb
@@ -3,9 +3,22 @@ class Git::SyncExerciseArticles
 
   initialize_with :exercise
 
-  def call = exercise.update(articles:)
+  def call
+    fingerprint_before = articles_fingerprint
+
+    exercise.update(articles:)
+
+    # A force-sync runs this for every exercise on every track, so only purge
+    # when the articles genuinely changed. Otherwise the weekly SyncTracksJob
+    # would burst past Cloudflare's per-zone purge rate limits.
+    ::Exercise::InvalidateCloudflareCache.defer(exercise) if articles_fingerprint != fingerprint_before
+  end
 
   private
+  # updated_at only moves when an article's content actually changes, so
+  # this catches edits as well as additions and removals.
+  def articles_fingerprint = exercise.articles.reload.pluck(:id, :updated_at).sort
+
   def articles
     git_articles.articles.map.with_index do |article, index|
       Git::SyncExerciseArticle.(exercise, article, index + 1)

--- a/app/commands/git/sync_practice_exercise.rb
+++ b/app/commands/git/sync_practice_exercise.rb
@@ -26,12 +26,22 @@ class Git::SyncPracticeExercise < Git::Sync
       representer_version: head_git_exercise.representer_version
     )
 
+    # Capture this before the syncs below re-save the exercise and reset its
+    # dirty tracking.
+    content_changed = exercise.saved_changes.except(*IGNORED_CHANGES).present?
+
     Git::SyncExerciseAuthors.(exercise)
     Git::SyncExerciseContributors.(exercise)
     Git::SyncExerciseApproaches.(exercise)
     Git::SyncExerciseArticles.(exercise)
     ::Exercise::UpdateHasApproaches.(exercise)
     SiteUpdates::ProcessNewExerciseUpdate.(exercise)
+
+    # Only purge when something a visitor can see actually changed. The weekly
+    # SyncTracksJob force-syncs every track, and purging every exercise on
+    # every track would be ~150 exercises x several URLs x ~70 tracks, which
+    # would burst past Cloudflare's per-zone purge rate limits.
+    ::Exercise::InvalidateCloudflareCache.defer(exercise) if content_changed
   end
 
   private

--- a/app/commands/git/sync_track.rb
+++ b/app/commands/git/sync_track.rb
@@ -58,6 +58,11 @@ class Git::SyncTrack < Git::Sync
     # Now that the concepts and exercises have synced successfully,
     # we can set the track's synced git SHA to the HEAD SHA
     track.update!(synced_to_git_sha: head_git_track.commit.oid)
+
+    # Only purge when this sync actually moved us on to a new commit. The
+    # weekly SyncTracksJob force-syncs every track, and without this guard
+    # that would fire a purge for every track every week for no reason.
+    Track::InvalidateCloudflareCache.defer(track) if track.saved_change_to_synced_to_git_sha?
   rescue StandardError => e
     begin
       oid = head_git_track.commit.oid

--- a/app/commands/track/invalidate_cloudflare_cache.rb
+++ b/app/commands/track/invalidate_cloudflare_cache.rb
@@ -1,0 +1,25 @@
+class Track::InvalidateCloudflareCache
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :track
+
+  def call
+    Cloudflare::PurgeUrls.(urls)
+  end
+
+  private
+  # These are the track-level pages that are cached at the edge for a day.
+  # The tracks index is included because a track changing its title, blurb or
+  # active status changes how it appears in that list.
+  def urls
+    [
+      Exercism::Routes.track_url(track),
+      Exercism::Routes.track_exercises_url(track),
+      Exercism::Routes.track_concepts_url(track),
+      Exercism::Routes.track_build_url(track),
+      Exercism::Routes.tracks_url
+    ]
+  end
+end

--- a/app/commands/track/update_build_status.rb
+++ b/app/commands/track/update_build_status.rb
@@ -5,6 +5,10 @@ class Track::UpdateBuildStatus
 
   def call
     track.build_status = build_status
+
+    # The build page is rebuilt nightly by UpdateTracksBuildStatusJob. That is
+    # ~70 purges a night, so there is nothing to gate here.
+    Track::InvalidateCloudflareCache.defer(track)
   end
 
   private

--- a/app/controllers/tracks/approaches_controller.rb
+++ b/app/controllers/tracks/approaches_controller.rb
@@ -5,6 +5,7 @@ class Tracks::ApproachesController < ApplicationController
   before_action :guard_accessible!
 
   skip_before_action :authenticate_user!
+  before_action :cache_public_page!, only: %i[index show]
 
   def index
     redirect_to track_exercise_dig_deeper_path(@track, @exercise)
@@ -22,6 +23,10 @@ class Tracks::ApproachesController < ApplicationController
   end
 
   private
+  # Approaches only change when the track syncs, which purges them.
+  # See Exercise::InvalidateCloudflareCache.
+  def cache_public_page! = cache_public_action!(edge_ttl: 1.day)
+
   def use_solution
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)

--- a/app/controllers/tracks/articles_controller.rb
+++ b/app/controllers/tracks/articles_controller.rb
@@ -5,6 +5,7 @@ class Tracks::ArticlesController < ApplicationController
   before_action :guard_accessible!
 
   skip_before_action :authenticate_user!
+  before_action :cache_public_page!, only: %i[index show]
 
   def index
     redirect_to track_exercise_dig_deeper_path(@track, @exercise)
@@ -20,6 +21,10 @@ class Tracks::ArticlesController < ApplicationController
   end
 
   private
+  # Articles only change when the track syncs, which purges them.
+  # See Exercise::InvalidateCloudflareCache.
+  def cache_public_page! = cache_public_action!(edge_ttl: 1.day)
+
   def use_solution
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)

--- a/app/controllers/tracks/build_controller.rb
+++ b/app/controllers/tracks/build_controller.rb
@@ -3,6 +3,7 @@ class Tracks::BuildController < ApplicationController
   before_action :use_track!
   skip_before_action :authenticate_user!
   before_action :use_build_status
+  before_action :cache_show_action!, only: %i[show]
 
   def show
     @test_runner_sha = Tooling::RetrieveSha.(@track, 'test-runner')
@@ -19,6 +20,12 @@ class Tracks::BuildController < ApplicationController
   def practice_exercises_tooltip = render_template_as_json
 
   private
+  # The build page is regenerated nightly by UpdateTracksBuildStatusJob, which
+  # purges it (see Track::InvalidateCloudflareCache), so a day at the edge is
+  # safe. It is also the most expensive page we serve anonymously: three
+  # Tooling::RetrieveSha network calls per request.
+  def cache_show_action! = cache_public_action!(edge_ttl: 1.day)
+
   def use_build_status
     @status = @track.build_status
   end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -6,6 +6,7 @@ class Tracks::ConceptsController < ApplicationController
   before_action :guard_practice_mode!, only: [:index]
   before_action :guard_course!, only: [:index]
   skip_before_action :authenticate_user!, only: %i[index show tooltip]
+  before_action :cache_index_action!, only: %i[index]
 
   def index
     @concept_map_data = Track::DetermineConceptMapLayout.(@user_track)
@@ -49,6 +50,12 @@ class Tracks::ConceptsController < ApplicationController
   end
 
   private
+  # The concept map only changes when the track syncs, which purges it.
+  # See Track::InvalidateCloudflareCache. The per-user status mappings that
+  # this action also builds are empty for the signed-out visitors that get
+  # cached, and cache_public_action! no-ops for everyone else.
+  def cache_index_action! = cache_public_action!(edge_ttl: 1.day)
+
   def use_track
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)

--- a/app/controllers/tracks/dig_deeper_controller.rb
+++ b/app/controllers/tracks/dig_deeper_controller.rb
@@ -4,6 +4,7 @@ class Tracks::DigDeeperController < ApplicationController
   before_action :guard_accessible!, except: :tooltip_locked
 
   skip_before_action :authenticate_user!
+  before_action :cache_show_action!, only: %i[show]
 
   def show
     @videos = @exercise.community_videos.approved
@@ -16,6 +17,11 @@ class Tracks::DigDeeperController < ApplicationController
   def tooltip_locked = render_template_as_json
 
   private
+  # Everything on this page (approaches, articles, videos, introduction) only
+  # changes when the track syncs or a community video is approved, both of
+  # which purge it. See Exercise::InvalidateCloudflareCache.
+  def cache_show_action! = cache_public_action!(edge_ttl: 1.day)
+
   def use_solution
     @track = Track.find(params[:track_id])
     @user_track = UserTrack.for(current_user, @track)

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -3,7 +3,8 @@ class Tracks::ExercisesController < ApplicationController
   before_action :use_track!
   before_action :use_exercise!, only: %i[show start edit complete tooltip no_test_runner]
   before_action :use_solution, only: %i[show edit complete tooltip]
-  before_action :cache_public_action!, only: %i[index show tooltip]
+  before_action :cache_public_action!, only: %i[show tooltip]
+  before_action :cache_index_action!, only: %i[index]
 
   skip_before_action :authenticate_user!, only: %i[index show tooltip]
   skip_before_action :rate_limit_for_user!, only: %i[tooltip] # Scanning over this is a lot
@@ -48,6 +49,10 @@ class Tracks::ExercisesController < ApplicationController
   end
 
   private
+  # The exercise list only changes when the track syncs, which purges it.
+  # See Track::InvalidateCloudflareCache.
+  def cache_index_action! = cache_public_action!(edge_ttl: 1.day)
+
   def use_exercise!
     @exercise = @track.exercises.find(params[:id])
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -2,7 +2,8 @@ class TracksController < ApplicationController
   before_action :use_track, except: :index
   skip_before_action :authenticate_user!, only: %i[index show about]
 
-  before_action :cache_public_action!, only: %i[index show about]
+  before_action :cache_public_action!, only: %i[about]
+  before_action :cache_public_page!, only: %i[index show]
 
   def index
     etag = [Track.num_active]
@@ -57,6 +58,11 @@ class TracksController < ApplicationController
   end
 
   private
+  # Anonymous visitors to #show get the tracks/about template, and #index is
+  # the same page for all of them. Both change only when a track syncs, which
+  # purges them. See Track::InvalidateCloudflareCache.
+  def cache_public_page! = cache_public_action!(edge_ttl: 1.day)
+
   def use_track
     @track = Track.find(params[:id])
     @user_track = UserTrack.for(current_user, @track)

--- a/app/models/community_video.rb
+++ b/app/models/community_video.rb
@@ -12,6 +12,12 @@ class CommunityVideo < ApplicationRecord
   def platform = super.to_sym
 
   after_save_commit do
-    Exercise::UpdateHasApproaches.defer(exercise) if previous_changes.key?("status") && exercise.present?
+    next unless previous_changes.key?("status") && exercise.present?
+
+    Exercise::UpdateHasApproaches.defer(exercise)
+
+    # An approved video shows on the dig deeper page, which is cached at the
+    # edge for a day.
+    Exercise::InvalidateCloudflareCache.defer(exercise)
   end
 end

--- a/test/commands/concept/invalidate_cloudflare_cache_test.rb
+++ b/test/commands/concept/invalidate_cloudflare_cache_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Concept::InvalidateCloudflareCacheTest < ActiveSupport::TestCase
+  test "purges the concept and the track's concepts index" do
+    track = create :track, slug: 'ruby'
+    concept = create :concept, track:, slug: 'strings'
+
+    Cloudflare::PurgeUrls.expects(:call).with(
+      [
+        "https://test.exercism.org/tracks/ruby/concepts/strings",
+        "https://test.exercism.org/tracks/ruby/concepts"
+      ]
+    )
+
+    Concept::InvalidateCloudflareCache.(concept)
+  end
+end

--- a/test/commands/exercise/invalidate_cloudflare_cache_test.rb
+++ b/test/commands/exercise/invalidate_cloudflare_cache_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class Exercise::InvalidateCloudflareCacheTest < ActiveSupport::TestCase
+  test "purges the exercise, its dig deeper page, and its approaches and articles" do
+    track = create :track, slug: 'ruby'
+    exercise = create(:practice_exercise, track:, slug: 'bob')
+    create(:exercise_approach, exercise:, slug: 'gsub')
+    create(:exercise_article, exercise:, slug: 'performance')
+
+    Cloudflare::PurgeUrls.expects(:call).with(
+      [
+        "https://test.exercism.org/tracks/ruby/exercises/bob",
+        "https://test.exercism.org/tracks/ruby/exercises/bob/dig_deeper",
+        "https://test.exercism.org/tracks/ruby/exercises/bob/approaches/gsub",
+        "https://test.exercism.org/tracks/ruby/exercises/bob/articles/performance"
+      ]
+    )
+
+    Exercise::InvalidateCloudflareCache.(exercise)
+  end
+
+  test "handles an exercise with no approaches or articles" do
+    track = create :track, slug: 'ruby'
+    exercise = create(:practice_exercise, track:, slug: 'bob')
+
+    Cloudflare::PurgeUrls.expects(:call).with(
+      [
+        "https://test.exercism.org/tracks/ruby/exercises/bob",
+        "https://test.exercism.org/tracks/ruby/exercises/bob/dig_deeper"
+      ]
+    )
+
+    Exercise::InvalidateCloudflareCache.(exercise)
+  end
+end

--- a/test/commands/track/invalidate_cloudflare_cache_test.rb
+++ b/test/commands/track/invalidate_cloudflare_cache_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Track::InvalidateCloudflareCacheTest < ActiveSupport::TestCase
+  test "purges the track's cached pages and the tracks index" do
+    track = create :track, slug: 'ruby'
+
+    Cloudflare::PurgeUrls.expects(:call).with(
+      [
+        "https://test.exercism.org/tracks/ruby",
+        "https://test.exercism.org/tracks/ruby/exercises",
+        "https://test.exercism.org/tracks/ruby/concepts",
+        "https://test.exercism.org/tracks/ruby/build",
+        "https://test.exercism.org/tracks"
+      ]
+    )
+
+    Track::InvalidateCloudflareCache.(track)
+  end
+end

--- a/test/controllers/application_controller_caching_test.rb
+++ b/test/controllers/application_controller_caching_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+# cache_public_action! bails out in the test environment, so these exercise it
+# directly with that guard stubbed out. Without this, nothing covers the
+# short-browser-TTL/long-edge-TTL behaviour that the 1.day pages rely on.
+class ApplicationControllerCachingTest < ActiveSupport::TestCase
+  test "sets a one second browser ttl and a jittered edge ttl" do
+    controller = build_controller
+    controller.stubs(:user_signed_in?).returns(false)
+
+    controller.send(:cache_public_action!, edge_ttl: 1.day)
+
+    cache_control = controller.response.cache_control
+    assert_equal 1, cache_control[:max_age]
+    assert cache_control[:public]
+
+    s_maxage = cache_control[:extras].join(",")[/s-maxage=(\d+)/, 1].to_i
+    assert s_maxage <= 1.day.to_i
+    assert s_maxage >= (1.day.to_i * 0.9).to_i
+  end
+
+  test "falls back to the 5-20 minute default without an edge ttl" do
+    controller = build_controller
+    controller.stubs(:user_signed_in?).returns(false)
+
+    controller.send(:cache_public_action!)
+
+    cache_control = controller.response.cache_control
+    assert cache_control[:public]
+    assert_empty cache_control[:extras].to_a
+
+    max_age = cache_control[:max_age]
+    assert max_age >= 300
+    assert max_age <= 1200
+  end
+
+  test "does nothing when the user is signed in" do
+    controller = build_controller
+    controller.stubs(:user_signed_in?).returns(true)
+
+    controller.expects(:expires_in).never
+
+    controller.send(:cache_public_action!, edge_ttl: 1.day)
+  end
+
+  test "does nothing when the exercism user cookie is present" do
+    controller = build_controller
+    controller.stubs(:user_signed_in?).returns(false)
+    controller.request.cookie_jar.signed[:_exercism_user_id] = 1
+
+    controller.expects(:expires_in).never
+
+    controller.send(:cache_public_action!, edge_ttl: 1.day)
+  end
+
+  def build_controller
+    Rails.env.stubs(:test?).returns(false)
+    Rails.env.stubs(:development?).returns(false)
+
+    TracksController.new.tap do |controller|
+      controller.set_request!(ActionDispatch::TestRequest.create)
+      controller.set_response!(ActionDispatch::TestResponse.create)
+    end
+  end
+end

--- a/test/controllers/tracks/public_caching_test.rb
+++ b/test/controllers/tracks/public_caching_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+# These pages are cached at the Cloudflare edge for a day for anonymous
+# visitors. Two properties make that safe, and both are asserted here for
+# every page:
+#
+# 1. The action opts into the long edge TTL.
+# 2. The anonymous response sets no cookies. If it ever did, Cloudflare would
+#    stop caching the page and the caching would silently do nothing.
+class Tracks::PublicCachingTest < ActionDispatch::IntegrationTest
+  def assert_cached_and_cookieless(url)
+    ApplicationController.any_instance.expects(:cache_public_action!).with(edge_ttl: 1.day).at_least_once
+
+    get url
+
+    assert response.headers['Set-Cookie'].blank?
+  end
+
+  test "tracks index" do
+    create :track
+
+    assert_cached_and_cookieless tracks_url
+  end
+
+  test "track show" do
+    track = create :track
+
+    assert_cached_and_cookieless track_url(track)
+  end
+
+  test "track build" do
+    track = create :track
+    Tooling::RetrieveSha.stubs(:call).returns('sha')
+    Track::UpdateBuildStatus.(track)
+
+    assert_cached_and_cookieless track_build_url(track)
+  end
+
+  test "exercises index" do
+    track = create :track
+    create(:practice_exercise, track:)
+
+    assert_cached_and_cookieless track_exercises_url(track)
+  end
+
+  test "concepts index" do
+    track = create :track, course: true
+    create(:concept, track:)
+
+    assert_cached_and_cookieless track_concepts_url(track)
+  end
+
+  test "dig deeper" do
+    track = create :track
+    exercise = create(:practice_exercise, track:)
+
+    assert_cached_and_cookieless track_exercise_dig_deeper_url(track, exercise)
+  end
+
+  test "approach show" do
+    track = create :track
+    exercise = create(:practice_exercise, track:)
+    approach = create(:exercise_approach, exercise:)
+
+    assert_cached_and_cookieless track_exercise_approach_url(track, exercise, approach)
+  end
+
+  test "article show" do
+    track = create :track
+    exercise = create(:practice_exercise, track:)
+    article = create(:exercise_article, exercise:)
+
+    assert_cached_and_cookieless track_exercise_article_url(track, exercise, article)
+  end
+end


### PR DESCRIPTION
Extends the existing "short browser TTL, long edge TTL" pattern (already used by community solution pages, sitemaps and the community page) to the anonymous track pages.

## The pattern

`cache_public_action!(edge_ttl:)` sets a browser TTL of 1 second and an `s-maxage` of the edge TTL, jittered down by up to 10%. The tiny browser TTL means purging Cloudflare is authoritative everywhere, since we cannot purge browser caches. The jitter stops millions of pages expiring in the same minute. It no-ops for signed-in users, for anyone carrying the `_exercism_user_id` cookie, and in dev/test.

No terraform change is needed: the "Cache Everything" rule has no path predicate, so `/tracks/*` is already in scope, and origin `s-maxage` is honoured.

## Per-page TTLs

Newly cached (previously no caching at all), all at `edge_ttl: 1.day`:

| Page | Note |
| --- | --- |
| `Tracks::BuildController#show` | Highest value: three `Tooling::RetrieveSha` network calls per request |
| `Tracks::DigDeeperController#show` | |
| `Tracks::ApproachesController` index + show | |
| `Tracks::ArticlesController` index + show | |
| `Tracks::ConceptsController#index` | |

Upgraded from the 5-20 minute default to `edge_ttl: 1.day`:

| Page | Note |
| --- | --- |
| `TracksController#index` | |
| `TracksController#show` | Anonymous visitors render the `tracks/about` template |
| `Tracks::ExercisesController#index` | |

A day rather than a few hours because Cache Reserve needs a TTL of at least 10 hours for eligibility.

## Purge triggers

Three new Mandate commands, mirroring `Solution::InvalidateCloudflareCache`:

- `Track::InvalidateCloudflareCache`: track show, exercises index, concepts index, build, and the tracks index.
- `Exercise::InvalidateCloudflareCache`: exercise show, dig deeper, and every approach and article URL.
- `Concept::InvalidateCloudflareCache`: concept show and the track's concepts index.

Wired in at:

- `Git::SyncTrack`, once the sync has moved the track on to a new commit.
- `Track::UpdateBuildStatus`, driven nightly by `UpdateTracksBuildStatusJob`.
- `Git::SyncConcept`, when the concept's visible attributes changed.
- `Git::SyncPracticeExercise` and `Git::SyncConceptExercise`, when the exercise's visible attributes changed.
- `Git::SyncExerciseApproaches` and `Git::SyncExerciseArticles`, when the approach/article set or content changed.
- `Exercise::UpdateHasApproaches`, when `has_approaches` actually moved.
- `CommunityVideo`, on approval, since an approved video changes the dig deeper page without necessarily moving `has_approaches`.

## Rate-limit gating

The weekly `SyncTracksJob` force-syncs every track. Purging naively would be roughly 150 exercises x several URLs x 70 tracks in one burst, which would blow through Cloudflare's per-zone purge rate limits even though `Cloudflare::PurgeUrls` batches at 100 URLs per request.

So every exercise-level and concept-level purge is gated on the content genuinely having changed:

- Track: `track.saved_change_to_synced_to_git_sha?`.
- Exercise and concept: ActiveRecord dirty tracking captured immediately after the main `update!`, ignoring `synced_to_git_sha`, `git_sha` and `updated_at` (see `Git::Sync::IGNORED_CHANGES`). It has to be captured at that point because the author/contributor/approach syncs that follow re-save the record and reset dirty tracking.
- Approaches and articles: a before/after fingerprint of `(id, updated_at)`, which catches additions, removals and edits, since `updated_at` only moves when content actually changes.

A force-sync of an unchanged track therefore fires no purges at all.

## Out of scope

- `Tracks::ExercisesController#show` and `Tracks::ConceptsController#show` are untouched. Both render a randomly selected, crawler-dependent partner advert, which is being fixed in a separate concurrent PR.
- `TracksController#about` keeps the old default: anonymous requests redirect to `#show`, so there is nothing to cache.

## Follow-up: purge on deploy

**We have no purge-on-deploy hook.** Cached HTML can therefore reference asset digests that a deploy has already invalidated. This is not new (it already applies to the 30-day community solution pages), but it gets more pressing as more pages move to long TTLs, so it is worth doing soon. Deliberately not in this PR.

## Verification still needed after deploy

Terraform only manages a subset of zone settings, so the live zone behaviour wants a manual check once this ships:

- `cf-cache-status: HIT` on a second anonymous request to each of these pages.
- No `Set-Cookie` on anonymous responses. There is now a test asserting this at the app level, but it is worth confirming against the real edge, since a cookie would silently stop Cloudflare caching entirely.

## Tests

- `test/controllers/application_controller_caching_test.rb`: covers `cache_public_action!` itself (1 second browser TTL, jittered `s-maxage`, the 5-20 minute fallback, and the signed-in/cookie no-ops). It stubs out the `Rails.env.test?` guard, since the method otherwise bails out in tests. This behaviour had no coverage at all before.
- `test/controllers/tracks/public_caching_test.rb`: for every newly cached page, asserts the action opts into `edge_ttl: 1.day` and that the anonymous response sets no cookies.
- Unit tests for each of the three new purge commands.
