### PR TITLE
docs: fix typo carefuly -> carefully

### DIFF
--- a/bootcamp_content/projects/style-puzzles/exercises/lemonade/introduction.md
+++ b/bootcamp_content/projects/style-puzzles/exercises/lemonade/introduction.md
@@ -49,7 +49,7 @@ That's normally because they've missed an instruction, or taken a more "hacky" a
 Here are common mistakes people make.
 I recommend double-checking each of them!
 
-- Not checking the diff/curtain carefuly enough.
+- Not checking the diff/curtain carefully enough.
 - Not using `cover`, `top right` for the background.
 - Unncessarily using `background-repeat: no-repeat`. This makes no visual difference, but does change the subpixel rendering.
 - Not using `px` for all margins and padding.


### PR DESCRIPTION
Corrects the misspelling `carefuly` -> `carefully` in `bootcamp_content/projects/style-puzzles/exercises/lemonade/introduction.md`.

Documentation only, no behaviour change.