### PR TITLE
Cache exercise and concept markdown in S3, and edge-cache both pages

### DIFF
--- a/app/commands/concept/cached_content/generate.rb
+++ b/app/commands/concept/cached_content/generate.rb
@@ -1,0 +1,18 @@
+# Reads a concept's about and introduction documents from git and parses
+# them to HTML. This is the expensive work the cache exists to avoid: a
+# git read per document plus a full markdown parse and sanitisation pass.
+#
+# Both documents are generated together because which one the page shows
+# depends on the viewer, so caching them as a pair keeps it to one read.
+class Concept::CachedContent::Generate
+  include Mandate
+
+  initialize_with :concept
+
+  def call
+    {
+      about: Markdown::Parse.(concept.about),
+      introduction: Markdown::Parse.(concept.introduction)
+    }
+  end
+end

--- a/app/commands/concept/cached_content/retrieve.rb
+++ b/app/commands/concept/cached_content/retrieve.rb
@@ -1,0 +1,38 @@
+# Retrieves a concept's parsed about and introduction documents from S3,
+# falling back to generating them live on a miss (and lazily filling the
+# cache off the request path). Any S3 failure also falls back to live
+# generation, so this can never raise to the user because of the cache.
+#
+# Keys are versioned with synced_to_git_sha, so there is nothing to
+# invalidate: a sync moves the concept onto a new key. Unlike an
+# exercise, a concept has no sha of its own and reads its documents at
+# the repository's HEAD, so this key turns over on every track sync
+# rather than only when the concept's own content changes. That costs a
+# regeneration per concept per sync, which is negligible against the
+# reads it saves in between.
+#
+# The uuid is sharded into the key to avoid hot S3 prefixes (uuids are
+# compact hex, so their leading characters are uniformly distributed).
+class Concept::CachedContent::Retrieve
+  include Mandate
+
+  initialize_with :concept
+
+  def call
+    cached || generate!
+  end
+
+  private
+  def cached = S3Cache::Read.(cache_key)
+
+  def generate!
+    Concept::CachedContent::Generate.(concept).tap do
+      Concept::CachedContent::Store.defer(concept)
+    end
+  end
+
+  def cache_key
+    uuid = concept.uuid
+    "concept-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{concept.synced_to_git_sha}.json"
+  end
+end

--- a/app/commands/concept/cached_content/store.rb
+++ b/app/commands/concept/cached_content/store.rb
@@ -1,0 +1,21 @@
+# Generates a concept's parsed content and writes it to the S3 cache.
+# Deferred from Retrieve on a cache miss so the write (and the repeat
+# generation it needs) happens off the request path.
+class Concept::CachedContent::Store
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :concept
+
+  def call
+    S3Cache::Write.(cache_key, Concept::CachedContent::Generate.(concept))
+  end
+
+  private
+  # Must match Concept::CachedContent::Retrieve#cache_key
+  def cache_key
+    uuid = concept.uuid
+    "concept-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{concept.synced_to_git_sha}.json"
+  end
+end

--- a/app/commands/exercise/cached_content/generate.rb
+++ b/app/commands/exercise/cached_content/generate.rb
@@ -1,0 +1,22 @@
+# Reads an exercise's introduction and instructions from git and parses
+# them to HTML. This is the expensive work the cache exists to avoid: a
+# git read per document plus a full markdown parse and sanitisation pass.
+#
+# When there is a solution we render its content rather than the
+# exercise's, because a solution pins the git sha it was created at and
+# must keep showing the instructions it was started against.
+class Exercise::CachedContent::Generate
+  include Mandate
+
+  initialize_with :exercise, :solution
+
+  def call
+    {
+      introduction: Markdown::Parse.(source.introduction),
+      instructions: Markdown::Parse.(source.instructions)
+    }
+  end
+
+  private
+  def source = solution || exercise
+end

--- a/app/commands/exercise/cached_content/retrieve.rb
+++ b/app/commands/exercise/cached_content/retrieve.rb
@@ -1,0 +1,41 @@
+# Retrieves an exercise's parsed introduction and instructions from S3,
+# falling back to generating them live on a miss (and lazily filling the
+# cache off the request path). Any S3 failure also falls back to live
+# generation, so this can never raise to the user because of the cache.
+#
+# Keys are versioned with the git sha the content is read at, which makes
+# the cached content immutable: a sync that changes an exercise changes
+# its sha and therefore its key, so there is nothing to invalidate. Old
+# shas are left behind as orphans rather than being swept, as a solution
+# pinned to one may still be rendered at any time.
+#
+# The sha is the one we actually read from, so anonymous visitors and
+# solutions that are up to date share a single entry, and only
+# out-of-date solutions get objects of their own.
+#
+# The uuid is sharded into the key to avoid hot S3 prefixes (uuids are
+# compact hex, so their leading characters are uniformly distributed).
+class Exercise::CachedContent::Retrieve
+  include Mandate
+
+  initialize_with :exercise, :solution
+
+  def call
+    cached || generate!
+  end
+
+  private
+  def cached = S3Cache::Read.(cache_key)
+
+  def generate!
+    Exercise::CachedContent::Generate.(exercise, solution).tap do
+      Exercise::CachedContent::Store.defer(exercise, solution)
+    end
+  end
+
+  def cache_key
+    uuid = exercise.uuid
+    sha = solution ? solution.git_sha : exercise.git_sha
+    "exercise-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{sha}.json"
+  end
+end

--- a/app/commands/exercise/cached_content/store.rb
+++ b/app/commands/exercise/cached_content/store.rb
@@ -1,0 +1,22 @@
+# Generates an exercise's parsed content and writes it to the S3 cache.
+# Deferred from Retrieve on a cache miss so the write (and the repeat
+# generation it needs) happens off the request path.
+class Exercise::CachedContent::Store
+  include Mandate
+
+  queue_as :background
+
+  initialize_with :exercise, :solution
+
+  def call
+    S3Cache::Write.(cache_key, Exercise::CachedContent::Generate.(exercise, solution))
+  end
+
+  private
+  # Must match Exercise::CachedContent::Retrieve#cache_key
+  def cache_key
+    uuid = exercise.uuid
+    sha = solution ? solution.git_sha : exercise.git_sha
+    "exercise-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{sha}.json"
+  end
+end

--- a/app/controllers/tracks/concepts_controller.rb
+++ b/app/controllers/tracks/concepts_controller.rb
@@ -7,6 +7,7 @@ class Tracks::ConceptsController < ApplicationController
   before_action :guard_course!, only: [:index]
   skip_before_action :authenticate_user!, only: %i[index show tooltip]
   before_action :cache_index_action!, only: %i[index]
+  before_action :cache_show_action!, only: %i[show]
 
   def index
     @concept_map_data = Track::DetermineConceptMapLayout.(@user_track)
@@ -55,6 +56,12 @@ class Tracks::ConceptsController < ApplicationController
   # this action also builds are empty for the signed-out visitors that get
   # cached, and cache_public_action! no-ops for everyone else.
   def cache_index_action! = cache_public_action!(edge_ttl: 1.day)
+
+  # A concept page only changes when the concept syncs, which purges it.
+  # See Concept::InvalidateCloudflareCache. The per-user data this action
+  # builds is empty for the signed-out visitors that get cached, and
+  # cache_public_action! no-ops for everyone else.
+  def cache_show_action! = cache_public_action!(edge_ttl: 1.day)
 
   def use_track
     @track = Track.find(params[:track_id])

--- a/app/controllers/tracks/exercises_controller.rb
+++ b/app/controllers/tracks/exercises_controller.rb
@@ -3,7 +3,8 @@ class Tracks::ExercisesController < ApplicationController
   before_action :use_track!
   before_action :use_exercise!, only: %i[show start edit complete tooltip no_test_runner]
   before_action :use_solution, only: %i[show edit complete tooltip]
-  before_action :cache_public_action!, only: %i[show tooltip]
+  before_action :cache_public_action!, only: %i[tooltip]
+  before_action :cache_show_action!, only: %i[show]
   before_action :cache_index_action!, only: %i[index]
 
   skip_before_action :authenticate_user!, only: %i[index show tooltip]
@@ -52,6 +53,10 @@ class Tracks::ExercisesController < ApplicationController
   # The exercise list only changes when the track syncs, which purges it.
   # See Track::InvalidateCloudflareCache.
   def cache_index_action! = cache_public_action!(edge_ttl: 1.day)
+
+  # An exercise page only changes when the exercise syncs, which purges it.
+  # See Exercise::InvalidateCloudflareCache.
+  def cache_show_action! = cache_public_action!(edge_ttl: 1.day)
 
   def use_exercise!
     @exercise = @track.exercises.find(params[:id])

--- a/app/views/tracks/concepts/show.html.haml
+++ b/app/views/tracks/concepts/show.html.haml
@@ -60,10 +60,11 @@
         %section.about.px-20.xl:px-32.py-20.xl:py-24
           .c-textual-content.--large
             %h2= t('.about.title', concept_name: @concept.name)
+            - content = Concept::CachedContent::Retrieve.(@concept)
             - if @user_track.external? || @user_track.concept_learnt?(@concept)
-              = raw Markdown::Parse.(@concept.about)
+              = raw content[:about]
             - else
-              = raw Markdown::Parse.(@concept.introduction)
+              = raw content[:introduction]
 
           - if @concept.links.present?
             .links

--- a/app/views/tracks/exercises/show/_instructions.html.haml
+++ b/app/views/tracks/exercises/show/_instructions.html.haml
@@ -1,9 +1,9 @@
 %section.instructions.c-textual-content.--large.px-20.lg:px-32.py-20.lg:py-24
-  - introduction = solution ? solution.introduction : exercise.introduction
-  - if introduction.present?
+  - content = Exercise::CachedContent::Retrieve.(exercise, solution)
+  - if content[:introduction].present?
     .border-b-1.border-borderColor5{ class: "!pb-8 !mb-32" }
       %h2= t('.introduction_heading')
-      .mb-32= raw Markdown::Parse.(introduction)
+      .mb-32= raw content[:introduction]
 
   - if exercise.tutorial?
     %h2= t('.introduction_heading')
@@ -16,8 +16,7 @@
       = vimeo_embed("853440496?h=6abbdfc68f")
 
   %h2= t('.instructions_heading')
-  - instructions = solution ? solution.instructions : exercise.instructions
-  = raw Markdown::Parse.(instructions)
+  = raw content[:instructions]
 
   - if exercise.source.present? || exercise.source_url.present?
     .source

--- a/test/commands/concept/cached_content/retrieve_test.rb
+++ b/test/commands/concept/cached_content/retrieve_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class Concept::CachedContent::RetrieveTest < ActiveSupport::TestCase
+  setup do
+    setup_s3_cache_bucket!
+  end
+
+  test "cache hit returns the stored payload without deferring a write" do
+    concept = create :concept
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, cache_key(concept, concept.synced_to_git_sha),
+      { about: "<p>cached about</p>", introduction: "<p>cached intro</p>" }.to_json
+    )
+
+    Concept::CachedContent::Store.expects(:defer).never
+
+    assert_equal(
+      { about: "<p>cached about</p>", introduction: "<p>cached intro</p>" },
+      Concept::CachedContent::Retrieve.(concept)
+    )
+  end
+
+  test "cache miss generates live and defers a write" do
+    concept = create :concept
+
+    Concept::CachedContent::Store.expects(:defer).with(concept)
+
+    assert_equal(
+      Concept::CachedContent::Generate.(concept),
+      Concept::CachedContent::Retrieve.(concept)
+    )
+  end
+
+  test "an old sha's cache entry is not read after the concept syncs" do
+    concept = create :concept
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, cache_key(concept, concept.synced_to_git_sha),
+      { about: "<p>stale</p>", introduction: "" }.to_json
+    )
+
+    concept.update!(synced_to_git_sha: "new-sha")
+    Concept::CachedContent::Store.expects(:defer).with(concept)
+
+    refute_equal "<p>stale</p>", Concept::CachedContent::Retrieve.(concept)[:about]
+  end
+
+  test "falls back to live generation on S3 failure" do
+    concept = create :concept
+    expected = Concept::CachedContent::Generate.(concept)
+
+    Exercism.stubs(:s3_client).raises(RuntimeError, "s3 is down")
+
+    assert_equal expected, Concept::CachedContent::Retrieve.(concept)
+  end
+
+  def cache_key(concept, sha)
+    uuid = concept.uuid
+    "concept-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{sha}.json"
+  end
+end

--- a/test/commands/concept/cached_content/store_test.rb
+++ b/test/commands/concept/cached_content/store_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Concept::CachedContent::StoreTest < ActiveSupport::TestCase
+  setup do
+    setup_s3_cache_bucket!
+  end
+
+  test "writes the generated payload to the sharded sha-versioned key" do
+    concept = create :concept
+
+    Concept::CachedContent::Store.(concept)
+
+    uuid = concept.uuid
+    key = "concept-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{concept.synced_to_git_sha}.json"
+
+    expected = JSON.parse(Concept::CachedContent::Generate.(concept).to_json, symbolize_names: true)
+    assert_equal expected, S3Cache::Read.(key)
+  end
+end

--- a/test/commands/exercise/cached_content/retrieve_test.rb
+++ b/test/commands/exercise/cached_content/retrieve_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+class Exercise::CachedContent::RetrieveTest < ActiveSupport::TestCase
+  setup do
+    setup_s3_cache_bucket!
+  end
+
+  test "cache hit returns the stored payload without deferring a write" do
+    exercise = create :practice_exercise
+    key = cache_key(exercise, exercise.git_sha)
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, key,
+      { introduction: "<p>cached intro</p>", instructions: "<p>cached instructions</p>" }.to_json
+    )
+
+    Exercise::CachedContent::Store.expects(:defer).never
+
+    assert_equal(
+      { introduction: "<p>cached intro</p>", instructions: "<p>cached instructions</p>" },
+      Exercise::CachedContent::Retrieve.(exercise, nil)
+    )
+  end
+
+  test "cache miss generates live and defers a write" do
+    exercise = create :practice_exercise
+
+    Exercise::CachedContent::Store.expects(:defer).with(exercise, nil)
+
+    assert_equal(
+      Exercise::CachedContent::Generate.(exercise, nil),
+      Exercise::CachedContent::Retrieve.(exercise, nil)
+    )
+  end
+
+  test "a solution reads the key for the sha it is pinned to" do
+    exercise = create :practice_exercise
+    solution = create :practice_solution, exercise:, git_sha: OLD_GIT_SHA
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, cache_key(exercise, OLD_GIT_SHA),
+      { introduction: "", instructions: "<p>pinned</p>" }.to_json
+    )
+
+    Exercise::CachedContent::Store.expects(:defer).never
+
+    assert_equal "<p>pinned</p>", Exercise::CachedContent::Retrieve.(exercise, solution)[:instructions]
+  end
+
+  test "an up to date solution shares the anonymous entry" do
+    exercise = create :practice_exercise
+    solution = create :practice_solution, exercise:, git_sha: exercise.git_sha
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, cache_key(exercise, exercise.git_sha),
+      { introduction: "", instructions: "<p>shared</p>" }.to_json
+    )
+
+    Exercise::CachedContent::Store.expects(:defer).never
+
+    assert_equal "<p>shared</p>", Exercise::CachedContent::Retrieve.(exercise, solution)[:instructions]
+  end
+
+  test "an old sha's cache entry is not read after the exercise syncs" do
+    exercise = create :practice_exercise
+    upload_to_s3(
+      Exercism.config.aws_cache_bucket, cache_key(exercise, exercise.git_sha),
+      { introduction: "", instructions: "<p>stale</p>" }.to_json
+    )
+
+    exercise.update_columns(git_sha: OLD_GIT_SHA)
+    Exercise::CachedContent::Store.expects(:defer).with(exercise, nil)
+
+    refute_equal "<p>stale</p>", Exercise::CachedContent::Retrieve.(exercise, nil)[:instructions]
+  end
+
+  test "falls back to live generation on S3 failure" do
+    exercise = create :practice_exercise
+    expected = Exercise::CachedContent::Generate.(exercise, nil)
+
+    Exercism.stubs(:s3_client).raises(RuntimeError, "s3 is down")
+
+    assert_equal expected, Exercise::CachedContent::Retrieve.(exercise, nil)
+  end
+
+  def cache_key(exercise, sha)
+    uuid = exercise.uuid
+    "exercise-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{sha}.json"
+  end
+
+  # A real commit in the test repo, so content can still be read at it.
+  OLD_GIT_SHA = '0b04b8976650d993ecf4603cf7413f3c6b898eff'.freeze
+end

--- a/test/commands/exercise/cached_content/store_test.rb
+++ b/test/commands/exercise/cached_content/store_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Exercise::CachedContent::StoreTest < ActiveSupport::TestCase
+  setup do
+    setup_s3_cache_bucket!
+  end
+
+  test "writes the generated payload to the sharded sha-versioned key" do
+    exercise = create :practice_exercise
+
+    Exercise::CachedContent::Store.(exercise, nil)
+
+    uuid = exercise.uuid
+    key = "exercise-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{exercise.git_sha}.json"
+
+    expected = JSON.parse(Exercise::CachedContent::Generate.(exercise, nil).to_json, symbolize_names: true)
+    assert_equal expected, S3Cache::Read.(key)
+  end
+
+  test "writes to the solution's pinned sha" do
+    exercise = create :practice_exercise
+    solution = create :practice_solution, exercise:, git_sha: OLD_GIT_SHA
+
+    Exercise::CachedContent::Store.(exercise, solution)
+
+    uuid = exercise.uuid
+    assert S3Cache::Read.("exercise-content/#{uuid[0, 2]}/#{uuid[2, 2]}/#{uuid}/#{OLD_GIT_SHA}.json")
+  end
+
+  # A real commit in the test repo, so content can still be read at it.
+  OLD_GIT_SHA = '0b04b8976650d993ecf4603cf7413f3c6b898eff'.freeze
+end


### PR DESCRIPTION
`Tracks::ExercisesController#show` sits at 352ms P50 / 896ms P95, and 88% of that is view rendering. The single biggest cost is `show/_instructions` at ~98ms, of which ~89ms is its own code: parsing an exercise's introduction and instructions out of git on every request.

## Caching the parsed markdown

Both documents now come from the S3 cache added in #9403, so a hit skips the git read and the markdown parse alike. The consumers follow the `Generate`/`Retrieve`/`Store` shape of `Solution::CachedSerializedView`.

Keys are versioned with the git sha the content is read at, which makes the cached content immutable and leaves nothing to invalidate: a sync moves the exercise onto a new sha and therefore a new key. There is no `Invalidate` command and no prefix delete, so none of the `except_key` race handling #9403 needed applies here.

Crucially the sha is the one we *actually read from*: `solution.git_sha` when there is a solution, since a solution pins the sha it was created at and must keep showing the instructions it was started against, and `exercise.git_sha` otherwise. Anonymous visitors and up-to-date solutions therefore share a single entry, and only out-of-date solutions get objects of their own.

Old shas are left behind as orphans rather than swept, deliberately: a solution pinned to one may be rendered at any time. It amounts to megabytes a year.

Concepts get the same treatment for their `about` and `introduction` documents. They have no sha of their own and read at the repository's `HEAD`, so they are versioned on `synced_to_git_sha`. That turns over on every track sync rather than only when the concept's content changes, costing one regeneration per concept per sync — a weaker cache than the exercise one, but still a large net win.

## Edge-caching both show pages

Both show actions get the one day edge TTL. #9387 deliberately skipped them because the partner advert was randomly selected and crawler-dependent; #9386 fixed exactly that, and `Exercise::InvalidateCloudflareCache` and `Concept::InvalidateCloudflareCache` already purge these URLs when a sync changes the content, gated on `content_changed`.

⚠️ Worth a careful look: the concepts show page had no `cache_public_action!` at all before this, so unlike the exercise page it wasn't pre-scoped as ready by #9387. Its `show` builds `@solutions` and calls `@user_track.concept_exercises_for_concept`, which are empty or external-shaped for signed-out visitors, and `cache_public_action!` no-ops for everyone else — the same reasoning the existing `cache_index_action!` comment on that controller uses.

## Testing

New command tests cover cache hits, misses with a deferred write, sha pinning, sha turnover, and S3-failure fallback. Controller tests pass. System tests not run locally; leaving those to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShHksEaUBSLvgwNzbkLFue