### PR TITLE
Cache the track page's updates article and activity ticker

### DIFF
--- a/app/helpers/react_components/track/activity_ticker.rb
+++ b/app/helpers/react_components/track/activity_ticker.rb
@@ -10,8 +10,17 @@ module ReactComponents
         })
       end
 
+      # This is only the payload the ticker starts with: once the page is up,
+      # useActivityTicker's MetricsChannel subscription replaces it with live
+      # activity. So it is safe to cache despite the ticker feeling live, and it
+      # is expensive enough to be worth caching.
+      # The ORDER BY id cannot use index_metrics_on_type_and_track_id_and_occurred_at,
+      # so the lookup filesorts, and to_broadcast_hash then walks the metric's
+      # whole object graph (submission, solution, exercise, user, profile).
       def initial_data
-        Metric.where(track_id: track.id, type: ALLOWED_METRIC_TYPES).last&.to_broadcast_hash
+        Rails.cache.fetch("track/#{track.id}/activity_ticker/initial_data", expires_in: 15.minutes) do
+          Metric.where(track_id: track.id, type: ALLOWED_METRIC_TYPES).last&.to_broadcast_hash
+        end
       rescue StandardError
         {}
       end

--- a/app/views/tracks/show/_updates_article.html.haml
+++ b/app/views/tracks/show/_updates_article.html.haml
@@ -1,9 +1,15 @@
--# TODO: This can be cached against track.updated_at and track.num_contributors
 %article.updates-article
   .lg-container
     %header
       = graphical_icon(:updates, hex: true, css_class: "graphical-icon")
 
   .lg-container.container
-    = render "tracks/show/updates_section", track: track, updates: updates
-    = render "tracks/show/contributors_section", track: track, contributors: track.top_contributors, num_contributors: track.num_contributors
+    -#
+      Nothing in here varies by user, so this is cached per track. The key
+      deliberately does not mention the updates or the contributors: working
+      either of them into it means running the very queries the cache exists to
+      avoid. The TTL covers them instead, so a newly published update or a
+      change in the contributor standings takes up to an hour to appear.
+    = cache "tracks/show/updates_article/#{track.id}/#{track.updated_at.to_i}/#{I18n.locale}/1", expires_in: 1.hour do
+      = render "tracks/show/updates_section", track: track, updates: updates
+      = render "tracks/show/contributors_section", track: track, contributors: track.top_contributors, num_contributors: track.num_contributors

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -56,6 +56,37 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     assert_rendered_404
   end
 
+  # The updates article is wrapped in a fragment cache, and perform_caching is
+  # off for the rest of the suite, so without turning it on here nothing would
+  # ever exercise the cached branch of that block.
+  test "show: renders the cached updates article on both a miss and a hit" do
+    user = create :user
+    track = create :track, active: true
+    create(:hello_world_exercise, track:)
+    create(:user_track, user:, track:)
+
+    stub_latest_track_forum_threads(track)
+    sign_in!(user)
+
+    with_caching do
+      get track_url(track)
+
+      assert_response :ok
+      assert_select "section.contributors-section"
+      assert_select "section.updates-section"
+
+      # Proves the second render is served from the fragment rather than being
+      # rebuilt: the contributor search is the expensive thing inside it.
+      Track.any_instance.expects(:top_contributors).never
+
+      get track_url(track)
+
+      assert_response :ok
+      assert_select "section.contributors-section"
+      assert_select "section.updates-section"
+    end
+  end
+
   test "about shows for joined member" do
     user = create :user
     track = create :track

--- a/test/helpers/react_components/track/activity_ticker_test.rb
+++ b/test/helpers/react_components/track/activity_ticker_test.rb
@@ -25,6 +25,29 @@ class ReactComponents::Track::ActivityTickerTest < ReactComponentTestCase
     assert_equal 'start_solution_metric', component.initial_data[:type]
   end
 
+  test "initial_data is cached per track" do
+    ruby = create :track
+    original = create :start_solution_metric, track: ruby
+
+    assert_equal original.id, ReactComponents::Track::ActivityTicker.new(ruby).initial_data[:id]
+
+    create :start_solution_metric, track: ruby
+
+    # The ticker picks new activity up over the MetricsChannel rather than by
+    # re-reading this, so the newer metric is deliberately not reflected here.
+    assert_equal original.id, ReactComponents::Track::ActivityTicker.new(ruby).initial_data[:id]
+  end
+
+  test "initial_data is not shared between tracks" do
+    ruby = create :track
+    js = create :track, slug: 'js'
+    ruby_metric = create :start_solution_metric, track: ruby
+    js_metric = create :start_solution_metric, track: js
+
+    assert_equal ruby_metric.id, ReactComponents::Track::ActivityTicker.new(ruby).initial_data[:id]
+    assert_equal js_metric.id, ReactComponents::Track::ActivityTicker.new(js).initial_data[:id]
+  end
+
   test "initial_data ignores metrics from other tracks" do
     ruby = create :track
     js = create :track, slug: 'js'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -353,6 +353,17 @@ class ActiveSupport::TestCase
     assert_no_enqueued_jobs
   end
 
+  # Fragment caching is off across the suite, so a `cache` block in a view just
+  # yields and its cached branch never runs. Wrap an assertion in this to
+  # exercise the real thing.
+  def with_caching
+    original = ActionController::Base.perform_caching
+    ActionController::Base.perform_caching = true
+    yield
+  ensure
+    ActionController::Base.perform_caching = original
+  end
+
   def stub_latest_track_forum_threads(track)
     stub_request(:get, "https://forum.exercism.org/c/programming/#{track.slug}/l/latest.json")
   end


### PR DESCRIPTION
Skylight has `TracksController#show` at **280ms p50 / 720ms p95** (turbo-frame variant, 2,820 req/6h) and **328ms / 832ms** (full HTML, 1,729 req/6h). ~74% of that is view rendering, and there is no single hotspot — 260–320 trace nodes, of which 47 of 50 children are under 5ms. It's death by a thousand queries, so the only way to move it is to stop rendering parts of the page per request.

Two sections vary by track and not by user, so they can be cached outright.

### Updates article — 31ms (17% of the request)

Runs the site-updates query, a `User::ReputationPeriod::Search` for the top contributors, and a `count` for `num_contributors`. The partial has carried a `TODO: This can be cached against track.updated_at and track.num_contributors` since it was written.

The key deliberately omits the updates and the contributors: working either into it means running the very queries the cache exists to avoid. The 1-hour TTL covers them instead, so a newly published update or a shift in the contributor standings takes up to an hour to show. Locale is in the key because the site serves `en`, `hu`, `nl` and Rails doesn't add it for us.

### Activity ticker — 16ms typical, 29ms in the slow bucket

11ms of that is one `Metric` lookup: the `ORDER BY id` can't use `index_metrics_on_type_and_track_id_and_occurred_at`, so it filesorts, and `to_broadcast_hash` then walks the metric's whole object graph (submission → solution → exercise → user → profile). This is only the payload the ticker *starts* with — `useActivityTicker` swaps in live activity over `MetricsChannel` as soon as the page is up — so a 15-minute TTL costs nothing anyone sees.

Together: roughly **a quarter of the request**.

### On cache size

Both keys are per-track, so this is bounded at ~70 entries (a few KB each, low single-digit MB in Redis) rather than growing with users. Invalidation replaces entries rather than adding them.

### Not included

- **The advert.** `Partner::Advert.for_track` is already cached per track by #9386. Fragment-caching the render on top would freeze the per-render `impression_uuid` across every viewer of a track. `Partner::LogAdvertClick` currently accepts that uuid and does nothing with it (the `doc` method is dead), so it's probably harmless — but that wants deciding on purpose, not as a side effect of a perf PR.
- **An etag on `show`.** `index` and `about` both call `stale?`; the logged-in `show` path doesn't. `user_track.summary_key` + `track.updated_at` would 304 a lot of repeat in-app navigation, and is likely the largest remaining win — but it needs care about what invalidates it.
- **A metrics index.** `(track_id, type, id)` might remove the filesort behind the ticker query, though the `type IN (6 values)` makes that less clear-cut than it looks. Cheaper to cache first and measure.
- **The layout.** ~30ms on the HTML variant (`layouts/nav/tracks` 18ms, `favorites` 8ms) plus an `UPDATE user_data ×3` and a `users` N+1. That taxes every HTML page on the site, so it deserves its own look.

Also worth flagging: `tracks/_header.html.haml` has an existing fragment cache whose key has no locale in it.

### Testing

Fragment caching is off across the whole suite (`perform_caching = false`), which means a `cache` block in a view is never actually exercised by any test — it just yields. Added a `with_caching` helper and a test that asserts the second render is served from the fragment by expecting `top_contributors` is never called again.

Ruby tests pass. System tests couldn't run locally (ChromeDriver 138 vs Chrome 151) — CI will cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DBMTcWX7tDRzuiG8xpRLX