### PR TITLE
Add Ctrl/Cmd+Enter shortcut to run tests in the editor

### DIFF
--- a/app/javascript/components/editor/FileEditorCodeMirror.tsx
+++ b/app/javascript/components/editor/FileEditorCodeMirror.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useMemo,
   useRef,
   useState,
   useEffect,
@@ -33,6 +34,7 @@ export function FileEditorCodeMirror({
   files: defaultFiles,
   settings,
   readonly,
+  onRunTests,
 }: {
   editorDidMount: (editor: FileEditorHandle) => void
   language: string
@@ -121,6 +123,14 @@ export function FileEditorCodeMirror({
     editor?.focus()
   }, [tab])
 
+  const commands = useMemo(() => {
+    if (!onRunTests) {
+      return []
+    }
+
+    return [{ key: 'Mod-Enter', run: onRunTests }]
+  }, [onRunTests])
+
   useEffect(() => {
     editorDidMount({ getFiles, setFiles, focus })
   }, [editorDidMount, getFiles, setFiles, focus])
@@ -170,7 +180,7 @@ export function FileEditorCodeMirror({
                 readonly={
                   readonly || file.type === 'legacy' || file.type === 'readonly'
                 }
-                commands={[]}
+                commands={commands}
               />
             </Suspense>
           </Tab.Panel>


### PR DESCRIPTION
Fixes exercism/exercism#6777

Adds a `Ctrl/Cmd+Enter` keyboard shortcut in the code editor to run tests, matching the Kotlin Playground "Run" behaviour. The `onRunTests` prop was already threaded into `FileEditorCodeMirror` but unused; it is now wired into a CodeMirror 6 keymap (`Mod-Enter`).
