### PR TITLE
Extend ActiveStorage blob redirect expiry to reduce endpoint hits

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,12 @@ module Website
     # Allow SVGs to render from active storage
     config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 
+    # Public assets (partner logos, avatars) are served via ActiveStorage's
+    # blob redirect endpoint, which is hit on every page load. Extending the
+    # signed URL expiry lets browsers/CDNs cache the redirect for longer,
+    # cutting repeat hits to that endpoint.
+    config.active_storage.service_urls_expire_in = 1.day
+
     Rails.autoloaders.main.ignore(Rails.root.join('app', 'css'))
   end
 end


### PR DESCRIPTION
## Summary
- Public assets (partner logos, avatars) served via ActiveStorage's blob redirect endpoint are hit heavily (~21k/day for two sponsor logo SVGs alone, per Skylight traffic data).
- Bumps `config.active_storage.service_urls_expire_in` to `1.day`, so the redirect response's `Cache-Control` lasts longer and browsers/CDN don't re-request it on every page load.
- Note: `Tracks::ConceptsController#index` caching was investigated too, but main already has this covered via `cache_index_action!` — no change needed there.

## Test plan
- [ ] Confirm partner logos / avatars still render correctly after a deploy
- [ ] Spot-check `Cache-Control` header on a blob redirect response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp59Cextj13Q1D9kUzEscw