### PR TITLE
Force index on last_analyzed_submission_representation lookup

### DIFF
--- a/app/commands/exercise/representation/create_search_index_document.rb
+++ b/app/commands/exercise/representation/create_search_index_document.rb
@@ -55,8 +55,14 @@ class Exercise::Representation::CreateSearchIndexDocument
 
   memoize
   def last_analyzed_submission_representation
+    # FORCE INDEX is essential here. Without it MySQL sees the ORDER BY id DESC
+    # LIMIT 1, assumes it'll hit a match early, and walks the whole table
+    # backwards down the PRIMARY key - 12.1M rows examined and 30-45s per call.
+    # Driving off index_ex_rep instead cuts it to the few thousand rows that
+    # actually share the digest.
     representation.
       submission_representations.
+      from("submission_representations FORCE INDEX (index_ex_rep)").
       joins(submission: :analysis).
       where(submission: { analysis_status: :completed }).
       last


### PR DESCRIPTION
## Problem

`Exercise::Representation::CreateSearchIndexDocument#last_analyzed_submission_representation` takes **30–45s** in production, ~20 times a day, examining an average of 8.7M rows (peaking at 12.1M — the entire `submission_representations` table) to return 0 or 1 rows.

From the RDS slow log:

```
Query_time: 46.530  Rows_sent: 0  Rows_examined: 12,104,595
Query_time: 42.929  Rows_sent: 0  Rows_examined: 12,103,984
Query_time: 34.104  Rows_sent: 1  Rows_examined:  7,433,667
```

The `Rows_sent: 0` cases are the worst — a full table scan that returns nothing.

## Cause

`EXPLAIN ANALYZE` against production:

```
-> Limit: 1 row(s)  (cost=15277 rows=1) (actual time=34556..34556 rows=0 loops=1)
    -> Nested loop inner join  (cost=11749 rows=10) (actual time=34556..34556 rows=0 loops=1)
        -> Filter: (exercise_id_and_ast_digest_idx_cache = '489126|1d36299d…')
           (cost=6.81 rows=10) (actual time=0.187..28817 rows=7310 loops=1)
            -> Index scan on submission_representations using PRIMARY (reverse)
               (cost=6.81 rows=8254) (actual time=0.0491..27330 rows=12.1e+6 loops=1)
```

MySQL sees `ORDER BY id DESC LIMIT 1`, assumes a match will turn up early in a reverse `PRIMARY` key walk, and costs that at **6.81**. It then reads all **12.1M** rows. Classic `ORDER BY … LIMIT` optimiser trap.

The digest filter itself only matches ~7,310 rows, so driving off `index_ex_rep` instead is roughly a **1,650× reduction** in rows examined.

## Fix

`FORCE INDEX` takes `PRIMARY` off the table so the optimiser cannot choose the walk.

The join to `submission_analyses` is **deliberately kept**. It looks redundant given `analysis_status: :completed`, but the EXPLAIN shows all 7,310 matching representations have no `submission_analyses` row at all (`rows=0 loops=7310`) — that's normal — and `#tags` calls `submission.analysis.tags`, so the join guards against a nil there.

## Verification

- Generated SQL is byte-identical to the production slow-log statement apart from the `FORCE INDEX` clause, and executes cleanly against MySQL.
- `test/commands/exercise/representation/create_search_index_document_test.rb`: 7 runs, 0 failures, 2 errors — identical to a stashed baseline. Both errors are `Aws::S3::Errors::NoSuchBucket` (no local minio), and they are the two tests that would exercise this query, so **CI is the real signal here**.

## Open question before merge

Production has an index not present in `schema.rb`: `index_submission_representations_on_digest_and_id`. If that is genuinely `(digest, id)` it may be the better hint target than `index_ex_rep`. Worth a `SHOW CREATE TABLE submission_representations` to confirm — it is a one-word change if so. There is some general prod/schema drift here worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeXNUBEU53xiTYhUth7mKi
