### PR TITLE
Serve ActiveStorage attachments via the proxy endpoint

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,10 +33,18 @@ module Website
     # Allow SVGs to render from active storage
     config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 
-    # Public assets (partner logos, avatars) are served via ActiveStorage's
-    # blob redirect endpoint, which is hit on every page load. Extending the
-    # signed URL expiry lets browsers/CDNs cache the redirect for longer,
-    # cutting repeat hits to that endpoint.
+    # Public assets (partner logos, avatars) are hit on every page load, so
+    # they need to be cacheable at the edge. The default blob *redirect*
+    # endpoint can never be: it 302s to a presigned S3 URL, so Rails marks the
+    # redirect `private` and caps its max-age at the signature's lifetime.
+    #
+    # Proxying instead means the URL is permanent and the response is served
+    # with `public, max-age=<forever>` (ActiveStorage::Blobs::ProxyController),
+    # so Cloudflare fetches each blob once and never asks again.
+    config.active_storage.resolve_model_to_route = :rails_storage_proxy
+
+    # Still relevant for anything that asks a blob for its service URL directly
+    # (direct downloads, the admin UI) rather than going through a route.
     config.active_storage.service_urls_expire_in = 1.day
 
     Rails.autoloaders.main.ignore(Rails.root.join('app', 'css'))

--- a/test/integration/active_storage_caching_test.rb
+++ b/test/integration/active_storage_caching_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class ActiveStorageCachingTest < ActionDispatch::IntegrationTest
+  test "attachments route to the proxy endpoint, not the redirect endpoint" do
+    partner = create :partner
+    attach_logo(partner)
+
+    url = Rails.application.routes.url_helpers.url_for(partner.light_logo)
+
+    assert_includes url, "/rails/active_storage/blobs/proxy/"
+  end
+
+  test "proxied attachments are publicly cacheable at the edge" do
+    partner = create :partner
+    attach_logo(partner)
+
+    get Rails.application.routes.url_helpers.url_for(partner.light_logo)
+
+    assert_response :success
+    assert_includes response.headers["Cache-Control"], "public"
+    refute_includes response.headers["Cache-Control"].to_s, "private"
+    assert_nil response.headers["Set-Cookie"]
+  end
+
+  private
+  def attach_logo(partner)
+    partner.light_logo.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "test.jpg")),
+      filename: "test.jpg",
+      content_type: "image/jpeg"
+    )
+  end
+end


### PR DESCRIPTION
The two most-requested uncacheable paths in the last 12h were a pair of ActiveStorage blob redirects (~6.9k requests each), which turn out to be the light/dark logos on the site-wide advert (`app/views/components/advert.html.haml`).

They were uncacheable by construction. `image_tag advert.light_logo` resolves to `ActiveStorage::Blobs::RedirectController`, which does:

```ruby
def show
  expires_in ActiveStorage.service_urls_expire_in   # no `public: true`
  redirect_to @blob.url(disposition: params[:disposition]), allow_other_host: true
end
```

`expires_in` defaults to `public: false`, so the response goes out as `Cache-Control: max-age=86400, private` and Cloudflare will never cache it. Raising `service_urls_expire_in` only moved the max-age, not the `private` flag. And the ceiling is real: the redirect target is a presigned S3 URL, so the redirect cannot outlive the signature.

This switches `config.active_storage.resolve_model_to_route` to `:rails_storage_proxy`. `ActiveStorage::Blobs::ProxyController` serves the bytes from a permanent URL under `http_cache_forever public: true`, and includes `ActiveStorage::DisableSession` so there is no `Set-Cookie` to bypass the edge either. Cloudflare fetches each blob once per PoP and never asks again.

Trade-off: a cache miss now streams bytes through a Rails process instead of 302ing to S3. For a handful of hot logos that is a few misses per PoP, in exchange for removing ~14k origin requests per 12h.

The change is global, so avatars and perk logos get the same treatment. Existing avatar traffic mostly goes through `AvatarsController` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLa7RVZtKEECSsYczu458W