### PR TITLE
Add covering (approach_id, solution_id) index to submissions

### DIFF
--- a/db/migrate/20260817233107_add_approach_solution_index_to_submissions.rb
+++ b/db/migrate/20260817233107_add_approach_solution_index_to_submissions.rb
@@ -1,0 +1,16 @@
+class AddApproachSolutionIndexToSubmissions < ActiveRecord::Migration[7.1]
+  def change
+    return if Rails.env.production?
+
+    # Submission::LinkApproach recounts an approach's distinct solutions on
+    # every link. index_submissions_on_approach_id covers (approach_id, id),
+    # so COUNT(DISTINCT solution_id) needed a clustered-index lookup per row:
+    # 14,774 random reads for the largest approach, 15.7s on a cold buffer
+    # pool. Adding solution_id makes it an index-only scan.
+    #
+    # Already created manually on production, hence if_not_exists.
+    add_index :submissions, %i[approach_id solution_id],
+      name: "index_submissions_on_approach_id_and_solution_id",
+      if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_17_233107) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1267,6 +1267,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
     t.integer "exercise_representer_version", limit: 2, default: 1, null: false
     t.bigint "approach_id"
     t.json "tags"
+    t.index ["approach_id", "solution_id"], name: "index_submissions_on_approach_id_and_solution_id"
     t.index ["approach_id"], name: "index_submissions_on_approach_id"
     t.index ["exercise_id", "git_important_files_hash"], name: "index_submissions_on_exercise_id_and_git_important_files_hash"
     t.index ["git_important_files_hash", "solution_id"], name: "submissions-git-optimiser-2"


### PR DESCRIPTION
`Submission::LinkApproach` recounts an approach's distinct solutions on every link (and twice when a submission moves between approaches), via:

```sql
SELECT COUNT(DISTINCT solution_id) FROM submissions WHERE approach_id = ?;
```

`index_submissions_on_approach_id` covers `(approach_id, id)` in InnoDB, so that count needed a clustered-index lookup per matching row just to read `solution_id`. For the largest approach that's 14,774 random reads:

```
-> Aggregate: count(distinct submissions.solution_id)  (actual time=15684..15684 rows=1)
    -> Index lookup using index_submissions_on_approach_id  (actual time=5.99..15669 rows=14774)
```

15.7s cold, 0.09s warm — the gap is buffer pool residency, which is why it only shows up in the slow log.

With `(approach_id, solution_id)` the count is index-only (`Extra: Using index`), so the clustered-index reads disappear entirely.

The index has already been created manually on production, hence `if_not_exists`.

## Notes

- Only rows with a non-null `approach_id` are indexed, so this is a small index on a large table.
- `index_submissions_on_approach_id` is now a redundant leftmost prefix and could be dropped. Production has no FK on `approach_id` (despite `db/schema.rb` declaring one — separate drift worth a look), so nothing depends on it. Left in place here as a separate decision.
- Not addressed: the recount is still O(n) per link. If `Exercise::Approach::LinkMatchingSubmissions` stays hot, recounting once at the end of the bulk job rather than per submission is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hhx48m4V4QVKwuFWs52Sxn