### PR TITLE
Simplify Metric::Sweep to one range delete, drop unused metrics indexes

### DIFF
--- a/app/commands/metric/sweep.rb
+++ b/app/commands/metric/sweep.rb
@@ -15,17 +15,15 @@ class Metric::Sweep
   def call
     return if boundary_id.nil?
 
-    # The delete is a pure primary-key range, so it stays cheap however large
-    # a backlog has accumulated - we never read a row in order to evaluate a
-    # predicate. (Filtering on occurred_at directly would: there is no index
-    # leading with it, which is the whole reason we find the boundary by id.)
+    # A single primary-key range delete. We already know the id to delete
+    # before, so there is nothing left to look up: no row is read in order to
+    # evaluate a predicate. (Filtering on occurred_at directly would: there is
+    # no index leading with it, which is the whole reason we find the boundary
+    # by id.)
     #
     # delete_all deliberately skips callbacks. Metric only has a before_create
     # (setting uniqueness_key/params), so there is nothing to run on destroy.
-    #
-    # in_batches is insurance for the catch-up case after the job has not run
-    # for a while, rather than for the ~64,000-row steady state.
-    Metric.where(id: ...boundary_id).in_batches(of: STEP).delete_all
+    Metric.where(id: ...boundary_id).delete_all
   end
 
   private
@@ -36,9 +34,15 @@ class Metric::Sweep
   # This costs ~13 primary-key seeks in steady state, and stays proportional
   # to backlog/STEP rather than to the size of the backlog itself.
   #
-  # This relies on id order matching occurred_at order, which holds because
-  # Metric::Create sets occurred_at at insertion time. If anything ever
-  # backdated occurred_at, this would behave differently to a timestamp filter.
+  # This sweeps by insertion order, not by occurred_at, and those are not the
+  # same thing: the GitHub metrics pass the PR/issue's own timestamp and
+  # :sign_up passes user.created_at, so a webhook for an old PR inserts a high
+  # id with a months-old occurred_at. Production currently holds rows a month
+  # older than RETENTION_PERIOD for exactly this reason.
+  #
+  # That is fine. Those rows age out on insertion order like everything else,
+  # a few days late. Read the retention as "7 days of inserts", and don't
+  # expect MIN(occurred_at) to sit on the cutoff.
   memoize
   def boundary_id
     cutoff = RETENTION_PERIOD.ago

--- a/db/migrate/20260817233019_remove_unused_metrics_indexes.rb
+++ b/db/migrate/20260817233019_remove_unused_metrics_indexes.rb
@@ -1,0 +1,28 @@
+class RemoveUnusedMetricsIndexes < ActiveRecord::Migration[7.1]
+  def change
+    return if Rails.env.production?
+
+    # performance_schema.table_io_waits_summary_by_index_usage on the writer
+    # showed zero fetches against all three of these, while
+    # index_metrics_on_track_id took 9.4m and
+    # index_metrics_on_type_and_track_id_and_occurred_at took 200k.
+    #
+    # Nothing queries metrics by user_id: there is no has_many :metrics, no
+    # foreign key, and the only reads are the activity ticker (track_id + type)
+    # and the impact map (type). belongs_to :user still writes the column.
+    remove_index :metrics, :user_id,
+      name: "index_metrics_on_user_id",
+      if_exists: true
+
+    # These two only ever existed on production - no migration creates them and
+    # they are absent from schema.rb. They are the same three columns in two
+    # different orders, so they look like a column-ordering experiment that was
+    # never cleaned up. if_exists because they are not present anywhere else.
+    remove_index :metrics, %i[occurred_at track_id type],
+      name: "index_metrics_on_occurred_at_and_track_id_and_type",
+      if_exists: true
+    remove_index :metrics, %i[occurred_at type track_id],
+      name: "index_metrics_on_occurred_at_and_type_and_track_id",
+      if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_17_233019) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -856,7 +856,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_215251) do
     t.index ["track_id"], name: "index_metrics_on_track_id"
     t.index ["type", "track_id", "occurred_at"], name: "index_metrics_on_type_and_track_id_and_occurred_at"
     t.index ["uniqueness_key"], name: "index_metrics_on_uniqueness_key", unique: true
-    t.index ["user_id"], name: "index_metrics_on_user_id"
   end
 
   create_table "oauth_access_grants", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
## What

Two changes to the `metrics` write path, both found by looking at `SweepMetricsJob` in Skylight after #9362 removed the aggregation layer:

1. `Metric::Sweep` does one primary-key range delete instead of ten `IN`-list deletes.
2. Drops three indexes from `metrics` that `performance_schema` shows are never read.

Plus a comment correction where the existing text claimed the opposite of what production does.

## The sweep

Skylight had `SweepMetricsJob` at 14.5s: 13.6s of `DELETE` across 10 statements, plus 0.4s of `SELECT` across 9, all flagged as N+1. The deletes looked like this:

```sql
DELETE FROM `metrics` WHERE `metrics`.`id` < ? AND `metrics`.`id` IN ?
```

The `IN` list came from `in_batches`. Rails only uses range iteration when the scope is empty (`activerecord/lib/active_record/relation/batches.rb:378`); ours has a `where(id: ...boundary_id)`, so it fell through to "select 5,000 ids, then delete by id list". The existing comment claimed the code was "a pure primary-key range... we never read a row in order to evaluate a predicate", which is not what it compiled to.

`boundary_id` already computes the id to delete before, so there is nothing left to look up:

```ruby
Metric.where(id: ...boundary_id).delete_all
```

One statement, no id materialisation, and the comment is now true. The 9 `SELECT`s disappear entirely.

Worth noting `use_ranges: true` would **not** have fixed this. That branch still does `ids = batch_relation.ids` and merely uses first/last as bounds, so the `SELECT`s would have stayed.

## The indexes

`performance_schema.table_io_waits_summary_by_index_usage` on the writer (`@@read_only = 0` confirmed), for `metrics`:

| index | count_fetch | total_wait_s |
|---|---|---|
| `index_metrics_on_track_id` | 9,430,843 | 7.2 |
| `PRIMARY` | 633,533 | 64.7 |
| `index_metrics_on_type_and_track_id_and_occurred_at` | 199,662 | 114.7 |
| `index_metrics_on_uniqueness_key` | 128 | 0.0 |
| `index_metrics_on_user_id` | **0** | 0.0 |
| `index_metrics_on_occurred_at_and_track_id_and_type` | **0** | 0.0 |
| `index_metrics_on_occurred_at_and_type_and_track_id` | **0** | 0.0 |

Dropping the three with zero fetches.

- **`index_metrics_on_user_id`** — nothing queries metrics by user. There is no `has_many :metrics`, no foreign key on the table at all, and the only two readers are the activity ticker (`track_id` + `type`) and the impact map (`type`). `belongs_to :user, optional: true` still writes the column; only the index goes.
- **`index_metrics_on_occurred_at_and_track_id_and_type`** and **`index_metrics_on_occurred_at_and_type_and_track_id`** — these exist *only* on production. No migration creates them and they are absent from `schema.rb`. They are the same three columns in two different orders, which reads like a column-ordering experiment that was never cleaned up. Hence `if_exists: true`.

This is write-path work as much as read-path: at roughly 57k inserts/day (398k of the table's 454k rows fall inside the 7-day retention window) every dropped index comes off every insert as well as every sweep delete.

Kept, for the record:

- `index_metrics_on_uniqueness_key` — only 128 fetches, but it is a UNIQUE **constraint**, not merely an index. `Metric::Create` relies on `rescue ActiveRecord::RecordNotUnique` for dedup, and the constraint check during `INSERT` is not counted as a fetch. Dropping it would be a correctness bug.
- `index_metrics_on_track_id` — the workhorse, and cheap at ~0.8µs per fetch.
- `index_metrics_on_type_and_track_id_and_occurred_at` — 199,662 fetches but 114.7s of wait, about 0.57ms each, roughly 700x costlier per read than `track_id`. Earning its place today, but it was built for the rollup `group(:type, :track_id)` scans that #9362 deleted, so it is worth revisiting separately.

## Comment correction

`boundary_id` asserted that id order matches `occurred_at` order "because `Metric::Create` sets `occurred_at` at insertion time". It does not. Four call sites backdate it:

```ruby
Metric::Queue.(:open_pull_request,  pull_request.data[:created_at], ...)
Metric::Queue.(:merge_pull_request, pull_request.data[:merged_at],  ...)
Metric::Queue.(:open_issue,         issue.opened_at,                ...)
Metric::Queue.(:sign_up,            user.created_at,                ...)
```

A webhook for an old PR inserts a high id with a months-old `occurred_at`, which is why production currently holds rows a month older than `RETENTION_PERIOD` under a 7-day policy. That is harmless — they age out on insertion order a few days late — but the comment claimed the reverse, so anyone checking `MIN(occurred_at)` against the cutoff would think the sweep was broken. Retention reads as "7 days of inserts".

## Production

The migration is `return if Rails.env.production?` per convention, so the index drops need running by hand:

```sql
ALTER TABLE metrics
  DROP INDEX index_metrics_on_user_id,
  DROP INDEX index_metrics_on_occurred_at_and_track_id_and_type,
  DROP INDEX index_metrics_on_occurred_at_and_type_and_track_id,
  ALGORITHM=INPLACE, LOCK=NONE;
```

`DROP INDEX` is in-place on InnoDB with no table rebuild, so on 454k rows this is effectively instant and non-blocking.

## Caveat on the measurement

The `performance_schema` counters are cumulative since server start, and uptime is 153 days — but the numbers do not reflect 153 days. At ~57k inserts/day, the table's 147,632 recorded inserts amount to roughly 3 days, so the counters were almost certainly reset when those extra indexes were built (`ALTER TABLE` resets a table's `performance_schema` rows). So this is "zero reads in ~3 days", not "zero reads in 153 days".

Three days of zero reads on a table taking 57k inserts/day is still a strong signal, and two of the three indexes are undocumented duplicates that no migration ever created. But it is weaker evidence than the raw uptime suggests, and worth knowing before merging. If you would rather have a clean window first, `TRUNCATE TABLE performance_schema.table_io_waits_summary_by_index_usage;` and re-check in 48 hours — `index_metrics_on_track_id` climbing into the millions immediately serves as a positive control that counting works.

## Not done

The delete is deliberately a single unbatched statement, as requested. A very large backlog after extended downtime would therefore be one long statement rather than several. At the current ~50k rows/night that is a non-issue; if it ever matters, `.limit(STEP)` in a loop restores the guard while still being a pure range delete with no `IN`.

## Verification

- `bin/rails db:migrate` runs clean; all three `remove_index` calls succeed.
- `bin/rails test test/commands/metric test/jobs/sweep_metrics_job_test.rb` → **21 runs, 49 assertions, 0 failures, 0 errors**, confirmed over 3 consecutive runs. This includes `"deletes a backlog spanning several steps"`, the case that previously exercised the batching.
- One earlier run showed a failure in `test/commands/metric/queue_test.rb:4`, which this PR does not touch and which did not reproduce across three subsequent runs. Flagging it as a pre-existing flake rather than silently ignoring it.
- `db/schema.rb` was hand-edited rather than regenerated, because running the migration locally also picks up unrelated pre-existing drift between the local DB and the checked-in schema. The diff here is one deleted index line plus the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1iLJ7HDb7yGv3ZBQ5pH3j
