### PR TITLE
Use @codemirror/lang-go for the Go editor

### DIFF
--- a/app/javascript/components/misc/CodeMirror/languageCompartment.ts
+++ b/app/javascript/components/misc/CodeMirror/languageCompartment.ts
@@ -27,6 +27,10 @@ export const loadLanguageCompartment = async (
       const { gleam } = await import('@exercism/codemirror-lang-gleam')
       return compartment.of(gleam())
     }
+    case 'go': {
+      const { go } = await import('@codemirror/lang-go')
+      return compartment.of(go())
+    }
     case 'javascript':
     case 'typescript': {
       const { javascript } = await import('@codemirror/lang-javascript')
@@ -157,10 +161,6 @@ export const loadLanguageCompartment = async (
     case 'gnu-apl': {
       const { apl } = await import('@codemirror/legacy-modes/mode/apl')
       return compartment.of(StreamLanguage.define(apl))
-    }
-    case 'go': {
-      const { go } = await import('@codemirror/legacy-modes/mode/go')
-      return compartment.of(StreamLanguage.define(go))
     }
     case 'groovy': {
       const { groovy } = await import('@codemirror/legacy-modes/mode/groovy')

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@codemirror/commands": "^6.7.1",
     "@codemirror/lang-cpp": "^6.0.2",
     "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-go": "^6.0.1",
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.2.1",
     "@codemirror/lang-php": "^6.0.1",

--- a/test/javascript/components/misc/CodeMirror/languageCompartment.test.ts
+++ b/test/javascript/components/misc/CodeMirror/languageCompartment.test.ts
@@ -1,0 +1,56 @@
+import { EditorState } from '@codemirror/state'
+import type { CompletionSource } from '@codemirror/autocomplete'
+import { CompletionContext } from '@codemirror/autocomplete'
+import { syntaxTree } from '@codemirror/language'
+import { loadLanguageCompartment } from '@/components/misc/CodeMirror/languageCompartment'
+
+const GO_EXERCISE = [
+  'package main',
+  '',
+  'func Welcome(name string) string {',
+  '\treturn na',
+  '}',
+].join('\n')
+
+async function goState() {
+  return EditorState.create({
+    doc: GO_EXERCISE,
+    extensions: [await loadLanguageCompartment('go')],
+  })
+}
+
+// Candidates come from the sources a language registers as `autocomplete`
+// language data, which is what the legacy Go stream mode was missing.
+async function completionsAt(state: EditorState, pos: number) {
+  const sources = state.languageDataAt<CompletionSource>('autocomplete', pos)
+  const options = []
+
+  for (const source of sources) {
+    const result = await source(new CompletionContext(state, pos, false))
+
+    if (result) options.push(...result.options)
+  }
+
+  return options
+}
+
+test('go suggests names declared in the file', async () => {
+  const state = await goState()
+  const options = await completionsAt(state, GO_EXERCISE.indexOf('na\n') + 2)
+
+  expect(options).toContainEqual(
+    expect.objectContaining({ label: 'name', type: 'var' })
+  )
+})
+
+test('go parses without errors', async () => {
+  const errors: string[] = []
+
+  syntaxTree(await goState()).iterate({
+    enter: (node) => {
+      if (node.type.isError) errors.push(node.name)
+    },
+  })
+
+  expect(errors).toEqual([])
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,6 +1102,17 @@
     "@lezer/common" "^1.0.2"
     "@lezer/css" "^1.1.7"
 
+"@codemirror/lang-go@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-go/-/lang-go-6.0.1.tgz#598222c90f56eae28d11069c612ca64d0306b057"
+  integrity sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/go" "^1.0.0"
+
 "@codemirror/lang-html@^6.0.0":
   version "6.4.9"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.9.tgz#d586f2cc9c341391ae07d1d7c545990dfa069727"
@@ -1853,6 +1864,15 @@
     "@lezer/common" "^1.2.0"
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
+
+"@lezer/go@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lezer/go/-/go-1.0.1.tgz#3004b54f5e4c9719edcba98653f380baf8c0d1a2"
+  integrity sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
 
 "@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3", "@lezer/highlight@^1.2.0":
   version "1.2.1"


### PR DESCRIPTION
Hi! I've been using Exercism for years and this is my first contribution to the site, so please do tell me if I've got the wrong end of the stick anywhere, or if this should have started as a forum topic instead.

I ran into this while working through the Go track in the online editor. I was filling in the usual stub:

```go
func Welcome(name string) string {
	panic("Please implement the Welcome function")
}
```

and when I started typing `return na` I expected `name` to be offered. Nothing came up. I assumed autocomplete was simply off in the editor, but then I tried the equivalent on the Python track:

```python
def welcome(name):
    return na
```

and there `name` appears straight away. So it is on — just not for Go.

## Why

Autocompletion is already enabled for every track: `misc/CodeMirror.tsx` uses `basicSetup`, which includes `autocompletion()`. The candidates themselves, though, come from whatever a language registers as `autocomplete` language data, and Go is still wired to the legacy stream mode:

```ts
case 'go': {
  const { go } = await import('@codemirror/legacy-modes/mode/go')
  return compartment.of(StreamLanguage.define(go))
}
```

`@codemirror/legacy-modes/mode/go` only declares `indentOnInput` and `commentTokens`, so Go ends up with no completion sources at all. Python and JavaScript get theirs from `lang-python` and `lang-javascript`.

As far as I can tell this isn't deliberate, just timing. `case 'go'` was added in #1005 in May 2021, when the legacy mode was the only option for Go — `@codemirror/lang-go` wasn't published until February 2024.

## What this changes

It moves Go out of the legacy block and onto `@codemirror/lang-go`, the same way `cpp`, `java`, `python` and `rust` are already wired. Julia had the same treatment in #2074 once a proper package existed for it.

That gives Go local completion of parameters, `var` and `:=` declarations, constants, types and same-file functions, plus keyword and snippet completion. It also swaps the regex-based stream mode for the Lezer parser, so highlighting, folding and indentation come from a real syntax tree rather than a token stream.

## What this isn't

I read the forum thread on [autocomplete in the editor](https://forum.exercism.org/t/autocomplete-in-editor/13370) before opening this, and I want to be clear I'm not trying to reopen that discussion. There's no language server here, no backend, and nothing extra to run or pay for. It only completes names already written in the file the student is looking at. Anything beyond that — stdlib symbols, types, cross-file lookups — would still need gopls and is out of scope.

## Cost

Two new dependencies, `@codemirror/lang-go` and its parser `@lezer/go`. That's roughly 12KB gzipped more than the legacy mode, and it stays in its own lazily-loaded chunk that only the Go track pulls in. I checked the build output to confirm nothing extra lands in the initial bundle.

## Testing

`yarn test` passes in full (162 suites). I added a small test that fails without the change:

- `name` is offered as a completion for the example above
- Go still parses without errors, so highlighting and indentation aren't affected

There were no existing tests around `languageCompartment`, so I kept it to those two — happy to drop it if you'd rather these PRs stay the usual three-file shape.

One caveat: I couldn't run rubocop or haml-lint locally as I don't have Ruby set up on this machine, but this PR doesn't touch any Ruby or HAML.
