### PR TITLE
Eager-load advert and partner logos in Partner::Advert.for_track

### DIFF
--- a/app/models/partner/advert.rb
+++ b/app/models/partner/advert.rb
@@ -17,7 +17,11 @@ class Partner::Advert < ApplicationRecord
       select_for_track(track)&.id
     end
 
-    find_by(id:)
+    includes(
+      light_logo_attachment: :blob,
+      dark_logo_attachment: :blob,
+      partner: [light_logo_attachment: :blob, dark_logo_attachment: :blob]
+    ).find_by(id:)
   end
 
   def self.select_for_track(track)


### PR DESCRIPTION
Skylight flagged `active_storage_attachments` (4 reps) and `active_storage_blobs` (2 reps) as N+1 queries on `Tracks::ExercisesController#show`, originating in `components/advert.html.haml`.

The advert view renders both light and dark logos, falling back to the partner's logos when the advert has none, which is exactly the four attachment plus blob lookups being flagged. `Partner::Advert.for_track` now eager-loads them all before `find_by(id:)`.

No behaviour change, so the existing `for_track` tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShHksEaUBSLvgwNzbkLFue