### PR TITLE
Rate-limit unauthenticated crawling of profile solutions

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -70,21 +70,22 @@ Rack::Attack.safelist("verified search engines") do |req|
   req.env['HTTP_X_SEARCH_ENGINE'] == 'true'
 end
 
-# These two endpoints are cheap to request and expensive to serve, and are
-# enumerable: there is one URL per exercise and one per submission, so anything
-# walking the site systematically can pull an unbounded number of them. Cap
-# unauthenticated access per-IP per-day. The limit is far above what any
-# person browsing the site would reach.
+# These endpoints are cheap to request and expensive to serve, and are
+# enumerable: there is one URL per exercise, one per submission, and one per
+# user handle, so anything walking the site systematically can pull an
+# unbounded number of them. Cap unauthenticated access per-IP per-day. The
+# limit is far above what any person browsing the site would reach.
 CRAWLED_EXERCISE_PATH = %r{\A/tracks/[^/]+/exercises/[^/]+(/|\z)}
 Rack::Attack.throttle("Unauthenticated crawling of expensive endpoints", limit: 500, period: 1.day) do |req|
   next unless req.get?
   next if req.signed_in?
 
-  # Only resolve the route for the API endpoint, and only once we know the
+  # Only resolve the route for the API endpoints, and only once we know the
   # path is in the right namespace: recognize_path walks the whole route set,
   # which is far too expensive to pay on every unauthenticated GET.
   matches = req.path.match?(CRAWLED_EXERCISE_PATH) ||
-            (req.path.starts_with?('/api/v2/solutions') && req.routed_to == 'api/solutions/submission_files#index')
+            (req.path.starts_with?('/api/v2/solutions') && req.routed_to == 'api/solutions/submission_files#index') ||
+            (req.path.starts_with?('/api/v2/profiles') && req.routed_to == 'api/profiles/solutions#index')
   next unless matches
 
   "unauthenticated-crawl|#{req.client_ip}"

--- a/test/initializers/rack_attack_test.rb
+++ b/test/initializers/rack_attack_test.rb
@@ -224,6 +224,33 @@ class RackAttackTest < Webhooks::BaseTestCase
     end
   end
 
+  test "unauthenticated profile solutions requests over the limit are throttled" do
+    profile_user = create(:user_profile).user
+    ip = "1.2.3.20"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get api_profile_solutions_path(profile_user), headers: crawler_headers(ip)
+      assert_response :too_many_requests
+    end
+  end
+
+  # Enumerating the handle space mostly produces 404s. Rack::Attack is
+  # middleware, so it counts the request before the app decides the profile
+  # doesn't exist — which is the whole point here, since a miss is exactly what
+  # a crawler walking usernames generates.
+  test "profile solutions requests for handles that do not exist still count towards the crawl throttle" do
+    ip = "1.2.3.21"
+
+    freeze_time do
+      fill_crawl_throttle(ip, 500)
+
+      get api_profile_solutions_path("no-such-handle"), headers: crawler_headers(ip)
+      assert_response :too_many_requests
+    end
+  end
+
   test "authenticated requests are not throttled by the crawl throttle" do
     create :practice_exercise
     ip = "1.2.3.7"


### PR DESCRIPTION
## What

Adds `api/profiles/solutions#index` to the existing **Unauthenticated crawling of expensive endpoints** throttle (500/day per IP), alongside the exercise pages and submission files.

## Why

That endpoint has every property the throttle was written for, and was simply not on the list:

- **enumerable** — one URL per user handle, and handles are public
- **unauthenticated**
- **cheap to request, more expensive to serve**

It had no GET throttle at all. We've seen sustained automated crawling of it, which is what prompted this.

Fixing it here rather than at the edge means it applies wherever the request arrives from and doesn't depend on the client's address staying the same.

## Implementation notes

The route is matched the same way as the existing submission-files clause — a cheap path-prefix guard first, so `recognize_path` is only paid once we already know the request is in the right namespace.

It inherits the existing exemptions for free: signed-in users and verified search engines are unaffected.

## Tests

Two added, both verified to fail without the initializer change:

- profile solutions requests over the limit are throttled
- **requests for handles that don't exist still count** — Rack::Attack is middleware, so it counts before the app 404s, which is the whole point when something is walking the handle space

`20 runs, 306 assertions, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
