### PR TITLE
fix: remove duplicated '(You can always change later.)' in track welcome modal

### DIFF
--- a/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
+++ b/app/javascript/components/modals/track-welcome-modal/LHS/steps/HasLearningModeStep.tsx
@@ -35,8 +35,7 @@ export function HasLearningModeStep({
           {t('hasLearningModeStep.startTrackInLearningOrPracticeMode', {
             trackTitle: track.title,
           })}
-        </span>{' '}
-        (You can always change later.)
+        </span>
       </p>
 
       <div className="grid grid-cols-2 gap-12 items-center">


### PR DESCRIPTION
## What

Fixes #6779

The track welcome modal rendered the text "(You can always change later.)" twice:

> Would you like to start the track in Learning Mode or Practice Mode? (You can always change later.) (You can always change later.)

The parenthetical is already part of the hasLearningModeStep.startTrackInLearningOrPracticeMode translation string (components-modals-track-welcome-modal-LHS-steps.ts), but HasLearningModeStep.tsx also hardcoded it after the translated span. Removed the duplicated hardcoded copy.

## Why

The sentence should only appear once.
