### PR TITLE
Split analysed-representation lookup into separate queries

### DIFF
--- a/app/commands/exercise/representation/create_search_index_document.rb
+++ b/app/commands/exercise/representation/create_search_index_document.rb
@@ -55,17 +55,30 @@ class Exercise::Representation::CreateSearchIndexDocument
 
   memoize
   def last_analyzed_submission_representation
-    # FORCE INDEX is essential here. Without it MySQL sees the ORDER BY id DESC
-    # LIMIT 1, assumes it'll hit a match early, and walks the whole table
-    # backwards down the PRIMARY key - 12.1M rows examined and 30-45s per call.
-    # Driving off index_ex_rep instead cuts it to the few thousand rows that
-    # actually share the digest.
-    representation.
+    # Done as separate queries rather than one join. As a single query MySQL
+    # walks the candidates newest-first, doing random lookups into submissions
+    # and submission_analyses for each until it finds a match. Analysed
+    # submissions are almost all old - for one hot digest the newest analysed
+    # representation sat at position 22,367 of 25,113 - so it does nearly the
+    # full set of random lookups every time, taking ~17s to return one row.
+    #
+    # Fetching the candidates first (index-only on index_ex_rep) and then
+    # resolving them in bulk lets MySQL batch those lookups instead.
+    candidates = representation.
       submission_representations.
       from("submission_representations FORCE INDEX (index_ex_rep)").
-      joins(submission: :analysis).
-      where(submission: { analysis_status: :completed }).
-      last
+      order(id: :desc).
+      pluck(:id, :submission_id)
+    return nil if candidates.empty?
+
+    analyzed_submission_ids = Submission.
+      joins(:analysis).
+      where(id: candidates.map(&:second), analysis_status: :completed).
+      pluck(:id).
+      to_set
+
+    id, = candidates.find { |_, submission_id| analyzed_submission_ids.include?(submission_id) }
+    id ? Submission::Representation.find(id) : nil
   end
 
   attr_reader :solution, :published_iteration


### PR DESCRIPTION
Follow-up to #9398.

## Why another PR

#9398 did what it claimed — the 12.1M-row reverse `PRIMARY` key walks are gone, and rows examined dropped ~500–1,000×:

| Time (UTC) | Rows_examined | Query_time |
|---|---|---|
| 14:24:40 (pre-deploy) | 2,373,743 | 12.9s |
| 14:35:23 (post-deploy) | 22,369 | 17.1s |
| 14:52:05 (post-deploy) | 12,147 | 18.2s |

But the time didn't improve. So the scan was never where the seconds went.

## Where the time actually goes

Not capacity — checked all of it on the `primary` cluster over the window:

- CPU peaks ~29%
- ACU peaks 19.5 against `MaxCapacity: 32` — not throttled
- `BufferCacheHitRatio` 98.9–99.4%
- **`ReadLatency` 1.09ms**

The cost is random IO from the join's row-at-a-time access. MySQL walks candidates newest-first, doing a lookup into `submissions` and `submission_analyses` for each until it finds a match. Analysed submissions are almost all old, so it nearly always walks the whole set:

```
-- digest 17412|a973094f...
analysed: 1926   total: 25113   depth_of_newest_analysed: 22367
```

The newest analysed representation sits at position **22,367 of 25,113** — matching the 22,369 `Rows_examined` above exactly. At 1.09ms per random read, ~22k lookups ≈ the observed 17s.

## The change

Fetch the candidates first (index-only on `index_ex_rep`, sequential), then resolve them in bulk so MySQL can batch the lookups instead of chasing them one at a time in id order.

Semantics are unchanged — still the newest representation whose submission has a completed analysis.

## Note on the rejected alternative

A bounded window ("take the newest 50, check those") would be much simpler, but the depth measurement rules it out: with the newest analysed row at position 22,367, any window small enough to be fast returns `nil` essentially always, silently emptying `tags` for exactly the hot representations that matter most.

## Verification

`test/commands/exercise/representation/create_search_index_document_test.rb`: **7 runs, 14 assertions, 0 failures, 0 errors**. This includes `uses tags from last analyzed submission`, which asserts the newest-analysed ordering this refactor had to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeXNUBEU53xiTYhUth7mKi
