### PR TITLE
Force the ranking index when picking the prestigious solution

### DIFF
--- a/app/commands/exercise/representation/recache.rb
+++ b/app/commands/exercise/representation/recache.rb
@@ -62,8 +62,19 @@ class Exercise::Representation::Recache
   # solvers), the naive `SELECT solutions.* ... LEFT JOIN user_tracks
   # ORDER BY COALESCE(reputation, 0)` took 108,000ms against this shape's
   # 81ms.
+  #
+  # The FORCE INDEX is load-bearing too. Left to itself the optimiser
+  # flattens the IN into a LooseScan semijoin driven from solutions, then
+  # does an eq_ref into user_tracks *per solver* via
+  # index_user_tracks_on_track_id_and_user_id, which is not covering. On
+  # representation 77 (track 48, 43,275 published solvers) that was 42,387
+  # single-row lookups at 0.514ms each - 21.8s of a 22.08s query, with a
+  # filesort over 41,073 rows on top because the semijoin plan has no early
+  # exit. Forcing the ranking index restores materialise-then-reverse-scan,
+  # which stops at the first match: 22.08s -> 0.09s.
   def prestigious_solution
     user_id = UserTrack.
+      from('user_tracks FORCE INDEX (index_user_tracks_track_reputation_user)').
       where(track_id: exercise.track_id).
       # This condition is load-bearing for *performance*, not just for the
       # oldest_solution fallback below. Without it the optimiser abandons


### PR DESCRIPTION
## Problem

`Exercise::Representation::Recache#prestigious_solution` was in the slow log at **349s across 26 calls**, with individual calls over 30s:

```sql
SELECT user_tracks.user_id FROM user_tracks
WHERE track_id = 48 AND reputation > 0
  AND user_id IN (SELECT user_id FROM solutions
                  WHERE published_exercise_representation_id = 77 AND status = 3)
ORDER BY reputation DESC LIMIT 1;
```

## Cause

The method already had the right shape (rank on user_ids only, then fetch the one winning solution), and the comments above it describe that plan. The optimiser was no longer picking it.

Instead it flattened the `IN` into a **LooseScan semijoin driven from `solutions`**, then did an `eq_ref` into `user_tracks` per solver via `index_user_tracks_on_track_id_and_user_id` — which is not covering. Since `user_tracks` rows average ~28KB, each lookup costs ~0.5ms cold. The semijoin plan also has no early exit, so it filesorted the whole result before applying `LIMIT 1`:

```
-> Single-row index lookup on user_tracks using index_user_tracks_on_track_id_and_user_id
   (actual time=0.514..0.514 rows=0.993 loops=42387)
```

42,387 loops × 0.514ms ≈ **21.8s of a 22.08s query**.

## Fix

Force `index_user_tracks_track_reputation_user`. That restores materialise-then-reverse-scan: build the solver-id set once, then walk the reputation index backwards and stop at the first match.

## Results

Verified with `EXPLAIN ANALYZE` against production:

| representation | published solvers | before | after |
|---|---|---|---|
| 77 (track 48) | 43,275 | 22.08s | **0.09s** |
| 942044 (track 16) | 64,146 | ~108s | **0.053s** |

The worst case I was watching for — a track where top-reputation users mostly aren't solvers, forcing a long reverse scan — didn't show up: rep 942044 found its match within the top 3 reputation holders (`rows=3`). The residual ~50ms is the one-off materialisation of the solver ids, which now happens once instead of per row.

## Testing note

`test/commands/exercise/representation/recache_test.rb` could not be run locally — all 6 tests error with `Aws::S3::Errors::NoSuchBucket` because LocalStack wasn't running. Those errors are identical with and without this change, but the behaviour is **not** covered by a passing test run here. CI should confirm. The generated SQL was verified to match the variant measured above.

## Follow-up (not in this PR)

There's index drift between `db/schema.rb` and production on `solutions`. Prod has `index_solutions_er_lookup`, `index_solutions_on_published_exercise_representation_id`, `index_solutions_on_user_id_and_status_and_allow_comments` and `index_solutions_profile_published_by_stars`; the schema has none of them. Worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNph9vJ5xYSP7nj5aC1FsF