### PR TITLE
Serve profile solutions from the DB rather than OpenSearch

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,7 +12,14 @@ class ProfilesController < ApplicationController
   def show
     return unless stale?(etag: @profile)
 
-    @solutions = Solution::SearchUserSolutions.(@user, status: :published, per: 3)
+    # This deliberately doesn't use Solution::SearchUserSolutions. There are no
+    # filters or paging here, so OpenSearch bought us nothing but a 114ms round
+    # trip on every request. index_solutions_profile_published_by_stars makes
+    # this a backward index scan that stops after 3 rows.
+    @solutions = @user.solutions.published.
+      order(num_stars: :desc, updated_at: :desc).
+      includes(:exercise, :track, :published_exercise_representation, :user).
+      limit(3)
 
     # TODO: Order by most prominent first (what is the most prominent testimonial?)
     @testimonials = @user.mentor_testimonials.published.first(3)

--- a/db/migrate/20260817230840_add_profile_published_solutions_index_to_solutions.rb
+++ b/db/migrate/20260817230840_add_profile_published_solutions_index_to_solutions.rb
@@ -1,0 +1,24 @@
+class AddProfilePublishedSolutionsIndexToSolutions < ActiveRecord::Migration[7.1]
+  def change
+    return if Rails.env.production?
+
+    # ProfilesController#show wants a user's top 3 published solutions by
+    # num_stars. index_solutions_on_user_id_and_status covers the filter but
+    # not the sort, so MySQL filesorted every published solution the user had
+    # to pick 3. Our worst user has 209,884 of them.
+    #
+    # Column order is the whole point. user_id and status are equality, which
+    # leaves num_stars and updated_at pre-sorted within that run, so the query
+    # is a backward index scan that stops after 3 rows (78us on that user).
+    # The existing (user_id, status, exercise_id) index can't do this: a third
+    # column of exercise_id orders the run by something we don't sort on.
+    #
+    # Mirrors solutions_ex_stat_stars_upat, which is the same index keyed on
+    # exercise_id for the per-exercise community solutions list.
+    #
+    # Already created manually on production, hence if_not_exists.
+    add_index :solutions, %i[user_id status num_stars updated_at],
+      name: "index_solutions_profile_published_by_stars",
+      if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_17_230840) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1150,6 +1150,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
     t.index ["user_id", "exercise_id"], name: "index_solutions_on_user_id_and_exercise_id"
     t.index ["user_id", "status", "exercise_id"], name: "index_solutions_on_user_id_and_status_and_exercise_id"
     t.index ["user_id", "status"], name: "index_solutions_on_user_id_and_status"
+    t.index ["user_id", "status", "num_stars", "updated_at"], name: "index_solutions_profile_published_by_stars"
     t.index ["uuid"], name: "index_solutions_on_uuid"
   end
 

--- a/test/system/flows/profile/user_views_profile_test.rb
+++ b/test/system/flows/profile/user_views_profile_test.rb
@@ -5,6 +5,36 @@ module Flows
   class UserViewsProfileTest < ApplicationSystemTestCase
     include CapybaraHelpers
 
+    test "shows the three most starred published solutions" do
+      # If we let this run then we need valid git filepaths
+      # for all of the stub exercises below, so we stub it
+      Solution::QueueHeadTestRun.stubs(:defer)
+
+      author = create :user
+      create :user_profile, user: author
+      ruby = create :track, title: "Ruby"
+
+      { "Strings" => 8, "Running" => 5, "Bob" => 3, "Leap" => 1 }.each do |title, num_stars|
+        exercise = create(:concept_exercise, track: ruby, slug: title.downcase, title:)
+        solution = create(:concept_solution, exercise:, user: author, published_at: 1.day.ago, num_stars:)
+        submission = create(:submission, solution:)
+        create(:iteration, solution:, submission:)
+      end
+
+      use_capybara_host do
+        visit profile_path(author.handle)
+
+        within('.published-solutions-section') do
+          assert_text "Strings"
+          assert_text "Running"
+          assert_text "Bob"
+
+          # Only the top 3 by stars are shown
+          assert_no_text "Leap"
+        end
+      end
+    end
+
     test "shows only revealed badges" do
       author = create :user
       create :user_profile, user: author


### PR DESCRIPTION
`ProfilesController#show` spends **114ms of its 345ms on an OpenSearch round trip** ([Skylight](https://www.skylight.io/app/applications/VNpB7GqXZDpQ/recent/6h/endpoints/ProfilesController%23show?responseType=html)), on 100% of requests, to fetch three published solutions.

There are no filters, no paging and no search criteria here, so OpenSearch was doing nothing SQL can't.

## Chesterton's fence

It wasn't arbitrary. dc35058c5 ("Speed up profile", #5758) deliberately moved this *to* OpenSearch as a performance fix, so a naive revert would re-break what that commit fixed.

The reason the SQL was slow is identifiable: `index_solutions_on_user_id_and_status` covers the filter but not the sort, so MySQL materialised every published solution the user had and filesorted it to pick 3. Our worst user has **209,884** published solutions. Confirmed on production before touching anything:

```
| key                                   | rows | Extra          |
| index_solutions_on_user_id_and_status |  75  | Using filesort |
```

So the fence stands against the revert alone, but not against revert + index.

## The index

`index_solutions_profile_published_by_stars` is `(user_id, status, num_stars, updated_at)`. Column order is the whole point: `user_id` and `status` are equality, which leaves `num_stars` and `updated_at` pre-sorted within that run. The existing `(user_id, status, exercise_id)` index can't do this — a third column of `exercise_id` orders the run by something we don't sort on.

This mirrors `solutions_ex_stat_stars_upat`, the same index keyed on `exercise_id`, which already solves the identical top-N-by-stars problem for the per-exercise community solutions list.

`EXPLAIN ANALYZE` on user 720036 in production, after adding it:

```
-> Limit: 3 row(s)  (actual time=0.0481..0.0775 rows=3 loops=1)
    -> Index lookup on solutions using index_solutions_profile_published_by_stars
       (user_id=720036, status=3) (reverse)  (actual time=0.0472..0.0764 rows=3 loops=1)
```

**78 microseconds, 3 rows read, no filesort** — against a 114ms network hop.

## Also

Preloading kills four N+1 groups Skylight was flagging (`exercises`, `tracks`, `exercise_representations`, `users`). The OpenSearch path did a bare `Solution.where(id: ids)` with no preloading, and the serializer touches all four per solution.

Ordering gains a deterministic `updated_at` tiebreak, which the OpenSearch sort (`num_stars` only) didn't have. It's free — it's the fourth column of the index.

The `solutions` tab still uses `Solution::SearchUserSolutions`; it has real filters, paging and sorting.

## Notes

- **The index is already live on production**, added manually with `ALGORITHM=INPLACE, LOCK=NONE` (2m04s, no blocking). The migration is guarded with `return if Rails.env.production?` and `if_not_exists: true` per the house pattern.
- Local system tests pass; the wider suite is left to CI.
- Two things spotted in passing, both out of scope: production has six indexes on `solutions` that aren't in `db/schema.rb` (`solutions-er-1`, `solutions-er-2`, `index_solutions_er_lookup`, `index_solutions_on_exercise_id_and_status`, `index_solutions_on_published_exercise_representation_id`, `index_solutions_on_user_id_and_status_and_allow_comments`), and the endpoint still has ~24ms in `contributions_tab?` doing a `reputation_tokens` existence check per render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9wyupaKYLSJqkYMYkTSnQ